### PR TITLE
Docs - Remove version param from session.request(), fixes #1856

### DIFF
--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -163,7 +163,7 @@ The client session supports the context manager protocol for self closing.
    .. comethod:: request(method, url, *, params=None, data=None, json=None,\
                          headers=None, skip_auto_headers=None, \
                          auth=None, allow_redirects=True,\
-                         max_redirects=10, version=HttpVersion(major=1, minor=1),\
+                         max_redirects=10,\
                          compress=None, chunked=None, expect100=False,\
                          read_until_eof=True, proxy=None, proxy_auth=None,\
                          timeout=5*60)
@@ -216,9 +216,6 @@ The client session supports the context manager protocol for self closing.
 
       :param bool allow_redirects: If set to ``False``, do not follow redirects.
                                    ``True`` by default (optional).
-
-      :param aiohttp.protocol.HttpVersion version: Request HTTP version
-                                                   (optional)
 
       :param bool compress: Set to ``True`` if request has to be compressed
          with deflate encoding. If `compress` can not be combined


### PR DESCRIPTION
## What do these changes do?

Removes from client ref docs the `version` param from `session.request()`, as it doesn't exist.

## Are there changes in behavior for the user?

No.

## Related issue number

#1856 

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [ ] Add a new entry to `CHANGES.rst`
  * Choose any open position to avoid merge conflicts with other PRs.
  * Add a link to the issue you are fixing (if any) using `#issue_number` format at the end of changelog message. Use Pull Request number if there are no issues for PR or PR covers the issue only partially.
