### PR TITLE
web: Fix 'send_eof' -> 'write_eof' typo in RuntimeError message

### DIFF
--- a/aiohttp/web.py
+++ b/aiohttp/web.py
@@ -548,7 +548,7 @@ class StreamResponse(HeadersMixin):
                             type(data))
 
         if self._eof_sent:
-            raise RuntimeError("Cannot call write() after send_eof()")
+            raise RuntimeError("Cannot call write() after write_eof()")
         if self._resp_impl is None:
             self.send_headers()
 


### PR DESCRIPTION
The method has been 'write_eof' since this error message landed in
b462684 (Work on web server, 2014-10-13).
