### PR TITLE
Use functools.wraps when wrapping synchronous handlers

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,8 @@ Changes
 
 - Add doc for add_head, update doc for add_get. #1944
 
--
+- Retain method attributes (e.g. :code:`__doc__`) when registering synchronous
+  handlers for resources. #1953
 
 -
 

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -2,6 +2,7 @@ Contributors
 ------------
 A. Jesse Jiryu Davis
 Adam Mills
+Adrián Chaves
 Alec Hanefeld
 Alejandro Gómez
 Aleksandr Danshyn

--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -7,6 +7,7 @@ import os
 import re
 import warnings
 from collections.abc import Container, Iterable, Sized
+from functools import wraps
 from pathlib import Path
 from types import MappingProxyType
 
@@ -106,6 +107,7 @@ class AbstractRoute(abc.ABC):
               issubclass(handler, AbstractView)):
             pass
         else:
+            @wraps(handler)
             @asyncio.coroutine
             def handler_wrapper(*args, **kwargs):
                 result = old_handler(*args, **kwargs)

--- a/tests/test_web_urldispatcher.py
+++ b/tests/test_web_urldispatcher.py
@@ -181,6 +181,31 @@ def test_url_escaping(loop, test_client, registered_path, request_url):
 
 
 @asyncio.coroutine
+def test_handler_metadata_persistence():
+    """
+    Tests accessing metadata of a handler after registering it on the app
+    router.
+    """
+    app = web.Application()
+
+    @asyncio.coroutine
+    def async_handler(_):
+        """Doc"""
+        return web.Response()
+
+    def sync_handler(_):
+        """Doc"""
+        return web.Response()
+
+    app.router.add_get('/async', async_handler)
+    app.router.add_get('/sync', sync_handler)
+
+    for resource in app.router.resources():
+        for route in resource:
+            assert route.handler.__doc__ == 'Doc'
+
+
+@asyncio.coroutine
 def test_unauthorized_folder_access(tmp_dir_path, loop, test_client):
     """
     Tests the unauthorized access to a folder of static file server.


### PR DESCRIPTION
## What do these changes do?

They change the code that wraps synchronous functions, using functools.wraps to ensure that aspects from the synchronous functions such as `__doc__` are also available on the wrapper.

This allows to use **aiohttp-swagger** with synchronous handlers.

## Are there changes in behavior for the user?

When accessed from the app, synchronous route handlers will now include additional metadata that before only asynchronous handlers provided.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] ~~Documentation reflects the changes~~
  *It’s a bug fix which should not affect the documentation.*
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new entry to `CHANGES.rst`
  * Choose any open position to avoid merge conflicts with other PRs.
  * Add a link to the issue you are fixing (if any) using `#issue_number` format at the end of changelog message. Use Pull Request number if there are no issues for PR or PR covers the issue only partially.
