### PR TITLE
Fix test_failed_request_one_failed false negative result

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -637,7 +637,7 @@ class HttpClientTests(unittest.TestCase):
         c = HttpClient(
             [('localhost', 56777), ('localhost', 56778)], loop=self.loop)
         c._hosts = []
-        c._failed.append((('localhost', 1000, False), now - 10))
+        c._failed.append((('localhost', 1000, True), now - 10))
         c._failed.append((('localhost', 1001, True), now - 10))
 
         self.assertRaises(


### PR DESCRIPTION
It expected that request to ('localhost', 1000, False) host will fail,
however it never will if there is web server running on localhost which
listens default port 80 (False flag tells to not use specified port).
With active web server on localhost ConnectionError never raises making
this test to produce false negative result.
