### PR TITLE
Raise RuntimeError is you try to set the Content Length with chunked encoding enable

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -23,7 +23,7 @@ Changes
 
 -
 
--
+- Raise RuntimeError is you try to set the Content Length and enable chunked encoding at the same time
 
 2.1.0 (2017-05-26)
 ------------------

--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -111,6 +111,10 @@ class StreamResponse(HeadersMixin):
     def enable_chunked_encoding(self, chunk_size=None):
         """Enables automatic chunked transfer encoding."""
         self._chunked = True
+
+        if hdrs.CONTENT_LENGTH in self._headers:
+            raise RuntimeError("You can't enable chunked encoding when "
+                               "a content length is set")
         if chunk_size is not None:
             warnings.warn('Chunk size is deprecated #1615', DeprecationWarning)
 
@@ -194,7 +198,9 @@ class StreamResponse(HeadersMixin):
     def content_length(self, value):
         if value is not None:
             value = int(value)
-            # TODO: raise error if chunked enabled
+            if self._chunked:
+                raise RuntimeError("You can't set content length when "
+                                   "chunked encoding is enable")
             self._headers[hdrs.CONTENT_LENGTH] = str(value)
         else:
             self._headers.pop(hdrs.CONTENT_LENGTH, None)

--- a/tests/test_web_response.py
+++ b/tests/test_web_response.py
@@ -86,6 +86,14 @@ def test_content_length_setter():
     assert 234 == resp.content_length
 
 
+def test_content_length_setter_with_enable_chunked_encoding():
+    resp = StreamResponse()
+
+    resp.enable_chunked_encoding()
+    with pytest.raises(RuntimeError):
+        resp.content_length = 234
+
+
 def test_drop_content_length_header_on_setting_len_to_None():
     resp = StreamResponse()
 
@@ -221,6 +229,14 @@ def test_chunked_encoding():
 
     msg = yield from resp.prepare(req)
     assert msg.chunked
+
+
+def test_enable_chunked_encoding_with_content_length():
+    resp = StreamResponse()
+
+    resp.content_length = 234
+    with pytest.raises(RuntimeError):
+        resp.enable_chunked_encoding()
 
 
 @asyncio.coroutine


### PR DESCRIPTION
## What do these changes do?

If you try to set a content length on a response with chunked encoding enable you get a RuntimeError

## Are there changes in behavior for the user?

User will get an exception and not will be able to set the content length.

## Related issue number

It's after a discussion here: https://github.com/aio-libs/aiohttp/pull/1933

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new entry to `CHANGES.rst`
  * Choose any open position to avoid merge conflicts with other PRs.
  * Add a link to the issue you are fixing (if any) using `#issue_number` format at the end of changelog message. Use Pull Request number if there are no issues for PR or PR covers the issue only partially.
