### PR TITLE
Add None type check for content_type

### DIFF
--- a/aiohttp/web_request.py
+++ b/aiohttp/web_request.py
@@ -409,7 +409,7 @@ class BaseRequest(collections.MutableMapping, HeadersMixin):
                     out.add(field.name, ff)
                 else:
                     value = yield from field.read(decode=True)
-                    if content_type.startswith('text/'):
+                    if content_type is not None and content_type.startswith('text/'):
                         charset = field.get_charset(default='utf-8')
                         value = value.decode(charset)
                     out.add(field.name, value)


### PR DESCRIPTION
If the Content-Type header is not set, content_type will be None.
We should not perform a string operation on None.
```
AttributeError: 'NoneType' object has no attribute 'startswith'
  File "laas/server.py", line 47, in middleware_handler
    return await handler(request)
  File "laas/server.py", line 22, in handle
    data = await request.post()
  File "aiohttp/web_request.py", line 412, in post
    if content_type.startswith('text/'):
```

<!-- Thank you for your contribution!

     Before submit your Pull Request, make sure you picked
     the right branch:

     - If you propose a new feature or improvement, select "master"
       as a target branch;
     - If this is a bug fix or documentation amendment, select
       the latest release branch (which looks like "0.xx") -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [ ] Add a new entry to `CHANGES.rst`
  * Choose any open position to avoid merge conflicts with other PRs.
  * Add a link to the issue you are fixing (if any) using `#issue_number` format at the end of changelog message. Use Pull Request number if there are no issues for PR or PR covers the issue only partially.
