### PR TITLE
Remove Content-Length when you enable chunked encoding

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 Changes
 =======
 
+2.0.8 (2017-XX-XX)
+------------------
+
+- Remove Content-Length when enabling chunked encoding
+
+
 2.0.7 (2017-04-12)
 ------------------
 

--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -112,6 +112,7 @@ class StreamResponse(HeadersMixin):
         self._chunked = True
         if chunk_size is not None:
             warnings.warn('Chunk size is deprecated #1615', DeprecationWarning)
+        self._headers.pop(hdrs.CONTENT_LENGTH, None)
 
     def enable_compression(self, force=None):
         """Enables response compression encoding."""

--- a/tests/test_web_response.py
+++ b/tests/test_web_response.py
@@ -89,6 +89,15 @@ def test_drop_content_length_header_on_setting_len_to_None():
     assert 'Content-Length' not in resp.headers
 
 
+def test_drop_content_length_header_on_setting_chunked():
+    resp = StreamResponse()
+
+    resp.content_length = 1
+    assert "1" == resp.headers['Content-Length']
+    resp.enable_chunked_encoding()
+    assert 'Content-Length' not in resp.headers
+
+
 def test_set_content_length_to_None_on_non_set():
     resp = StreamResponse()
 


### PR DESCRIPTION
This ensure that no content lenght header remain after you enable
chunked.

## What do these changes do?

Remove Content-Length when you enable chunked encoding

This ensure that no content lenght header remain after you enable chunked.

## Are there changes in behavior for the user?

No Content-Length will be send when you have enable chunked encoding

## Related issue number

No issue

## Checklist

- [*] I think the code is well written
- [*] Unit tests for the changes exist
- [*] Documentation reflects the changes
- [*] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [*] Add a new entry to `CHANGES.rst`
  * Choose any open position to avoid merge conflicts with other PRs.
  * Add a link to the issue you are fixing (if any) using `#issue_number` format at the end of changelog message. Use Pull Request number if there are no issues for PR or PR covers the issue only partially.
