### PR TITLE
The `connector` argument for `request` (#27)

### DIFF
--- a/aiohttp/__init__.py
+++ b/aiohttp/__init__.py
@@ -1,6 +1,7 @@
 # This relies on each of the submodules having an __all__ variable.
 
 from .protocol import *
+from .connector import *
 from .client import *
 from .errors import *
 from .parsers import *
@@ -12,6 +13,7 @@ __all__ = (client.__all__ +
            parsers.__all__ +
            protocol.__all__ +
            session.__all__ +
+           connector.__all__ +
            ['__version__'])
 
 __version__ = '0.7.0b6'

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -1,0 +1,17 @@
+import asyncio
+
+
+__all__ = ['DefaultConnector']
+
+
+class DefaultConnector(object):
+
+    def create_connection(self, proto, host, port, *, loop=None, **kwargs):
+        """Create connection. Has same keyword arguments
+        as BaseEventLoop.create_connection
+        """
+        if loop is None:
+            loop = asyncio.get_event_loop()
+        conn = yield from loop.create_connection(proto, host, port, **kwargs)
+        return conn
+

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -1,0 +1,66 @@
+"""Tests of http client with custom Connector"""
+
+import gc
+import io
+import os.path
+import http.cookies
+import asyncio
+import unittest
+
+import aiohttp
+from aiohttp import client
+from aiohttp import test_utils
+
+from tests.test_client_functional import Functional
+
+
+class UnixSocketConnector(aiohttp.DefaultConnector):
+
+    def __init__(self, path):
+        self.path = path
+
+    def create_connection(self, proto, host, port, *, loop=None, **kwargs):
+        if loop is None:
+            loop = asyncio.get_event_loop()
+        conn = yield from loop.create_unix_connection(
+            proto, self.path, **kwargs)
+        return conn
+
+
+class HttpClientConnectorTests(unittest.TestCase):
+
+    def setUp(self):
+        self.loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(None)
+
+    def tearDown(self):
+        # just in case if we have transport close callbacks
+        test_utils.run_briefly(self.loop)
+
+        self.loop.close()
+        gc.collect()
+
+
+    def test_default_connector(self):
+        with test_utils.run_server(self.loop, router=Functional) as httpd:
+            r = self.loop.run_until_complete(client.request('get',
+                httpd.url('method', 'get'),
+                connector=aiohttp.DefaultConnector(),
+                loop=self.loop))
+            content = self.loop.run_until_complete(r.content.read())
+            content = content.decode()
+            self.assertEqual(r.status, 200)
+            r.close()
+
+    def test_unix_connector(self):
+        path = '/tmp/aiohttp_unix.sock'
+        with test_utils.run_server(self.loop,
+            listen_addr=path, router=Functional) as httpd:
+            r = self.loop.run_until_complete(client.request('get',
+                httpd.url('method', 'get'),
+                connector=UnixSocketConnector(path),
+                loop=self.loop))
+            content = self.loop.run_until_complete(r.content.read())
+            content = content.decode()
+            self.assertEqual(r.status, 200)
+            r.close()


### PR DESCRIPTION
This is needed if http is run over unix socket. May also be used for
various kinds of proxies and potentially different transports

The implementation is partial. It doesn't use connector for Session yet.
