### PR TITLE
Refactor named routes

### DIFF
--- a/aiohttp/abc.py
+++ b/aiohttp/abc.py
@@ -9,11 +9,6 @@ class AbstractRouter(metaclass=ABCMeta):
     def resolve(self, request):
         """Return MATCH_INFO for given request"""
 
-    @asyncio.coroutine
-    @abstractmethod
-    def reverse(self, method, endpoint, **kwargs):
-        """Return URL string for """
-
 
 class AbstractMatchInfo(metaclass=ABCMeta):
 
@@ -21,8 +16,3 @@ class AbstractMatchInfo(metaclass=ABCMeta):
     @abstractmethod
     def handler(self):
         """Return handler for match info"""
-
-    @property
-    @abstractmethod
-    def endpoint(self):
-        """Return endpoint for match info"""


### PR DESCRIPTION
Second try to bring up route names.
Solution solves only `UrlDispatcher` requests, other implementations may have another public API.
`Entry` converted to `Route` with `PlainRoute`, `DynamicRoute` and `StaticRoute` descendants.
UrlDispatcher is a `Mapping` with `__getitem__` and other required methods.

@fafhrd91 thoughts?
