### PR TITLE
Proxy from environment variables

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,6 +23,8 @@ Changes
 
 - Avoid creating TimerContext when there is no timeout to allow compatibility with Tornado. #1817 #1180
 
+- Add `proxy_from_env` to `ClientRequest` to read from environment variables. #1791
+
 
 2.0.7 (2017-04-12)
 ------------------

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -109,6 +109,7 @@ Martin Melka
 Martin Richard
 Mathias Fröjdman
 Matthieu Hauglustaine
+Matthieu Rigal
 Michael Ihnatenko
 Mikhail Kashkin
 Mikhail Lukyanchenko

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -292,7 +292,10 @@ class ClientRequest:
         if expect:
             self._continue = helpers.create_future(self.loop)
 
-    def update_proxy(self, proxy, proxy_auth):
+    def update_proxy(self, proxy, proxy_auth, proxy_from_env):
+        if proxy_from_env and not proxy:
+            proxy_url = getproxies().get(self.original_url.scheme)
+            proxy = URL(proxy_url) if proxy_url else None
         if proxy and not proxy.scheme == 'http':
             raise ValueError("Only http proxies are supported")
         if proxy_auth and not isinstance(proxy_auth, helpers.BasicAuth):

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -6,6 +6,7 @@ import sys
 import traceback
 import warnings
 from http.cookies import CookieError, Morsel
+from urllib.request import getproxies
 
 from multidict import CIMultiDict, CIMultiDictProxy, MultiDict, MultiDictProxy
 from yarl import URL
@@ -63,7 +64,8 @@ class ClientRequest:
                  auth=None, version=http.HttpVersion11, compress=None,
                  chunked=None, expect100=False,
                  loop=None, response_class=None,
-                 proxy=None, proxy_auth=None, timer=None):
+                 proxy=None, proxy_auth=None, proxy_from_env=None,
+                 timer=None):
 
         if loop is None:
             loop = asyncio.get_event_loop()
@@ -96,7 +98,7 @@ class ClientRequest:
         self.update_cookies(cookies)
         self.update_content_encoding(data)
         self.update_auth(auth)
-        self.update_proxy(proxy, proxy_auth)
+        self.update_proxy(proxy, proxy_auth, proxy_from_env)
 
         self.update_body_from_data(data, skip_auto_headers)
         self.update_transfer_encoding()

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -64,7 +64,7 @@ class ClientRequest:
                  auth=None, version=http.HttpVersion11, compress=None,
                  chunked=None, expect100=False,
                  loop=None, response_class=None,
-                 proxy=None, proxy_auth=None, proxy_from_env=None,
+                 proxy=None, proxy_auth=None, proxy_from_env=False,
                  timer=None):
 
         if loop is None:

--- a/docs/client.rst
+++ b/docs/client.rst
@@ -555,7 +555,17 @@ aiohttp supports proxy. You have to use
                               proxy="http://some.proxy.com") as resp:
            print(resp.status)
 
-it also supports proxy authorization::
+Contrary to the ``requests`` library, it won't read environment variables by
+default. But you can do so by setting :attr:`proxy_from_env` to True.
+It will use the ``getproxies()`` method from ``urllib`` and thus read the
+value of the ``$url-scheme_proxy`` variable::
+
+   async with aiohttp.ClientSession() as session:
+       async with session.get("http://python.org",
+                              proxy_from_env=True) as resp:
+           print(resp.status)
+
+It also supports proxy authorization::
 
    async with aiohttp.ClientSession() as session:
        proxy_auth = aiohttp.BasicAuth('user', 'pass')

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -547,9 +547,49 @@ class TestProxy(unittest.TestCase):
     @mock.patch.dict(os.environ, {'https_proxy': 'http://proxy.example.com'})
     @mock.patch('aiohttp.connector.ClientRequest')
     def test_connect_env_var_https_used(self, ClientRequestMock):
+        proxy_req = ClientRequest('GET', URL('http://proxy.example.com'),
+                                  loop=self.loop)
+        ClientRequestMock.return_value = proxy_req
+
+        proxy_resp = ClientResponse('get', URL('http://proxy.example.com'))
+        proxy_resp._loop = self.loop
+        proxy_req.send = send_mock = mock.Mock()
+        send_mock.return_value = proxy_resp
+        proxy_resp.start = make_mocked_coro(mock.Mock(status=200))
+
+        connector = aiohttp.TCPConnector(loop=self.loop)
+        connector._resolve_host = make_mocked_coro(
+            [{'hostname': 'hostname', 'host': '127.0.0.1', 'port': 80,
+              'family': socket.AF_INET, 'proto': 0, 'flags': 0}])
+
+        tr, proto = mock.Mock(), mock.Mock()
+        self.loop.create_connection = make_mocked_coro((tr, proto))
+
         req = ClientRequest(
             'GET', URL('https://www.python.org'),
             proxy_from_env=True,
+            loop=self.loop,
+        )
+        self.loop.run_until_complete(connector._create_connection(req))
+
+        self.assertEqual(req.url.path, '/')
+        self.assertEqual(proxy_req.method, 'CONNECT')
+        self.assertEqual(proxy_req.url, URL('https://www.python.org'))
+        tr.close.assert_called_once_with()
+        tr.get_extra_info.assert_called_with('socket', default=None)
+
+        self.loop.run_until_complete(proxy_req.close())
+        proxy_resp.close()
+        self.loop.run_until_complete(req.close())
+        self.assertIn('https', getproxies())
+
+    @mock.patch.dict(os.environ, {'http_proxy': 'http://proxy23.example.com'})
+    @mock.patch('aiohttp.connector.ClientRequest')
+    def test_connect_env_var_not_overwriting(self, ClientRequestMock):
+        req = ClientRequest(
+            'GET', URL('http://www.python.org'),
+            proxy_from_env=True,
+            proxy=URL('http://proxy.example.com'),
             loop=self.loop
         )
         self.assertEqual(str(req.proxy), 'http://proxy.example.com')
@@ -571,4 +611,4 @@ class TestProxy(unittest.TestCase):
             auth=None,
             headers={'Host': 'www.python.org'},
             loop=self.loop)
-        self.assertIn('https', getproxies())
+        self.assertIn('http', getproxies())


### PR DESCRIPTION
## What do these changes do?

Allows optional reading proxy from environment variables. Addresses #1791 #529 and #102

## Are there changes in behavior for the user?

They can use proxy from environment variables like in requests, even if it is disabled by default here

## Related issue number

Resolving open issue #1791

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new entry to `CHANGES.rst`
  * Choose any open position to avoid merge conflicts with other PRs.
  * Add a link to the issue you are fixing (if any) using `#issue_number` format at the end of changelog message. Use Pull Request number if there are no issues for PR or PR covers the issue only partially.