### PR TITLE
Add new ttl option to expire DNS entries after N seconds

### DIFF
--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -6,6 +6,7 @@ import traceback
 import warnings
 from collections import defaultdict
 from hashlib import md5, sha1, sha256
+from time import monotonic
 from types import MappingProxyType
 
 from . import hdrs, helpers
@@ -16,11 +17,6 @@ from .client_proto import ResponseHandler
 from .client_reqrep import ClientRequest
 from .helpers import SimpleCookie, is_ip_address, noop, sentinel
 from .resolver import DefaultResolver
-
-try:
-    from time import monotonic
-except ImportError:
-    from time import time as monotonic
 
 
 __all__ = ('BaseConnector', 'TCPConnector', 'UnixConnector')

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -689,7 +689,7 @@ TCPConnector
 
 .. class:: TCPConnector(*, verify_ssl=True, fingerprint=None,\
                         use_dns_cache=True, \
-                        ttl_dns_cache=None, \
+                        ttl_dns_cache=10, \
                         family=0, ssl_context=None, conn_timeout=None, \
                         keepalive_timeout=30, limit=None, \
                         force_close=False, loop=None, local_addr=None, \
@@ -732,7 +732,7 @@ TCPConnector
          The default is changed to ``True``
 
    :param int ttl_dns_cache: expire after some seconds the DNS entries, ``None``
-      by default therefore cached forever.
+      means cached forever. By default 10 seconds.
 
       By default DNS entries are cached forever, in some environments the IP
       addresses related to a specific HOST can change after a specific time. Use 

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -689,6 +689,7 @@ TCPConnector
 
 .. class:: TCPConnector(*, verify_ssl=True, fingerprint=None,\
                         use_dns_cache=True, \
+                        ttl_dns_cache=None, \
                         family=0, ssl_context=None, conn_timeout=None, \
                         keepalive_timeout=30, limit=None, \
                         force_close=False, loop=None, local_addr=None, \
@@ -729,6 +730,16 @@ TCPConnector
       .. versionchanged:: 1.0
 
          The default is changed to ``True``
+
+   :param int ttl_dns_cache: expire after some seconds the DNS entries, ``None``
+      by default therefore cached forever.
+
+      By default DNS entries are cached forever, in some environments the IP
+      addresses related to a specific HOST can change after a specific time. Use 
+      this option to keep the DNS cache updated refreshing each entry after N
+      seconds.
+
+      .. versionadded:: 2.0.8
 
    :param aiohttp.abc.AbstractResolver resolver: Custom resolver
       instance to use.  ``aiohttp.DefaultResolver`` by

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -397,7 +397,7 @@ def test_tcp_connector_resolve_host_twice_dns_cache_expired(loop):
     )
 
     res = yield from conn._resolve_host('localhost', 8080)
-    yield from asyncio.sleep(0.2)
+    yield from asyncio.sleep(0.2, loop=loop)
     res2 = yield from conn._resolve_host('localhost', 8080)
 
     assert res is not res2

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -345,7 +345,7 @@ def test_release_close(loop):
 
 
 @asyncio.coroutine
-def test_tcp_connector_resolve_host_use_dns_cache(loop):
+def test_tcp_connector_resolve_host(loop):
     conn = aiohttp.TCPConnector(loop=loop, use_dns_cache=True)
 
     res = yield from conn._resolve_host('localhost', 8080)
@@ -365,21 +365,11 @@ def test_tcp_connector_resolve_host_use_dns_cache(loop):
 
 
 @asyncio.coroutine
-def test_tcp_connector_resolve_host_twice_use_dns_cache(loop):
-    conn = aiohttp.TCPConnector(loop=loop, use_dns_cache=True)
-
-    res = yield from conn._resolve_host('localhost', 8080)
-    res2 = yield from conn._resolve_host('localhost', 8080)
-
-    assert res is res2
-
-
-@asyncio.coroutine
-def test_tcp_connector_resolve_host_twice_dns_cache_not_expired(loop):
+def test_tcp_connector_dns_cache_not_expired(loop):
     conn = aiohttp.TCPConnector(
         loop=loop,
         use_dns_cache=True,
-        ttl_dns_cache=60
+        ttl_dns_cache=10
     )
 
     res = yield from conn._resolve_host('localhost', 8080)
@@ -389,19 +379,26 @@ def test_tcp_connector_resolve_host_twice_dns_cache_not_expired(loop):
 
 
 @asyncio.coroutine
-def test_tcp_connector_resolve_host_twice_dns_cache_expired(loop):
+def test_tcp_connector_dns_cache_forever(loop):
     conn = aiohttp.TCPConnector(
         loop=loop,
         use_dns_cache=True,
-        ttl_dns_cache=0.1
+        ttl_dns_cache=None
     )
 
     res = yield from conn._resolve_host('localhost', 8080)
-    yield from asyncio.sleep(0.2, loop=loop)
+    res2 = yield from conn._resolve_host('localhost', 8080)
+    assert res is res2
+
+
+@asyncio.coroutine
+def test_tcp_connector_use_dns_cache_disabled(loop):
+    conn = aiohttp.TCPConnector(loop=loop, use_dns_cache=False)
+
+    res = yield from conn._resolve_host('localhost', 8080)
     res2 = yield from conn._resolve_host('localhost', 8080)
 
     assert res is not res2
-    assert res == res2
 
 
 def test_get_pop_empty_conns(loop):


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Before submit your Pull Request, make sure you picked
     the right branch:

     - If you propose a new feature or improvement, select "master"
       as a target branch;
     - If this is a bug fix or documentation amendment, select
       the latest release branch (which looks like "0.xx") -->

## What do these changes do?

Add a new option to expire DNS cached entries at some point, this will avoid having invalid DNS entries for those environments where translations changes in some time policy.

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

By default it behaves as backward compatibility, entries are cached forever. Using the new `ttl_dns_cache` parameter the user can specify how many seconds a DNS entry will be keep into the table before to be refreshed. 

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [ ] Add a new entry to `CHANGES.rst`
  * Choose any open position to avoid merge conflicts with other PRs.
  * Add a link to the issue you are fixing (if any) using `#issue_number` format at the end of changelog message. Use Pull Request number if there are no issues for PR or PR covers the issue only partially.
