### PR TITLE
use io.BytesIO instead of joining bytes to avoid copying everything

### DIFF
--- a/aiohttp/web_fileresponse.py
+++ b/aiohttp/web_fileresponse.py
@@ -26,10 +26,6 @@ class SendfilePayloadWriter(PayloadWriter):
             if not waiter.done():
                 waiter.set_result(None)
 
-    def _write(self, chunk):
-        self.output_size += len(chunk)
-        self._buffer.append(chunk)
-
     def _sendfile_cb(self, fut, out_fd, in_fd,
                      offset, count, loop, registered):
         if registered:
@@ -68,7 +64,7 @@ class SendfilePayloadWriter(PayloadWriter):
 
         loop = self.loop
         try:
-            yield from loop.sock_sendall(out_socket, b''.join(self._buffer))
+            yield from loop.sock_sendall(out_socket, self._buffer.getvalue())
             fut = create_future(loop)
             self._sendfile_cb(fut, out_fd, in_fd, offset, count, loop, False)
             yield from fut


### PR DESCRIPTION
The most important change here is the update in `web_request.Request.read`: reading the request body entirely then return `b''.join(chunks)` is very inefficient because it has to copy the complete body just before returning.
This means that currently, when a 200MB request is sent to an aiohttp server, the server would need up to 400MB of RAM to handle it (it would be less in real life because the client does not transmit the entire body at once. But it's still a lot).
With `io.BytesIO`, the actual underlying buffer is returned when calling `BytesIO.getvalue`, this way only 200MB of RAM is needed to handle the same request.


I have also updated other parts of the library (mainly the HTTP payload writer) to use BytesIO instead of joining lists of bytes.