### PR TITLE
fix issues caused by websocket frame fragmentation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,7 +11,7 @@ Changes
 
 -
 
--
+- Fix websocket issues caused by frame fragmentation. #1962
 
 -
 

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -91,6 +91,7 @@ Joongi Kim
 Josep Cugat
 Julia Tsemusheva
 Julien Duponchelle
+Jungkook Park
 Junjie Tao
 Justas Trimailovas
 Justin Turner Arthur


### PR DESCRIPTION
## What do these changes do?

This MR fixes issues caused by websocket frame fragmentation.

Based on [autobahn-testsuite](https://github.com/crossbario/autobahn-testsuite), there were several bugs in websocket implementation which is mainly caused by wrong handling of fragmented frames. 

The rationale of deleting the test case "test_parse_frame_header_continuation" is that according to [RFC6455 Section 5.5](https://tools.ietf.org/html/rfc6455#section-5.5), control frames can be injected in the middle of a fragmented message and therefore we cannot reject the frame only seeing the "FIN" flag of the last frame. Also, test for invalid continuation frame without preceding text/binary frame is done by test case "test_unknown_frame".

Here is the report generated from autobahn-testsuite.
- Before: https://cdn.rawgit.com/pjknkda/ws-spec-check/f778edb0/reports/fuzzingclient/index.html
- After: https://cdn.rawgit.com/pjknkda/ws-spec-check/aiohttp-2.1.0-dev/reports/fuzzingclient/index.html

## Related issue number

#1845, #1951 


## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new entry to `CHANGES.rst`
  * Choose any open position to avoid merge conflicts with other PRs.
  * Add a link to the issue you are fixing (if any) using `#issue_number` format at the end of changelog message. Use Pull Request number if there are no issues for PR or PR covers the issue only partially.
