### PR TITLE
Update db preparation script

### DIFF
--- a/demos/polls/aiohttpdemo_polls/db.py
+++ b/demos/polls/aiohttpdemo_polls/db.py
@@ -36,7 +36,7 @@ class RecordNotFound(Exception):
 
 
 async def init_pg(app):
-    conf = app['config']
+    conf = app['config']['postgres']
     engine = await aiopg.sa.create_engine(
         database=conf['database'],
         user=conf['user'],

--- a/demos/polls/aiohttpdemo_polls/templates/results.html
+++ b/demos/polls/aiohttpdemo_polls/templates/results.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% set title = question.question %}
+{% set title = question.question_text %}
 
 {% block content %}
 <ul>

--- a/demos/polls/init_db.py
+++ b/demos/polls/init_db.py
@@ -1,0 +1,50 @@
+import subprocess
+
+import sqlalchemy as sa
+import yaml
+
+from aiohttpdemo_polls.db import question, choice
+
+
+config_path = 'config/polls.yaml'
+with open(config_path) as f:
+    data = yaml.load(f)
+
+CONF = data['postgres']
+
+DSN = '{drivername}://{username}:{password}@{host}:{port}/{database}'.format(
+    drivername='postgresql',
+    username=CONF['user'],
+    password=CONF['password'],
+    host=CONF['host'],
+    port=CONF['port'],
+    database=CONF['database'],
+)
+
+
+def recreate_database():
+    print('-- Recreate database and roles --')
+    subprocess.run(["bash", "sql/recreate_database.sh"])
+
+
+def create_tables():
+    print('-- Create tables --')
+    meta = sa.MetaData()
+    engine = sa.create_engine(DSN)
+    meta.create_all(
+        bind=engine,
+        tables=[question, choice]
+    )
+
+
+def populate_tables():
+    print('-- Populate tables --')
+    subprocess.run(["bash", "sql/populate_database.sh"])
+
+
+if __name__ == '__main__':
+    recreate_database()
+    create_tables()
+    populate_tables()
+
+

--- a/demos/polls/sql/populate_database.sh
+++ b/demos/polls/sql/populate_database.sh
@@ -1,0 +1,1 @@
+cat sql/sample_data.sql | sudo -u postgres psql -d aiohttpdemo_polls -a 

--- a/demos/polls/sql/recreate_database.sh
+++ b/demos/polls/sql/recreate_database.sh
@@ -3,6 +3,3 @@ sudo -u postgres psql -c "DROP ROLE IF EXISTS aiohttpdemo_user"
 sudo -u postgres psql -c "CREATE USER aiohttpdemo_user WITH PASSWORD 'aiohttpdemo_user';"
 sudo -u postgres psql -c "CREATE DATABASE aiohttpdemo_polls ENCODING 'UTF8';" 
 sudo -u postgres psql -c "GRANT ALL PRIVILEGES ON DATABASE aiohttpdemo_polls TO aiohttpdemo_user;"
-
-cat sql/create_tables.sql | sudo -u postgres psql -d aiohttpdemo_polls -a 
-cat sql/sample_data.sql | sudo -u postgres psql -d aiohttpdemo_polls -a 


### PR DESCRIPTION
This PR does the following:

- Create `init_db.py` script to create tables via sqlalchemy according to existing models and not recreate them with raw sql (replacement for `create_tables.sql` and, consequently, for `install.sh`).

- fix db config initialization
- fix title in `results.html`
    
If/when it merges I could update `Database schema` part of tutorial documentation