### PR TITLE
Added support for aiohttp.__version__

### DIFF
--- a/aiohttp/__init__.py
+++ b/aiohttp/__init__.py
@@ -11,4 +11,7 @@ __all__ = (client.__all__ +
            errors.__all__ +
            parsers.__all__ +
            protocol.__all__ +
-           session.__all__)
+           session.__all__ +
+           ['__version__'])
+
+__version__ = '0.6.5'

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,17 @@
+import codecs
 import os
+import re
 import sys
 from setuptools import setup, find_packages
 
-version = '0.6.5'
+
+with codecs.open(os.path.join(os.path.abspath(os.path.dirname(
+        __file__)), 'aiohttp', '__init__.py'), 'r', 'latin1') as fp:
+    try:
+        version = re.findall(r"^__version__ = '([^']+)'$", fp.read(), re.M)[0]
+    except IndexError:
+        raise RuntimeError('Unable to determine version.')
+
 
 if sys.version_info >= (3,4):
     install_requires = []


### PR DESCRIPTION
Just to support being able to programmatically determine the aiohttp version using the standard convention of `package.__version__`

Just pulled the code from other setup.py implementations I have lying around that look awfully similar to what's at https://github.com/pypa/sampleproject/blob/master/setup.py linked from http://packaging.python.org/en/latest/tutorial.html#creating-your-own-project though admittedly mine is simpler (but works in most cases including this one). :smile: 
