### PR TITLE
Don't parse message body for HEAD responses

### DIFF
--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -644,8 +644,11 @@ class ClientResponse:
             self.message.headers.items(getall=True))
 
         # payload
+        response_with_body = self.method.lower() != 'head'
         self.content = self._reader.set_parser(
-            aiohttp.HttpPayloadParser(self.message, readall=read_until_eof))
+            aiohttp.HttpPayloadParser(self.message,
+                                      readall=read_until_eof,
+                                      response_with_body=response_with_body))
 
         # cookies
         self.cookies = http.cookies.SimpleCookie()

--- a/aiohttp/protocol.py
+++ b/aiohttp/protocol.py
@@ -253,11 +253,13 @@ class HttpResponseParser(HttpParser):
 
 class HttpPayloadParser:
 
-    def __init__(self, message, length=None, compression=True, readall=False):
+    def __init__(self, message, length=None, compression=True, readall=False,
+                 response_with_body=True):
         self.message = message
         self.length = length
         self.compression = compression
         self.readall = readall
+        self.response_with_body = response_with_body
 
     def __call__(self, out, buf):
         # payload params
@@ -270,7 +272,11 @@ class HttpPayloadParser:
             out = DeflateBuffer(out, self.message.compression)
 
         # payload parser
-        if 'chunked' in self.message.headers.get('TRANSFER-ENCODING', ''):
+        if not self.response_with_body:
+            # don't parse payload if it's not expected to be received
+            pass
+
+        elif 'chunked' in self.message.headers.get('TRANSFER-ENCODING', ''):
             yield from self.parse_chunked_payload(out, buf)
 
         elif length is not None:

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -39,7 +39,10 @@ class HttpClientFunctionalTests(unittest.TestCase):
                 content = content1.decode()
 
                 self.assertEqual(r.status, 200)
-                self.assertIn('"method": "%s"' % meth.upper(), content)
+                if meth == 'head':
+                    self.assertEqual(b'', content1)
+                else:
+                    self.assertIn('"method": "%s"' % meth.upper(), content)
                 self.assertEqual(content1, content2)
                 r.close()
 
@@ -56,7 +59,10 @@ class HttpClientFunctionalTests(unittest.TestCase):
                 content = content1.decode()
 
                 self.assertEqual(r.status, 200)
-                self.assertIn('"method": "%s"' % meth.upper(), content)
+                if meth == 'head':
+                    self.assertEqual(b'', content1)
+                else:
+                    self.assertIn('"method": "%s"' % meth.upper(), content)
                 self.assertEqual(content1, content2)
                 r.close()
 
@@ -74,7 +80,10 @@ class HttpClientFunctionalTests(unittest.TestCase):
                 content = content1.decode()
 
                 self.assertEqual(r.status, 200)
-                self.assertIn('"method": "%s"' % meth.upper(), content)
+                if meth == 'head':
+                    self.assertEqual(b'', content1)
+                else:
+                    self.assertIn('"method": "%s"' % meth.upper(), content)
                 self.assertEqual(content1, content2)
                 r.close()
 
@@ -92,7 +101,10 @@ class HttpClientFunctionalTests(unittest.TestCase):
                 content = content1.decode()
 
                 self.assertEqual(r.status, 200)
-                self.assertIn('"method": "%s"' % meth.upper(), content)
+                if meth == 'head':
+                    self.assertEqual(b'', content1)
+                else:
+                    self.assertIn('"method": "%s"' % meth.upper(), content)
                 self.assertEqual(content1, content2)
                 r.close()
 
@@ -125,7 +137,10 @@ class HttpClientFunctionalTests(unittest.TestCase):
                     content = yield from r.read()
 
                     self.assertEqual(r.status, 200)
-                    self.assertEqual(content, b'Test message')
+                    if meth == 'head':
+                        self.assertEqual(b'', content)
+                    else:
+                        self.assertEqual(content, b'Test message')
                     r.close()
                     # let loop to make one iteration to call connection_lost
                     # and close socket


### PR DESCRIPTION
Currently, there is a bug when aiohttp after receiving response headers falls into awaiting for further message body of specified size or chunked transfer, since Server SHOULD send them as is for GET request. Certainly, it will never receive any body from _valid_ HTTP server.

```
 The HEAD method is identical to GET except that the server MUST NOT
 send a message body in the response (i.e., the response terminates at
 the end of the header section).  The server SHOULD send the same
 header fields in response to a HEAD request as it would have sent if
 the request had been a GET, except that the payload header fields
 (Section 3.3) MAY be omitted.

 -- http://tools.ietf.org/html/rfc7231#section-4.3.2
```
