### PR TITLE
Add missing HTTP status codes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -58,6 +58,9 @@ Changes
 - Use Forwarded, X-Forwarded-Scheme and X-Forwarded-Host for better scheme and
   host resolution. #1134
 
+- Extend list of web exceptions, add HTTPUnprocessableEntity,
+  HTTPFailedDependency, HTTPInsufficientStorage status codes #1920
+
 
 2.0.7 (2017-04-12)
 ------------------

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -149,6 +149,7 @@ Stanislas Plum
 Stanislav Prokop
 Stephen Granade
 Steven Seguin
+Sunghyun Hwang
 Sviatoslav Bulbakha
 Taha Jahangir
 Taras Voinarovskyi

--- a/aiohttp/web_exceptions.py
+++ b/aiohttp/web_exceptions.py
@@ -41,6 +41,7 @@ __all__ = (
     'HTTPRequestRangeNotSatisfiable',
     'HTTPExpectationFailed',
     'HTTPMisdirectedRequest',
+    'HTTPUnprocessableEntity',
     'HTTPUpgradeRequired',
     'HTTPPreconditionRequired',
     'HTTPTooManyRequests',
@@ -269,6 +270,10 @@ class HTTPExpectationFailed(HTTPClientError):
 
 class HTTPMisdirectedRequest(HTTPClientError):
     status_code = 421
+
+
+class HTTPUnprocessableEntity(HTTPClientError):
+    status_code = 422
 
 
 class HTTPUpgradeRequired(HTTPClientError):

--- a/aiohttp/web_exceptions.py
+++ b/aiohttp/web_exceptions.py
@@ -42,6 +42,7 @@ __all__ = (
     'HTTPExpectationFailed',
     'HTTPMisdirectedRequest',
     'HTTPUnprocessableEntity',
+    'HTTPFailedDependency',
     'HTTPUpgradeRequired',
     'HTTPPreconditionRequired',
     'HTTPTooManyRequests',
@@ -274,6 +275,10 @@ class HTTPMisdirectedRequest(HTTPClientError):
 
 class HTTPUnprocessableEntity(HTTPClientError):
     status_code = 422
+
+
+class HTTPFailedDependency(HTTPClientError):
+    status_code = 424
 
 
 class HTTPUpgradeRequired(HTTPClientError):

--- a/aiohttp/web_exceptions.py
+++ b/aiohttp/web_exceptions.py
@@ -56,6 +56,7 @@ __all__ = (
     'HTTPGatewayTimeout',
     'HTTPVersionNotSupported',
     'HTTPVariantAlsoNegotiates',
+    'HTTPInsufficientStorage',
     'HTTPNotExtended',
     'HTTPNetworkAuthenticationRequired',
 )
@@ -350,6 +351,10 @@ class HTTPVersionNotSupported(HTTPServerError):
 
 class HTTPVariantAlsoNegotiates(HTTPServerError):
     status_code = 506
+
+
+class HTTPInsufficientStorage(HTTPServerError):
+    status_code = 507
 
 
 class HTTPNotExtended(HTTPServerError):

--- a/docs/web.rst
+++ b/docs/web.rst
@@ -802,6 +802,7 @@ HTTP Exception hierarchy chart::
            * 504 - HTTPGatewayTimeout
            * 505 - HTTPVersionNotSupported
            * 506 - HTTPVariantAlsoNegotiates
+           * 507 - HTTPInsufficientStorage
            * 510 - HTTPNotExtended
            * 511 - HTTPNetworkAuthenticationRequired
 

--- a/docs/web.rst
+++ b/docs/web.rst
@@ -788,6 +788,7 @@ HTTP Exception hierarchy chart::
            * 417 - HTTPExpectationFailed
            * 421 - HTTPMisdirectedRequest
            * 422 - HTTPUnprocessableEntity
+           * 424 - HTTPFailedDependency
            * 426 - HTTPUpgradeRequired
            * 428 - HTTPPreconditionRequired
            * 429 - HTTPTooManyRequests

--- a/docs/web.rst
+++ b/docs/web.rst
@@ -787,6 +787,7 @@ HTTP Exception hierarchy chart::
            * 416 - HTTPRequestRangeNotSatisfiable
            * 417 - HTTPExpectationFailed
            * 421 - HTTPMisdirectedRequest
+           * 422 - HTTPUnprocessableEntity
            * 426 - HTTPUpgradeRequired
            * 428 - HTTPPreconditionRequired
            * 429 - HTTPTooManyRequests


### PR DESCRIPTION
## What do these changes do?

Extend list of `web_exceptions`, add [HTTPUnprocessableEntity](https://tools.ietf.org/html/rfc4918#section-11.2), [HTTPFailedDependency](https://tools.ietf.org/html/rfc4918#section-11.4), [HTTPInsufficientStorage](https://tools.ietf.org/html/rfc4918#section-11.5) status codes

## Are there changes in behavior for the user?

Use **HTTPUnprocessableEntity**, **HTTPFailedDependency**, **HTTPInsufficientStorage** to respond with appropriate status codes.

## Checklist

- [x] I think the code is well written
- [x] ~Unit tests for the changes exist~
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
- [x] Add a new entry to `CHANGES.rst`