### PR TITLE
drop the CancelledError in ClientResponse.write_bytes if the underlying connection is already closed

### DIFF
--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -344,6 +344,9 @@ class ClientRequest:
             new_exc.__context__ = exc
             new_exc.__cause__ = exc
             conn.protocol.set_exception(new_exc)
+        except asyncio.CancelledError as exc:
+            if not conn.closed:
+                conn.protocol.set_exception(exc)
         except Exception as exc:
             conn.protocol.set_exception(exc)
         finally:


### PR DESCRIPTION
The `ClientRequest` class is trying to bubble-up `CancelledError`s after the underlying connection is closed, which leads to:

```
Task exception was never retrieved
future: <Task finished coro=<ClientRequest.write_bytes() done, defined at /Users/arthur/Documents/reaaad/lib/aiohttp/aiohttp/client_reqrep.py:321> exception=AttributeError("'NoneType' object has no attribute 'set_exception'",)>
Traceback (most recent call last):
  File "/Users/arthur/Documents/reaaad/lib/aiohttp/aiohttp/client_reqrep.py", line 331, in write_bytes
    yield from self.body.write(writer)
  File "/Users/arthur/Documents/reaaad/lib/aiohttp/aiohttp/payload_streamer.py", line 58, in write
    yield from self._value(writer)
  File "/Users/arthur/Documents/reaaad/lib/aiohttp/aiohttp/payload_streamer.py", line 41, in __call__
    yield from self.coro(writer, *self.args, **self.kwargs)
  File "a.py", line 15, in streamer
    await asyncio.sleep(.1)
  File "/usr/local/Cellar/python3/3.6.0b3_3/Frameworks/Python.framework/Versions/3.6/lib/python3.6/asyncio/tasks.py", line 476, in sleep
    return (yield from future)
concurrent.futures._base.CancelledError

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/arthur/Documents/reaaad/lib/aiohttp/aiohttp/client_reqrep.py", line 348, in write_bytes
    conn.protocol.set_exception(exc)
AttributeError: 'NoneType' object has no attribute 'set_exception'
```

Minimum failing code:
```python
import aiohttp
import aiohttp.web
import asyncio


async def server(loop):
	app = aiohttp.web.Application(loop=loop)
	app.router.add_get('/', lambda _: aiohttp.web.Response(text="OK"))
	handler = app.make_handler()
	await loop.create_server(handler, '0.0.0.0', 8080)

@aiohttp.streamer
async def streamer(writer):
	await writer.write(b'0')
	await asyncio.sleep(.1)
	await writer.write(b'0')

async def main(loop):
	srv = await server(loop)
	async with aiohttp.ClientSession() as session:
		async with session.get('http://0.0.0.0:8080/', data=streamer()) as resp:
			print('--->', resp.status)

loop = asyncio.get_event_loop()
loop.run_until_complete(main(loop))
```


I haven't managed to write tests for this, if you have a chance to I guess it would be best to add one