### PR TITLE
Allow ClientResponse to define custom flow control

### DIFF
--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -561,6 +561,7 @@ class ClientResponse:
     content = None  # Payload stream
 
     connection = None  # current connection
+    flow_control_class = FlowControlStreamReader  # reader flow control
     _reader = None     # input stream
     _response_parser = aiohttp.HttpResponseParser()
     _connection_wr = None  # weakref to self for releasing connection on del
@@ -594,7 +595,7 @@ class ClientResponse:
     def _setup_connection(self, connection):
         self._reader = connection.reader
         self.connection = connection
-        self.content = FlowControlStreamReader(
+        self.content = self.flow_control_class(
             connection.reader, loop=connection.loop)
 
         msg = ('ClientResponse has to be closed explicitly! {}:{}:{}'

--- a/aiohttp/streams.py
+++ b/aiohttp/streams.py
@@ -3,7 +3,6 @@ __all__ = ['EofStream',
            'FlowControlStreamReader', 'FlowControlDataQueue']
 
 import asyncio
-import asyncio.streams
 import collections
 
 _DEFAULT_LIMIT = 2**16
@@ -317,7 +316,7 @@ class DataQueue:
             if self._exception is not None:
                 raise self._exception
             else:
-                raise EofStream
+                return b''
 
 
 class FlowControlDataQueue(DataQueue):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -193,6 +193,13 @@ class ClientResponseTests(unittest.TestCase):
         self.assertEqual(res, {'тест': 'пройден'})
         self.assertTrue(self.response.close.called)
 
+    def test_override_flow_control(self):
+        class MyResponse(ClientResponse):
+            flow_control_class = aiohttp.FlowControlDataQueue
+        response = MyResponse('get', 'http://python.org')
+        response._setup_connection(self.connection)
+        self.assertIsInstance(response.content, aiohttp.FlowControlDataQueue)
+
 
 class ClientRequestTests(unittest.TestCase):
 

--- a/tests/test_streams.py
+++ b/tests/test_streams.py
@@ -502,8 +502,8 @@ class DataQueueTests(unittest.TestCase):
             buffer.feed_eof()
         self.loop.call_soon(cb)
 
-        self.assertRaises(
-            streams.EofStream, self.loop.run_until_complete, read_task)
+        self.loop.run_until_complete(read_task)
+        self.assertTrue(buffer.at_eof())
 
     def test_read_cancelled(self):
         buffer = streams.DataQueue(loop=self.loop)
@@ -529,8 +529,9 @@ class DataQueueTests(unittest.TestCase):
         data = self.loop.run_until_complete(buffer.read())
         self.assertIs(data, item)
 
-        self.assertRaises(
-            streams.EofStream, self.loop.run_until_complete, buffer.read())
+        thing = self.loop.run_until_complete(buffer.read())
+        self.assertEqual(thing, b'')
+        self.assertTrue(buffer.at_eof())
 
     def test_read_exception(self):
         buffer = streams.DataQueue(loop=self.loop)


### PR DESCRIPTION
Also make DataQueue act as like as StreamReader to let FlowControlStreamReader get able to be replaced by FlowControlDataQueue preserving the common behaviour.
