### PR TITLE
web: Yield from self._resp_impl.write in StreamResponse.write

### DIFF
--- a/aiohttp/web.py
+++ b/aiohttp/web.py
@@ -531,7 +531,9 @@ class StreamResponse(HeadersMixin):
             self.send_headers()
 
         if data:
-            self._resp_impl.write(data)
+            yield from self._resp_impl.write(data)
+        else:
+            return ()
 
     @asyncio.coroutine
     def write_eof(self):


### PR DESCRIPTION
We need to iterate through this to consume any 'yield from' calls and
other asynchronous activity in the underlying response implementation
(like transport.drain()).
