### PR TITLE
Middleware

### DIFF
--- a/aiohttp/web.py
+++ b/aiohttp/web.py
@@ -1160,9 +1160,8 @@ class RequestHandler(ServerHttpProtocol):
     @asyncio.coroutine
     def handle_request(self, message, payload):
         now = self._loop.time()
-        app = self._app
 
-        request = Request(app, message, payload,
+        request = Request(self._app, message, payload,
                           self.transport, self.writer, self.keep_alive_timeout)
         try:
             match_info = yield from self._router.resolve(request)


### PR DESCRIPTION
Please review.

Long story short: the most trivial aiohttp.web middleware is a coroutine like:

```
@asyncio.coroutine
def middleware(request, handler):
        return (yield from handler(request))
```

It accepts `request` like regular web handler but has also `handler` parameter.

_handler_ is a next web handler in middleware stack. 
The most bottom handler is web handler itself (found by `router.resolve` call).
Handlers on top of that are middlewares.

Middleware usually calls descending handler (but may do something other, like displaying 403 Forbidden page or raising HTTPForbiddenException if user has no permissions to access underlying resource).
Also middleware may render errors raised by handler, do some pre- and post- processing like handling CORS and so on.

The concept is pretty widespread: Pyramid has tweens with similar functionality for example.

The PR has no tests, examples and docs -- I'll do it later but before merging.
