### PR TITLE
Include the port number in the host header.

### DIFF
--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -214,6 +214,9 @@ class HttpRequest:
             if len(self.auth) == 1:
                 self.auth.append('')
 
+        # Record entire netloc for usage in host header
+        self.netloc = netloc
+
         # extract host and port
         self.ssl = scheme == 'https'
         if ':' in netloc:
@@ -294,7 +297,7 @@ class HttpRequest:
 
         # add host
         if 'host' not in self.headers:
-            self.headers['Host'] = self.host
+            self.headers['Host'] = self.netloc
 
     def update_cookies(self, cookies):
         """Update request cookies header."""

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -159,9 +159,19 @@ class HttpRequestTests(unittest.TestCase):
         req = HttpRequest('get', 'http://python.org/')
         self.assertEqual(req.headers['host'], 'python.org')
 
+        req = HttpRequest('get', 'http://python.org:80/')
+        self.assertEqual(req.headers['host'], 'python.org:80')
+
+        req = HttpRequest('get', 'http://python.org:99/')
+        self.assertEqual(req.headers['host'], 'python.org:99')
+
         req = HttpRequest('get', 'http://python.org/',
                           headers={'host': 'example.com'})
         self.assertEqual(req.headers['host'], 'example.com')
+
+        req = HttpRequest('get', 'http://python.org/',
+                          headers={'host': 'example.com:99'})
+        self.assertEqual(req.headers['host'], 'example.com:99')
 
     def test_headers(self):
         req = HttpRequest('get', 'http://python.org/',


### PR DESCRIPTION
Hello.  This fixes an issue where the port number is not included in the `HOST` header being sent to the remote server.  Servers on nonstandard ports sometimes use the `HOST` header when returning redirects (django does this for example), and following such a redirect would lead the client to the wrong destination.
