### PR TITLE
Splitting DataQueue into a base queue and a flow-control-aware queue.

### DIFF
--- a/tests/test_websocket.py
+++ b/tests/test_websocket.py
@@ -284,7 +284,7 @@ class WebsocketParserTests(unittest.TestCase):
                 return websocket.Message(websocket.OPCODE_CLOSE, b'', b'')
 
         m_parse_message.side_effect = parse_message
-        out = aiohttp.DataQueue(unittest.mock.Mock())
+        out = aiohttp.FlowControlDataQueue(unittest.mock.Mock())
         buf = aiohttp.ParserBuffer()
         p = websocket.WebSocketParser(out, buf)
         next(p)
@@ -298,7 +298,7 @@ class WebsocketParserTests(unittest.TestCase):
         self.assertTrue(out._eof)
 
     def test_parser_eof(self):
-        out = aiohttp.DataQueue(unittest.mock.Mock())
+        out = aiohttp.FlowControlDataQueue(unittest.mock.Mock())
         buf = aiohttp.ParserBuffer()
         p = websocket.WebSocketParser(out, buf)
         next(p)

--- a/tests/test_wsgi.py
+++ b/tests/test_wsgi.py
@@ -27,7 +27,7 @@ class HttpWsgiServerProtocolTests(unittest.TestCase):
         self.headers = multidict.MutableMultiDict()
         self.message = protocol.RawRequestMessage(
             'GET', '/path', (1, 0), self.headers, True, 'deflate')
-        self.payload = aiohttp.DataQueue(self.reader)
+        self.payload = aiohttp.FlowControlDataQueue(self.reader)
         self.payload.feed_data(b'data')
         self.payload.feed_data(b'data')
         self.payload.feed_eof()


### PR DESCRIPTION
We're finding DataQueue quite useful on its own, decoupled from any transports; this change separates the flow-control logic in `DataQueue.read()` into a new subclass `FlowControlDataQueue`.
