### PR TITLE
Add 'stacklevel=2' to deprecation message.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -116,3 +116,6 @@ CHANGES
 
 - Deprecated: `Application.finish()` and `Application.register_on_finish()`
   will be removed in 1.4 #1602
+
+- Add the `allow_head` keyword argument for `add_get` and
+  `router.set_defaults(allow_head=True/False)` #1618

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,8 @@ CHANGES
 
 1.3.4 (2017-02-..)
 ------------------
+- `run_app` and the Command Line Interface now support serving over Unix domain sockets for
+  faster inter-process communication.
 
 - Revert timeout handling in client request
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -44,6 +44,8 @@ CHANGES
 - Multipart reader accepts multipart messages with or without their epilogue
   to consistently handle valid and legacy behaviors #1526 #1581
 
+- Add the `allow_head=True` keyword argument for `add_get` #1618
+
 - Separate read + connect + request timeouts # 1523
 
 - Do not swallow Upgrade header #1587

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,7 @@ CHANGES
 
 1.3.4 (2017-02-..)
 ------------------
+
 - `run_app` and the Command Line Interface now support serving over Unix domain sockets for
   faster inter-process communication.
 

--- a/aiohttp/abc.py
+++ b/aiohttp/abc.py
@@ -14,10 +14,9 @@ class AbstractRouter(ABC):
     def post_init(self, app):
         """Post init stage.
 
-        It's not an abstract method for sake of backward compatibility
-        but if router wans to be aware about application it should
-        override it.
-
+        Not an abstract method for sake of backward compatibility,
+        but if the router wants to be aware of the application
+        it can override this.
         """
 
     @property

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -719,7 +719,8 @@ def request(method, url, *,
       >>> data = yield from resp.read()
 
     """
-    warnings.warn("Use ClientSession().request() instead", DeprecationWarning)
+    warnings.warn("Use ClientSession().request() instead", DeprecationWarning,
+                  stacklevel=2)
     if connector is None:
         connector = aiohttp.TCPConnector(loop=loop, force_close=True)
 

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -547,7 +547,7 @@ class TCPConnector(BaseConnector):
             resolver = DefaultResolver(loop=self._loop)
         self._resolver = resolver
 
-        self._use_dns_cache = _use_dns_cache
+        self._use_dns_cache = use_dns_cache
         self._cached_hosts = {}
         self._ssl_context = ssl_context
         self._family = family

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -547,7 +547,7 @@ class TCPConnector(BaseConnector):
             resolver = DefaultResolver(loop=self._loop)
         self._resolver = resolver
 
-        self._use_dns_cache = use_dns_cache
+        self._use_dns_cache = _use_dns_cache
         self._cached_hosts = {}
         self._ssl_context = ssl_context
         self._family = family

--- a/aiohttp/pytest_plugin.py
+++ b/aiohttp/pytest_plugin.py
@@ -1,7 +1,9 @@
 import asyncio
 import contextlib
+import tempfile
 
 import pytest
+from py import path
 
 from aiohttp.web import Application
 
@@ -155,3 +157,13 @@ def test_client(loop):
             yield from clients.pop().close()
 
     loop.run_until_complete(finalize())
+
+
+@pytest.fixture
+def shorttmpdir():
+    """Provides a temporary directory with a shorter file system path than the
+    tmpdir fixture.
+    """
+    tmpdir = path.local(tempfile.mkdtemp())
+    yield tmpdir
+    tmpdir.remove(rec=1)

--- a/aiohttp/test_utils.py
+++ b/aiohttp/test_utils.py
@@ -490,7 +490,7 @@ def make_mocked_request(method, path, headers=None, *,
                         payload=sentinel,
                         sslcontext=None,
                         secure_proxy_ssl_header=None,
-                        client_max_size=None):
+                        client_max_size=1024**2):
     """Creates mocked web.Request testing purposes.
 
     Useful in unit tests, when spinning full web server is overkill or

--- a/aiohttp/test_utils.py
+++ b/aiohttp/test_utils.py
@@ -489,7 +489,8 @@ def make_mocked_request(method, path, headers=None, *,
                         transport=sentinel,
                         payload=sentinel,
                         sslcontext=None,
-                        secure_proxy_ssl_header=None):
+                        secure_proxy_ssl_header=None,
+                        client_max_size=None):
     """Creates mocked web.Request testing purposes.
 
     Useful in unit tests, when spinning full web server is overkill or
@@ -541,7 +542,8 @@ def make_mocked_request(method, path, headers=None, *,
     req = Request(message, payload,
                   transport, reader, writer,
                   time_service, task,
-                  secure_proxy_ssl_header=secure_proxy_ssl_header)
+                  secure_proxy_ssl_header=secure_proxy_ssl_header,
+                  client_max_size=client_max_size)
 
     match_info = UrlMappingMatchInfo({}, mock.Mock())
     match_info.add_app(app)

--- a/aiohttp/web.py
+++ b/aiohttp/web.py
@@ -5,7 +5,7 @@ import stat
 import sys
 import warnings
 from argparse import ArgumentParser
-from collections import MutableMapping
+from collections import Iterable, MutableMapping
 from importlib import import_module
 
 from yarl import URL
@@ -321,7 +321,8 @@ def run_app(app, *, host='0.0.0.0', port=None, path=None,
 
     if path is None:
         paths = ()
-    elif isinstance(path, str):
+    elif isinstance(path, (str, bytes, bytearray, memoryview))\
+            or not isinstance(path, Iterable):
         paths = (path,)
     else:
         paths = path
@@ -331,7 +332,8 @@ def run_app(app, *, host='0.0.0.0', port=None, path=None,
             hosts = ()
         else:
             hosts = ("0.0.0.0",)
-    elif isinstance(host, str):
+    elif isinstance(host, (str, bytes, bytearray, memoryview))\
+            or not isinstance(host, Iterable):
         hosts = (host,)
     else:
         hosts = host
@@ -363,7 +365,7 @@ def run_app(app, *, host='0.0.0.0', port=None, path=None,
         # Clean up prior socket path if stale and not abstract.
         # CPython 3.5.3+'s event loop already does this. See
         # https://github.com/python/asyncio/issues/425
-        if path[0] not in (0, '\x00'):
+        if path[0] not in (0, '\x00'):  # pragma: no branch
             try:
                 if stat.S_ISSOCK(os.stat(path).st_mode):
                     os.remove(path)

--- a/aiohttp/web.py
+++ b/aiohttp/web.py
@@ -35,7 +35,8 @@ class Application(MutableMapping):
 
     def __init__(self, *, logger=web_logger, loop=None,
                  router=None,
-                 middlewares=(), debug=...):
+                 middlewares=(), debug=...,
+                 client_max_size=None):
         if loop is None:
             loop = asyncio.get_event_loop()
         if router is None:
@@ -64,6 +65,7 @@ class Application(MutableMapping):
         self._on_startup = Signal(self)
         self._on_shutdown = Signal(self)
         self._on_cleanup = Signal(self)
+        self._client_max_size = client_max_size
 
     # MutableMapping API
 
@@ -246,7 +248,8 @@ class Application(MutableMapping):
             message, payload,
             protocol.transport, protocol.reader, protocol.writer,
             protocol.time_service, protocol._request_handler,
-            secure_proxy_ssl_header=self._secure_proxy_ssl_header)
+            secure_proxy_ssl_header=self._secure_proxy_ssl_header,
+            client_max_size=self._client_max_size)
 
     @asyncio.coroutine
     def _handle(self, request):

--- a/aiohttp/web.py
+++ b/aiohttp/web.py
@@ -306,12 +306,6 @@ def run_app(app, *, host='0.0.0.0', port=None, path=None,
             print=print, backlog=128, access_log_format=None,
             access_log=access_logger):
     """Run an app locally"""
-    if port is None and path is None:
-        if not ssl_context:
-            port = 8080
-        else:
-            port = 8443
-
     loop = app.loop
 
     make_handler_kwargs = dict()
@@ -323,26 +317,48 @@ def run_app(app, *, host='0.0.0.0', port=None, path=None,
     loop.run_until_complete(app.startup())
 
     scheme = 'https' if ssl_context else 'http'
+    base_url = URL('{}://localhost'.format(scheme)).with_port(port)
 
     if path is None:
-        # Assume IP networking
-        srv_creation = loop.create_server(
-            handler, host, port, ssl=ssl_context, backlog=backlog
-        )
-        base_url = URL('{}://localhost'.format(scheme)).with_port(port)
-        if isinstance(host, str):
-            urls = (base_url.with_host(host),)
-        else:
-            urls = [base_url.with_host(h) for h in host]
+        paths = ()
+    elif isinstance(path, str):
+        paths = (path,)
     else:
-        srv_creation = loop.create_unix_server(
-            handler, path, ssl=ssl_context, backlog=backlog
-        )
-        # nginx-style URLs for Unix socket paths
-        if isinstance(path, str):
-            urls = ('{}://unix:{}:'.format(scheme, path),)
+        paths = path
+
+    if host is None:
+        if paths and not port:
+            hosts = ()
         else:
-            urls = ['{}://unix:{}:'.format(scheme, p) for p in path]
+            hosts = ("0.0.0.0",)
+    elif isinstance(host, str):
+        hosts = (host,)
+    else:
+        hosts = host
+
+    if hosts and port is None:
+        port = 8443 if ssl_context else 8080
+
+    server_creations = []
+    uris = [str(base_url.with_host(host)) for host in hosts]
+    if hosts:
+        # Multiple hosts bound to same server is available in most loop
+        # implementations, but only send multiple if we have multiple.
+        host_binding = hosts[0] if len(hosts) == 1 else hosts
+        server_creations.append(
+            loop.create_server(
+                handler, host_binding, port, ssl=ssl_context, backlog=backlog
+            )
+        )
+    for path in paths:
+        # Most loop implementations don't support multiple paths bound in same
+        # server, so create a server for each.
+        server_creations.append(
+            loop.create_unix_server(
+                handler, path, ssl=ssl_context, backlog=backlog
+            )
+        )
+        uris.append('{}://unix:{}:'.format(scheme, path))
 
         # Clean up prior socket path if stale and not abstract.
         # CPython 3.5.3+'s event loop already does this. See
@@ -354,18 +370,23 @@ def run_app(app, *, host='0.0.0.0', port=None, path=None,
             except FileNotFoundError:
                 pass
 
-    srv = loop.run_until_complete(srv_creation)
+    servers = loop.run_until_complete(
+        asyncio.gather(*server_creations, loop=loop)
+    )
 
     print("======== Running on {} ========\n"
-          "(Press CTRL+C to quit)".format(', '.join(str(u) for u in urls)))
+          "(Press CTRL+C to quit)".format(', '.join(uris)))
 
     try:
         loop.run_forever()
     except KeyboardInterrupt:  # pragma: no cover
         pass
     finally:
-        srv.close()
-        loop.run_until_complete(srv.wait_closed())
+        server_closures = []
+        for srv in servers:
+            srv.close()
+            server_closures.append(srv.wait_closed())
+        loop.run_until_complete(asyncio.gather(*server_closures, loop=loop))
         loop.run_until_complete(app.shutdown())
         loop.run_until_complete(handler.shutdown(shutdown_timeout))
         loop.run_until_complete(app.cleanup())

--- a/aiohttp/web_reqrep.py
+++ b/aiohttp/web_reqrep.py
@@ -16,7 +16,7 @@ from types import MappingProxyType
 from multidict import CIMultiDict, CIMultiDictProxy, MultiDict, MultiDictProxy
 from yarl import URL
 
-from . import hdrs, multipart, web_exceptions
+from . import hdrs, multipart
 from .helpers import HeadersMixin, SimpleCookie, reify, sentinel
 from .protocol import WebResponse as ResponseImpl
 from .protocol import HttpVersion10, HttpVersion11
@@ -390,6 +390,7 @@ class BaseRequest(collections.MutableMapping, HeadersMixin):
                 chunk = yield from self._payload.readany()
                 body.extend(chunk)
                 if len(body) >= self._client_max_size:
+                    from aiohttp import web_exceptions
                     msg = 'Request body too large'
                     raise web_exceptions.HTTPRequestEntityTooLarge(text=msg)
                 if not chunk:

--- a/aiohttp/web_reqrep.py
+++ b/aiohttp/web_reqrep.py
@@ -50,7 +50,8 @@ class BaseRequest(collections.MutableMapping, HeadersMixin):
     POST_METHODS = {hdrs.METH_PATCH, hdrs.METH_POST, hdrs.METH_PUT,
                     hdrs.METH_TRACE, hdrs.METH_DELETE}
 
-    def __init__(self, message, payload, protocol, time_service, task, *,
+    def __init__(self, message, payload, transport, reader, writer,
+                 time_service, task, *,
                  loop=None, secure_proxy_ssl_header=None,
                  client_max_size=1024**2):
         self._loop = loop

--- a/aiohttp/web_reqrep.py
+++ b/aiohttp/web_reqrep.py
@@ -16,8 +16,6 @@ from types import MappingProxyType
 from multidict import CIMultiDict, CIMultiDictProxy, MultiDict, MultiDictProxy
 from yarl import URL
 
-from . import hdrs, multipart
-from .helpers import HeadersMixin, SimpleCookie, reify, sentinel
 from . import hdrs, multipart, web_exceptions
 from .helpers import HeadersMixin, SimpleCookie, reify, sentinel
 from .protocol import WebResponse as ResponseImpl

--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -717,7 +717,6 @@ class UrlDispatcher(AbstractRouter, collections.abc.Mapping):
         super().__init__()
         self._resources = []
         self._named_resources = {}
-        self._default_allow_head = False
 
     @asyncio.coroutine
     def resolve(self, request):
@@ -757,9 +756,6 @@ class UrlDispatcher(AbstractRouter, collections.abc.Mapping):
 
     def named_resources(self):
         return MappingProxyType(self._named_resources)
-
-    def set_defaults(self, *, allow_head):
-        self._default_allow_head = allow_head
 
     def register_resource(self, resource):
         assert isinstance(resource, AbstractResource), \
@@ -861,12 +857,12 @@ class UrlDispatcher(AbstractRouter, collections.abc.Mapping):
         """
         return self.add_route(hdrs.METH_HEAD, *args, **kwargs)
 
-    def add_get(self, *args, allow_head=None, name=None, **kwargs):
+    def add_get(self, *args, name=None, allow_head=True, **kwargs):
         """
         Shortcut for add_route with method GET, if allow_head is true another
         route is added allowing head requests to the same endpoint
         """
-        if allow_head or (allow_head is None and self._default_allow_head):
+        if allow_head:
             # the head route can't have "name" set or it would conflict with
             # the GET route below
             self.add_route(hdrs.METH_HEAD, *args, **kwargs)

--- a/demos/polls/aiohttpdemo_polls/db.py
+++ b/demos/polls/aiohttpdemo_polls/db.py
@@ -80,4 +80,4 @@ async def vote(conn, question_id, choice_id):
     record = await result.fetchone()
     if not record:
         msg = "Question with id: {} or choice id: {} does not exists"
-        raise RecordNotFound(msg.format(question_id), choice_id)
+        raise RecordNotFound(msg.format(question_id, choice_id))

--- a/docs/client.rst
+++ b/docs/client.rst
@@ -442,7 +442,17 @@ parameter to *connector*::
 
     conn = aiohttp.TCPConnector(limit=30)
 
-The example limits amount of parallel connections to `30`.
+The example limits total amount of parallel connections to `30`.
+
+The default is `100`.
+
+If you explicitly want not to have limits, pass `0`. For example::
+
+    conn = aiohttp.TCPConnector(limit=0)
+
+To limit amount of simultaneously opened connection to the same
+endpoint (``(host, port, is_ssl)`` triple) you can pass *limit_per_host*
+parameter to *connector*::
 
 The default is `20`.
 

--- a/docs/web.rst
+++ b/docs/web.rst
@@ -85,22 +85,9 @@ Handlers are setup to handle requests by registering them with the
 *path* pair) using methods like :class:`UrlDispatcher.add_get` and
 :class:`UrlDispatcher.add_post`::
 
-   app.router.set_defaults(allow_head=True)
    app.router.add_get('/', handler)
    app.router.add_post('/post', post_handler)
    app.router.add_put('/put', put_handler)
-
-Setting ``allow_head=True`` in :meth:`~UrlDispatcher.set_defaults` means
-endpoints added with :meth:`~UrlDispatcher.add_get` will accept ``HEAD``
-requests by default, this is the standard for most http servers and is
-recommended. You can also set ``HEAD`` request permissions on each route::
-
-   app.router.add_get('/a', handler, allow_head=True)  # will allow HEAD requests
-   app.router.add_get('/a', handler, allow_head=False)  # will not allow HEAD requests
-
-If ``set_defaults(allow_head=True)`` is not called or called with ``False``
-or ``allow_head=False`` is explicitly set on the route, ``HEAD`` requests to
-routes added with :meth:`~UrlDispatcher.add_get will return ``405``.
 
 :meth:`~UrlDispatcher.add_route` also supports the wildcard *HTTP method*,
 allowing a handler to serve incoming requests on a *path* having **any**
@@ -111,6 +98,26 @@ allowing a handler to serve incoming requests on a *path* having **any**
 The *HTTP method* can be queried later in the request handler using the
 :attr:`Request.method` property.
 
+By default endpoints added with :meth:`~UrlDispatcher.add_get` will accept
+``HEAD`` requests and return the same response headers as they would
+for a ``GET`` request. You can also deny ``HEAD`` requests on a route::
+
+   app.router.add_get('/', handler, allow_head=False)
+
+Here ``handler`` won't be called and the server will response with ``405``.
+
+.. note::
+
+   This is a change as of **aiohttp v2.0** to act in accordance with
+   `RFC 7231 <https://tools.ietf.org/html/rfc7231#section-4.3.2>`_.
+
+   Previous version always returned ``405`` for ``HEAD`` requests
+   to routes added with :meth:`~UrlDispatcher.add_get`.
+
+If you have handlers which perform lots of processing to write the response
+body you may wish to improve performance by skipping that processing
+in the case of ``HEAD`` requests while still taking care to respond with
+the same headers as with ``GET`` requests.
 
 .. _aiohttp-web-resource-and-route:
 

--- a/docs/web.rst
+++ b/docs/web.rst
@@ -85,9 +85,22 @@ Handlers are setup to handle requests by registering them with the
 *path* pair) using methods like :class:`UrlDispatcher.add_get` and
 :class:`UrlDispatcher.add_post`::
 
+   app.router.set_defaults(allow_head=True)
    app.router.add_get('/', handler)
    app.router.add_post('/post', post_handler)
    app.router.add_put('/put', put_handler)
+
+Setting ``allow_head=True`` in :meth:`~UrlDispatcher.set_defaults` means
+endpoints added with :meth:`~UrlDispatcher.add_get` will accept ``HEAD``
+requests by default, this is the standard for most http servers and is
+recommended. You can also set ``HEAD`` request permissions on each route::
+
+   app.router.add_get('/a', handler, allow_head=True)  # will allow HEAD requests
+   app.router.add_get('/a', handler, allow_head=False)  # will not allow HEAD requests
+
+If ``set_defaults(allow_head=True)`` is not called or called with ``False``
+or ``allow_head=False`` is explicitly set on the route, ``HEAD`` requests to
+routes added with :meth:`~UrlDispatcher.add_get will return ``405``.
 
 :meth:`~UrlDispatcher.add_route` also supports the wildcard *HTTP method*,
 allowing a handler to serve incoming requests on a *path* having **any**

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -2115,7 +2115,7 @@ Utilities
    .. seealso:: :ref:`aiohttp-web-file-upload`
 
 
-.. function:: run_app(app, *, host='0.0.0.0', port=None, path=None, \
+.. function:: run_app(app, *, host=None, port=None, path=None, \
                       loop=None, shutdown_timeout=60.0, \
                       ssl_context=None, print=print, backlog=128, \
                       access_log_format=None, \
@@ -2131,17 +2131,29 @@ Utilities
 
    The function uses *app.loop* as event loop to run.
 
+   The server will listen on any host or Unix domain socket path you supply.
+   If no hosts or paths are supplied, or only a port is supplied, a TCP server
+   listening on 0.0.0.0 (all hosts) will be launched.
+
+   Distributing HTTP traffic to multiple hosts or paths on the same
+   application process provides no performance benefit as the requests are
+   handled on the same event loop. See :doc:`deployment` for ways of
+   distributing work for increased performance.
+
    :param app: :class:`Application` instance to run
 
-   :param str host: host for HTTP server, ``'0.0.0.0'`` by default
+   :param str host: TCP/IP host or a sequence of hosts for HTTP server.
+                    Default is ``'0.0.0.0'`` if *port* has been specified
+                    or if *path* is not supplied.
 
-   :param int port: TCP port for HTTP server. By default is ``8080`` for
-                    plain text HTTP and ``8443`` for HTTP via SSL
-                    (when *ssl_context* parameter is specified).
+   :param int port: TCP/IP port for HTTP server. Default is ``8080`` for plain
+                    text HTTP and ``8443`` for HTTP via SSL (when
+                    *ssl_context* parameter is specified).
 
    :param str path: file system path for HTTP server Unix domain socket.
-                    If supplied, TCP/IP parameters `host` and
-                    `port` are ignored.
+                    A sequence of file system paths can be used to bind
+                    multiple domain sockets. Listening on Unix domain
+                    sockets is not supported by all operating systems.
 
    :param int shutdown_timeout: a delay to wait for graceful server
                                 shutdown before disconnecting all

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -2115,9 +2115,9 @@ Utilities
    .. seealso:: :ref:`aiohttp-web-file-upload`
 
 
-.. function:: run_app(app, *, host='0.0.0.0', port=None, loop=None, \
-                      shutdown_timeout=60.0, ssl_context=None, \
-                      print=print, backlog=128, \
+.. function:: run_app(app, *, host='0.0.0.0', port=None, path=None, \
+                      loop=None, shutdown_timeout=60.0, \
+                      ssl_context=None, print=print, backlog=128, \
                       access_log_format=None, \
                       access_log=aiohttp.log.access_logger)
 
@@ -2135,9 +2135,13 @@ Utilities
 
    :param str host: host for HTTP server, ``'0.0.0.0'`` by default
 
-   :param int port: port for HTTP server. By default is ``8080`` for
+   :param int port: TCP port for HTTP server. By default is ``8080`` for
                     plain text HTTP and ``8443`` for HTTP via SSL
                     (when *ssl_context* parameter is specified).
+
+   :param str path: file system path for HTTP server Unix domain socket.
+                    If supplied, TCP/IP parameters `host` and
+                    `port` are ignored.
 
    :param int shutdown_timeout: a delay to wait for graceful server
                                 shutdown before disconnecting all

--- a/tests/test_client_ws.py
+++ b/tests/test_client_ws.py
@@ -245,6 +245,8 @@ def test_ws_connect_common_headers(ws_key, loop, key_data):
             with mock.patch('aiohttp.client.ClientSession.get',
                             side_effect=mock_get) as m_req:
                 m_os.urandom.return_value = key_data
+                #m_req.return_value = helpers.create_future(loop)
+                #m_req.return_value.set_result(resp)
 
                 res = yield from aiohttp.ClientSession(loop=loop).ws_connect(
                     'http://test.org',
@@ -258,6 +260,8 @@ def test_ws_connect_common_headers(ws_key, loop, key_data):
     yield from test_connection()
     # Generate a new ws key
     key_data = os.urandom(16)
+    ws_key = base64.b64encode(
+        hashlib.sha1(base64.b64encode(key_data) + WS_KEY).digest()).decode()
     yield from test_connection()
 
 

--- a/tests/test_client_ws.py
+++ b/tests/test_client_ws.py
@@ -245,8 +245,6 @@ def test_ws_connect_common_headers(ws_key, loop, key_data):
             with mock.patch('aiohttp.client.ClientSession.get',
                             side_effect=mock_get) as m_req:
                 m_os.urandom.return_value = key_data
-                #m_req.return_value = helpers.create_future(loop)
-                #m_req.return_value.set_result(resp)
 
                 res = yield from aiohttp.ClientSession(loop=loop).ws_connect(
                     'http://test.org',
@@ -260,8 +258,6 @@ def test_ws_connect_common_headers(ws_key, loop, key_data):
     yield from test_connection()
     # Generate a new ws key
     key_data = os.urandom(16)
-    ws_key = base64.b64encode(
-        hashlib.sha1(base64.b64encode(key_data) + WS_KEY).digest()).decode()
     yield from test_connection()
 
 

--- a/tests/test_run_app.py
+++ b/tests/test_run_app.py
@@ -1,5 +1,10 @@
+import socket
 import ssl
+
+from io import StringIO
 from unittest import mock
+
+import pytest
 
 from aiohttp import web
 
@@ -92,3 +97,40 @@ def test_run_app_custom_backlog(loop, mocker):
     loop.create_server.assert_called_with(mock.ANY, '0.0.0.0', 8080,
                                           ssl=None, backlog=10)
     app.startup.assert_called_once_with()
+
+
+@pytest.mark.skipif(not hasattr(socket, 'AF_UNIX'), reason="UNIX sockets are not supported")
+def test_run_app_http_unix_socket(loop, mocker, shorttmpdir):
+    mocker.spy(loop, 'create_unix_server')
+    loop.call_later(0.05, loop.stop)
+
+    app = web.Application(loop=loop)
+    mocker.spy(app, 'startup')
+
+    sock_path = str(shorttmpdir.join('socket.sock'))
+    printed = StringIO()
+    web.run_app(app, path=sock_path, print=printed.write)
+
+    assert loop.is_closed()
+    loop.create_unix_server.assert_called_with(mock.ANY, sock_path, ssl=None, backlog=128)
+    app.startup.assert_called_once_with()
+    assert "http://unix:{}:".format(sock_path) in printed.getvalue()
+
+
+@pytest.mark.skipif(not hasattr(socket, 'AF_UNIX'), reason="UNIX sockets are not supported")
+def test_run_app_https_unix_socket(loop, mocker, shorttmpdir):
+    mocker.spy(loop, 'create_unix_server')
+    loop.call_later(0.05, loop.stop)
+
+    app = web.Application(loop=loop)
+    mocker.spy(app, 'startup')
+
+    sock_path = str(shorttmpdir.join('socket.sock'))
+    printed = StringIO()
+    ssl_context = ssl.create_default_context()
+    web.run_app(app, path=sock_path, ssl_context=ssl_context, print=printed.write)
+
+    assert loop.is_closed()
+    loop.create_unix_server.assert_called_with(mock.ANY, sock_path, ssl=ssl_context, backlog=128)
+    app.startup.assert_called_once_with()
+    assert "https://unix:{}:".format(sock_path) in printed.getvalue()

--- a/tests/test_run_app.py
+++ b/tests/test_run_app.py
@@ -99,7 +99,8 @@ def test_run_app_custom_backlog(loop, mocker):
     app.startup.assert_called_once_with()
 
 
-@pytest.mark.skipif(not hasattr(socket, 'AF_UNIX'), reason="UNIX sockets are not supported")
+@pytest.mark.skipif(not hasattr(socket, 'AF_UNIX'),
+                    reason="UNIX sockets are not supported")
 def test_run_app_http_unix_socket(loop, mocker, shorttmpdir):
     mocker.spy(loop, 'create_unix_server')
     loop.call_later(0.05, loop.stop)
@@ -112,12 +113,14 @@ def test_run_app_http_unix_socket(loop, mocker, shorttmpdir):
     web.run_app(app, path=sock_path, print=printed.write)
 
     assert loop.is_closed()
-    loop.create_unix_server.assert_called_with(mock.ANY, sock_path, ssl=None, backlog=128)
+    loop.create_unix_server.assert_called_with(mock.ANY, sock_path,
+                                               ssl=None, backlog=128)
     app.startup.assert_called_once_with()
     assert "http://unix:{}:".format(sock_path) in printed.getvalue()
 
 
-@pytest.mark.skipif(not hasattr(socket, 'AF_UNIX'), reason="UNIX sockets are not supported")
+@pytest.mark.skipif(not hasattr(socket, 'AF_UNIX'),
+                    reason="UNIX sockets are not supported")
 def test_run_app_https_unix_socket(loop, mocker, shorttmpdir):
     mocker.spy(loop, 'create_unix_server')
     loop.call_later(0.05, loop.stop)
@@ -128,9 +131,11 @@ def test_run_app_https_unix_socket(loop, mocker, shorttmpdir):
     sock_path = str(shorttmpdir.join('socket.sock'))
     printed = StringIO()
     ssl_context = ssl.create_default_context()
-    web.run_app(app, path=sock_path, ssl_context=ssl_context, print=printed.write)
+    web.run_app(app, path=sock_path, ssl_context=ssl_context,
+                print=printed.write)
 
     assert loop.is_closed()
-    loop.create_unix_server.assert_called_with(mock.ANY, sock_path, ssl=ssl_context, backlog=128)
+    loop.create_unix_server.assert_called_with(mock.ANY, sock_path,
+                                               ssl=ssl_context, backlog=128)
     app.startup.assert_called_once_with()
     assert "https://unix:{}:".format(sock_path) in printed.getvalue()

--- a/tests/test_web_cli.py
+++ b/tests/test_web_cli.py
@@ -96,6 +96,19 @@ def test_entry_func_non_existent_attribute(mocker):
     )
 
 
+def test_path_when_unsupported(mocker, monkeypatch):
+    argv = "--path=test_path.sock alpha.beta:func".split()
+    mocker.patch("aiohttp.web.import_module")
+    monkeypatch.delattr("socket.AF_UNIX")
+
+    error = mocker.patch("aiohttp.web.ArgumentParser.error",
+                         side_effect=SystemExit)
+    with pytest.raises(SystemExit):
+        web.main(argv)
+
+    error.assert_called_with("file system paths not supported by your operating environment")
+
+
 def test_entry_func_call(mocker):
     mocker.patch("aiohttp.web.run_app")
     import_module = mocker.patch("aiohttp.web.import_module")
@@ -125,5 +138,5 @@ def test_running_application(mocker):
     with pytest.raises(SystemExit):
         web.main(argv)
 
-    run_app.assert_called_with(app, host="testhost", port=6666)
+    run_app.assert_called_with(app, host="testhost", port=6666, path=None)
     exit.assert_called_with(message="Stopped\n")

--- a/tests/test_web_cli.py
+++ b/tests/test_web_cli.py
@@ -106,7 +106,8 @@ def test_path_when_unsupported(mocker, monkeypatch):
     with pytest.raises(SystemExit):
         web.main(argv)
 
-    error.assert_called_with("file system paths not supported by your operating environment")
+    error.assert_called_with("file system paths not supported by your"
+                             " operating environment")
 
 
 def test_entry_func_call(mocker):

--- a/tests/test_web_cli.py
+++ b/tests/test_web_cli.py
@@ -99,7 +99,7 @@ def test_entry_func_non_existent_attribute(mocker):
 def test_path_when_unsupported(mocker, monkeypatch):
     argv = "--path=test_path.sock alpha.beta:func".split()
     mocker.patch("aiohttp.web.import_module")
-    monkeypatch.delattr("socket.AF_UNIX")
+    monkeypatch.delattr("socket.AF_UNIX", raising=False)
 
     error = mocker.patch("aiohttp.web.ArgumentParser.error",
                          side_effect=SystemExit)

--- a/tests/test_web_functional.py
+++ b/tests/test_web_functional.py
@@ -1268,4 +1268,29 @@ def test_app_max_client_size_adjusted(loop, test_client):
     resp = yield from client.post('/', data=too_large_data)
     assert 413 == resp.status
     resp_text = yield from resp.text()
-    assert 'Request body too large' in resp_text
+    assert 'Request Entity Too Large' in resp_text
+
+
+@asyncio.coroutine
+def test_app_max_client_size_none(loop, test_client):
+
+    @asyncio.coroutine
+    def handler(request):
+        yield from request.post()
+        return web.Response(body=b'ok')
+
+    default_max_size = 1024**2
+    custom_max_size = None
+    app = web.Application(loop=loop, client_max_size=custom_max_size)
+    app.router.add_post('/', handler)
+    client = yield from test_client(app)
+    data = {'long_string': default_max_size * 'x' + 'xxx'}
+    resp = yield from client.post('/', data=data)
+    assert 200 == resp.status
+    resp_text = yield from resp.text()
+    assert 'ok' == resp_text
+    too_large_data = {'log_string': default_max_size * 2 * 'x'}
+    resp = yield from client.post('/', data=too_large_data)
+    assert 200 == resp.status
+    resp_text = yield from resp.text()
+    assert resp_text == 'ok'

--- a/tests/test_web_functional.py
+++ b/tests/test_web_functional.py
@@ -1225,7 +1225,6 @@ def test_response_prepared_with_clone(loop, test_client):
 
     resp = yield from client.get('/')
     assert 200 == resp.status
-    assert srv_resp.task is None
 
 
 @asyncio.coroutine

--- a/tests/test_web_request.py
+++ b/tests/test_web_request.py
@@ -6,6 +6,7 @@ import pytest
 from multidict import CIMultiDict, MultiDict
 from yarl import URL
 
+from aiohttp import web_exceptions
 from aiohttp.protocol import HttpVersion
 from aiohttp.streams import StreamReader
 from aiohttp.test_utils import make_mocked_request
@@ -318,3 +319,31 @@ def test_cannot_clone_after_read(loop):
     yield from req.read()
     with pytest.raises(RuntimeError):
         req.clone()
+
+
+@asyncio.coroutine
+def test_make_too_big_request(loop):
+    payload = StreamReader(loop=loop)
+    large_file = 1024 ** 2 * b'x'
+    too_large_file = large_file + b'x'
+    payload.feed_data(too_large_file)
+    payload.feed_eof()
+    req = make_mocked_request('POST', '/', payload=payload)
+    with pytest.raises(web_exceptions.HTTPRequestEntityTooLarge) as err:
+        yield from req.read()
+    assert err.value.status == 413
+    assert err.value.text == 'Request body too large'
+
+
+@asyncio.coroutine
+def test_make_too_big_request_adjust_limit(loop):
+    payload = StreamReader(loop=loop)
+    large_file = 1024 ** 2 * b'x'
+    too_large_file = large_file + b'x'
+    payload.feed_data(too_large_file)
+    payload.feed_eof()
+    max_size = 1024**2 + 2
+    req = make_mocked_request('POST', '/', payload=payload,
+                              client_max_size=max_size)
+    txt = yield from req.read()
+    assert len(txt) == 1024**2 + 1

--- a/tests/test_web_request.py
+++ b/tests/test_web_request.py
@@ -6,10 +6,10 @@ import pytest
 from multidict import CIMultiDict, MultiDict
 from yarl import URL
 
-from aiohttp import web_exceptions
 from aiohttp.protocol import HttpVersion
 from aiohttp.streams import StreamReader
 from aiohttp.test_utils import make_mocked_request
+from aiohttp.web_exceptions import HTTPRequestEntityTooLarge
 
 
 @pytest.fixture
@@ -329,10 +329,10 @@ def test_make_too_big_request(loop):
     payload.feed_data(too_large_file)
     payload.feed_eof()
     req = make_mocked_request('POST', '/', payload=payload)
-    with pytest.raises(web_exceptions.HTTPRequestEntityTooLarge) as err:
+    with pytest.raises(HTTPRequestEntityTooLarge) as err:
         yield from req.read()
-    assert err.value.status == 413
-    assert err.value.text == 'Request body too large'
+
+    assert err.value.status_code == 413
 
 
 @asyncio.coroutine
@@ -343,6 +343,20 @@ def test_make_too_big_request_adjust_limit(loop):
     payload.feed_data(too_large_file)
     payload.feed_eof()
     max_size = 1024**2 + 2
+    req = make_mocked_request('POST', '/', payload=payload,
+                              client_max_size=max_size)
+    txt = yield from req.read()
+    assert len(txt) == 1024**2 + 1
+
+
+@asyncio.coroutine
+def test_make_too_big_request_limit_None(loop):
+    payload = StreamReader(loop=loop)
+    large_file = 1024 ** 2 * b'x'
+    too_large_file = large_file + b'x'
+    payload.feed_data(too_large_file)
+    payload.feed_eof()
+    max_size = None
     req = make_mocked_request('POST', '/', payload=payload,
                               client_max_size=max_size)
     txt = yield from req.read()

--- a/tests/test_web_urldispatcher.py
+++ b/tests/test_web_urldispatcher.py
@@ -321,7 +321,7 @@ def test_allow_head(loop, test_client):
 
     def handler(_):
         return web.Response()
-    app.router.add_get('/a', handler, allow_head=True, name='a')
+    app.router.add_get('/a', handler, name='a')
     app.router.add_get('/b', handler, allow_head=False, name='b')
     client = yield from test_client(app)
 
@@ -339,34 +339,4 @@ def test_allow_head(loop, test_client):
 
     r = yield from client.head('/b')
     assert r.status == 405
-    yield from r.release()
-
-
-@pytest.mark.parametrize('dft_allow_head,allow_head,status', [
-    (True, False, 405),
-    (True, True, 200),
-    (True, None, 200),
-    (False, False, 405),
-    (False, True, 200),
-    (False, None, 405),
-])
-@asyncio.coroutine
-def test_allow_head(loop, test_client, dft_allow_head, allow_head, status):
-    """
-    Test allow_head on routes.
-    """
-    app = web.Application(loop=loop)
-
-    def handler(_):
-        return web.Response()
-    app.router.set_defaults(allow_head=dft_allow_head)
-    app.router.add_get('/', handler, allow_head=allow_head)
-    client = yield from test_client(app)
-
-    r = yield from client.get('/')
-    assert r.status == 200
-    yield from r.release()
-
-    r = yield from client.head('/')
-    assert r.status == status
     yield from r.release()

--- a/tests/test_web_urldispatcher.py
+++ b/tests/test_web_urldispatcher.py
@@ -310,3 +310,63 @@ def test_412_is_returned(loop, test_client):
     resp = yield from client.get('/')
 
     assert resp.status == 412
+
+
+@asyncio.coroutine
+def test_allow_head(loop, test_client):
+    """
+    Test allow_head on routes.
+    """
+    app = web.Application(loop=loop)
+
+    def handler(_):
+        return web.Response()
+    app.router.add_get('/a', handler, allow_head=True, name='a')
+    app.router.add_get('/b', handler, allow_head=False, name='b')
+    client = yield from test_client(app)
+
+    r = yield from client.get('/a')
+    assert r.status == 200
+    yield from r.release()
+
+    r = yield from client.head('/a')
+    assert r.status == 200
+    yield from r.release()
+
+    r = yield from client.get('/b')
+    assert r.status == 200
+    yield from r.release()
+
+    r = yield from client.head('/b')
+    assert r.status == 405
+    yield from r.release()
+
+
+@pytest.mark.parametrize('dft_allow_head,allow_head,status', [
+    (True, False, 405),
+    (True, True, 200),
+    (True, None, 200),
+    (False, False, 405),
+    (False, True, 200),
+    (False, None, 405),
+])
+@asyncio.coroutine
+def test_allow_head(loop, test_client, dft_allow_head, allow_head, status):
+    """
+    Test allow_head on routes.
+    """
+    app = web.Application(loop=loop)
+
+    def handler(_):
+        return web.Response()
+    app.router.set_defaults(allow_head=dft_allow_head)
+    app.router.add_get('/', handler, allow_head=allow_head)
+    client = yield from test_client(app)
+
+    r = yield from client.get('/')
+    assert r.status == 200
+    yield from r.release()
+
+    r = yield from client.head('/')
+    assert r.status == status
+    yield from r.release()


### PR DESCRIPTION
This will cause the message to reference the line where the user code calls the function, rather than the line where the deprecation message is in the aiohttp source.  This will make it easier for the user to fix their code.