### PR TITLE
Removed asyncio from install_requires for Python versions greater or equal to 3.4

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,13 @@
 import os
+import sys
 from setuptools import setup, find_packages
 
 version = '0.4.5dev'
 
-install_requires = ['asyncio']
+if sys.version_info >= (3,4):
+    install_requires = []
+else:
+    install_requires = ['asyncio']
 tests_require = install_requires + ['nose', 'gunicorn']
 
 


### PR DESCRIPTION
as they come with asyncio

This means that aiohttp can be installed on Windows without a compiler
on 3.4 or greater.
