### PR TITLE
Fix noop for python 3.4

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,6 +27,8 @@ Changes
 
 - Add DummyCookieJar helper. #1830
 
+- Fix assertion errors in Python 3.4 from noop helper. #1847
+
 
 2.0.7 (2017-04-12)
 ------------------

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -53,34 +53,22 @@ SEPARATORS = {'(', ')', '<', '>', '@', ',', ';', ':', '\\', '"', '/', '[', ']',
               '?', '=', '{', '}', ' ', chr(9)}
 TOKEN = CHAR ^ CTL ^ SEPARATORS
 
+coroutines = asyncio.coroutines
+old_debug = coroutines._DEBUG
+coroutines._DEBUG = False
 
-if sys.version_info < (3, 5):  # pragma: no cover
-    noop = tuple
 
-    coroutines = asyncio.coroutines
-    old_debug = coroutines._DEBUG
-    coroutines._DEBUG = False
+@asyncio.coroutine
+def noop(*args, **kwargs):
+    return
 
-    @asyncio.coroutine
-    def deprecated_noop(message):
-        warnings.warn(message, DeprecationWarning, stacklevel=3)
 
-    coroutines._DEBUG = old_debug
+@asyncio.coroutine
+def deprecated_noop(message):
+    warnings.warn(message, DeprecationWarning, stacklevel=3)
 
-else:
-    coroutines = asyncio.coroutines
-    old_debug = coroutines._DEBUG
-    coroutines._DEBUG = False
 
-    @asyncio.coroutine
-    def noop(*args, **kwargs):
-        return
-
-    @asyncio.coroutine
-    def deprecated_noop(message):
-        warnings.warn(message, DeprecationWarning, stacklevel=3)
-
-    coroutines._DEBUG = old_debug
+coroutines._DEBUG = old_debug
 
 
 class BasicAuth(namedtuple('BasicAuth', ['login', 'password', 'encoding'])):

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -124,6 +124,7 @@ namespace
 nginx
 Nginx
 Nikolay
+noop
 nowait
 optimizations
 os


### PR DESCRIPTION
## What do these changes do?

This change switches the `noop` helper in python 3.4 from returning a tuple to returning an empty coroutine. Python 3.4 supports the coroutine decorator syntax, so I'm not sure why this was done differently to begin with. The current code is causing assertion errors when the coroutine is passed to loop.create_task.

After this change both branches were the same, so the branching is removed.

## Are there changes in behavior for the user?

No

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new entry to `CHANGES.rst`
  * Choose any open position to avoid merge conflicts with other PRs.
  * Add a link to the issue you are fixing (if any) using `#issue_number` format at the end of changelog message. Use Pull Request number if there are no issues for PR or PR covers the issue only partially.
