### PR TITLE
fix Issue #1861: Client request timeout parameters are inconsistent

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -170,6 +170,7 @@ Willem de Groot
 Wilson Ong
 Yannick Koechlin
 Young-Ho Cha
+Yuriy Shatrov
 Yury Selivanov
 Yusuke Tsutsumi
 Марк Коренберг

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -111,9 +111,10 @@ The client session supports the context manager protocol for self closing.
 
       .. versionadded:: 2.0
 
-   :param float read_timeout: Request operations timeout. read_timeout is
+   :param float read_timeout: Request operations timeout. ``read_timeout`` is
       cumulative for all request operations (request, redirects, responses,
-      data consuming)
+      data consuming). By default, the read timeout is 5*60 seconds.
+      Use ``None`` or ``0`` to disable timeout checks.
 
    :param float conn_timeout: timeout for connection establishing
       (optional). Values ``0`` or ``None`` mean no timeout.
@@ -240,8 +241,7 @@ The client session supports the context manager protocol for self closing.
       :param aiohttp.BasicAuth proxy_auth: an object that represents proxy HTTP
                                            Basic Authorization (optional)
 
-      :param int timeout: a timeout for IO operations, 5min by default.
-                          Use ``None`` or ``0`` to disable timeout checks.
+      :param int timeout: override the session's timeout (``read_timeout``) for IO operations.
 
       :return ClientResponse: a :class:`client response <ClientResponse>` object.
 
@@ -714,7 +714,7 @@ TCPConnector
         server presents matches. Useful for `certificate pinning
         <https://en.wikipedia.org/wiki/Transport_Layer_Security#Certificate_pinning>`_.
 
-        Note: use of MD5 or SHA1 digests is insecure and deprecated. 
+        Note: use of MD5 or SHA1 digests is insecure and deprecated.
 
         .. versionadded:: 0.16
 
@@ -735,7 +735,7 @@ TCPConnector
       means cached forever. By default 10 seconds.
 
       By default DNS entries are cached forever, in some environments the IP
-      addresses related to a specific HOST can change after a specific time. Use 
+      addresses related to a specific HOST can change after a specific time. Use
       this option to keep the DNS cache updated refreshing each entry after N
       seconds.
 
@@ -1372,7 +1372,7 @@ Hierarchy of exceptions:
     - `aiohttp.ClientOSError` - subset of connection errors that are initiated by an OSError exception
 
       - `aiohttp.ClientConnectorError` - connector related exceptions
- 
+
          - `aiohttp.ClientProxyConnectionError` - proxy connection initialization error
 
     - `aiohttp.ServerConnectionError` - server connection related errors

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -635,7 +635,7 @@ def test_timeout_on_session_read_timeout(loop, test_client, mocker):
     client = yield from test_client(app, connector=conn, read_timeout=0.01)
 
     with pytest.raises(asyncio.TimeoutError):
-        yield from client.get('/', timeout=None)
+        yield from client.get('/')
 
 
 @asyncio.coroutine


### PR DESCRIPTION
## What do these changes do?

Use sentinel (instead of `None`) for checking the timeout arguments passed.

aiohttp/client.py:
* ClientSession.__init__():
  * set the `read_timeout` argument default value to `sentinel`
  * if it is equal to `sentinel` during the call, set it to the value of `DEFAULT_TIMEOUT`
* ClientSession._request():
  * set the `timeout` argument default value to `sentinel`
  * if it is equal to `sentinel` during the call, set it to the value of `self.read_timeout`

Update documentation to match the consistent usage of timeouts.
Update tests (excluding the confusing `timeout=None` argument usage).

## Are there changes in behavior for the user?

* The `read_timeout` argument to `ClientSession` constructor, when omitted, now defaults to `DEFAULT_TIMEOUT` which is 5 min, and not to `None` which is no timeout. 
* The `timeout` argument should be omitted in session's `request()` methods in order to use the session's `read_timeout`.
* The `timeout` argument explicitly passed as `None` to session's `request()` methods now disables the request timeout instead of resulting in the session's `read_timeout` being used.

## Related issue number

Issue #1861  Client request timeout parameters are inconsistent

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [ ] Add a new entry to `CHANGES.rst`
  * Choose any open position to avoid merge conflicts with other PRs.
  * Add a link to the issue you are fixing (if any) using `#issue_number` format at the end of changelog message. Use Pull Request number if there are no issues for PR or PR covers the issue only partially.
