### PR TITLE
Fix web.run_app not to bind to default host:port if only socket is passed

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,9 @@ Changes
 
 - Dropped "%O" in access logger #1673
 
+- Fix ``web.run_app`` not to bind to default host-port pair if only socket is
+  passed #1786
+
 
 2.0.6 (2017-04-04)
 ------------------

--- a/aiohttp/web.py
+++ b/aiohttp/web.py
@@ -331,8 +331,15 @@ def run_app(app, *, host=None, port=None, path=None, sock=None,
     else:
         paths = path
 
+    if sock is None:
+        socks = ()
+    elif not isinstance(sock, Iterable):
+        socks = (sock,)
+    else:
+        socks = sock
+
     if host is None:
-        if paths and not port:
+        if (paths or socks) and not port:
             hosts = ()
         else:
             hosts = ("0.0.0.0",)
@@ -344,13 +351,6 @@ def run_app(app, *, host=None, port=None, path=None, sock=None,
 
     if hosts and port is None:
         port = 8443 if ssl_context else 8080
-
-    if sock is None:
-        socks = ()
-    elif not isinstance(sock, Iterable):
-        socks = (sock,)
-    else:
-        socks = sock
 
     server_creations = []
     uris = [str(base_url.with_host(host)) for host in hosts]

--- a/tests/test_run_app.py
+++ b/tests/test_run_app.py
@@ -72,6 +72,7 @@ mock_server_multi = [
 mock_server_default_8989 = [
     mock.call(mock.ANY, '0.0.0.0', 8989, ssl=None, backlog=128)
 ]
+mock_socket = mock.Mock(getsockname=lambda: ('mock-socket', 123))
 mixed_bindings_tests = (
     (
         "Nothing Specified",
@@ -136,7 +137,27 @@ mixed_bindings_tests = (
         [mock.call(mock.ANY, ('127.0.0.1', '192.168.1.1'), 8000, ssl=None,
                    backlog=128)],
         mock_unix_server_multi
-    )
+    ),
+    (
+        "Only socket",
+        {"sock": [mock_socket]},
+        [mock.call(mock.ANY, ssl=None, sock=mock_socket, backlog=128)],
+        [],
+    ),
+    (
+        "Socket, port",
+        {"sock": [mock_socket], "port": 8765},
+        [mock.call(mock.ANY, '0.0.0.0', 8765, ssl=None, backlog=128),
+         mock.call(mock.ANY, sock=mock_socket, ssl=None, backlog=128)],
+        [],
+    ),
+    (
+        "Socket, Host, No port",
+        {"sock": [mock_socket], "host": 'localhost'},
+        [mock.call(mock.ANY, 'localhost', 8080, ssl=None, backlog=128),
+         mock.call(mock.ANY, sock=mock_socket, ssl=None, backlog=128)],
+        [],
+    ),
 )
 mixed_bindings_test_ids = [test[0] for test in mixed_bindings_tests]
 mixed_bindings_test_params = [test[1:] for test in mixed_bindings_tests]


### PR DESCRIPTION
## What do these changes do?

`web.run_app` fix to create server only for specified socket if no other arguments are passed.
Currently, `run_app` will also bind to default host if only socket is passed which is wrong.

## Are there changes in behavior for the user?

no

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new entry to `CHANGES.rst`
  * Choose any open position to avoid merge conflicts with other PRs.
  * Add a link to the issue you are fixing (if any) using `#issue_number` format at the end of changelog message. Use Pull Request number if there are no issues for PR or PR covers the issue only partially.
