### PR TITLE
`RedirectURLError` is raised instead of RuntimeError

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -44,6 +44,7 @@ Chris AtLee
 Chris Laws
 Chris Moore
 Christopher Schmitt
+Claudiu Popa
 Damien Nadé
 Daniel García
 Daniel Nelson

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -26,6 +26,7 @@ from .cookiejar import CookieJar
 from .helpers import (PY_35, CeilTimeout, TimeoutHandle, deprecated_noop,
                       sentinel)
 from .http import WS_KEY, WebSocketReader, WebSocketWriter
+from .http_exceptions import RedirectURLError
 from .streams import FlowControlDataQueue
 
 
@@ -274,7 +275,7 @@ class ClientSession:
                         r_url = (resp.headers.get(hdrs.LOCATION) or
                                  resp.headers.get(hdrs.URI))
                         if r_url is None:
-                            raise RuntimeError(
+                            raise RedirectURLError(
                                 "{0.method} {0.url} returns "
                                 "a redirect [{0.status}] status "
                                 "but response lacks a Location "

--- a/aiohttp/http_exceptions.py
+++ b/aiohttp/http_exceptions.py
@@ -57,6 +57,10 @@ class ContentLengthError(PayloadEncodingError):
     """Not enough data for satisfy content length header."""
 
 
+class RedirectURLError(BadHttpMessage):
+    """A redirect response lacks a Location or URI HTTP header"""
+
+
 class LineTooLong(BadHttpMessage):
 
     def __init__(self, line, limit='Unknown'):

--- a/changes/2009.feature
+++ b/changes/2009.feature
@@ -1,0 +1,3 @@
+`RedirectURLError` is raised instead of RuntimeError
+
+Raise `RedirectURLError` if a redirect response has no Location or URI HTTP header.

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -15,6 +15,7 @@ import aiohttp
 from aiohttp import hdrs, web
 from aiohttp.client import ServerFingerprintMismatch
 from aiohttp.helpers import create_future
+from aiohttp.http_exceptions import RedirectURLError
 from aiohttp.multipart import MultipartWriter
 
 
@@ -2106,12 +2107,13 @@ def test_redirect_without_location_header(loop, test_client):
     app.router.add_route('GET', '/redirect', handler_redirect)
     client = yield from test_client(app)
 
-    with pytest.raises(RuntimeError) as ctx:
+    with pytest.raises(RedirectURLError) as ctx:
         yield from client.get('/redirect')
-    assert str(ctx.value) == ('GET http://127.0.0.1:{}/redirect returns '
-                              'a redirect [301] status but response lacks '
-                              'a Location or URI HTTP header'
-                              .format(client.port))
+    expected_msg = ('GET http://127.0.0.1:{}/redirect returns '
+                    'a redirect [301] status but response lacks '
+                    'a Location or URI HTTP header'
+                    .format(client.port))
+    assert str(ctx.value.message) == expected_msg
 
 
 @asyncio.coroutine


### PR DESCRIPTION
## What do these changes do?

Raise `RedirectWithoutLocationError` if a redirect response has no Location or URI HTTP header.

## Are there changes in behavior for the user?

Users won't need to catch ``RuntimeError`` in this case, just this newly added error. This is not backwards compatible though, but I think it is alright.

## Related issue number

#2009

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `changes` folder
  * name it `<issue_id>.<type>` for example (588.bug)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
