### PR TITLE
Client response

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changes
 2.0.1 (2017-xx-xx)
 ------------------
 
-- Added `request_info` to response object.
+- Added `request_info` to response object and `ClientResponseError`.
 
 2.0.0 (2017-03-20)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,8 @@
 Changes
 =======
 
+- Added `request_info` to response object.
+
 2.0.0 (2017-03-20)
 ------------------
 

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -17,6 +17,7 @@ Alexander Travov
 Alexandru Mihai
 Alexey Firsov
 Alexey Popravka
+Alexey Stepanov
 Alex Key
 Alex Khomchenko
 Alex Lisovoy

--- a/aiohttp/client_exceptions.py
+++ b/aiohttp/client_exceptions.py
@@ -26,11 +26,13 @@ class ClientResponseError(ClientError):
     message = ''
     headers = None
 
-    def __init__(self, *, code=None, message='', headers=None):
+    def __init__(self, *, code=None, message='', headers=None,
+                 request_info=None):
         if code is not None:
             self.code = code
             self.message = message
             self.headers = headers
+            self.request_info = request_info
 
         super().__init__("%s, message='%s'" % (self.code, message))
 

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -621,7 +621,8 @@ class ClientResponse(HeadersMixin):
             raise ClientResponseError(
                 code=self.status,
                 message=self.reason,
-                headers=self.headers)
+                headers=self.headers,
+                request_info=self.request_info)
 
     def _cleanup_writer(self):
         if self._writer is not None and not self._writer.done():

--- a/docs/client.rst
+++ b/docs/client.rst
@@ -168,6 +168,12 @@ It is not possible to use :meth:`~ClientResponse.read`,
 :meth:`~ClientResponse.json` and :meth:`~ClientResponse.text` after
 explicit reading from :attr:`~ClientResponse.content`.
 
+RequestInfo
+-----------
+
+`ClientResponse` object contains :attr:`~ClientResponse.request_info` property,
+which contains request fields: `url` and `headers`.
+
 
 Custom Headers
 --------------

--- a/docs/client.rst
+++ b/docs/client.rst
@@ -173,6 +173,7 @@ RequestInfo
 
 `ClientResponse` object contains :attr:`~ClientResponse.request_info` property,
 which contains request fields: `url` and `headers`.
+On `raise_for_status` structure is copied to `ClientResponseError` instance.
 
 
 Custom Headers

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -1060,6 +1060,11 @@ Response object
       :return: *BODY* as *JSON* data parsed by *loads* parameter or
                ``None`` if *BODY* is empty or contains white-spaces only.
 
+    .. attribute:: request_info
+
+       A namedtuple with request URL and headers from :class:`ClientRequest`
+       object.
+
 
 ClientWebSocketResponse
 -----------------------

--- a/tests/test_client_response.py
+++ b/tests/test_client_response.py
@@ -464,4 +464,4 @@ def test_request_info_in_exception():
     response.reason = 'CONFLICT'
     with pytest.raises(aiohttp.ClientResponseError) as cm:
         response.raise_for_status()
-    assert cm.request_info == response.request_info
+    assert cm.value.request_info == response.request_info

--- a/tests/test_client_response.py
+++ b/tests/test_client_response.py
@@ -439,3 +439,11 @@ def test_response_request_info():
     )
     assert URL(url) == response.request_info.url
     assert headers == response.request_info.headers
+
+
+def test_response_request_info_empty():
+    url = 'http://def-cl-resp.org'
+    response = ClientResponse(
+        'get', URL(url),
+    )
+    assert response.request_info is None

--- a/tests/test_client_response.py
+++ b/tests/test_client_response.py
@@ -10,7 +10,7 @@ from yarl import URL
 
 import aiohttp
 from aiohttp import helpers
-from aiohttp.client_reqrep import ClientResponse
+from aiohttp.client_reqrep import ClientResponse, RequestInfo
 
 
 def test_del():
@@ -425,3 +425,17 @@ def test_charset_no_charset():
     response.headers = {'Content-Type': 'application/json'}
 
     assert response.charset is None
+
+
+def test_response_request_info():
+    url = 'http://def-cl-resp.org'
+    headers = {'Content-Type': 'application/json;charset=cp1251'}
+    response = ClientResponse(
+        'get', URL(url),
+        request_info=RequestInfo(
+            url,
+            headers
+        )
+    )
+    assert URL(url) == response.request_info.url
+    assert headers == response.request_info.headers

--- a/tests/test_client_response.py
+++ b/tests/test_client_response.py
@@ -437,7 +437,7 @@ def test_response_request_info():
             headers
         )
     )
-    assert URL(url) == response.request_info.url
+    assert url == response.request_info.url
     assert headers == response.request_info.headers
 
 
@@ -447,3 +447,20 @@ def test_response_request_info_empty():
         'get', URL(url),
     )
     assert response.request_info is None
+
+def test_request_info_in_exception():
+    url = 'http://def-cl-resp.org'
+    headers = {'Content-Type': 'application/json;charset=cp1251'}
+    response = ClientResponse(
+        'get',
+        URL(url),
+        request_info=RequestInfo(
+            url,
+            headers
+        )
+    )
+    response.status = 409
+    response.reason = 'CONFLICT'
+    with pytest.raises(aiohttp.ClientResponseError) as cm:
+        response.raise_for_status()
+    assert cm.request_info == response.request_info

--- a/tests/test_client_response.py
+++ b/tests/test_client_response.py
@@ -448,6 +448,7 @@ def test_response_request_info_empty():
     )
     assert response.request_info is None
 
+
 def test_request_info_in_exception():
     url = 'http://def-cl-resp.org'
     headers = {'Content-Type': 'application/json;charset=cp1251'}


### PR DESCRIPTION
## What do these changes do?

Attach request_info to response object

## Are there changes in behavior for the user?

Possible to get request url and headers from response object.

## Related issue number

#1705