### PR TITLE
Fix crash on multipart/form-data post

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -67,6 +67,7 @@ Georges Dubus
 Greg Holt
 Gregory Haynes
 Günther Jena
+Hu Bo
 Hugo Herter
 Igor Pavlov
 Ingmar Steen

--- a/aiohttp/web_request.py
+++ b/aiohttp/web_request.py
@@ -409,7 +409,8 @@ class BaseRequest(collections.MutableMapping, HeadersMixin):
                     out.add(field.name, ff)
                 else:
                     value = yield from field.read(decode=True)
-                    if content_type.startswith('text/'):
+                    if content_type is None or \
+                            content_type.startswith('text/'):
                         charset = field.get_charset(default='utf-8')
                         value = value.decode(charset)
                     out.add(field.name, value)

--- a/tests/test_web_request.py
+++ b/tests/test_web_request.py
@@ -336,6 +336,28 @@ def test_make_too_big_request_adjust_limit(loop):
 
 
 @asyncio.coroutine
+def test_multipart_formdata(loop):
+    payload = StreamReader(loop=loop)
+    payload.feed_data(b"""-----------------------------326931944431359\r
+Content-Disposition: form-data; name="a"\r
+\r
+b\r
+-----------------------------326931944431359\r
+Content-Disposition: form-data; name="c"\r
+\r
+d\r
+-----------------------------326931944431359--\r\n""")
+    content_type = "multipart/form-data; boundary="\
+                   "---------------------------326931944431359"
+    payload.feed_eof()
+    req = make_mocked_request('POST', '/',
+                              headers={'CONTENT-TYPE': content_type},
+                              payload=payload)
+    result = yield from req.post()
+    assert dict(result) == {'a': 'b', 'c': 'd'}
+
+
+@asyncio.coroutine
 def test_make_too_big_request_limit_None(loop):
     payload = StreamReader(loop=loop)
     large_file = 1024 ** 2 * b'x'


### PR DESCRIPTION
## What do these changes do?

When multipart/form-data format data is posted to aiohttp server and is processed by request.post(), if there are fields without filename and "Content-Type" header, the request crashes on checking content_type.startswith("text/"). Many browsers and tools generates this kind of post data.

## Are there changes in behavior for the user?

No. There may be different opinions on whether to decode the data to unicode string or leave it as bytes, but it should be better than crashing.

## Related issue number

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [ ] Add a new entry to `CHANGES.rst`
  * Choose any open position to avoid merge conflicts with other PRs.
  * Add a link to the issue you are fixing (if any) using `#issue_number` format at the end of changelog message. Use Pull Request number if there are no issues for PR or PR covers the issue only partially.
