### PR TITLE
Allow body in DELETE requests

### DIFF
--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -143,8 +143,8 @@ def request(method, url, *,
 
 class ClientRequest:
 
-    GET_METHODS = {'DELETE', 'GET', 'HEAD', 'OPTIONS'}
-    POST_METHODS = {'PATCH', 'POST', 'PUT', 'TRACE'}
+    GET_METHODS = {'GET', 'HEAD', 'OPTIONS'}
+    POST_METHODS = {'PATCH', 'POST', 'PUT', 'TRACE', 'DELETE'}
     ALL_METHODS = GET_METHODS.union(POST_METHODS)
 
     DEFAULT_HEADERS = {


### PR DESCRIPTION
Body is not forbidden for DELETE requests, it can be seen from rfc http://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html and http://stackoverflow.com/questions/299628/is-an-entity-body-allowed-for-an-http-delete-request . 
However, currently aiohttp fails if body is added to DELETE request.
