### PR TITLE
Fix note block wording and position

### DIFF
--- a/docs/client.rst
+++ b/docs/client.rst
@@ -119,12 +119,6 @@ You can also access the response body as bytes, for non-text requests::
 The ``gzip`` and ``deflate`` transfer-encodings are automatically
 decoded for you.
 
-.. note::
-
-   This methods reads whole response body into memory. If you are planing
-   planing to read a lot of data consider to use streaming response.
-
-
 JSON Response Content
 ---------------------
 
@@ -136,6 +130,12 @@ There's also a built-in JSON decoder, in case you're dealing with JSON data::
 In case that JSON decoding fails, :meth:`~ClientResponse.json` will
 raise an exception. It is possible to specify custom encoding and
 decoder functions for the :meth:`~ClientResponse.json` call.
+
+.. note::
+
+    The methods above reads the whole response body into memory. If you are
+    planning on reading lots of data, consider using the streaming response
+    method documented below.
 
 
 Streaming Response Content


### PR DESCRIPTION
Fix wording of the note block instructing users to use the streaming response if lots of data is going to be read; move it down a notch for better positioning and making it less confusion-prone.
