### PR TITLE
Concurrent drains

### DIFF
--- a/tests/test_http_stream_writer.py
+++ b/tests/test_http_stream_writer.py
@@ -361,7 +361,7 @@ def test_concurrent_drains(loop):
         assert res == PACKET*3
         fut2.set_result(None)
 
-    server = yield from asyncio.start_server(read, '127.0.0.1', 0)
+    server = yield from asyncio.start_server(read, '127.0.0.1', 0, loop=loop)
     port = server.sockets[0].getsockname()[1]
 
     tr, pr = yield from loop.create_connection(Proto, '127.0.0.1', port)

--- a/tests/test_http_stream_writer.py
+++ b/tests/test_http_stream_writer.py
@@ -364,7 +364,8 @@ def test_concurrent_drains(loop):
     server = yield from asyncio.start_server(read, '127.0.0.1', 0, loop=loop)
     port = server.sockets[0].getsockname()[1]
 
-    tr, pr = yield from loop.create_connection(Proto, '127.0.0.1', port)
+    tr, pr = yield from loop.create_connection(lambda: Proto(loop=loop),
+                                               '127.0.0.1', port)
 
     stream = StreamWriter(pr, tr, loop)
     tr.set_write_buffer_limits(1, 1)


### PR DESCRIPTION
asyncio doesn't support concurrent `.drain()` calls (https://github.com/aio-libs/aiohttp/pull/1886#issuecomment-301355495)
This PR proposes a workaround for the issue.