### PR TITLE
Add route decorator

### DIFF
--- a/aiohttp/web.py
+++ b/aiohttp/web.py
@@ -1273,6 +1273,12 @@ class Application(dict):
 
         self.update(**kwargs)
 
+    def route(self, path, method='GET'):
+        def decorator(f):
+            self.router.add_route(method, path, f)
+            return f
+        return decorator
+
     @property
     def router(self):
         return self._router

--- a/docs/web.rst
+++ b/docs/web.rst
@@ -705,6 +705,12 @@ arbitrary properties for later access from
                   :class:`aiohttp.server.ServerHttpProtocol`
                   constructor during :meth:`make_handler` call.
 
+   .. method:: route(rule, method='GET')
+
+      A decorator used to append the decorated function to the router table.
+
+      .. seealso:: :meth:`~UrlDispatcher.add_route`
+
    .. attribute:: router
 
       Read-only property that returns *router instance*.

--- a/tests/test_web.py
+++ b/tests/test_web.py
@@ -79,6 +79,13 @@ class TestWeb(unittest.TestCase):
                     'message': 'Error in finish callback'}
         handler.assert_called_once_with(self.loop, exc_info)
 
+    def test_app_route_decorator(self):
+        app = web.Application(loop=self.loop)
+        handler = lambda x: x
+        with mock.patch.object(app.router, 'add_route') as mock_router:
+            app.route('/')(handler)
+            mock_router.assert_called_once_with('GET', '/', handler)
+
     def test_non_default_router(self):
         router = web.UrlDispatcher()
         app = web.Application(loop=self.loop, router=router)


### PR DESCRIPTION
This adds a flask like `route` decorator:

```
app = web.Application()

@app.route('/')
def hello_world(request):
    return web.Response(request, b"Hello, world")
```
