### PR TITLE
Added `default_headers` property to `ClientSession`.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,8 @@ Changes
 
 - Added `history` to `ClientResponseError`. #1741
 
+- Added `default_headers` property to `ClientSession`.  #1746
+
 
 2.0.2 (2017-03-21)
 ------------------

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -126,6 +126,11 @@ class ClientSession:
                 context['source_traceback'] = self._source_traceback
             self._loop.call_exception_handler(context)
 
+    @property
+    def default_headers(self) -> CIMultiDict:
+        """default headers getter."""
+        return self._default_headers
+
     def request(self, method, url, **kwargs):
         """Perform HTTP request."""
         return _RequestContextManager(self._request(method, url, **kwargs))

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -128,6 +128,11 @@ The client session supports the context manager protocol for self closing.
 
    .. attribute:: connector
 
+   .. attribute:: default_headers
+      Getter for default session headers (object type: ``CIMultiDict``).
+
+      .. versionadded:: 2.1
+
    :class:`aiohttp.connector.BaseConnector` derived instance used
       for the session.
 

--- a/tests/test_client_session.py
+++ b/tests/test_client_session.py
@@ -68,6 +68,7 @@ def test_init_headers_simple_dict(create_session):
                                       "h2": "header2"})
     assert (sorted(session._default_headers.items()) ==
             ([("H1", "header1"), ("H2", "header2")]))
+    assert session.default_headers == session._default_headers
 
 
 def test_init_headers_list_of_tuples(create_session):


### PR DESCRIPTION
## What do these changes do?

Added `default_headers` property to `ClientSession`.

## Are there changes in behavior for the user?

Session default_headers is public available.

## Related issue number

#1746
