### PR TITLE
Throttle simultaneous DNS requests

### DIFF
--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -684,7 +684,7 @@ class TCPConnector(BaseConnector):
             if key in self._throttle_dns_events:
                 yield from self._throttle_dns_events[key].wait()
             else:
-                self._throttle_dns_events[key] = Event()
+                self._throttle_dns_events[key] = Event(loop=self._loop)
                 try:
                     addrs = yield from \
                         self._resolver.resolve(host, port, family=self._family)

--- a/aiohttp/locks.py
+++ b/aiohttp/locks.py
@@ -1,0 +1,29 @@
+import asyncio
+
+
+class Event(asyncio.locks.Event):
+    """
+    Adhoc Event class that modifies the `set` method, it allows to
+    pass an exception to wake the waiters with an exception.
+
+    This is used when the event creator cant accommplish the requirements
+    due to an exception, instead of try to built a sophisticated solution
+    the same exeption is passed to the waiters.
+    """
+
+    def set(self, exc=None):
+        """Set the internal flag to true. All coroutines waiting for it to
+        become true are awakened. Coroutine that call wait() once the flag is
+        true will not block at all.
+
+        If `exc` is different than None the `future.set_exception` is called
+        """
+        if not self._value:
+            self._value = True
+
+            for fut in self._waiters:
+                if not fut.done():
+                    if not exc:
+                        fut.set_result(True)
+                    else:
+                        fut.set_exception(exc)

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -694,6 +694,7 @@ TCPConnector
 .. class:: TCPConnector(*, verify_ssl=True, fingerprint=None,\
                         use_dns_cache=True, \
                         ttl_dns_cache=10, \
+                        throttle_dns=False, \
                         family=0, ssl_context=None, conn_timeout=None, \
                         keepalive_timeout=30, limit=None, \
                         force_close=False, loop=None, local_addr=None, \
@@ -744,6 +745,12 @@ TCPConnector
       seconds.
 
       .. versionadded:: 2.0.8
+
+   :param int throttle_dns: When simultanious requests get into the server and
+      there is a miss in the cache only one request wll end up making the DNS
+      resolution . By default False.
+
+      .. versionadded:: 2.1.0
 
    :param aiohttp.abc.AbstractResolver resolver: Custom resolver
       instance to use.  ``aiohttp.DefaultResolver`` by

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -361,15 +361,18 @@ def test_tcp_connector_resolve_host(loop):
                 assert rec['host'] == '::1'
 
 
-@asyncio.coroutine
-def dns_response():
-    # simulates a network operation
-    yield from asyncio.sleep(0)
-    return ["127.0.0.1"]
+@pytest.fixture
+def dns_response(loop):
+    @asyncio.coroutine
+    def coro():
+        # simulates a network operation
+        yield from asyncio.sleep(0, loop=loop)
+        return ["127.0.0.1"]
+    return coro
 
 
 @asyncio.coroutine
-def test_tcp_connector_dns_cache_not_expired(loop):
+def test_tcp_connector_dns_cache_not_expired(loop, dns_response):
     with mock.patch('aiohttp.connector.DefaultResolver') as m_resolver:
         conn = aiohttp.TCPConnector(
             loop=loop,
@@ -387,7 +390,7 @@ def test_tcp_connector_dns_cache_not_expired(loop):
 
 
 @asyncio.coroutine
-def test_tcp_connector_dns_cache_forever(loop):
+def test_tcp_connector_dns_cache_forever(loop, dns_response):
     with mock.patch('aiohttp.connector.DefaultResolver') as m_resolver:
         conn = aiohttp.TCPConnector(
             loop=loop,
@@ -405,7 +408,7 @@ def test_tcp_connector_dns_cache_forever(loop):
 
 
 @asyncio.coroutine
-def test_tcp_connector_use_dns_cache_disabled(loop):
+def test_tcp_connector_use_dns_cache_disabled(loop, dns_response):
     with mock.patch('aiohttp.connector.DefaultResolver') as m_resolver:
         conn = aiohttp.TCPConnector(loop=loop, use_dns_cache=False)
         m_resolver().resolve.return_value = dns_response()
@@ -418,7 +421,7 @@ def test_tcp_connector_use_dns_cache_disabled(loop):
 
 
 @asyncio.coroutine
-def test_tcp_connector_dns_not_throttle_requests(loop):
+def test_tcp_connector_dns_not_throttle_requests(loop, dns_response):
     with mock.patch('aiohttp.connector.DefaultResolver') as m_resolver:
         conn = aiohttp.TCPConnector(
             loop=loop,
@@ -445,7 +448,7 @@ def test_tcp_connector_dns_throttle_requests_needs_cache_enabled(loop):
 
 
 @asyncio.coroutine
-def test_tcp_connector_dns_throttle_requests(loop):
+def test_tcp_connector_dns_throttle_requests(loop, dns_response):
     with mock.patch('aiohttp.connector.DefaultResolver') as m_resolver:
         conn = aiohttp.TCPConnector(
             loop=loop,

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -430,8 +430,8 @@ def test_tcp_connector_dns_not_throttle_requests(loop, dns_response):
             throttle_dns=False
         )
         m_resolver().resolve.return_value = dns_response()
-        asyncio.ensure_future(conn._resolve_host('localhost', 8080), loop=loop)
-        asyncio.ensure_future(conn._resolve_host('localhost', 8080), loop=loop)
+        helpers.ensure_future(conn._resolve_host('localhost', 8080), loop=loop)
+        helpers.ensure_future(conn._resolve_host('localhost', 8080), loop=loop)
         yield from asyncio.sleep(0)
         c = mock.call('localhost', 8080, family=0)
         m_resolver().resolve.assert_has_calls([c, c])
@@ -457,8 +457,8 @@ def test_tcp_connector_dns_throttle_requests(loop, dns_response):
             throttle_dns=True
         )
         m_resolver().resolve.return_value = dns_response()
-        asyncio.ensure_future(conn._resolve_host('localhost', 8080), loop=loop)
-        asyncio.ensure_future(conn._resolve_host('localhost', 8080), loop=loop)
+        helpers.ensure_future(conn._resolve_host('localhost', 8080), loop=loop)
+        helpers.ensure_future(conn._resolve_host('localhost', 8080), loop=loop)
         yield from asyncio.sleep(0)
         m_resolver().resolve.assert_called_once_with(
             'localhost',
@@ -478,11 +478,11 @@ def test_tcp_connector_dns_throttle_requests_exception_spread(loop):
         )
         e = Exception()
         m_resolver().resolve.side_effect = e
-        r1 = asyncio.ensure_future(
+        r1 = helpers.ensure_future(
             conn._resolve_host('localhost', 8080),
             loop=loop
         )
-        r2 = asyncio.ensure_future(
+        r2 = helpers.ensure_future(
             conn._resolve_host('localhost', 8080),
             loop=loop
         )

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -432,7 +432,7 @@ def test_tcp_connector_dns_not_throttle_requests(loop, dns_response):
         m_resolver().resolve.return_value = dns_response()
         helpers.ensure_future(conn._resolve_host('localhost', 8080), loop=loop)
         helpers.ensure_future(conn._resolve_host('localhost', 8080), loop=loop)
-        yield from asyncio.sleep(0)
+        yield from asyncio.sleep(0, loop=loop)
         c = mock.call('localhost', 8080, family=0)
         m_resolver().resolve.assert_has_calls([c, c])
 
@@ -459,7 +459,7 @@ def test_tcp_connector_dns_throttle_requests(loop, dns_response):
         m_resolver().resolve.return_value = dns_response()
         helpers.ensure_future(conn._resolve_host('localhost', 8080), loop=loop)
         helpers.ensure_future(conn._resolve_host('localhost', 8080), loop=loop)
-        yield from asyncio.sleep(0)
+        yield from asyncio.sleep(0, loop=loop)
         m_resolver().resolve.assert_called_once_with(
             'localhost',
             8080,
@@ -486,7 +486,7 @@ def test_tcp_connector_dns_throttle_requests_exception_spread(loop):
             conn._resolve_host('localhost', 8080),
             loop=loop
         )
-        yield from asyncio.sleep(0)
+        yield from asyncio.sleep(0, loop=loop)
         assert r1.exception() == e
         assert r2.exception() == e
 

--- a/tests/test_locks.py
+++ b/tests/test_locks.py
@@ -7,8 +7,8 @@ from aiohttp.locks import Event
 class TestEvent:
 
     @asyncio.coroutine
-    def test_set_exception(self):
-        ev = Event()
+    def test_set_exception(self, loop):
+        ev = Event(loop=loop)
 
         @asyncio.coroutine
         def c():
@@ -26,8 +26,8 @@ class TestEvent:
         assert t.result() == e
 
     @asyncio.coroutine
-    def test_set(self):
-        ev = Event()
+    def test_set(self, loop):
+        ev = Event(loop=loop)
 
         @asyncio.coroutine
         def c():

--- a/tests/test_locks.py
+++ b/tests/test_locks.py
@@ -1,0 +1,41 @@
+"""Tests of custom aiohttp locks implementations"""
+import asyncio
+
+from aiohttp.locks import Event
+
+
+class TestEvent:
+
+    @asyncio.coroutine
+    def test_set_exception(self):
+        ev = Event()
+
+        @asyncio.coroutine
+        def c():
+            try:
+                yield from ev.wait()
+            except Exception as e:
+                return e
+            return 1
+
+        t = asyncio.ensure_future(c())
+        yield from asyncio.sleep(0)
+        e = Exception()
+        ev.set(exc=e)
+        yield from asyncio.sleep(0)
+        assert t.result() == e
+
+    @asyncio.coroutine
+    def test_set(self):
+        ev = Event()
+
+        @asyncio.coroutine
+        def c():
+            yield from ev.wait()
+            return 1
+
+        t = asyncio.ensure_future(c())
+        yield from asyncio.sleep(0)
+        ev.set()
+        yield from asyncio.sleep(0)
+        assert t.result() == 1

--- a/tests/test_locks.py
+++ b/tests/test_locks.py
@@ -1,6 +1,7 @@
 """Tests of custom aiohttp locks implementations"""
 import asyncio
 
+from aiohttp import helpers
 from aiohttp.locks import Event
 
 
@@ -18,7 +19,7 @@ class TestEvent:
                 return e
             return 1
 
-        t = asyncio.ensure_future(c())
+        t = helpers.ensure_future(c())
         yield from asyncio.sleep(0)
         e = Exception()
         ev.set(exc=e)
@@ -34,7 +35,7 @@ class TestEvent:
             yield from ev.wait()
             return 1
 
-        t = asyncio.ensure_future(c())
+        t = helpers.ensure_future(c())
         yield from asyncio.sleep(0)
         ev.set()
         yield from asyncio.sleep(0)


### PR DESCRIPTION
## What do these changes do?

Added a new option at TCPConnector level called `throttle_dns` that
allows to the connector throttle simultaneous DNS requests for a specific
domain. This functionality it's only compatible when the DNS cache is
enabled and it is disabled by default. Therefore,  many requests can
end up making the same DNS resolution.

## Are there changes in behavior for the user?

no

## Related issue number

no

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [ ] Add a new entry to `CHANGES.rst`
  * Choose any open position to avoid merge conflicts with other PRs.
  * Add a link to the issue you are fixing (if any) using `#issue_number` format at the end of changelog message. Use Pull Request number if there are no issues for PR or PR covers the issue only partially.
