### PR TITLE
Fix examples/docs for websocket send commands being a coroutine

### DIFF
--- a/demos/chat/aiohttpdemo_chat/views.py
+++ b/demos/chat/aiohttpdemo_chat/views.py
@@ -19,11 +19,11 @@ async def index(request):
     name = (random.choice(string.ascii_uppercase) +
             ''.join(random.sample(string.ascii_lowercase*10, 10)))
     log.info('%s joined.', name)
-    resp.send_str(json.dumps({'action': 'connect',
-                              'name': name}))
+    await resp.send_str(json.dumps({'action': 'connect',
+                                    'name': name}))
     for ws in request.app['sockets'].values():
-        ws.send_str(json.dumps({'action': 'join',
-                                'name': name}))
+        await ws.send_str(json.dumps({'action': 'join',
+                                      'name': name}))
     request.app['sockets'][name] = resp
 
     while True:
@@ -32,17 +32,17 @@ async def index(request):
         if msg.type == web.MsgType.text:
             for ws in request.app['sockets'].values():
                 if ws is not resp:
-                    ws.send_str(json.dumps({'action': 'sent',
-                                            'name': name,
-                                            'text': msg.data}))
+                    await ws.send_str(json.dumps({'action': 'sent',
+                                                  'name': name,
+                                                  'text': msg.data}))
         else:
             break
 
     del request.app['sockets'][name]
     log.info('%s disconnected.', name)
     for ws in request.app['sockets'].values():
-        ws.send_str(json.dumps({'action': 'disconnect',
-                                'name': name}))
+        await ws.send_str(json.dumps({'action': 'disconnect',
+                                      'name': name}))
     return resp
 
 

--- a/docs/client.rst
+++ b/docs/client.rst
@@ -699,7 +699,7 @@ methods::
                    await ws.close()
                    break
                else:
-                   ws.send_str(msg.data + '/answer')
+                   await ws.send_str(msg.data + '/answer')
            elif msg.type == aiohttp.WSMsgType.CLOSED:
                break
            elif msg.type == aiohttp.WSMsgType.ERROR:

--- a/docs/web.rst
+++ b/docs/web.rst
@@ -676,7 +676,7 @@ with the peer::
                 if msg.data == 'close':
                     await ws.close()
                 else:
-                    ws.send_str(msg.data + '/answer')
+                    await ws.send_str(msg.data + '/answer')
             elif msg.type == aiohttp.WSMsgType.ERROR:
                 print('ws connection closed with exception %s' %
                       ws.exception())

--- a/examples/background_tasks.py
+++ b/examples/background_tasks.py
@@ -31,7 +31,7 @@ async def listen_to_redis(app):
         async for msg in ch.iter(encoding='utf-8'):
             # Forward message to all connected websockets:
             for ws in app['websockets']:
-                ws.send_str('{}: {}'.format(ch.name, msg))
+                await ws.send_str('{}: {}'.format(ch.name, msg))
             print("message in {}: {}".format(ch.name, msg))
     except asyncio.CancelledError:
         pass

--- a/examples/web_ws.py
+++ b/examples/web_ws.py
@@ -23,14 +23,14 @@ async def wshandler(request):
     try:
         print('Someone joined.')
         for ws in request.app['sockets']:
-            ws.send_str('Someone joined')
+            await ws.send_str('Someone joined')
         request.app['sockets'].append(resp)
 
         async for msg in resp:
             if msg.type == WSMsgType.TEXT:
                 for ws in request.app['sockets']:
                     if ws is not resp:
-                        ws.send_str(msg.data)
+                        await ws.send_str(msg.data)
             else:
                 return resp
         return resp
@@ -39,7 +39,7 @@ async def wshandler(request):
         request.app['sockets'].remove(resp)
         print('Someone disconnected.')
         for ws in request.app['sockets']:
-            ws.send_str('Someone disconnected.')
+            await ws.send_str('Someone disconnected.')
 
 
 async def on_shutdown(app):

--- a/tests/autobahn/client.py
+++ b/tests/autobahn/client.py
@@ -19,9 +19,9 @@ def client(loop, url, name):
             msg = yield from ws.receive()
 
             if msg.type == aiohttp.WSMsgType.text:
-                ws.send_str(msg.data)
+                yield from ws.send_str(msg.data)
             elif msg.type == aiohttp.WSMsgType.binary:
-                ws.send_bytes(msg.data)
+                yield from ws.send_bytes(msg.data)
             elif msg.type == aiohttp.WSMsgType.close:
                 yield from ws.close()
                 break

--- a/tests/test_client_ws_functional.py
+++ b/tests/test_client_ws_functional.py
@@ -23,7 +23,7 @@ def test_send_recv_text(loop, test_client):
         yield from ws.prepare(request)
 
         msg = yield from ws.receive_str()
-        ws.send_str(msg+'/answer')
+        yield from ws.send_str(msg+'/answer')
         yield from ws.close()
         return ws
 
@@ -31,7 +31,7 @@ def test_send_recv_text(loop, test_client):
     app.router.add_route('GET', '/', handler)
     client = yield from test_client(app)
     resp = yield from client.ws_connect('/')
-    resp.send_str('ask')
+    yield from resp.send_str('ask')
 
     assert resp.get_extra_info('socket') is not None
 
@@ -51,7 +51,7 @@ def test_send_recv_bytes_bad_type(loop, test_client):
         yield from ws.prepare(request)
 
         msg = yield from ws.receive_str()
-        ws.send_str(msg+'/answer')
+        yield from ws.send_str(msg+'/answer')
         yield from ws.close()
         return ws
 
@@ -59,7 +59,7 @@ def test_send_recv_bytes_bad_type(loop, test_client):
     app.router.add_route('GET', '/', handler)
     client = yield from test_client(app)
     resp = yield from client.ws_connect('/')
-    resp.send_str('ask')
+    yield from resp.send_str('ask')
 
     with pytest.raises(TypeError):
         yield from resp.receive_bytes()
@@ -75,7 +75,7 @@ def test_send_recv_bytes(loop, test_client):
         yield from ws.prepare(request)
 
         msg = yield from ws.receive_bytes()
-        ws.send_bytes(msg+b'/answer')
+        yield from ws.send_bytes(msg+b'/answer')
         yield from ws.close()
         return ws
 
@@ -84,7 +84,7 @@ def test_send_recv_bytes(loop, test_client):
     client = yield from test_client(app)
     resp = yield from client.ws_connect('/')
 
-    resp.send_bytes(b'ask')
+    yield from resp.send_bytes(b'ask')
 
     data = yield from resp.receive_bytes()
     assert data == b'ask/answer'
@@ -101,7 +101,7 @@ def test_send_recv_text_bad_type(loop, test_client):
         yield from ws.prepare(request)
 
         msg = yield from ws.receive_bytes()
-        ws.send_bytes(msg+b'/answer')
+        yield from ws.send_bytes(msg+b'/answer')
         yield from ws.close()
         return ws
 
@@ -110,7 +110,7 @@ def test_send_recv_text_bad_type(loop, test_client):
     client = yield from test_client(app)
     resp = yield from client.ws_connect('/')
 
-    resp.send_bytes(b'ask')
+    yield from resp.send_bytes(b'ask')
 
     with pytest.raises(TypeError):
         yield from resp.receive_str()
@@ -127,7 +127,7 @@ def test_send_recv_json(loop, test_client):
         yield from ws.prepare(request)
 
         data = yield from ws.receive_json()
-        ws.send_json({'response': data['request']})
+        yield from ws.send_json({'response': data['request']})
         yield from ws.close()
         return ws
 
@@ -155,7 +155,7 @@ def test_ping_pong(loop, test_client):
 
         msg = yield from ws.receive_bytes()
         ws.ping()
-        ws.send_bytes(msg+b'/answer')
+        yield from ws.send_bytes(msg+b'/answer')
         try:
             yield from ws.close()
         finally:
@@ -168,7 +168,7 @@ def test_ping_pong(loop, test_client):
     resp = yield from client.ws_connect('/')
 
     resp.ping()
-    resp.send_bytes(b'ask')
+    yield from resp.send_bytes(b'ask')
 
     msg = yield from resp.receive()
     assert msg.type == aiohttp.WSMsgType.BINARY
@@ -193,7 +193,7 @@ def test_ping_pong_manual(loop, test_client):
 
         msg = yield from ws.receive_bytes()
         ws.ping()
-        ws.send_bytes(msg+b'/answer')
+        yield from ws.send_bytes(msg+b'/answer')
         try:
             yield from ws.close()
         finally:
@@ -206,7 +206,7 @@ def test_ping_pong_manual(loop, test_client):
     resp = yield from client.ws_connect('/', autoping=False)
 
     resp.ping()
-    resp.send_bytes(b'ask')
+    yield from resp.send_bytes(b'ask')
 
     msg = yield from resp.receive()
     assert msg.type == aiohttp.WSMsgType.PONG
@@ -233,7 +233,7 @@ def test_close(loop, test_client):
         yield from ws.prepare(request)
 
         yield from ws.receive_bytes()
-        ws.send_str('test')
+        yield from ws.send_str('test')
 
         yield from ws.receive()
         return ws
@@ -243,7 +243,7 @@ def test_close(loop, test_client):
     client = yield from test_client(app)
     resp = yield from client.ws_connect('/')
 
-    resp.send_bytes(b'ask')
+    yield from resp.send_bytes(b'ask')
 
     closed = yield from resp.close()
     assert closed
@@ -265,7 +265,7 @@ def test_concurrent_close(loop, test_client):
         yield from ws.prepare(request)
 
         yield from ws.receive_bytes()
-        ws.send_str('test')
+        yield from ws.send_str('test')
 
         yield from client_ws.close()
 
@@ -278,7 +278,7 @@ def test_concurrent_close(loop, test_client):
     client = yield from test_client(app)
     ws = client_ws = yield from client.ws_connect('/')
 
-    ws.send_bytes(b'ask')
+    yield from ws.send_bytes(b'ask')
 
     msg = yield from ws.receive()
     assert msg.type == aiohttp.WSMsgType.CLOSING
@@ -310,7 +310,7 @@ def test_close_from_server(loop, test_client):
     client = yield from test_client(app)
     resp = yield from client.ws_connect('/')
 
-    resp.send_bytes(b'ask')
+    yield from resp.send_bytes(b'ask')
 
     msg = yield from resp.receive()
     assert msg.type == aiohttp.WSMsgType.CLOSE
@@ -333,7 +333,7 @@ def test_close_manual(loop, test_client):
         yield from ws.prepare(request)
 
         yield from ws.receive_bytes()
-        ws.send_str('test')
+        yield from ws.send_str('test')
 
         try:
             yield from ws.close()
@@ -345,7 +345,7 @@ def test_close_manual(loop, test_client):
     app.router.add_route('GET', '/', handler)
     client = yield from test_client(app)
     resp = yield from client.ws_connect('/', autoclose=False)
-    resp.send_bytes(b'ask')
+    yield from resp.send_bytes(b'ask')
 
     msg = yield from resp.receive()
     assert msg.data == 'test'
@@ -369,7 +369,7 @@ def test_close_timeout(loop, test_client):
         ws = web.WebSocketResponse()
         yield from ws.prepare(request)
         yield from ws.receive_bytes()
-        ws.send_str('test')
+        yield from ws.send_str('test')
         yield from asyncio.sleep(1, loop=loop)
         return ws
 
@@ -378,7 +378,7 @@ def test_close_timeout(loop, test_client):
     client = yield from test_client(app)
     resp = yield from client.ws_connect('/', timeout=0.2, autoclose=False)
 
-    resp.send_bytes(b'ask')
+    yield from resp.send_bytes(b'ask')
 
     msg = yield from resp.receive()
     assert msg.data == 'test'
@@ -397,7 +397,7 @@ def test_close_cancel(loop, test_client):
         ws = web.WebSocketResponse()
         yield from ws.prepare(request)
         yield from ws.receive_bytes()
-        ws.send_str('test')
+        yield from ws.send_str('test')
         yield from asyncio.sleep(10, loop=loop)
 
     app = web.Application()
@@ -405,7 +405,7 @@ def test_close_cancel(loop, test_client):
     client = yield from test_client(app)
     resp = yield from client.ws_connect('/', autoclose=False)
 
-    resp.send_bytes(b'ask')
+    yield from resp.send_bytes(b'ask')
 
     text = yield from resp.receive()
     assert text.data == 'test'
@@ -449,7 +449,7 @@ def test_additional_headers(loop, test_client):
         ws = web.WebSocketResponse()
         yield from ws.prepare(request)
 
-        ws.send_str('answer')
+        yield from ws.send_str('answer')
         yield from ws.close()
         return ws
 
@@ -479,7 +479,7 @@ def test_recv_protocol_error(loop, test_client):
     app.router.add_route('GET', '/', handler)
     client = yield from test_client(app)
     resp = yield from client.ws_connect('/')
-    resp.send_str('ask')
+    yield from resp.send_str('ask')
 
     msg = yield from resp.receive()
     assert msg.type == aiohttp.WSMsgType.ERROR
@@ -508,7 +508,7 @@ def test_recv_timeout(loop, test_client):
     app.router.add_route('GET', '/', handler)
     client = yield from test_client(app)
     resp = yield from client.ws_connect('/')
-    resp.send_str('ask')
+    yield from resp.send_str('ask')
 
     with pytest.raises(asyncio.TimeoutError):
         with aiohttp.Timeout(0.01, loop=app.loop):

--- a/tests/test_py35/test_client_websocket_35.py
+++ b/tests/test_py35/test_client_websocket_35.py
@@ -11,7 +11,7 @@ async def test_client_ws_async_for(loop, test_client):
         ws = web.WebSocketResponse()
         await ws.prepare(request)
         for i in items:
-            ws.send_str(i)
+            await ws.send_str(i)
         await ws.close()
         return ws
 
@@ -36,7 +36,7 @@ async def test_client_ws_async_with(loop, test_server):
         ws = web.WebSocketResponse()
         await ws.prepare(request)
         msg = await ws.receive()
-        ws.send_str(msg.data + '/answer')
+        await ws.send_str(msg.data + '/answer')
         await ws.close()
         return ws
 
@@ -47,7 +47,7 @@ async def test_client_ws_async_with(loop, test_server):
 
     async with aiohttp.ClientSession(loop=loop) as client:
         async with client.ws_connect(server.make_url('/')) as ws:
-            ws.send_str('request')
+            await ws.send_str('request')
             msg = await ws.receive()
             assert msg.data == 'request/answer'
 
@@ -61,7 +61,7 @@ async def test_client_ws_async_with_send(loop, test_server):
         ws = web.WebSocketResponse()
         await ws.prepare(request)
         msg = await ws.receive()
-        ws.send_str(msg.data + '/answer')
+        await ws.send_str(msg.data + '/answer')
         await ws.close()
         return ws
 
@@ -85,7 +85,7 @@ async def test_client_ws_async_with_shortcut(loop, test_server):
         ws = web.WebSocketResponse()
         await ws.prepare(request)
         msg = await ws.receive()
-        ws.send_str(msg.data + '/answer')
+        await ws.send_str(msg.data + '/answer')
         await ws.close()
         return ws
 
@@ -95,7 +95,7 @@ async def test_client_ws_async_with_shortcut(loop, test_server):
 
     async with aiohttp.ClientSession(loop=loop) as client:
         async with client.ws_connect(server.make_url('/')) as ws:
-            ws.send_str('request')
+            await ws.send_str('request')
             msg = await ws.receive()
             assert msg.data == 'request/answer'
 
@@ -111,7 +111,7 @@ async def test_closed_async_for(loop, test_client):
         await ws.prepare(request)
 
         try:
-            ws.send_bytes(b'started')
+            await ws.send_bytes(b'started')
             await ws.receive_bytes()
         finally:
             closed.set_result(1)

--- a/tests/test_py35/test_web_websocket_35.py
+++ b/tests/test_py35/test_web_websocket_35.py
@@ -47,7 +47,7 @@ async def test_closed_async_for(loop, test_client):
         async for msg in ws:
             messages.append(msg)
             if 'stop' == msg.data:
-                ws.send_str('stopping')
+                await ws.send_str('stopping')
                 await ws.close()
 
         assert 1 == len(messages)
@@ -62,7 +62,7 @@ async def test_closed_async_for(loop, test_client):
     client = await test_client(app)
 
     ws = await client.ws_connect('/')
-    ws.send_str('stop')
+    await ws.send_str('stop')
     msg = await ws.receive()
     assert msg.type == WSMsgType.TEXT
     assert msg.data == 'stopping'

--- a/tests/test_test_utils.py
+++ b/tests/test_test_utils.py
@@ -30,7 +30,7 @@ def _create_example_app():
             if msg.data == 'close':
                 yield from ws.close()
             else:
-                ws.send_str(msg.data + '/answer')
+                yield from ws.send_str(msg.data + '/answer')
 
         return ws
 


### PR DESCRIPTION
## What do these changes do?

Version 1.3 made websocket send commands awaitable: b3c80ee3f7d5d8f0b8bc27afe52e4d46621eaf99. However that change did not update tests/examples. This PR finishes that work.

It went unnoticed because when a send method is called, the bytes are actually written to the socket and a coroutine is returned for the drain command.

Noticed it because setting `PYTHONASYNCIODEBUG` to 1 started printing errors about unawaited coroutines.

## Are there changes in behavior for the user?

No

## Related issue number

No

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [ ] Add a new entry to `CHANGES.rst`
  * Choose any open position to avoid merge conflicts with other PRs.
  * Add a link to the issue you are fixing (if any) using `#issue_number` format at the end of changelog message. Use Pull Request number if there are no issues for PR or PR covers the issue only partially.
