### PR TITLE
Always trigger cleanup if startup has been sent

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,7 +15,7 @@ Changes
 
 -
 
--
+- Make sure cleanup signal is sent if startup signal has been sent
 
 -
 


### PR DESCRIPTION
## What do these changes do?

Add contexts:
 *  send_startup_shutdown_signals: this will make that that if we leave the context, the cleanup signal is sent
 *  create_servers: doesn't change the current implementation, but it ensures that the servers are removed when leaving the context

## Are there changes in behavior for the user?

The only real change is that if the server cannot be created (port already opened for example) the cleanup signal will still be sent.

## Related issue number

#1959 

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new entry to `CHANGES.rst`
  * Choose any open position to avoid merge conflicts with other PRs.
  * Add a link to the issue you are fixing (if any) using `#issue_number` format at the end of changelog message. Use Pull Request number if there are no issues for PR or PR covers the issue only partially.
