### PR TITLE
Made travis use latest setuptools

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ python:
   - 3.3
 
 install:
+  - pip install --upgrade setuptools
   - pip install coveralls --use-mirrors
   - python setup.py develop
 


### PR DESCRIPTION
This was casing problems since [#build54](https://travis-ci.org/fafhrd91/aiohttp/builds/14501366) which is directly linked with [setuptools-issue-131](https://bitbucket.org/pypa/setuptools/issue/131/test-failures-with-python33).

[Recetly](https://bitbucket.org/pypa/setuptools/src/tip/CHANGES.txt?at=default) setuptools got more bugfixes
