### PR TITLE
Terminate properly with signal TERM and INT

### DIFF
--- a/aiohttp/worker.py
+++ b/aiohttp/worker.py
@@ -104,6 +104,9 @@ class AsyncGunicornWorker(base.Worker):
 
         yield from self.close()
 
+    def handle_exit(self, sig, frame):
+        self.alive = False
+
 
 class PortMapperWorker(AsyncGunicornWorker):
     """Special worker that uses different wsgi application depends on port.

--- a/examples/gunicorn_worker.py
+++ b/examples/gunicorn_worker.py
@@ -1,0 +1,35 @@
+import asyncio
+
+
+HELLO_WORLD = b"Hello world!\n"
+
+
+@asyncio.coroutine
+def application(environ, start_response):
+    """Simplest possible application object"""
+    status = '200 OK'
+    response_headers = [('Content-type', 'text/plain')]
+    start_response(status, response_headers)
+    yield from asyncio.sleep(1)
+    return [HELLO_WORLD]
+
+
+@asyncio.coroutine
+def close():
+    print('Stopping Application')
+    yield from asyncio.sleep(2)
+    print('Application stopped')
+
+
+setattr(application, 'close', close)
+
+
+if __name__ == '__main__':
+    print ("""This is an example of gunicorn worker that run application.
+You must install gunicorn before running the example then.
+
+Usage:
+
+    gunicorn --worker-class aiohttp.worker.AsyncGunicornWorker gunicorn_worker
+
+""")


### PR DESCRIPTION
Before this commit, only the QUIT commit do
the cleanup correctly.
Gunicorn base worker call sys.exit(0) on TERM
and INT wich does not close the loop properly.

When running gunicorn in my terminal, terminate it with CTRL+C
or with "pkill gunicorn" should call the close method to properly
exit.
