### PR TITLE
Add a parameter to optionally not close loop on exit

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Changes
 2.1.0 (2017-xx-xx)
 ------------------
 
-- Add `close_loop` option to `run_app`. Useful for allowing clients to specify their own cleanup before closing the asyncio loop
+- Only call `loop.close` in `run_app` if the user did *not* supply a loop.  Useful for allowing clients to specify their own cleanup before closing the asyncio loop if they wish to tightly control loop behavior
 
 - Content disposition with semicolon in filename #917
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,8 @@ Changes
 2.1.0 (2017-xx-xx)
 ------------------
 
+- Add `close_loop` option to `run_app`. Useful for allowing clients to specify their own cleanup before closing the asyncio loop
+
 - Content disposition with semicolon in filename #917
 
 - Added `request_info` to response object and `ClientResponseError`. #1733

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -56,6 +56,7 @@ Dmitry Trofimov
 Dmytro Kuznetsov
 Dustin J. Mitchell
 Eduard Iskandarov
+Eli Ribble
 Elizabeth Leddy
 Enrique Saez
 Erich Healy

--- a/aiohttp/web.py
+++ b/aiohttp/web.py
@@ -313,8 +313,9 @@ class Application(MutableMapping):
 def run_app(app, *, host=None, port=None, path=None, sock=None,
             shutdown_timeout=60.0, ssl_context=None,
             print=print, backlog=128, access_log_format=None,
-            access_log=access_logger, loop=None, close_loop=True):
+            access_log=access_logger, loop=None):
     """Run an app locally"""
+    user_supplied_loop = loop is not None
     if loop is None:
         loop = asyncio.get_event_loop()
 
@@ -421,7 +422,7 @@ def run_app(app, *, host=None, port=None, path=None, sock=None,
         loop.run_until_complete(app.shutdown())
         loop.run_until_complete(handler.shutdown(shutdown_timeout))
         loop.run_until_complete(app.cleanup())
-    if close_loop:
+    if not user_supplied_loop:
         loop.close()
 
 

--- a/aiohttp/web.py
+++ b/aiohttp/web.py
@@ -313,7 +313,7 @@ class Application(MutableMapping):
 def run_app(app, *, host=None, port=None, path=None, sock=None,
             shutdown_timeout=60.0, ssl_context=None,
             print=print, backlog=128, access_log_format=None,
-            access_log=access_logger, loop=None):
+            access_log=access_logger, loop=None, close_loop=True):
     """Run an app locally"""
     if loop is None:
         loop = asyncio.get_event_loop()
@@ -421,7 +421,8 @@ def run_app(app, *, host=None, port=None, path=None, sock=None,
         loop.run_until_complete(app.shutdown())
         loop.run_until_complete(handler.shutdown(shutdown_timeout))
         loop.run_until_complete(app.cleanup())
-    loop.close()
+    if close_loop:
+        loop.close()
 
 
 def main(argv):


### PR DESCRIPTION
The issue here is that some clients, like me, may have other cleanup
they need to do to gracefully shut down other coroutines outside of the
aiohttp server request handler coroutines. Because run_app closes the
loop those coroutines that are running the same loop but are outside of
aiohttp's control will immediately emit ugly stack traces because they
are attempting to continue operating on a closed loop.

By adding a parameter that controls closing the loop clients like me can
simply disable closing the loop and do our own additional cleanup before
closing the loop ourselves

<!-- Thank you for your contribution!

     Before submit your Pull Request, make sure you picked
     the right branch:

     - If you propose a new feature or improvement, select "master"
       as a target branch;
     - If this is a bug fix or documentation amendment, select
       the latest release branch (which looks like "0.xx") -->

## What do these changes do?

Allow users to disable closing the event loop on KeyboardInterrupt

## Are there changes in behavior for the user?

No, the default behavior remains the same, it just gives users the option, if they want it, of changing the behavior

## Related issue number

No

## Checklist

- [x] I think the code is well written
- [] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [X] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [X] Add a new entry to `CHANGES.rst`
  * Choose any open position to avoid merge conflicts with other PRs.
  * Add a link to the issue you are fixing (if any) using `#issue_number` format at the end of changelog message. Use Pull Request number if there are no issues for PR or PR covers the issue only partially.
