### PR TITLE
Raise original exception in `write_bytes`.

### DIFF
--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -506,9 +506,7 @@ class ClientRequest:
                 for chunk in self.body:
                     request.write(chunk)
         except Exception as exc:
-            reader.set_exception(
-                aiohttp.ClientRequestError(
-                    'Can not write request body for %s' % self.url))
+            reader.set_exception(exc)
         else:
             try:
                 ret = request.write_eof()
@@ -518,9 +516,7 @@ class ClientRequest:
                         isinstance(ret, asyncio.Future)):
                     yield from ret
             except Exception as exc:
-                reader.set_exception(
-                    aiohttp.ClientRequestError(
-                        'Can not write request body for %s' % self.url))
+                reader.set_exception(exc)
 
         self._writer = None
 

--- a/aiohttp/errors.py
+++ b/aiohttp/errors.py
@@ -9,7 +9,7 @@ __all__ = [
 
     'ClientError', 'ClientHttpProcessingError', 'ClientConnectionError',
     'ClientOSError', 'ClientTimeoutError', 'ProxyConnectionError',
-    'ClientRequestError', 'ClientResponseError']
+    'ClientResponseError']
 
 from asyncio import TimeoutError
 
@@ -32,10 +32,6 @@ class ClientError(Exception):
 
 class ClientHttpProcessingError(ClientError):
     """Base class for client http processing errors."""
-
-
-class ClientRequestError(ClientHttpProcessingError):
-    """Connection error during sending request."""
 
 
 class ClientResponseError(ClientHttpProcessingError):


### PR DESCRIPTION
`ClientRequest#write_bytes` catches all exceptions and replaces them
with a generic `ClientRequestError`, which leads to tracebacks that can
be hard to interpret. This patch preserves the original exception and
traceback for simpler debugging.

Alternatively, if you want to raise the `ClientRequestError`, we could 
pass the original exception to it so that it's still possible to figure out what
went wrong during debugging:

``` python
reader.set_exception(
    aiohttp.ClientRequestError(     
        'Can not write request body for %s' % self.url,
        error=exc))
```
