### PR TITLE
Handle %2f in URL correctly for HttpRequest

### DIFF
--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -22,6 +22,7 @@ import urllib.parse
 
 import aiohttp
 
+from requests.utils import requote_uri
 
 @asyncio.coroutine
 def request(method, url, *,
@@ -253,8 +254,6 @@ class HttpRequest:
         scheme, netloc, path, query, fragment = urllib.parse.urlsplit(self.url)
         if not path:
             path = '/'
-        else:
-            path = urllib.parse.unquote(path)
 
         if isinstance(params, dict):
             params = list(params.items())
@@ -273,7 +272,7 @@ class HttpRequest:
                 query = params
 
         self.path = urllib.parse.urlunsplit(
-            ('', '', urllib.parse.quote(path), query, fragment))
+            ('', '', requote_uri(path), query, fragment))
 
     def update_headers(self, headers):
         """Update request headers."""

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 import codecs
 import os
 import re
@@ -12,11 +14,9 @@ with codecs.open(os.path.join(os.path.abspath(os.path.dirname(
     except IndexError:
         raise RuntimeError('Unable to determine version.')
 
-
-if sys.version_info >= (3,4):
-    install_requires = []
-else:
-    install_requires = ['asyncio']
+install_requires = ['requests']
+if sys.version_info < (3,4):
+    install_requires += ['asyncio']
 
 tests_require = install_requires + ['nose', 'gunicorn']
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -198,6 +198,9 @@ class HttpRequestTests(unittest.TestCase):
         req = HttpRequest('get', "http://0.0.0.0/get/test%20case")
         self.assertEqual(req.path, "/get/test%20case")
 
+        req = HttpRequest('get', "http://0.0.0.0/get/test%2fcase")
+        self.assertEqual(req.path, "/get/test%2fcase")
+
     def test_params_are_added_before_fragment(self):
         req = HttpRequest(
             'GET', "http://example.com/path#fragment", params={"a": "b"})


### PR DESCRIPTION
Hi,

I've a problem with HttpRequest to handle %2f in URL (ex: /get/test%2fcase), because HttpRequest will make the request to /get/test/case instead of /get/test%2fcase.

I need this to retrieve data from CouchDB in a database that it has / character in his name.

About my solution, I've used Requests because I know a little bit internally, but I've also find this:
https://github.com/quantmind/pulsar/blob/master/pulsar/utils/httpurl.py

It's only a suggestion to reuse some work from another library, you could also reimplement this piece of code.

Regards.
