### PR TITLE
Support custom encoding for basic auth credentials

### DIFF
--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -12,7 +12,7 @@ import weakref
 
 from .errors import HttpProxyError
 from .errors import ProxyConnectionError
-from .client import ClientRequest, BasicAuth
+from .client import ClientRequest, BasicAuth, BasicAuthEx
 
 
 class Connection(object):
@@ -285,8 +285,10 @@ class ProxyConnector(TCPConnector):
         self._proxy_auth = proxy_auth
         assert proxy.startswith('http://'), (
             "Only http proxy supported", proxy)
-        assert proxy_auth is None or isinstance(proxy_auth, BasicAuth), (
-            "proxy_auth must be None or BasicAuth() tuple", proxy_auth)
+        assert (proxy_auth is None
+                or isinstance(proxy_auth, (BasicAuth, BasicAuthEx))), \
+            ("proxy_auth must be None, BasicAuth() or BasicAuthEx() tuple",
+             proxy_auth)
 
     @property
     def proxy(self):

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -395,6 +395,13 @@ class ClientRequestTests(unittest.TestCase):
         self.assertIn('AUTHORIZATION', req.headers)
         self.assertEqual('Basic bmtpbToxMjM0', req.headers['AUTHORIZATION'])
 
+    def test_basic_auth_utf8(self):
+        req = ClientRequest('get', 'http://python.org',
+                            auth=aiohttp.BasicAuthEx('nkim', 'секрет', 'utf-8'))
+        self.assertIn('AUTHORIZATION', req.headers)
+        self.assertEqual('Basic bmtpbTrRgdC10LrRgNC10YI=',
+                         req.headers['AUTHORIZATION'])
+
     def test_basic_auth_tuple_deprecated(self):
         req = ClientRequest('get', 'http://python.org', auth=('nkim', '1234'))
         self.assertIn('AUTHORIZATION', req.headers)

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -427,6 +427,14 @@ class ProxyConnectorTests(unittest.TestCase):
             loop=unittest.mock.ANY, headers=unittest.mock.ANY)
 
     @unittest.mock.patch('aiohttp.connector.ClientRequest')
+    def test_auth_utf8(self, ClientRequestMock):
+        proxy_req = ClientRequest(
+            'GET', 'http://proxy.example.com',
+            auth=aiohttp.BasicAuthEx('юзер', 'пасс', 'utf-8'))
+        ClientRequestMock.return_value = proxy_req
+        self.assertIn('AUTHORIZATION', proxy_req.headers)
+
+    @unittest.mock.patch('aiohttp.connector.ClientRequest')
     def test_auth_from_url(self, ClientRequestMock):
         proxy_req = ClientRequest('GET', 'http://user:pass@proxy.example.com')
         ClientRequestMock.return_value = proxy_req


### PR DESCRIPTION
This introduces BasicAuthEx namedtuple which acts as like as BasicAuth
one with single exception as it handles encoding as third argument.

RFC2617, section 2 (HTTP Authentication) defines basic-credentials:

```
basic-credentials = base64-user-pass
base64-user-pass  = <base64 encoding of user-pass,
                     except not limited to 76 char/line>
user-pass         = userid ":" password
userid            = *<TEXT excluding ":">
password          = *TEXT
```

RFC 2616, section 2.1 defines TEXT to have ISO-8859-1 encoding
(aka latin1):

```
The TEXT rule is only used for descriptive field contents and values
that are not intended to be interpreted by the message parser. Words
of *TEXT MAY contain characters from character sets other than
ISO-8859-1 only when encoded according to the rules of RFC 2047.
```

In fact, I know no Basic Auth implementation which respects RFC 2047
for Basic Auth.

However, the truth of the real world is that the most major browsers
are already uses UTF-8 instead of ISO-8859-1 for the credentials as
like as any modern web services which allows non-ASCII login/password.

Also, there is the RFC draft which aims to handle the case when
credentials will optionally get always encoded with UTF-8:
http://tools.ietf.org/html/draft-ietf-httpauth-basicauth-update-01

While we should strictly follow common standards, we also need to handle
real world use cases. This change allows that and makes aiohttp ready
for further Basic Auth scheme standard update.
