### PR TITLE
check for runtime warnings in tests

### DIFF
--- a/aiohttp/pytest_plugin.py
+++ b/aiohttp/pytest_plugin.py
@@ -1,6 +1,7 @@
 import asyncio
 import contextlib
 import tempfile
+import warnings
 
 import pytest
 from py import path
@@ -35,7 +36,31 @@ def fast(request):
 
 
 @contextlib.contextmanager
+def _runtime_warning_context():
+    """
+    Context manager which checks for RuntimeWarnings, specifically to
+    avoid "coroutine 'X' was never awaited" warnings being missed.
+
+    If RuntimeWarnings occur in the context a RuntimeError is raised.
+    """
+    with warnings.catch_warnings(record=True) as _warnings:
+        yield
+        rw = ['{w.filename}:{w.lineno}:{w.message}'.format(w=w)
+              for w in _warnings if w.category == RuntimeWarning]
+        if rw:
+            raise RuntimeError('{} Runtime Warning{},\n{}'.format(
+                len(rw),
+                '' if len(rw) == 1 else 's',
+                '\n'.join(rw)
+            ))
+
+
+@contextlib.contextmanager
 def _passthrough_loop_context(loop, fast=False):
+    """
+    setups and tears down a loop unless one is passed in via the loop
+    argument when it's passed straight through.
+    """
     if loop:
         # loop already exists, pass it straight through
         yield loop
@@ -61,12 +86,13 @@ def pytest_pyfunc_call(pyfuncitem):
     fast = pyfuncitem.config.getoption("--fast")
     if asyncio.iscoroutinefunction(pyfuncitem.function):
         existing_loop = pyfuncitem.funcargs.get('loop', None)
-        with _passthrough_loop_context(existing_loop, fast=fast) as _loop:
-            testargs = {arg: pyfuncitem.funcargs[arg]
-                        for arg in pyfuncitem._fixtureinfo.argnames}
+        with _runtime_warning_context():
+            with _passthrough_loop_context(existing_loop, fast=fast) as _loop:
+                testargs = {arg: pyfuncitem.funcargs[arg]
+                            for arg in pyfuncitem._fixtureinfo.argnames}
 
-            task = _loop.create_task(pyfuncitem.obj(**testargs))
-            _loop.run_until_complete(task)
+                task = _loop.create_task(pyfuncitem.obj(**testargs))
+                _loop.run_until_complete(task)
 
         return True
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,6 +9,7 @@ ignore = N801,N802,N803,E226
 max-line-length=79
 
 [tool:pytest]
+testpaths = tests
 timeout = 4
 
 [isort]

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -1,7 +1,11 @@
+import re
+import sys
+import pytest
+
 pytest_plugins = 'pytester'
 
 
-def test_myplugin(testdir):
+def test_aiohttp_plugin(testdir):
     testdir.makepyfile("""\
 import asyncio
 import pytest
@@ -150,3 +154,27 @@ def test_client_failed_to_create(test_client):
     # i dont know how to fix this
     # result = testdir.runpytest('-p', 'no:sugar')
     # result.assert_outcomes(passed=11, failed=1)
+
+
+@pytest.mark.skipif(sys.version_info < (3, 5), reason='old python')
+def test_warning_checks(testdir, capsys):
+    testdir.makepyfile("""\
+import asyncio
+
+pytest_plugins = 'aiohttp.pytest_plugin'
+
+async def foobar():
+    return 123
+
+async def test_good():
+    v = await foobar()
+    assert v == 123
+
+async def test_bad():
+    foobar()
+""")
+    result = testdir.runpytest('-p', 'no:sugar', '-s')
+    result.assert_outcomes(passed=1, failed=1)
+    stdout, _ = capsys.readouterr()
+    assert ("test_warning_checks.py:__LINE__:coroutine 'foobar' was "
+            "never awaited" in re.sub('\d{2,}', '__LINE__', stdout))


### PR DESCRIPTION
## What do these changes do?

Checks for `coroutine 'X' was never awaited` runtime warnings and raises an exception, thus preventing tests which silently don't await coroutines (via pytest's muting of stdout/stderr).

## Are there changes in behavior for the user?

No