### PR TITLE
Fix #1839: python 3.7 regression for regexp escaping

### DIFF
--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -29,6 +29,7 @@ __all__ = ('UrlDispatcher', 'UrlMappingMatchInfo',
            'StaticResource', 'View')
 
 HTTP_METHOD_RE = re.compile(r"^[0-9A-Za-z!#\$%&'\*\+\-\.\^_`\|~]+$")
+PATH_SEP = re.escape('/')
 
 
 class AbstractResource(Sized, Iterable):
@@ -328,7 +329,7 @@ class DynamicResource(Resource):
 
     def __init__(self, pattern, formatter, *, name=None):
         super().__init__(name=name)
-        assert pattern.pattern.startswith('\\/')
+        assert pattern.pattern.startswith(PATH_SEP)
         assert formatter.startswith('/')
         self._pattern = pattern
         self._formatter = formatter

--- a/tests/test_urldispatch.py
+++ b/tests/test_urldispatch.py
@@ -12,9 +12,10 @@ import aiohttp
 from aiohttp import hdrs, web
 from aiohttp.test_utils import make_mocked_request
 from aiohttp.web import HTTPMethodNotAllowed, HTTPNotFound, Response
-from aiohttp.web_urldispatcher import (AbstractResource, ResourceRoute,
-                                       SystemRoute, View,
-                                       _defaultExpectHandler)
+from aiohttp.web_urldispatcher import (AbstractResource,
+                                       ResourceRoute, SystemRoute,
+                                       View, _defaultExpectHandler,
+                                       PATH_SEP)
 
 
 def make_request(method, path):
@@ -495,8 +496,11 @@ def test_add_route_with_invalid_re(router):
     with pytest.raises(ValueError) as ctx:
         router.add_route('GET', r'/handler/{to:+++}', handler)
     s = str(ctx.value)
-    assert s.startswith(
-        "Bad pattern '\/handler\/(?P<to>+++)': nothing to repeat")
+    assert s.startswith("Bad pattern '" +
+                        PATH_SEP +
+                        "handler" +
+                        PATH_SEP +
+                        "(?P<to>+++)': nothing to repeat")
     assert ctx.value.__cause__ is None
 
 
@@ -798,7 +802,7 @@ def test_match_info_get_info_dynamic(router):
     req = make_request('GET', '/value')
     info = yield from router.resolve(req)
     assert info.get_info() == {
-        'pattern': re.compile('\\/(?P<a>[^{}/]+)'),
+        'pattern': re.compile(PATH_SEP+'(?P<a>[^{}/]+)'),
         'formatter': '/{a}'}
 
 
@@ -809,7 +813,10 @@ def test_match_info_get_info_dynamic2(router):
     req = make_request('GET', '/path/to')
     info = yield from router.resolve(req)
     assert info.get_info() == {
-        'pattern': re.compile('\\/(?P<a>[^{}/]+)\\/(?P<b>[^{}/]+)'),
+        'pattern': re.compile(PATH_SEP +
+                              '(?P<a>[^{}/]+)' +
+                              PATH_SEP +
+                              '(?P<b>[^{}/]+)'),
         'formatter': '/{a}/{b}'}
 
 

--- a/tests/test_urldispatch.py
+++ b/tests/test_urldispatch.py
@@ -12,10 +12,9 @@ import aiohttp
 from aiohttp import hdrs, web
 from aiohttp.test_utils import make_mocked_request
 from aiohttp.web import HTTPMethodNotAllowed, HTTPNotFound, Response
-from aiohttp.web_urldispatcher import (AbstractResource,
-                                       ResourceRoute, SystemRoute,
-                                       View, _defaultExpectHandler,
-                                       PATH_SEP)
+from aiohttp.web_urldispatcher import (PATH_SEP, AbstractResource,
+                                       ResourceRoute, SystemRoute, View,
+                                       _defaultExpectHandler)
 
 
 def make_request(method, path):


### PR DESCRIPTION
See #1839 