### PR TITLE
fixes KeepSafe/aiohttp#1707 fixes KeepSafe/aiohttp#1595

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,10 @@ CHANGES
 
 - Fix StreamResponse representation after eof
 
+- Fix file_sender to not fall on bad request (range out of file size)
+
+- Fix file_sender to correct stream video to Chromes
+
 
 1.3.3 (2017-02-19)
 ------------------


### PR DESCRIPTION
- Fix file_sender to not fall on bad request (range out of file size)
- Fix file_sender to correct stream video to Chromes