### PR TITLE
Drop deprecated RequestHandler.finish_connections

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,7 +9,7 @@ Changes
 
 - Make enable_compression work on HTTP/1.0 #1828
 
--
+- Drop deprecated `Server.finish_connections`
 
 -
 

--- a/aiohttp/web_server.py
+++ b/aiohttp/web_server.py
@@ -45,7 +45,5 @@ class Server:
         self._connections.clear()
         self.time_service.close()
 
-    finish_connections = shutdown
-
     def __call__(self):
         return RequestHandler(self, loop=self._loop, **self._kwargs)

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -1391,19 +1391,6 @@ A protocol factory compatible with
       A :ref:`coroutine<coroutine>` that should be called to close all opened
       connections.
 
-   .. coroutinemethod:: Server.finish_connections(timeout)
-
-      .. deprecated:: 1.2
-
-         A deprecated alias for :meth:`shutdown`.
-
-   .. versionchanged:: 1.2
-
-      ``Server`` was called ``RequestHandlerFactory`` before ``aiohttp==1.2``.
-
-      The rename has no deprecation period but it's safe: no user
-      should instantiate the class by hands.
-
 
 Router
 ^^^^^^

--- a/tests/autobahn/server.py
+++ b/tests/autobahn/server.py
@@ -45,7 +45,7 @@ def main(loop):
 @asyncio.coroutine
 def finish(app, srv, handler):
     srv.close()
-    yield from handler.finish_connections()
+    yield from handler.shutdown()
     yield from srv.wait_closed()
 
 

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -1102,7 +1102,7 @@ class TestHttpClientConnector(unittest.TestCase):
 
     def tearDown(self):
         if self.handler:
-            self.loop.run_until_complete(self.handler.finish_connections())
+            self.loop.run_until_complete(self.handler.shutdown())
         self.loop.stop()
         self.loop.run_forever()
         self.loop.close()

--- a/tests/test_web_request_handler.py
+++ b/tests/test_web_request_handler.py
@@ -34,7 +34,7 @@ def test_connections(loop):
 
 
 @asyncio.coroutine
-def test_finish_connection_no_timeout(loop):
+def test_shutdown_no_timeout(loop):
     app = web.Application()
     manager = app.make_handler(loop=loop)
 
@@ -43,7 +43,7 @@ def test_finish_connection_no_timeout(loop):
     transport = mock.Mock()
     manager.connection_made(handler, transport)
 
-    yield from manager.finish_connections()
+    yield from manager.shutdown()
 
     manager.connection_lost(handler, None)
     assert manager.connections == []
@@ -51,7 +51,7 @@ def test_finish_connection_no_timeout(loop):
 
 
 @asyncio.coroutine
-def test_finish_connection_timeout(loop):
+def test_shutdown_timeout(loop):
     app = web.Application()
     manager = app.make_handler(loop=loop)
 
@@ -60,7 +60,7 @@ def test_finish_connection_timeout(loop):
     transport = mock.Mock()
     manager.connection_made(handler, transport)
 
-    yield from manager.finish_connections(timeout=0.1)
+    yield from manager.shutdown(timeout=0.1)
 
     manager.connection_lost(handler, None)
     assert manager.connections == []


### PR DESCRIPTION
We deprecated it in aiohttp 1.2 and I pretty sure nobody use it now.