### PR TITLE
Yield from session.close() to silence warnings

### DIFF
--- a/aiohttp/test_utils.py
+++ b/aiohttp/test_utils.py
@@ -330,7 +330,7 @@ class TestClient:
                 resp.close()
             for ws in self._websockets:
                 yield from ws.close()
-            self._session.close()
+            yield from self._session.close()
             yield from self._server.close()
             self._closed = True
 


### PR DESCRIPTION
## What do these changes do?

This will silence a warning about ClientSession.close being a coroutine.

```
tests/components/test_alexa.py::test_flash_briefing_valid[pyloop]
  /Users/paulus/dev/python/home-assistant/lib/python3.6/site-packages/aiohttp/helpers.py:72: DeprecationWarning: ClientSession.close() is a coroutine
    warnings.warn(self._msg, DeprecationWarning)
```

You can get it by running `py.test -W once test/a_test_using_test_utils.py`

## Are there changes in behavior for the user?

No

## Related issue number

Nah

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
