### PR TITLE
Update client_reqrep.py to fix exception when proxied

### DIFF
--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -588,8 +588,10 @@ class ClientResponse(HeadersMixin):
 
         if self._connection is not None:
             # websocket, protocol could be None because
-            # connection could be detached
+            # connection could be detached, and does not exist
+            # if proxied.
             if (self._connection.protocol is not None and
+                    hasattr(self._connection.protocol, 'upgraded') and
                     self._connection.protocol.upgraded):
                 return
 


### PR DESCRIPTION
Ensure _connection.protocol is actually an attribute before polling on _response_eof to avoid exception thrown.