### PR TITLE
fix allow-head to include name on route

### DIFF
--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -859,9 +859,10 @@ class UrlDispatcher(AbstractRouter, collections.abc.Mapping):
         route is added allowing head requests to the same endpoint
         """
         if allow_head:
-            # the head route can't have "name" set or it would conflict with
+            # it name is not None append -head to avoid it conflicting with
             # the GET route below
-            self.add_route(hdrs.METH_HEAD, *args, **kwargs)
+            head_name = name and '{}-head'.format(name)
+            self.add_route(hdrs.METH_HEAD, *args, name=head_name, **kwargs)
         return self.add_route(hdrs.METH_GET, *args, name=name, **kwargs)
 
     def add_post(self, *args, **kwargs):


### PR DESCRIPTION
My original mistake on #1668, it's useful for the `HEAD` route to be named too, eg. [here](https://github.com/tutorcruncher/socket-server/blob/master/tcsocket/app/middleware.py#L186) I'm checking the view name against a whitelist of "public views" before authentication.

Alternatively, routing could be entirely redesigned to allow "child" routes with duplicate names to their parents, but that sounds like overkill. :hocho: 