### PR TITLE
Implement history for ClientResponseError.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,8 @@ Changes
 
 - Dropped "%O" in access logger #1673
 
+- Added `history` to `ClientResponseError`. #1741
+
 
 2.0.2 (2017-03-21)
 ------------------

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -386,6 +386,7 @@ class ClientSession:
             if resp.status != 101:
                 raise WSServerHandshakeError(
                     resp.request_info,
+                    resp.history,
                     message='Invalid response status',
                     code=resp.status,
                     headers=resp.headers)
@@ -393,6 +394,7 @@ class ClientSession:
             if resp.headers.get(hdrs.UPGRADE, '').lower() != 'websocket':
                 raise WSServerHandshakeError(
                     resp.request_info,
+                    resp.history,
                     message='Invalid upgrade header',
                     code=resp.status,
                     headers=resp.headers)
@@ -400,6 +402,7 @@ class ClientSession:
             if resp.headers.get(hdrs.CONNECTION, '').lower() != 'upgrade':
                 raise WSServerHandshakeError(
                     resp.request_info,
+                    resp.history,
                     message='Invalid connection header',
                     code=resp.status,
                     headers=resp.headers)
@@ -411,6 +414,7 @@ class ClientSession:
             if key != match:
                 raise WSServerHandshakeError(
                     resp.request_info,
+                    resp.history,
                     message='Invalid challenge response',
                     code=resp.status,
                     headers=resp.headers)

--- a/aiohttp/client_exceptions.py
+++ b/aiohttp/client_exceptions.py
@@ -25,11 +25,13 @@ class ClientResponseError(ClientError):
     :param request_info: instance of RequestInfo
     """
 
-    def __init__(self, request_info, *, code=0, message='', headers=None):
+    def __init__(self, request_info, *, code=0, message='', headers=None,
+                 history=None):
         self.request_info = request_info
         self.code = code
         self.message = message
         self.headers = headers
+        self.history = history if history is not None else []
 
         super().__init__("%s, message='%s'" % (code, message))
 

--- a/aiohttp/client_exceptions.py
+++ b/aiohttp/client_exceptions.py
@@ -25,13 +25,13 @@ class ClientResponseError(ClientError):
     :param request_info: instance of RequestInfo
     """
 
-    def __init__(self, request_info, *, code=0, message='', headers=None,
-                 history=None):
+    def __init__(self, request_info, history, *,
+                 code=0, message='', headers=None):
         self.request_info = request_info
         self.code = code
         self.message = message
         self.headers = headers
-        self.history = history if history is not None else ()
+        self.history = history
 
         super().__init__("%s, message='%s'" % (code, message))
 

--- a/aiohttp/client_exceptions.py
+++ b/aiohttp/client_exceptions.py
@@ -31,7 +31,7 @@ class ClientResponseError(ClientError):
         self.code = code
         self.message = message
         self.headers = headers
-        self.history = history if history is not None else []
+        self.history = history if history is not None else ()
 
         super().__init__("%s, message='%s'" % (code, message))
 

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -546,10 +546,9 @@ class ClientResponse(HeadersMixin):
                     (message, payload) = yield from self._protocol.read()
                 except http.HttpProcessingError as exc:
                     raise ClientResponseError(
-                        self.request_info,
+                        self.request_info, self.history,
                         code=exc.code,
-                        message=exc.message, headers=exc.headers,
-                        history=self.history) from exc
+                        message=exc.message, headers=exc.headers) from exc
 
                 if (message.code < 100 or
                         message.code > 199 or message.code == 101):
@@ -633,10 +632,10 @@ class ClientResponse(HeadersMixin):
         if 400 <= self.status:
             raise ClientResponseError(
                 self.request_info,
+                self.history,
                 code=self.status,
                 message=self.reason,
-                headers=self.headers,
-                history=self.history)
+                headers=self.headers)
 
     def _cleanup_writer(self):
         if self._writer is not None and not self._writer.done():
@@ -709,10 +708,10 @@ class ClientResponse(HeadersMixin):
             if content_type not in ctype:
                 raise ClientResponseError(
                     self.request_info,
+                    self.history,
                     message=('Attempt to decode JSON with '
                              'unexpected mimetype: %s' % ctype),
-                    headers=self.headers,
-                    history=self.history)
+                    headers=self.headers)
 
         stripped = self._content.strip()
         if not stripped:

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -548,7 +548,8 @@ class ClientResponse(HeadersMixin):
                     raise ClientResponseError(
                         self.request_info,
                         code=exc.code,
-                        message=exc.message, headers=exc.headers) from exc
+                        message=exc.message, headers=exc.headers,
+                        history=self.history) from exc
 
                 if (message.code < 100 or
                         message.code > 199 or message.code == 101):
@@ -634,7 +635,8 @@ class ClientResponse(HeadersMixin):
                 self.request_info,
                 code=self.status,
                 message=self.reason,
-                headers=self.headers)
+                headers=self.headers,
+                history=self.history)
 
     def _cleanup_writer(self):
         if self._writer is not None and not self._writer.done():
@@ -709,7 +711,8 @@ class ClientResponse(HeadersMixin):
                     self.request_info,
                     message=('Attempt to decode JSON with '
                              'unexpected mimetype: %s' % ctype),
-                    headers=self.headers)
+                    headers=self.headers,
+                    history=self.history)
 
         stripped = self._content.strip()
         if not stripped:

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -727,6 +727,7 @@ class TCPConnector(BaseConnector):
                     if resp.status != 200:
                         raise ClientHttpProxyError(
                             proxy_resp.request_info,
+                            resp.history,
                             code=resp.status,
                             message=resp.reason,
                             headers=resp.headers)

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -1335,6 +1335,9 @@ Hierarchy of exceptions:
    .. attribute:: request_info
                   Instance of `RequestInfo` object, contains information about request.
 
+   .. attribute:: history
+                  History from `ClientResponse` object, if available, else empty list.
+
   * `WSServerHandshakeError` - web socket server response error
 
     - `ClientHttpProxyError` - proxy response

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -1336,7 +1336,7 @@ Hierarchy of exceptions:
                   Instance of `RequestInfo` object, contains information about request.
 
    .. attribute:: history
-                  History from `ClientResponse` object, if available, else empty list.
+                  History from `ClientResponse` object, if available, else empty tuple.
 
   * `WSServerHandshakeError` - web socket server response error
 

--- a/tests/test_client_response.py
+++ b/tests/test_client_response.py
@@ -509,7 +509,7 @@ def test_no_redirect_history_in_exception():
     response.reason = 'CONFLICT'
     with pytest.raises(aiohttp.ClientResponseError) as cm:
         response.raise_for_status()
-    assert [] == cm.value.history
+    assert () == cm.value.history
 
 
 def test_redirect_history_in_exception():

--- a/tests/test_client_response.py
+++ b/tests/test_client_response.py
@@ -491,3 +491,61 @@ def test_request_info_in_exception():
     with pytest.raises(aiohttp.ClientResponseError) as cm:
         response.raise_for_status()
     assert cm.value.request_info == response.request_info
+
+
+def test_no_redirect_history_in_exception():
+    url = 'http://def-cl-resp.org'
+    headers = {'Content-Type': 'application/json;charset=cp1251'}
+    response = ClientResponse(
+        'get',
+        URL(url),
+        request_info=RequestInfo(
+            url,
+            'get',
+            headers
+        )
+    )
+    response.status = 409
+    response.reason = 'CONFLICT'
+    with pytest.raises(aiohttp.ClientResponseError) as cm:
+        response.raise_for_status()
+    assert [] == cm.value.history
+
+
+def test_redirect_history_in_exception():
+    hist_url = 'http://def-cl-resp.org'
+    url = 'http://def-cl-resp.org/index.htm'
+    hist_headers = {'Content-Type': 'application/json;charset=cp1251',
+                    'Location': url
+                    }
+    headers = {'Content-Type': 'application/json;charset=cp1251'}
+    response = ClientResponse(
+        'get',
+        URL(url),
+        request_info=RequestInfo(
+            url,
+            'get',
+            headers
+        )
+    )
+    response.status = 409
+    response.reason = 'CONFLICT'
+
+    hist_response = ClientResponse(
+        'get',
+        URL(hist_url),
+        request_info=RequestInfo(
+            url,
+            'get',
+            headers
+        )
+    )
+
+    hist_response.headers = hist_headers
+    hist_response.status = 301
+    hist_response.reason = 'REDIRECT'
+
+    response._history = [hist_response]
+    with pytest.raises(aiohttp.ClientResponseError) as cm:
+        response.raise_for_status()
+    assert [hist_response] == cm.value.history


### PR DESCRIPTION
## What do these changes do?

ClientResponseError will contain history from ClientResponse.

## Are there changes in behavior for the user?

User can extract redirect history from exception and use it for error investigation purposes.

## Related issue number

#1741 