### PR TITLE
Use istr from multidict (rename of upstr)

### DIFF
--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -81,7 +81,7 @@ The client session supports the context manager protocol for self closing.
       that generation. Note that ``Content-Length`` autogeneration can't
       be skipped.
 
-      Iterable of :class:`str` or :class:`~aiohttp.upstr` (optional)
+      Iterable of :class:`str` or :class:`~aiohttp.istr` (optional)
 
    :param aiohttp.BasicAuth auth: an object that represents HTTP Basic
                                   Authorization (optional)
@@ -208,7 +208,7 @@ The client session supports the context manager protocol for self closing.
          passed. Using ``skip_auto_headers`` parameter allows to skip
          that generation.
 
-         Iterable of :class:`str` or :class:`~aiohttp.upstr`
+         Iterable of :class:`str` or :class:`~aiohttp.istr`
          (optional)
 
       :param aiohttp.BasicAuth auth: an object that represents HTTP

--- a/tests/test_client_request.py
+++ b/tests/test_client_request.py
@@ -8,7 +8,7 @@ import zlib
 from unittest import mock
 
 import pytest
-from multidict import CIMultiDict, CIMultiDictProxy, upstr
+from multidict import CIMultiDict, CIMultiDictProxy, istr
 from yarl import URL
 
 import aiohttp
@@ -257,7 +257,7 @@ def test_default_headers_useragent_custom(make_request):
 
 def test_skip_default_useragent_header(make_request):
     req = make_request('get', 'http://python.org/',
-                       skip_auto_headers=set([upstr('user-agent')]))
+                       skip_auto_headers=set([istr('user-agent')]))
 
     assert 'User-Agent' not in req.headers
 


### PR DESCRIPTION
## What do these changes do?

Use `istr` in docs and other places instead of `upstr`. `upstr` has been renamed to `istr` since multidict 2.0.

The rename in multidict is backwards compatible, but it would be nice to use the renamed one in aiohttp docs.

## Are there changes in behavior for the user?

No.

## Related issue number

None.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [ ] Add a new entry to `CHANGES.rst`
  * Choose any open position to avoid merge conflicts with other PRs.
  * Add a link to the issue you are fixing (if any) using `#issue_number` format at the end of changelog message. Use Pull Request number if there are no issues for PR or PR covers the issue only partially.
