### PR TITLE
add ids to loop params in pytest plugin

### DIFF
--- a/aiohttp/pytest_plugin.py
+++ b/aiohttp/pytest_plugin.py
@@ -83,22 +83,28 @@ def pytest_configure(config):
         without_uvloop = True
 
     LOOP_FACTORIES.clear()
+    LOOP_FACTORY_IDS.clear()
     if uvloop_only and uvloop is not None:
         LOOP_FACTORIES.append(uvloop.new_event_loop)
+        LOOP_FACTORY_IDS.append('uvloop')
     elif without_uvloop:
         LOOP_FACTORIES.append(asyncio.new_event_loop)
+        LOOP_FACTORY_IDS.append('pyloop')
     else:
         LOOP_FACTORIES.append(asyncio.new_event_loop)
+        LOOP_FACTORY_IDS.append('pyloop')
         if uvloop is not None:
             LOOP_FACTORIES.append(uvloop.new_event_loop)
+            LOOP_FACTORY_IDS.append('uvloop')
 
     asyncio.set_event_loop(None)
 
 
 LOOP_FACTORIES = []
+LOOP_FACTORY_IDS = []
 
 
-@pytest.yield_fixture(params=LOOP_FACTORIES)
+@pytest.yield_fixture(params=LOOP_FACTORIES, ids=LOOP_FACTORY_IDS)
 def loop(request):
     """Return an instance of the event loop."""
     fast = request.config.getoption('--fast')


### PR DESCRIPTION
this should make the two loop params clearer, particularly when users suddenly find their tests "running twice". When using pytest with `-v` the tests should now use these ides instead of `[loop-o]` and `[loop-1]`.

I'm open to better names than "uvloop" and "pyloop", but I couldn't immediately think of better options.