### PR TITLE
Add DummyCookieJar helper

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -25,6 +25,8 @@ Changes
 
 - Add `proxy_from_env` to `ClientRequest` to read from environment variables. #1791
 
+- Add DummyCookieJar helper. #1830
+
 
 2.0.7 (2017-04-12)
 ------------------

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -150,6 +150,7 @@ Sviatoslav Bulbakha
 Taha Jahangir
 Taras Voinarovskyi
 Terence Honles
+Thanos Lefteris
 Thomas Grainger
 Tolga Tezel
 Vaibhav Sagar

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -22,6 +22,7 @@ from urllib.parse import quote
 from async_timeout import timeout
 
 from . import hdrs
+from .abc import AbstractCookieJar
 
 try:
     from asyncio import ensure_future
@@ -39,7 +40,7 @@ else:
 
 
 __all__ = ('BasicAuth', 'create_future', 'parse_mimetype',
-           'Timeout', 'ensure_future', 'noop')
+           'Timeout', 'ensure_future', 'noop', 'DummyCookieJar')
 
 
 sentinel = object()
@@ -762,3 +763,30 @@ class HeadersMixin:
             return None
         else:
             return int(l)
+
+
+class DummyCookieJar(AbstractCookieJar):
+    """Implements a dummy cookie storage.
+
+    It can be used with the ClientSession when no cookie processing is needed.
+
+    """
+
+    def __init__(self, *, loop=None):
+        super().__init__(loop=loop)
+
+    def __iter__(self):
+        while False:
+            yield None
+
+    def __len__(self):
+        return 0
+
+    def clear(self):
+        pass
+
+    def update_cookies(self, cookies, response_url=None):
+        pass
+
+    def filter_cookies(self, request_url):
+        return None

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -99,6 +99,9 @@ The client session supports the context manager protocol for self closing.
       One example is not processing cookies at all when working in
       proxy mode.
 
+      If no cookie processing is needed, a :class:`aiohttp.helpers.DummyCookieJar`
+      instance can be provided.
+
       .. versionadded:: 0.22
 
    :param callable json_serialize: Json `serializer` function. (:func:`json.dumps` by default)

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -5,6 +5,7 @@ import sys
 from unittest import mock
 
 import pytest
+from yarl import URL
 
 from aiohttp import helpers
 
@@ -533,3 +534,15 @@ def test_set_content_disposition_bad_param():
     with pytest.raises(ValueError):
         helpers.content_disposition_header('inline',
                                            **{'foo\x00bar': 'baz'})
+
+
+def test_dummy_cookie_jar(loop):
+    cookie = helpers.SimpleCookie('foo=bar; Domain=example.com;')
+    dummy_jar = helpers.DummyCookieJar(loop=loop)
+    assert len(dummy_jar) == 0
+    dummy_jar.update_cookies(cookie)
+    assert len(dummy_jar) == 0
+    with pytest.raises(StopIteration):
+        next(iter(dummy_jar))
+    assert dummy_jar.filter_cookies(URL("http://example.com/")) is None
+    dummy_jar.clear()


### PR DESCRIPTION
## What do these changes do?

Adds a `DummyCookieJar` class in the helpers module. It's a no-op cookie storage that can be used with ClientSession when cookie processing is not needed.

## Are there changes in behavior for the user?

No.

## Related issue number

There was [an issue comment](https://github.com/aio-libs/aiohttp/issues/1029#issuecomment-237010794) that encouraged this contribution.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new entry to `CHANGES.rst`
  * Choose any open position to avoid merge conflicts with other PRs.
  * Add a link to the issue you are fixing (if any) using `#issue_number` format at the end of changelog message. Use Pull Request number if there are no issues for PR or PR covers the issue only partially.
