### PR TITLE
Small improvement in setup.py to build easier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ var/*
 *.egg
 *.tar.gz
 *.so
+build/
 .tox
 .DS_Store
 .coverage

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 import codecs
 import os
 import re
@@ -13,10 +14,9 @@ with codecs.open(os.path.join(os.path.abspath(os.path.dirname(
         raise RuntimeError('Unable to determine version.')
 
 
-if sys.version_info >= (3,4):
-    install_requires = []
-else:
-    install_requires = ['asyncio']
+install_requires = []
+if sys.version_info < (3,4):
+    install_requires += ['asyncio']
 
 tests_require = install_requires + ['nose', 'gunicorn']
 


### PR DESCRIPTION
You can launch setup.py directly + avoid to add build folder.
