### PR TITLE
Accept bytearray in request bodies

### DIFF
--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -500,7 +500,7 @@ class ClientRequest:
                             'Bytes object is expected, got: %s.' %
                             type(result))
             else:
-                if isinstance(self.body, bytes):
+                if isinstance(self.body, (bytes, bytearray)):
                     self.body = (self.body,)
 
                 for chunk in self.body:


### PR DESCRIPTION
When calling aiohttp.request(...) with the `data` parameter set to a `bytearray`, the original code would iterate through that `bytearray` and end up sending each byte as an `int` through the underlying transport.

This shall fix the issue.
