### PR TITLE
Fix checking for coroutine in HTTP server

### DIFF
--- a/aiohttp/server.py
+++ b/aiohttp/server.py
@@ -4,7 +4,6 @@ __all__ = ['ServerHttpProtocol']
 
 import asyncio
 import http.server
-import inspect
 import logging
 import time
 import traceback
@@ -186,7 +185,7 @@ class ServerHttpProtocol(aiohttp.StreamProtocol):
                 payload = reader.set_parser(aiohttp.HttpPayloadParser(message))
 
                 handler = self.handle_request(message, payload)
-                if (inspect.isgenerator(handler) or
+                if (asyncio.iscoroutine(handler) or
                         isinstance(handler, asyncio.Future)):
                     yield from handler
 


### PR DESCRIPTION
The `inspect.isgenerator` doesn't work if `PYTHONASYNCIODEBUG=1` is
enabled, because all coroutines become `asyncio.tasks.CoroWrapper` in
this case
