### PR TITLE
[WIP] New route definitions

### DIFF
--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -897,9 +897,9 @@ class UrlDispatcher(AbstractRouter, collections.abc.Mapping):
 
 
 def _reg_http_method(func, method, **kwargs):
-    if not hasattr(func, '__aiohttp_data__'):
-        func.__aiohttp_data__ = {}
-    func.__aiohttp_data__[method] = kwargs
+    if not hasattr(func, '__aiohttp_web__'):
+        func.__aiohttp_web__ = {}
+    func.__aiohttp_web__[method] = kwargs
     return func
 
 
@@ -912,7 +912,7 @@ def head(**kwargs):
     return wrapper
 
 
-def add_get(self, *args, name=None, allow_head=True, **kwargs):
+def get(self, *args, name=None, allow_head=True, **kwargs):
     """
     Shortcut for add_route with method GET, if allow_head is true another
     route is added allowing head requests to the same endpoint
@@ -924,11 +924,13 @@ def add_get(self, *args, name=None, allow_head=True, **kwargs):
         self.add_route(hdrs.METH_HEAD, *args, name=head_name, **kwargs)
     return self.add_route(hdrs.METH_GET, *args, name=name, **kwargs)
 
+
 def add_post(self, *args, **kwargs):
     """
     Shortcut for add_route with method POST
     """
     return self.add_route(hdrs.METH_POST, *args, **kwargs)
+
 
 def add_put(self, *args, **kwargs):
     """
@@ -936,11 +938,13 @@ def add_put(self, *args, **kwargs):
     """
     return self.add_route(hdrs.METH_PUT, *args, **kwargs)
 
+
 def add_patch(self, *args, **kwargs):
     """
     Shortcut for add_route with method PATCH
     """
     return self.add_route(hdrs.METH_PATCH, *args, **kwargs)
+
 
 def add_delete(self, *args, **kwargs):
     """

--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -31,7 +31,7 @@ __all__ = ('UrlDispatcher', 'UrlMappingMatchInfo',
            'AbstractResource', 'Resource', 'PlainResource', 'DynamicResource',
            'AbstractRoute', 'ResourceRoute',
            'StaticResource', 'View',
-           'head', 'get', 'post', 'patch', 'put', 'delete')
+           'head', 'get', 'post', 'patch', 'put', 'delete', 'route')
 
 HTTP_METHOD_RE = re.compile(r"^[0-9A-Za-z!#\$%&'\*\+\-\.\^_`\|~]+$")
 PATH_SEP = re.escape('/')
@@ -909,6 +909,7 @@ class UrlDispatcher(AbstractRouter, collections.abc.Mapping):
             resource.freeze()
 
     def add_routes(self, routes):
+        # TODO: add_table maybe?
         for route in routes:
             route.register(self)
 

--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -914,7 +914,7 @@ class UrlDispatcher(AbstractRouter, collections.abc.Mapping):
 
     def scan(self, package):
         prefix = package + '.'
-        for modname, mod in sys.modules.items():
+        for modname, mod in sorted(sys.modules.items()):
             if modname == package or modname.startswith(prefix):
                 for name in dir(mod):
                     obj = getattr(mod, name)

--- a/examples/web_srv_route_deco.py
+++ b/examples/web_srv_route_deco.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Example for aiohttp.web basic server
+with decorator definition for routes
+"""
+
+import asyncio
+import textwrap
+
+from aiohttp import web
+
+
+@web.get('/')
+async def intro(request):
+    txt = textwrap.dedent("""\
+        Type {url}/hello/John  {url}/simple or {url}/change_body
+        in browser url bar
+    """).format(url='127.0.0.1:8080')
+    binary = txt.encode('utf8')
+    resp = web.StreamResponse()
+    resp.content_length = len(binary)
+    resp.content_type = 'text/plain'
+    await resp.prepare(request)
+    resp.write(binary)
+    return resp
+
+
+@web.get('/simple')
+async def simple(request):
+    return web.Response(text="Simple answer")
+
+
+@web.get('/change_body')
+async def change_body(request):
+    resp = web.Response()
+    resp.body = b"Body changed"
+    resp.content_type = 'text/plain'
+    return resp
+
+
+@web.get('/hello')
+async def hello(request):
+    resp = web.StreamResponse()
+    name = request.match_info.get('name', 'Anonymous')
+    answer = ('Hello, ' + name).encode('utf8')
+    resp.content_length = len(answer)
+    resp.content_type = 'text/plain'
+    await resp.prepare(request)
+    resp.write(answer)
+    await resp.write_eof()
+    return resp
+
+
+async def init():
+    app = web.Application()
+    app.router.scan('__main__')
+    return app
+
+loop = asyncio.get_event_loop()
+app = loop.run_until_complete(init())
+web.run_app(app)

--- a/examples/web_srv_route_table.py
+++ b/examples/web_srv_route_table.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Example for aiohttp.web basic server
+with table definition for routes
+"""
+
+import asyncio
+import textwrap
+
+from aiohttp import web
+
+
+async def intro(request):
+    txt = textwrap.dedent("""\
+        Type {url}/hello/John  {url}/simple or {url}/change_body
+        in browser url bar
+    """).format(url='127.0.0.1:8080')
+    binary = txt.encode('utf8')
+    resp = web.StreamResponse()
+    resp.content_length = len(binary)
+    resp.content_type = 'text/plain'
+    await resp.prepare(request)
+    resp.write(binary)
+    return resp
+
+
+async def simple(request):
+    return web.Response(text="Simple answer")
+
+
+async def change_body(request):
+    resp = web.Response()
+    resp.body = b"Body changed"
+    resp.content_type = 'text/plain'
+    return resp
+
+
+async def hello(request):
+    resp = web.StreamResponse()
+    name = request.match_info.get('name', 'Anonymous')
+    answer = ('Hello, ' + name).encode('utf8')
+    resp.content_length = len(answer)
+    resp.content_type = 'text/plain'
+    await resp.prepare(request)
+    resp.write(answer)
+    await resp.write_eof()
+    return resp
+
+
+async def init():
+    app = web.Application()
+    app.router.add_routes([
+        web.get('/', intro),
+        web.get('/simple', simple),
+        web.get('/change_body', change_body),
+        web.get('/hello/{name}', hello),
+        web.get('/hello', hello),
+    ])
+    return app
+
+loop = asyncio.get_event_loop()
+app = loop.run_until_complete(init())
+web.run_app(app)

--- a/tests/test_route_deco.py
+++ b/tests/test_route_deco.py
@@ -27,7 +27,7 @@ if sys.version_info >= (3, 5):
             del sys.modules[mod.__name__]
 else:
     @pytest.fixture
-    def create_module(name):
+    def create_module():
         from imp import new_module
 
         mods = []

--- a/tests/test_route_deco.py
+++ b/tests/test_route_deco.py
@@ -1,13 +1,44 @@
 import asyncio
 import sys
-from importlib.machinery import ModuleSpec, SourceFileLoader
-from importlib.util import module_from_spec
 from textwrap import dedent
 
 import pytest
 
 from aiohttp import web
 from aiohttp.web_urldispatcher import UrlDispatcher
+
+
+if sys.version_info >= (3, 5):
+    @pytest.fixture
+    def create_module():
+        from importlib.machinery import ModuleSpec, SourceFileLoader
+        from importlib.util import module_from_spec
+        mods = []
+
+        def maker(name, *, is_package=False):
+            loader = SourceFileLoader('<fullname>', '<path>')
+            spec = ModuleSpec(name, loader, is_package=is_package)
+            mod = module_from_spec(spec)
+            sys.modules[mod.__name__] = mod
+            mods.append(mod)
+            return mod
+        yield maker
+        for mod in mods:
+            del sys.modules[mod.__name__]
+else:
+    @pytest.fixture
+    def create_module(name):
+        from imp import new_module
+
+        mods = []
+
+        def maker(name, *, is_package=False):
+            mod = new_module(name)
+            sys.modules[mod.__name__] = mod
+            mods.append(mod)
+        yield maker
+        for mod in mods:
+            del sys.modules[mod.__name__]
 
 
 @pytest.fixture
@@ -37,11 +68,8 @@ def test_add_routeinfo_twice(router):
             pass
 
 
-def test_scan(router):
-    loader = SourceFileLoader('<fullname>', '<path>')
-    spec = ModuleSpec('aiohttp.tmp_test', loader, is_package=False)
-    mod = module_from_spec(spec)
-    sys.modules[mod.__name__] = mod
+def test_scan_mod(router, create_module):
+    mod = create_module('aiohttp.tmp.test_mod')
     content = dedent("""\
         import asyncio
         from aiohttp import web
@@ -51,14 +79,48 @@ def test_scan(router):
         def handler(request):
             pass
     """)
-    try:
-        exec(content, mod.__dict__)
-        router.scan(mod.__name__)
+    exec(content, mod.__dict__)
+    router.scan(mod.__name__)
 
-        assert len(router.routes()) == 1
+    assert len(router.routes()) == 1
 
-        route = list(router.routes())[0]
-        assert route.method == 'HEAD'
-        assert str(route.url_for()) == '/path'
-    finally:
-        del sys.modules[mod.__name__]
+    route = list(router.routes())[0]
+    assert route.method == 'HEAD'
+    assert str(route.url_for()) == '/path'
+
+
+def test_scan_package(router, create_module):
+    mod = create_module('aiohttp.tmp', is_package=True)
+    mod1 = create_module('aiohttp.tmp.test_mod1')
+    content1 = dedent("""\
+        import asyncio
+        from aiohttp import web
+
+        @web.head('/path1')
+        @asyncio.coroutine
+        def handler(request):
+            pass
+    """)
+    exec(content1, mod1.__dict__)
+    mod2 = create_module('aiohttp.tmp.test_mod2')
+    content2 = dedent("""\
+        import asyncio
+        from aiohttp import web
+
+        @web.put('/path2')
+        @asyncio.coroutine
+        def handler(request):
+            pass
+    """)
+    exec(content2, mod2.__dict__)
+    router.scan(mod.__package__)
+
+    assert len(router.routes()) == 2
+
+    route1 = list(router.routes())[0]
+    assert route1.method == 'HEAD'
+    assert str(route1.url_for()) == '/path1'
+
+    route1 = list(router.routes())[1]
+    assert route1.method == 'PUT'
+    assert str(route1.url_for()) == '/path2'

--- a/tests/test_route_deco.py
+++ b/tests/test_route_deco.py
@@ -1,0 +1,64 @@
+import asyncio
+import sys
+from importlib.machinery import ModuleSpec, SourceFileLoader
+from importlib.util import module_from_spec
+from textwrap import dedent
+
+import pytest
+
+from aiohttp import web
+from aiohttp.web_urldispatcher import UrlDispatcher
+
+
+@pytest.fixture
+def router():
+    return UrlDispatcher()
+
+
+def test_add_routeinfo(router):
+    @web.get('/path')
+    @asyncio.coroutine
+    def handler(request):
+        pass
+
+    assert hasattr(handler, '__aiohttp_web__')
+    info = handler.__aiohttp_web__
+    assert info.method == 'GET'
+    assert info.path == '/path'
+    assert info.handler is handler
+
+
+def test_add_routeinfo_twice(router):
+    with pytest.raises(ValueError):
+        @web.get('/path')
+        @web.post('/path')
+        @asyncio.coroutine
+        def handler(request):
+            pass
+
+
+def test_scan(router):
+    loader = SourceFileLoader('<fullname>', '<path>')
+    spec = ModuleSpec('aiohttp.tmp_test', loader, is_package=False)
+    mod = module_from_spec(spec)
+    sys.modules[mod.__name__] = mod
+    content = dedent("""\
+        import asyncio
+        from aiohttp import web
+
+        @web.head('/path')
+        @asyncio.coroutine
+        def handler(request):
+            pass
+    """)
+    try:
+        exec(content, mod.__dict__)
+        router.scan(mod.__name__)
+
+        assert len(router.routes()) == 1
+
+        route = list(router.routes())[0]
+        assert route.method == 'HEAD'
+        assert str(route.url_for()) == '/path'
+    finally:
+        del sys.modules[mod.__name__]

--- a/tests/test_route_table.py
+++ b/tests/test_route_table.py
@@ -19,11 +19,11 @@ def test_get(router):
     router.add_routes([web.get('/', handler)])
     assert len(router.routes()) == 2  # GET and HEAD
 
-    route = list(router.routes())[0]
+    route = list(router.routes())[1]
     assert route.handler is handler
     assert route.method == 'GET'
 
-    route2 = list(router.routes())[1]
+    route2 = list(router.routes())[0]
     assert route2.handler is handler
     assert route2.method == 'HEAD'
 
@@ -97,9 +97,9 @@ def test_route(router):
     def handler(request):
         pass
 
-    router.add_routes([web.route('OPTIONS', '/', handler)])
+    router.add_routes([web.route('OTHER', '/', handler)])
     assert len(router.routes()) == 1
 
     route = list(router.routes())[0]
     assert route.handler is handler
-    assert route.method == 'OPTIONS'
+    assert route.method == 'OTHER'

--- a/tests/test_route_table.py
+++ b/tests/test_route_table.py
@@ -22,6 +22,7 @@ def test_get(router):
     route = list(router.routes())[1]
     assert route.handler is handler
     assert route.method == 'GET'
+    assert str(route.url_for()) == '/'
 
     route2 = list(router.routes())[0]
     assert route2.handler is handler
@@ -39,6 +40,7 @@ def test_head(router):
     route = list(router.routes())[0]
     assert route.handler is handler
     assert route.method == 'HEAD'
+    assert str(route.url_for()) == '/'
 
 
 def test_post(router):
@@ -51,6 +53,7 @@ def test_post(router):
     route = list(router.routes())[0]
     assert route.handler is handler
     assert route.method == 'POST'
+    assert str(route.url_for()) == '/'
 
 
 def test_put(router):
@@ -64,6 +67,7 @@ def test_put(router):
     route = list(router.routes())[0]
     assert route.handler is handler
     assert route.method == 'PUT'
+    assert str(route.url_for()) == '/'
 
 
 def test_patch(router):
@@ -77,6 +81,7 @@ def test_patch(router):
     route = list(router.routes())[0]
     assert route.handler is handler
     assert route.method == 'PATCH'
+    assert str(route.url_for()) == '/'
 
 
 def test_delete(router):
@@ -90,6 +95,7 @@ def test_delete(router):
     route = list(router.routes())[0]
     assert route.handler is handler
     assert route.method == 'DELETE'
+    assert str(route.url_for()) == '/'
 
 
 def test_route(router):
@@ -103,3 +109,4 @@ def test_route(router):
     route = list(router.routes())[0]
     assert route.handler is handler
     assert route.method == 'OTHER'
+    assert str(route.url_for()) == '/'

--- a/tests/test_route_table.py
+++ b/tests/test_route_table.py
@@ -1,0 +1,105 @@
+import asyncio
+
+import pytest
+
+from aiohttp import web
+from aiohttp.web_urldispatcher import UrlDispatcher
+
+
+@pytest.fixture
+def router():
+    return UrlDispatcher()
+
+
+def test_get(router):
+    @asyncio.coroutine
+    def handler(request):
+        pass
+
+    router.add_routes([web.get('/', handler)])
+    assert len(router.routes()) == 2  # GET and HEAD
+
+    route = list(router.routes())[0]
+    assert route.handler is handler
+    assert route.method == 'GET'
+
+    route2 = list(router.routes())[1]
+    assert route2.handler is handler
+    assert route2.method == 'HEAD'
+
+
+def test_head(router):
+    @asyncio.coroutine
+    def handler(request):
+        pass
+
+    router.add_routes([web.head('/', handler)])
+    assert len(router.routes()) == 1
+
+    route = list(router.routes())[0]
+    assert route.handler is handler
+    assert route.method == 'HEAD'
+
+
+def test_post(router):
+    @asyncio.coroutine
+    def handler(request):
+        pass
+
+    router.add_routes([web.post('/', handler)])
+
+    route = list(router.routes())[0]
+    assert route.handler is handler
+    assert route.method == 'POST'
+
+
+def test_put(router):
+    @asyncio.coroutine
+    def handler(request):
+        pass
+
+    router.add_routes([web.put('/', handler)])
+    assert len(router.routes()) == 1
+
+    route = list(router.routes())[0]
+    assert route.handler is handler
+    assert route.method == 'PUT'
+
+
+def test_patch(router):
+    @asyncio.coroutine
+    def handler(request):
+        pass
+
+    router.add_routes([web.patch('/', handler)])
+    assert len(router.routes()) == 1
+
+    route = list(router.routes())[0]
+    assert route.handler is handler
+    assert route.method == 'PATCH'
+
+
+def test_delete(router):
+    @asyncio.coroutine
+    def handler(request):
+        pass
+
+    router.add_routes([web.delete('/', handler)])
+    assert len(router.routes()) == 1
+
+    route = list(router.routes())[0]
+    assert route.handler is handler
+    assert route.method == 'DELETE'
+
+
+def test_route(router):
+    @asyncio.coroutine
+    def handler(request):
+        pass
+
+    router.add_routes([web.route('OPTIONS', '/', handler)])
+    assert len(router.routes()) == 1
+
+    route = list(router.routes())[0]
+    assert route.handler is handler
+    assert route.method == 'OPTIONS'


### PR DESCRIPTION
Now we have methods like `app.router.add_get()` for filling route table.
It works pretty well but I see constant request for other approaches: url table in django/tornado style and decorators like bottle or django.

The PR proposes support these two ways.

Url table:
```
    app.router.add_routes([
        web.get('/path', handler1),
        web.post('/path', handler2),
    ])
```
`.add_routes()` appends table to the router.

Other approach is using decorators for web handlers in pyramid-style:
```
@web.get('/simple')
async def simple(request):
    return web.Response()

app.router.scan(__name__)
```
Decorator stores info into `handler.__dict__` without adding it into router.
`app.router.scan(__name__)` scans module content and adds all registered routes.
`app.router.scan(__package__)` scans all *imported* modules from the package. 
Technically it iterates over `sys.modules` and scans all modules started from given name in alphabetical order.

Why use `.scan(name)` instead of `@app.router.get()` decoration? Because it doesn't create application on import stage which is the *very bad style* I believe.

Decoration is maybe not good for big projects but very convenient for relative small code base at least.

P.S.
I used to hope somebody invent these approaches in third-party library but I see no success.
Maybe the concept is not very easy to implement. So let's do it ourself.

P.P.S.
Documentation is needed to be updated, sure.
Honestly I have no idea what route definition style should be proposed first (in `index.rst` and tutorial).

Opinions?