### PR TITLE
Fix #1828: make enable_compression work on HTTP/1.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -140,6 +140,8 @@ Changes
 
 - Cancel websocket heartbeat on close #1793
 
+- Make enable_compression work on HTTP/1.0 #1828
+
 
 2.0.6 (2017-04-04)
 ------------------

--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -298,7 +298,7 @@ class StreamResponse(HeadersMixin):
 
     def _do_start_compression(self, coding):
         if coding != ContentCoding.identity:
-            self._headers[hdrs.CONTENT_ENCODING] = coding.value
+            self.headers[hdrs.CONTENT_ENCODING] = coding.value
             self._payload_writer.enable_compression(coding.value)
             # Compressed payload may have different content length,
             # remove the header
@@ -347,13 +347,13 @@ class StreamResponse(HeadersMixin):
         version = request.version
         writer = self._payload_writer = request._writer
 
-        if self._compression:
-            self._start_compression(request)
-
         headers = self._headers
         for cookie in self._cookies.values():
             value = cookie.output(header='')[1:]
             headers.add(SET_COOKIE, value)
+
+        if self._compression:
+            self._start_compression(request)
 
         if self._chunked:
             if version != HttpVersion11:

--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -628,7 +628,8 @@ class Response(StreamResponse):
             self._compressed_body = compressobj.compress(self._body) +\
                 compressobj.flush()
             self._headers[hdrs.CONTENT_ENCODING] = coding.value
-            self._headers[hdrs.CONTENT_LENGTH] = str(len(self._compressed_body))
+            self._headers[hdrs.CONTENT_LENGTH] = \
+                str(len(self._compressed_body))
 
 
 def json_response(data=sentinel, *, text=None, body=None, status=200,

--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -5,6 +5,7 @@ import json
 import math
 import time
 import warnings
+import zlib
 from email.utils import parsedate
 
 from multidict import CIMultiDict, CIMultiDictProxy
@@ -297,9 +298,12 @@ class StreamResponse(HeadersMixin):
 
     def _do_start_compression(self, coding):
         if coding != ContentCoding.identity:
-            self.headers[hdrs.CONTENT_ENCODING] = coding.value
+            self._headers[hdrs.CONTENT_ENCODING] = coding.value
             self._payload_writer.enable_compression(coding.value)
-            self._chunked = True
+            # Compressed payload may have different content length,
+            # remove the header
+            if hdrs.CONTENT_LENGTH in self._headers:
+                del self._headers[hdrs.CONTENT_LENGTH]
 
     def _start_compression(self, request):
         if self._compression_force:
@@ -343,13 +347,13 @@ class StreamResponse(HeadersMixin):
         version = request.version
         writer = self._payload_writer = request._writer
 
+        if self._compression:
+            self._start_compression(request)
+
         headers = self._headers
         for cookie in self._cookies.values():
             value = cookie.output(header='')[1:]
             headers.add(SET_COOKIE, value)
-
-        if self._compression:
-            self._start_compression(request)
 
         if self._chunked:
             if version != HttpVersion11:
@@ -362,11 +366,14 @@ class StreamResponse(HeadersMixin):
                 del headers[CONTENT_LENGTH]
         elif self._length_check:
             writer.length = self.content_length
-            if writer.length is None and version >= HttpVersion11:
-                writer.enable_chunking()
-                headers[TRANSFER_ENCODING] = 'chunked'
-                if CONTENT_LENGTH in headers:
-                    del headers[CONTENT_LENGTH]
+            if writer.length is None:
+                if version >= HttpVersion11:
+                    writer.enable_chunking()
+                    headers[TRANSFER_ENCODING] = 'chunked'
+                    if CONTENT_LENGTH in headers:
+                        del headers[CONTENT_LENGTH]
+                else:
+                    keep_alive = False
 
         headers.setdefault(CONTENT_TYPE, 'application/octet-stream')
         headers.setdefault(DATE, request.time_service.strtime())
@@ -489,6 +496,8 @@ class Response(StreamResponse):
         else:
             self.body = body
 
+        self._compressed_body = None
+
     @property
     def body(self):
         return self._body
@@ -513,12 +522,13 @@ class Response(StreamResponse):
 
             headers = self._headers
 
-            # enable chunked encoding if needed
+            # set content-length header if needed
             if not self._chunked and CONTENT_LENGTH not in headers:
                 size = body.size
                 if size is None:
-                    self._chunked = True
-                elif CONTENT_LENGTH not in headers:
+                    if CONTENT_LENGTH in headers:
+                        del headers[CONTENT_LENGTH]
+                elif size is not None and CONTENT_LENGTH not in headers:
                     headers[CONTENT_LENGTH] = str(size)
 
             # set content-type
@@ -530,6 +540,8 @@ class Response(StreamResponse):
                 for (key, value) in body.headers.items():
                     if key not in headers:
                         headers[key] = value
+
+        self._compressed_body = None
 
     @property
     def text(self):
@@ -549,6 +561,7 @@ class Response(StreamResponse):
 
         self._body = text.encode(self.charset)
         self._body_payload = False
+        self._compressed_body = None
 
     @property
     def content_length(self):
@@ -558,7 +571,13 @@ class Response(StreamResponse):
         if hdrs.CONTENT_LENGTH in self.headers:
             return super().content_length
 
-        if self._body is not None:
+        if self._compressed_body is not None:
+            # Return length of the compressed body
+            return len(self._compressed_body)
+        elif self._body_payload:
+            # A payload without content length, or a compressed payload
+            return None
+        elif self._body is not None:
             return len(self._body)
         else:
             return 0
@@ -571,7 +590,10 @@ class Response(StreamResponse):
     def write_eof(self):
         if self._eof_sent:
             return
-        body = self._body
+        if self._compressed_body is not None:
+            body = self._compressed_body
+        else:
+            body = self._body
         if body is not None:
             if (self._req._method == hdrs.METH_HEAD or
                     self._status in [204, 304]):
@@ -586,12 +608,27 @@ class Response(StreamResponse):
 
     def _start(self, request):
         if not self._chunked and hdrs.CONTENT_LENGTH not in self._headers:
-            if self._body is not None:
-                self._headers[hdrs.CONTENT_LENGTH] = str(len(self._body))
-            else:
-                self._headers[hdrs.CONTENT_LENGTH] = '0'
+            if not self._body_payload:
+                if self._body is not None:
+                    self._headers[hdrs.CONTENT_LENGTH] = str(len(self._body))
+                else:
+                    self._headers[hdrs.CONTENT_LENGTH] = '0'
 
         return super()._start(request)
+
+    def _do_start_compression(self, coding):
+        if self._body_payload or self._chunked:
+            return super()._do_start_compression(coding)
+        if coding != ContentCoding.identity:
+            # Instead of using _payload_writer.enable_compression,
+            # compress the whole body
+            zlib_mode = (16 + zlib.MAX_WBITS
+                         if coding.value == 'gzip' else -zlib.MAX_WBITS)
+            compressobj = zlib.compressobj(wbits=zlib_mode)
+            self._compressed_body = compressobj.compress(self._body) +\
+                compressobj.flush()
+            self._headers[hdrs.CONTENT_ENCODING] = coding.value
+            self._headers[hdrs.CONTENT_LENGTH] = str(len(self._compressed_body))
 
 
 def json_response(data=sentinel, *, text=None, body=None, status=200,

--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -525,10 +525,7 @@ class Response(StreamResponse):
             # set content-length header if needed
             if not self._chunked and CONTENT_LENGTH not in headers:
                 size = body.size
-                if size is None:
-                    if CONTENT_LENGTH in headers:
-                        del headers[CONTENT_LENGTH]
-                elif size is not None and CONTENT_LENGTH not in headers:
+                if size is not None:
                     headers[CONTENT_LENGTH] = str(size)
 
             # set content-type

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -1756,11 +1756,49 @@ def test_encoding_deflate(loop, test_client):
 
 
 @asyncio.coroutine
+def test_encoding_deflate_nochunk(loop, test_client):
+    @asyncio.coroutine
+    def handler(request):
+        resp = web.Response(text='text')
+        resp.enable_compression(web.ContentCoding.deflate)
+        return resp
+
+    app = web.Application()
+    app.router.add_get('/', handler)
+    client = yield from test_client(app)
+
+    resp = yield from client.get('/')
+    assert 200 == resp.status
+    txt = yield from resp.text()
+    assert txt == 'text'
+    resp.close()
+
+
+@asyncio.coroutine
 def test_encoding_gzip(loop, test_client):
     @asyncio.coroutine
     def handler(request):
         resp = web.Response(text='text')
         resp.enable_chunked_encoding()
+        resp.enable_compression(web.ContentCoding.gzip)
+        return resp
+
+    app = web.Application()
+    app.router.add_get('/', handler)
+    client = yield from test_client(app)
+
+    resp = yield from client.get('/')
+    assert 200 == resp.status
+    txt = yield from resp.text()
+    assert txt == 'text'
+    resp.close()
+
+
+@asyncio.coroutine
+def test_encoding_gzip_nochunk(loop, test_client):
+    @asyncio.coroutine
+    def handler(request):
+        resp = web.Response(text='text')
         resp.enable_compression(web.ContentCoding.gzip)
         return resp
 

--- a/tests/test_web_response.py
+++ b/tests/test_web_response.py
@@ -470,6 +470,23 @@ def test_force_compression_identity():
 
 
 @asyncio.coroutine
+def test_force_compression_identity_response():
+    writer = mock.Mock()
+
+    def write_headers(status_line, headers):
+        assert headers[hdrs.CONTENT_LENGTH] == "6"
+        assert hdrs.TRANSFER_ENCODING not in headers
+
+    writer.write_headers.side_effect = write_headers
+    req = make_request('GET', '/',
+                       payload_writer=writer)
+    resp = Response(body=b'answer')
+    resp.enable_compression(ContentCoding.identity)
+    yield from resp.prepare(req)
+    assert resp.content_length == 6
+
+
+@asyncio.coroutine
 def test_remove_content_length_if_compression_enabled_on_payload_http11():
     writer = mock.Mock()
 

--- a/tests/test_web_response.py
+++ b/tests/test_web_response.py
@@ -385,13 +385,13 @@ def test_force_compression_no_accept_gzip():
 
 
 @asyncio.coroutine
-def test_delete_content_length_if_compression_enabled():
+def test_change_content_length_if_compression_enabled():
     req = make_request('GET', '/')
     resp = Response(body=b'answer')
     resp.enable_compression(ContentCoding.gzip)
 
     yield from resp.prepare(req)
-    assert resp.content_length is None
+    assert resp.content_length != len(b'answer')
 
 
 @asyncio.coroutine

--- a/tests/test_web_response.py
+++ b/tests/test_web_response.py
@@ -482,7 +482,7 @@ def test_remove_content_length_if_compression_enabled_on_payload_http11():
     payload = BytesPayload(b'answer', headers={"X-Test-Header": "test"})
     resp = Response(body=payload)
     assert resp.content_length == 6
-    resp.body = resp
+    resp.body = payload
     resp.enable_compression(ContentCoding.gzip)
     yield from resp.prepare(req)
     assert resp.content_length is None

--- a/tests/test_web_response.py
+++ b/tests/test_web_response.py
@@ -479,8 +479,7 @@ def test_remove_content_length_if_compression_enabled_on_payload_http11():
 
     writer.write_headers.side_effect = write_headers
     req = make_request('GET', '/', payload_writer=writer)
-    payload = BytesPayload(b'answer')
-    payload.headers['X-Test-Header'] = 'test'
+    payload = BytesPayload(b'answer', headers={"X-Test-Header": "test"})
     resp = Response(body=payload)
     assert resp.content_length == 6
     resp.body = resp

--- a/tests/test_web_response.py
+++ b/tests/test_web_response.py
@@ -523,22 +523,6 @@ def test_remove_content_length_if_compression_enabled_on_payload_http10():
 
 
 @asyncio.coroutine
-def test_remove_content_length_if_chunked():
-    writer = mock.Mock()
-
-    def write_headers(status_line, headers):
-        assert hdrs.CONTENT_LENGTH not in headers
-        assert headers[hdrs.TRANSFER_ENCODING] == 'chunked'
-
-    writer.write_headers.side_effect = write_headers
-    req = make_request('GET', '/', payload_writer=writer)
-    resp = StreamResponse()
-    resp.content_length = 123
-    resp.enable_chunked_encoding()
-    yield from resp.prepare(req)
-
-
-@asyncio.coroutine
 def test_content_length_on_chunked():
     req = make_request('GET', '/')
     resp = Response(body=b'answer')


### PR DESCRIPTION
## What do these changes do?

This pr fix #1828 i.e. generate a correctly compressed response for HTTP/1.0 requests.

## Are there changes in behavior for the user?

Call enable_compression on **Response** class with **body** set to some bytes now generates a response with content-length instead of chunk-encoded response.

## Related issue number

#1828 

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new entry to `CHANGES.rst`
  * Choose any open position to avoid merge conflicts with other PRs.
  * Add a link to the issue you are fixing (if any) using `#issue_number` format at the end of changelog message. Use Pull Request number if there are no issues for PR or PR covers the issue only partially.
