### PR TITLE
Add route options

### DIFF
--- a/tests/test_urldispatch.py
+++ b/tests/test_urldispatch.py
@@ -300,3 +300,20 @@ class TestUrlDispatcher(unittest.TestCase):
             "Bad pattern '/handler/(?P<to>+++)': nothing to repeat",
             str(ctx.exception))
         self.assertIsNone(ctx.exception.__cause__)
+
+    def test_add_plain_route_options(self):
+        handler = asyncio.coroutine(lambda req: Response(req))
+        route = self.router.add_route('GET', r'/handler', handler, cors=True)
+        self.assertEqual({'cors': True}, route.options)
+
+    def test_add_dynamic_route_options(self):
+        handler = asyncio.coroutine(lambda req: Response(req))
+        route = self.router.add_route('GET', r'/handler/{name}',
+                                      handler, cors=True)
+        self.assertEqual({'cors': True}, route.options)
+
+    def test_add_static_route_options(self):
+        route = self.router.add_static('/st',
+                                       os.path.dirname(aiohttp.__file__),
+                                       name='static', cors=True)
+        self.assertEqual({'cors': True}, route.options)


### PR DESCRIPTION
On adding CORS support I figured out we need storage for custom parameters per route: CORS may be enabled for limited URLs only (while all work can be done in middleware which can live in separate aiohttp_cors library).

The solution is: add `**options` parameter to `router.add_route()` call.

The drawbacks are: 
1. `options` names can clash between different middlewares (we cannot avoid it).
2. Maybe we add new params to `add_route` later, this will clash with existing names used by third party middlewares and other tools.

I like `router.add_route(..., my_name=val)` syntax instead of `router.add_route(..., {'my_name': val})` but the last one can avoid problem number 2.

What do you prefer?
