### PR TITLE
Avoid creating TimerContext when there is no timeout

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,6 +21,8 @@ Changes
 
 - Added `iter_chunks` to response.content object. #1805
 
+- Avoid creating TimerContext when there is no timeout to allow compatibility with Tornado. #1817 #1180
+
 
 2.0.7 (2017-04-12)
 ------------------

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -84,6 +84,7 @@ Jesus Cea
 Jinkyu Yi
 Joel Watts
 Joongi Kim
+Josep Cugat
 Julia Tsemusheva
 Julien Duponchelle
 Junjie Tao

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -641,8 +641,11 @@ class TimeoutHandle:
             return self._loop.call_at(at, self.__call__)
 
     def timer(self):
-        timer = TimerContext(self._loop)
-        self.register(timer.timeout)
+        if self._timeout is not None and self._timeout > 0:
+            timer = TimerContext(self._loop)
+            self.register(timer.timeout)
+        else:
+            timer = TimerNoop()
         return timer
 
     def __call__(self):


### PR DESCRIPTION
This will allow to use aiohttp with ioloops that don't implement
asyncio.Task.current_task, like Tornado's couroutine runner.

More info: https://github.com/aio-libs/aiohttp/issues/1180

<!-- Thank you for your contribution!

     Before submit your Pull Request, make sure you picked
     the right branch:

     - If you propose a new feature or improvement, select "master"
       as a target branch;
     - If this is a bug fix or documentation amendment, select
       the latest release branch (which looks like "0.xx") -->

## What do these changes do?

This will allow to use aiohttp with ioloops that don't implement asyncio.Task.current_task, like Tornado's couroutine runner.

## Are there changes in behavior for the user?

This will restore previous functionality that was available in v1.3.3, which was possible to run with Tornado when setting `timeout=None`. This was lost in this refactor: 38360f9a05aa09ac2bf9a7077edbc2fb0e2520aa

## Related issue number

More information is available in the original issue: https://github.com/aio-libs/aiohttp/issues/1180

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new entry to `CHANGES.rst`
  * Choose any open position to avoid merge conflicts with other PRs.
  * Add a link to the issue you are fixing (if any) using `#issue_number` format at the end of changelog message. Use Pull Request number if there are no issues for PR or PR covers the issue only partially.
