### PR TITLE
Pass falsy data to ClientRequest.update_body_from_data handler

### DIFF
--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -205,9 +205,7 @@ class ClientRequest:
                     'not supported at the same time.')
             data = files
 
-        if data:
-            self.update_body_from_data(data)
-
+        self.update_body_from_data(data)
         self.update_transfer_encoding()
         self.update_expect_continue(expect100)
 
@@ -361,6 +359,9 @@ class ClientRequest:
         self.headers['AUTHORIZATION'] = auth.encode()
 
     def update_body_from_data(self, data):
+        if not data:
+            return
+
         if isinstance(data, str):
             data = data.encode(self.encoding)
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -504,6 +504,13 @@ class ClientRequestTests(unittest.TestCase):
             self.assertEqual('application/x-www-form-urlencoded',
                              req.headers['CONTENT-TYPE'])
 
+    @unittest.mock.patch('aiohttp.client.ClientRequest.update_body_from_data')
+    def test_pass_falsy_data(self, _):
+        req = ClientRequest(
+            'post', 'http://python.org/',
+            data={}, loop=self.loop)
+        req.update_body_from_data.assert_called_once_with({})
+
     def test_get_with_data(self):
         for meth in ClientRequest.GET_METHODS:
             req = ClientRequest(


### PR DESCRIPTION
While logic of processing only "true" values to form request body is ok
for plain raw requests, it causes troubles when you inherit from
ClientRequest to produce requests for some specific content type.
For instance, it's ok to pass "falsy" `0`, `False`, `{}` data if you're
implementing JsonClientRequest class that automatically encodes data
inside update_body_from_data method.
