### PR TITLE
Tutorial remove depricated constructor parameter loop

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -34,8 +34,8 @@ command:
 
 .. code-block:: shell
 
- $ python -c 'import aiohttp; print(aiohttp.__version__)'
- 1.1.5
+ $ python3 -c 'import aiohttp; print(aiohttp.__version__)'
+ 2.0.5
 
 Project structure looks very similar to other python based web projects:
 
@@ -84,18 +84,17 @@ It is used for registering *startup*/*cleanup* signals, connecting routes etc.
 
 The following code creates an application::
 
-   import asyncio
    from aiohttp import web
 
-   loop = asyncio.get_event_loop()
-   app = web.Application(loop=loop)
+
+   app = web.Application()
    web.run_app(app, host='127.0.0.1', port=8080)
 
 Save it under ``aiohttpdemo_polls/main.py`` and start the server:
 
 .. code-block:: shell
 
-   $ python main.py  
+   $ python3 main.py  
    
 You'll see the following output on the command line:
 
@@ -138,13 +137,11 @@ Now we should create a route for this ``index`` view. Put this into ``aiohttpdem
 
 Also, we should call ``setup_routes`` function somewhere, and the best place is in the ``main.py`` ::
 
-   import asyncio
    from aiohttp import web
    from routes import setup_routes
 
 
-   loop = asyncio.get_event_loop()
-   app = web.Application(loop=loop)
+   app = web.Application()
    setup_routes(app)
    web.run_app(app, host='127.0.0.1', port=8080)
 


### PR DESCRIPTION
[Constructor parameter loop is deprecated](http://aiohttp.readthedocs.io/en/latest/migration.html#application) in aiohttp v2.

<!-- Thank you for your contribution!

     Before submit your Pull Request, make sure you picked
     the right branch:

     - If you propose a new feature or improvement, select "master"
       as a target branch;
     - If this is a bug fix or documentation amendment, select
       the latest release branch (which looks like "0.xx") -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [ ] Add a new entry to `CHANGES.rst`
  * Choose any open position to avoid merge conflicts with other PRs.
  * Add a link to the issue you are fixing (if any) using `#issue_number` format at the end of changelog message. Use Pull Request number if there are no issues for PR or PR covers the issue only partially.
