### PR TITLE
Remove copy of body headers into request headers

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,8 @@ Changes
 
 - Dropped "%O" in access logger #1673
 
+- Headers from body are not in Request headers anymore
+
 
 2.0.3 (2017-03-24)
 ------------------

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -82,6 +82,7 @@ Jeroen van der Heijden
 Jesus Cea
 Jinkyu Yi
 Joel Watts
+Johan Lorenzo
 Joongi Kim
 Julien Duponchelle
 Junjie Tao

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -275,12 +275,6 @@ class ClientRequest:
                 hdrs.CONTENT_TYPE not in skip_auto_headers):
             self.headers[hdrs.CONTENT_TYPE] = body.content_type
 
-        # copy payload headers
-        if body.headers:
-            for (key, value) in body.headers.items():
-                if key not in self.headers:
-                    self.headers[key] = value
-
     def update_expect_continue(self, expect=False):
         if expect:
             self.headers[hdrs.EXPECT] = '100-continue'


### PR DESCRIPTION
Thank you for this library! Mozilla uses aiohttp to upload artifacts on Amazon S3.

We recently migrated to 2.0.0, which gave this particular side-effect: https://github.com/mozilla-releng/scriptworker/issues/98. We noticed 'Content-Disposition' is now added to PUT request that contain a data payload (like a text/plain document). This has the unwanted effect to confuse Firefox when downloading artifacts from S3. Before then, artifacts could be directly displayed in browser, but now they are considered as blobs to be downloaded.

I found headers are now extended by the ones detected from the body. in https://github.com/aio-libs/aiohttp/commit/d69838a5b0ea8ce8e6ac5e39cb797ac81f943028. I'm not sure what was the context at the time.


## What do these changes do?

With this patch, body headers are not included in the actual headers of a request. Based on https://github.com/aio-libs/aiohttp/commit/d69838a5b0ea8ce8e6ac5e39cb797ac81f943028, this was the behavior before this commit.

What do you think @fafhrd91 ?

## Are there changes in behavior for the user?

That fixes a regression from 1.x.

## Related issue number

* https://github.com/mozilla-releng/scriptworker/issues/98

## Checklist

- [x] I think the code is well written
(Side note: I just deleted some lines 😃 )

- [ ] Unit tests for the changes exist
It seems this particular area wasn't tested. I haven't changed the tests. 

- [ ] Documentation reflects the changes
I'm not sure if changes are needed in the docs.

- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`

- [x] Add a new entry to `CHANGES.rst`
