### PR TITLE
Add method for iterating of chunks sent by server

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,6 +21,8 @@ Changes
 
 - Dropped "%O" in access logger #1673
 
+- Added `iter_chunks` to response.content object. #1805
+
 
 2.0.6 (2017-04-04)
 ------------------

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -3,6 +3,7 @@ Contributors
 
 A. Jesse Jiryu Davis
 Adam Mills
+Alec Hanefeld
 Alejandro Gómez
 Aleksandr Danshyn
 Aleksey Kutepov

--- a/aiohttp/streams.py
+++ b/aiohttp/streams.py
@@ -425,6 +425,10 @@ class EmptyStreamReader(AsyncStreamReaderMixin):
         return b''
 
     @asyncio.coroutine
+    def readone(self):
+        return b''
+
+    @asyncio.coroutine
     def readexactly(self, n):
         raise asyncio.streams.IncompleteReadError(b'', n)
 
@@ -563,6 +567,14 @@ class FlowControlStreamReader(StreamReader):
     def readany(self):
         try:
             return (yield from super().readany())
+        finally:
+            if self._size < self._b_limit and self._protocol._reading_paused:
+                self._protocol.resume_reading()
+
+    @asyncio.coroutine
+    def readone(self):
+        try:
+            return (yield from super().readone())
         finally:
             if self._size < self._b_limit and self._protocol._reading_paused:
                 self._protocol.resume_reading()

--- a/aiohttp/streams.py
+++ b/aiohttp/streams.py
@@ -70,7 +70,7 @@ class AsyncStreamReaderMixin:
 
             Python-3.5 available for Python 3.5+ only
             """
-            return AsyncStreamIterator(self.readone)
+            return AsyncStreamIterator(self.readchunk)
 
 
 class StreamReader(AsyncStreamReaderMixin):
@@ -318,12 +318,12 @@ class StreamReader(AsyncStreamReaderMixin):
         return self._read_nowait(-1)
 
     @asyncio.coroutine
-    def readone(self):
+    def readchunk(self):
         if self._exception is not None:
             raise self._exception
 
         if not self._buffer and not self._eof:
-            yield from self._wait('readone')
+            yield from self._wait('readchunk')
 
         return self._read_nowait_chunk(-1)
 
@@ -433,7 +433,7 @@ class EmptyStreamReader(AsyncStreamReaderMixin):
         return b''
 
     @asyncio.coroutine
-    def readone(self):
+    def readchunk(self):
         return b''
 
     @asyncio.coroutine
@@ -580,9 +580,9 @@ class FlowControlStreamReader(StreamReader):
                 self._protocol.resume_reading()
 
     @asyncio.coroutine
-    def readone(self):
+    def readchunk(self):
         try:
-            return (yield from super().readone())
+            return (yield from super().readchunk())
         finally:
             if self._size < self._b_limit and self._protocol._reading_paused:
                 self._protocol.resume_reading()

--- a/aiohttp/streams.py
+++ b/aiohttp/streams.py
@@ -64,6 +64,14 @@ class AsyncStreamReaderMixin:
             """
             return AsyncStreamIterator(self.readany)
 
+        def iter_chunks(self):
+            """Returns an asynchronous iterator that yields chunks of the
+            size as received by the server.
+
+            Python-3.5 available for Python 3.5+ only
+            """
+            return AsyncStreamIterator(self.readone)
+
 
 class StreamReader(AsyncStreamReaderMixin):
     """An enhancement of asyncio.StreamReader.

--- a/aiohttp/streams.py
+++ b/aiohttp/streams.py
@@ -310,6 +310,16 @@ class StreamReader(AsyncStreamReaderMixin):
         return self._read_nowait(-1)
 
     @asyncio.coroutine
+    def readone(self):
+        if self._exception is not None:
+            raise self._exception
+
+        if not self._buffer and not self._eof:
+            yield from self._wait('readone')
+
+        return self._read_nowait_chunk(-1)
+
+    @asyncio.coroutine
     def readexactly(self, n):
         if self._exception is not None:
             raise self._exception

--- a/docs/streams.rst
+++ b/docs/streams.rst
@@ -96,12 +96,20 @@ size limit and over any available data.
       async for data in response.content.iter_chunked(1024):
           print(data)
 
-.. comethod:: StreamReader.iter_any(n)
+.. comethod:: StreamReader.iter_any()
    :async-for:
 
    Iterates over data chunks in order of intaking them into the stream::
 
       async for data in response.content.iter_any():
+          print(data)
+
+.. comethod:: StreamReader.iter_chunks()
+   :async-for:
+
+   Iterates over data chunks as received from the server:: 
+
+      async for data in response.content.iter_chunks():
           print(data)
 
 

--- a/tests/test_flowcontrol_streams.py
+++ b/tests/test_flowcontrol_streams.py
@@ -68,6 +68,21 @@ class TestFlowControlStreamReader(unittest.TestCase):
         self.assertEqual(res, b'data')
         self.assertTrue(r._protocol.resume_reading.called)
 
+    def test_readone(self):
+        r = self._make_one()
+        r.feed_data(b'data', 4)
+        res = self.loop.run_until_complete(r.readone())
+        self.assertEqual(res, b'data')
+        self.assertFalse(r._protocol.resume_reading.called)
+
+    def test_readone_resume_paused(self):
+        r = self._make_one()
+        r._protocol._reading_paused = True
+        r.feed_data(b'data', 4)
+        res = self.loop.run_until_complete(r.readone())
+        self.assertEqual(res, b'data')
+        self.assertTrue(r._protocol.resume_reading.called)
+
     def test_readexactly(self):
         r = self._make_one()
         r.feed_data(b'data', 4)

--- a/tests/test_flowcontrol_streams.py
+++ b/tests/test_flowcontrol_streams.py
@@ -68,18 +68,18 @@ class TestFlowControlStreamReader(unittest.TestCase):
         self.assertEqual(res, b'data')
         self.assertTrue(r._protocol.resume_reading.called)
 
-    def test_readone(self):
+    def test_readchunk(self):
         r = self._make_one()
         r.feed_data(b'data', 4)
-        res = self.loop.run_until_complete(r.readone())
+        res = self.loop.run_until_complete(r.readchunk())
         self.assertEqual(res, b'data')
         self.assertFalse(r._protocol.resume_reading.called)
 
-    def test_readone_resume_paused(self):
+    def test_readchunk_resume_paused(self):
         r = self._make_one()
         r._protocol._reading_paused = True
         r.feed_data(b'data', 4)
-        res = self.loop.run_until_complete(r.readone())
+        res = self.loop.run_until_complete(r.readchunk())
         self.assertEqual(res, b'data')
         self.assertTrue(r._protocol.resume_reading.called)
 

--- a/tests/test_streams.py
+++ b/tests/test_streams.py
@@ -546,6 +546,21 @@ class TestStreamReader(unittest.TestCase):
 
         self.assertRaises(RuntimeError, stream.read_nowait)
 
+    def test_readone(self):
+
+        stream = self._make_one()
+
+        def cb():
+            stream.feed_data(b'chunk1')
+            stream.feed_data(b'chunk2')
+        self.loop.call_soon(cb)
+
+        data = self.loop.run_until_complete(stream.readone())
+        self.assertEqual(b'chunk1', data)
+
+        data = self.loop.run_until_complete(stream.readone())
+        self.assertEqual(b'chunk2', data)
+
     def test___repr__(self):
         stream = self._make_one()
         self.assertEqual("<StreamReader>", repr(stream))

--- a/tests/test_streams.py
+++ b/tests/test_streams.py
@@ -631,6 +631,8 @@ class TestEmptyStreamReader(unittest.TestCase):
             self.loop.run_until_complete(s.readline()), b'')
         self.assertEqual(
             self.loop.run_until_complete(s.readany()), b'')
+        self.assertEqual(
+            self.loop.run_until_complete(s.readone()), b'')
         self.assertRaises(
             asyncio.IncompleteReadError,
             self.loop.run_until_complete, s.readexactly(10))

--- a/tests/test_streams.py
+++ b/tests/test_streams.py
@@ -553,6 +553,7 @@ class TestStreamReader(unittest.TestCase):
         def cb():
             stream.feed_data(b'chunk1')
             stream.feed_data(b'chunk2')
+            stream.feed_eof()
         self.loop.call_soon(cb)
 
         data = self.loop.run_until_complete(stream.readone())
@@ -560,6 +561,9 @@ class TestStreamReader(unittest.TestCase):
 
         data = self.loop.run_until_complete(stream.readone())
         self.assertEqual(b'chunk2', data)
+
+        data = self.loop.run_until_complete(stream.read())
+        self.assertEqual(b'', data)
 
     def test___repr__(self):
         stream = self._make_one()

--- a/tests/test_streams.py
+++ b/tests/test_streams.py
@@ -546,7 +546,7 @@ class TestStreamReader(unittest.TestCase):
 
         self.assertRaises(RuntimeError, stream.read_nowait)
 
-    def test_readone(self):
+    def test_readchunk(self):
 
         stream = self._make_one()
 
@@ -556,10 +556,10 @@ class TestStreamReader(unittest.TestCase):
             stream.feed_eof()
         self.loop.call_soon(cb)
 
-        data = self.loop.run_until_complete(stream.readone())
+        data = self.loop.run_until_complete(stream.readchunk())
         self.assertEqual(b'chunk1', data)
 
-        data = self.loop.run_until_complete(stream.readone())
+        data = self.loop.run_until_complete(stream.readchunk())
         self.assertEqual(b'chunk2', data)
 
         data = self.loop.run_until_complete(stream.read())
@@ -636,7 +636,7 @@ class TestEmptyStreamReader(unittest.TestCase):
         self.assertEqual(
             self.loop.run_until_complete(s.readany()), b'')
         self.assertEqual(
-            self.loop.run_until_complete(s.readone()), b'')
+            self.loop.run_until_complete(s.readchunk()), b'')
         self.assertRaises(
             asyncio.IncompleteReadError,
             self.loop.run_until_complete, s.readexactly(10))


### PR DESCRIPTION
## What do these changes do?

This patch adds the `iter_chunks` and the `readchunk` method to the `StreamReader`.
`readchunk` will read a single element from the buffer, which represents one chunk as received from the server.
This enables the `iter_chunks` method which allows for asynchronous iteration over the chunks in the size as received fromt the server.

See [similar behaviour in the Requests library](http://docs.python-requests.org/en/master/api/#requests.Response.iter_content)

## Are there changes in behavior for the user?

The existing method `iter_chunked` is not modified.
Instead I added the `iter_chunks` method to avoid breaking something by changing the behaviour of the `iter_chunked` signature.

I believe that my choice of naming is a bit unfortunate as it could lead to confusion between the two similarly named methods. On the other hand the method does iterate over the chunks of the response so the name is on point.


## Improvements
Ideally there would be only one method with a default value of `n=None` which would implement the desired behaviour. Any thoughts on this?

## Related issue number

#1805

