### PR TITLE
Allow clients to indicated that paths in URLs need not be quoted

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -448,6 +448,14 @@ class ClientRequestTests(unittest.TestCase):
         req = ClientRequest('get', "http://0.0.0.0/get/test%20case")
         self.assertEqual(req.path, "/get/test%20case")
 
+    def test_path_encoding_is_skipped(self):
+        req = ClientRequest('get', "http://0.0.0.0/get/test case")
+        self.assertEqual(req.path, "/get/test%20case")
+
+        req = ClientRequest('get', "http://0.0.0.0/get/test case",
+                            quote_path=False)
+        self.assertEqual(req.path, "/get/test case")
+
     def test_params_are_added_before_fragment(self):
         req = ClientRequest(
             'GET', "http://example.com/path#fragment", params={"a": "b"})


### PR DESCRIPTION
I was dealing with a server which only accepted something like `http://some.server/dGVzdCBjYXNlPQ==`, but not `http://some.server/dGVzdCBjYXNlPQ%3D%3D`. And the server is out of my control, so I can only work on it on the client side.

I was thinking it would be good to have the client offload the path-quoting operation to it's calling code too, so one more keyword parameter `quote_path` is added to `aiohttp.request(...)` and `ClientRequest.__init__(...)`
