### PR TITLE
Run app preexisting socket

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,10 @@ CHANGES
 - `run_app` and the Command Line Interface now support serving over
   Unix domain sockets for faster inter-process communication.
 
+- `run_app` now supports passing a preexisting socket object. This can be useful
+  e.g. for socket-based activated applications, when binding of a socket is
+  done by the parent process.
+
 - Implementation for Trailer headers parser is broken #1619
 
 - Fix FileResponse to not fall on bad request (range out of file size)

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -123,6 +123,7 @@ Rafael Viotti
 Raúl Cumplido
 Required Field
 Robert Lu
+Roman Podoliaka
 Samuel Colvin
 Sebastian Hanula
 Sebastian Hüther

--- a/aiohttp/web.py
+++ b/aiohttp/web.py
@@ -274,7 +274,7 @@ class Application(MutableMapping):
         return "<Application 0x{:x}>".format(id(self))
 
 
-def run_app(app, *, host=None, port=None, path=None,
+def run_app(app, *, host=None, port=None, path=None, sock=None,
             shutdown_timeout=60.0, ssl_context=None,
             print=print, backlog=128, access_log_format=None,
             access_log=access_logger):
@@ -314,6 +314,13 @@ def run_app(app, *, host=None, port=None, path=None,
     if hosts and port is None:
         port = 8443 if ssl_context else 8080
 
+    if sock is None:
+        socks = ()
+    elif not isinstance(sock, Iterable):
+        socks = (sock,)
+    else:
+        socks = sock
+
     server_creations = []
     uris = [str(base_url.with_host(host)) for host in hosts]
     if hosts:
@@ -344,6 +351,18 @@ def run_app(app, *, host=None, port=None, path=None,
                     os.remove(path)
             except FileNotFoundError:
                 pass
+    for sock in socks:
+        server_creations.append(
+            loop.create_server(
+                handler, sock=sock, ssl=ssl_context, backlog=backlog
+            )
+        )
+
+        if sock.family == socket.AF_UNIX:
+            uris.append('{}://unix:{}:'.format(scheme, sock.getsockname()))
+        else:
+            host, port = sock.getsockname()
+            uris.append(str(base_url.with_host(host).with_port(port)))
 
     servers = loop.run_until_complete(
         asyncio.gather(*server_creations, loop=loop)

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -2066,6 +2066,9 @@ Utilities
                     multiple domain sockets. Listening on Unix domain
                     sockets is not supported by all operating systems.
 
+   :param socket sock: a preexisting socket object to accept connections on.
+                       A sequence of socket objects can be passed.
+
    :param int shutdown_timeout: a delay to wait for graceful server
                                 shutdown before disconnecting all
                                 open client sockets hard way.


### PR DESCRIPTION
## What do these changes do?

Make `run_app()` an additional argument `sock`, so that it's possible to pass one or more preexisting socket objects to accept new connections on. This can be useful for implementing socket-based activated applications, e.g. with systemd [1]. In this case `bind()` is done by the parent process and the app just need to use the given socket (or multiple), and does not create a new one.

[1] http://0pointer.de/blog/projects/socket-activation.html

## Are there changes in behavior for the user?

Existing workflows are not changed. This just extends the interface of `run_app()` to allow for a new use case -  passing preexisting socket objects.

## Related issue number

N/A

## Checklist

- [X] I think the code is well written
- [X] Unit tests for the changes exist
- [X] Documentation reflects the changes
- [X] Add yourself to `CONTRIBUTORS.txt`
- [X] Add a new entry to `CHANGES.rst`