### PR TITLE
Fixing the documentation of AioHTTPTestCase get_application at testing.rst

### DIFF
--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -205,9 +205,9 @@ functionality, the AioHTTPTestCase is provided::
     class MyAppTestCase(AioHTTPTestCase):
 
         async def get_application(self):
-            """Override the get_app method to return your application.
             """
-            # it's important to use the loop passed here.
+            Override the get_app method to return your application.
+            """
             return web.Application()
 
         # the unittest_run_loop decorator can be used in tandem with


### PR DESCRIPTION
On versions 1.x  `AioHttpTestCase.get_application` had to be overwritten with a `loop` parameter. It doesn`t anymore and the documentation doesn't reflect that change