### PR TITLE
Add SIGTERM handling in web.run_app

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,7 +9,7 @@ Changes
 - Retain method attributes (e.g. :code:`__doc__`) when registering synchronous
   handlers for resources. #1953
 
--
+- Added signal TERM handling in `run_app` to gracefully exit #1932
 
 - Fix websocket issues caused by frame fragmentation. #1962
 

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -37,6 +37,7 @@ Brett Cannon
 Brian C. Lane
 Brian Muller
 Carl George
+Cecile Tonglet
 Chien-Wei Huang
 Chih-Yuan Chen
 Chris AtLee

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -2085,10 +2085,11 @@ Utilities
 
 
 .. function:: run_app(app, *, host=None, port=None, path=None, \
-                      loop=None, shutdown_timeout=60.0, \
+                      sock=None, shutdown_timeout=60.0, \
                       ssl_context=None, print=print, backlog=128, \
                       access_log_format=None, \
-                      access_log=aiohttp.log.access_logger)
+                      access_log=aiohttp.log.access_logger, \
+                      handle_signals=True, loop=None)
 
    A utility function for running an application, serving it until
    keyboard interrupt and performing a
@@ -2154,6 +2155,9 @@ Utilities
    :param access_log_format: access log format, see
                              :ref:`aiohttp-logging-access-log-format-spec`
                              for details.
+
+   :param bool handle_signals: override signal TERM handling to gracefully
+                               exit the application.
 
    :param loop: an *event loop* used for running the application
                 (``None`` by default).


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Before submit your Pull Request, make sure you picked
     the right branch:

     - If you propose a new feature or improvement, select "master"
       as a target branch;
     - If this is a bug fix or documentation amendment, select
       the latest release branch (which looks like "0.xx") -->

## What do these changes do?

Makes `web.run_app()` handle SIGTERM by default to gracefully exit the application.

## Are there changes in behavior for the user?

The application run with `web.run_app()` will override any existing SIGTERM handler in the current process.

## Related issue number

#1932 

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new entry to `CHANGES.rst`
  * Choose any open position to avoid merge conflicts with other PRs.
  * Add a link to the issue you are fixing (if any) using `#issue_number` format at the end of changelog message. Use Pull Request number if there are no issues for PR or PR covers the issue only partially.
