### PR TITLE
Start test server on socket instead of host/port pair.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -50,6 +50,7 @@ Changes
 
 - Fix static location in index when prefix is used #1662
 
+- Make test server more reliable #1896
 
 2.0.7 (2017-04-12)
 ------------------

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -72,6 +72,7 @@ Gregory Haynes
 Günther Jena
 Hu Bo
 Hugo Herter
+Igor Davydenko
 Igor Pavlov
 Ingmar Steen
 Jacob Champion

--- a/aiohttp/test_utils.py
+++ b/aiohttp/test_utils.py
@@ -56,7 +56,9 @@ class BaseTestServer(ABC):
         if self.server:
             return
         self._loop = loop
-        self.port = unused_port()
+        self._socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self._socket.bind((self.host, 0))
+        self.port = self._socket.getsockname()[1]
         self._ssl = kwargs.pop('ssl', None)
         if self.scheme is sentinel:
             if self._ssl:
@@ -70,7 +72,7 @@ class BaseTestServer(ABC):
 
         handler = yield from self._make_factory(**kwargs)
         self.server = yield from self._loop.create_server(
-            handler, self.host, self.port, ssl=self._ssl)
+            handler, ssl=self._ssl, sock=self._socket)
 
     @abstractmethod  # pragma: no cover
     @asyncio.coroutine


### PR DESCRIPTION
## What do these changes do?

Fix random `OSError` on running tests for aiohttp app on large amount of tests.

## Are there changes in behavior for the user?

Changes should just work for most of users. It's improvement of creating test server, by passing `sock` instead of `host` / `port` pair

## Related issue number

#1895

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new entry to `CHANGES.rst`
  * Choose any open position to avoid merge conflicts with other PRs.
  * Add a link to the issue you are fixing (if any) using `#issue_number` format at the end of changelog message. Use Pull Request number if there are no issues for PR or PR covers the issue only partially.
