### PR TITLE
Fix documentation and remove sign 'coroutine' where it is deprecated

### DIFF
--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -483,7 +483,7 @@ The client session supports the context manager protocol for self closing.
 
       Release all acquired resources.
 
-      ..versionchanged:: 2.0
+      .. versionchanged:: 2.0
 
    .. method:: detach()
 

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -482,8 +482,8 @@ The client session supports the context manager protocol for self closing.
       Close underlying connector.
 
       Release all acquired resources.
-      
-      ..versionchanged:: 2.0.7
+
+      ..versionchanged:: 2.0
 
    .. method:: detach()
 
@@ -1170,9 +1170,9 @@ manually.
       :raise TypeError: if value returned by ``dumps(data)`` is not
                         :class:`str`
 
-   .. method:: close(*, code=1000, message=b'')
+   .. comethod:: close(*, code=1000, message=b'')
 
-      A method that initiates closing handshake by sending
+      A :ref:`coroutine<coroutine>` that initiates closing handshake by sending
       :const:`~aiohttp.WSMsgType.CLOSE` message. It waits for
       close response from server. To add a timeout to `close()` call
       just wrap the call with `asyncio.wait()` or `asyncio.wait_for()`.
@@ -1181,8 +1181,6 @@ manually.
 
       :param message: optional payload of *pong* message,
          :class:`str` (converted to *UTF-8* encoded bytes) or :class:`bytes`.
-      
-      ..versionchanged:: 2.0.7
 
    .. comethod:: receive()
 

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -482,6 +482,8 @@ The client session supports the context manager protocol for self closing.
       Close underlying connector.
 
       Release all acquired resources.
+      
+      ..versionchanged:: 2.0.7
 
    .. method:: detach()
 
@@ -1179,6 +1181,8 @@ manually.
 
       :param message: optional payload of *pong* message,
          :class:`str` (converted to *UTF-8* encoded bytes) or :class:`bytes`.
+      
+      ..versionchanged:: 2.0.7
 
    .. comethod:: receive()
 

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -477,7 +477,7 @@ The client session supports the context manager protocol for self closing.
 
          URLs may be either :class:`str` or :class:`~yarl.URL`
 
-   .. comethod:: close()
+   .. method:: close()
 
       Close underlying connector.
 
@@ -1168,12 +1168,12 @@ manually.
       :raise TypeError: if value returned by ``dumps(data)`` is not
                         :class:`str`
 
-   .. comethod:: close(*, code=1000, message=b'')
+   .. method:: close(*, code=1000, message=b'')
 
-      A :ref:`coroutine<coroutine>` that initiates closing handshake by sending
+      A method that initiates closing handshake by sending
       :const:`~aiohttp.WSMsgType.CLOSE` message. It waits for
-      close response from server. It add timeout to `close()` call just wrap
-      call with `asyncio.wait()` or `asyncio.wait_for()`.
+      close response from server. To add a timeout to `close()` call
+      just wrap the call with `asyncio.wait()` or `asyncio.wait_for()`.
 
       :param int code: closing code
 


### PR DESCRIPTION
Closes https://github.com/aio-libs/aiohttp/issues/1851.

<!-- Thank you for your contribution!

     Before submit your Pull Request, make sure you picked
     the right branch:

     - If you propose a new feature or improvement, select "master"
       as a target branch;
     - If this is a bug fix or documentation amendment, select
       the latest release branch (which looks like "0.xx") -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
Fixes the documentation on the close function for new users to know it is not a coroutine.

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->
No, it just lets them know that close is a normal function.

## Related issue number
#1851 

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [x] Documentation reflects the changes
- [ ] Add a new entry to `CHANGES.rst`
  * Choose any open position to avoid merge conflicts with other PRs.
  * Add a link to the issue you are fixing (if any) using `#issue_number` format at the end of changelog message. Use Pull Request number if there are no issues for PR or PR covers the issue only partially.
