### PR TITLE
Fix typo at "TimeOuts" section in client.rst

### DIFF
--- a/docs/client.rst
+++ b/docs/client.rst
@@ -681,7 +681,7 @@ By default all IO operations have 5min timeout. The timeout may be
 overridden by passing ``timeout`` parameter into
 :meth:`ClientSession.get` and family::
 
-    aync with session.get('https://github.com', timeout=60) as r:
+    async with session.get('https://github.com', timeout=60) as r:
         ...
 
 ``None`` or ``0`` disables timeout check.


### PR DESCRIPTION
## What do these changes do?
Fix typo
