### PR TITLE
Fix missing app.loop in startup hook during test

### DIFF
--- a/aiohttp/test_utils.py
+++ b/aiohttp/test_utils.py
@@ -148,6 +148,7 @@ class TestServer(BaseTestServer):
 
     @asyncio.coroutine
     def _make_factory(self, **kwargs):
+        self.app._set_loop(self._loop)
         yield from self.app.startup()
         self.handler = self.app.make_handler(loop=self._loop, **kwargs)
         return self.handler

--- a/changes/2060.bugfix
+++ b/changes/2060.bugfix
@@ -1,0 +1,1 @@
+Fix missing app.loop on startup hooks during tests

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -1,0 +1,21 @@
+import asyncio
+
+from aiohttp import web
+from aiohttp.test_utils import AioHTTPTestCase, unittest_run_loop
+
+
+class TestCase(AioHTTPTestCase):
+    @asyncio.coroutine
+    def get_application(self):
+        app = web.Application()
+        app.on_startup.append(self.on_startup_hook)
+        return app
+
+    @asyncio.coroutine
+    def on_startup_hook(self, app):
+        self.startup_loop = app.loop
+
+    @unittest_run_loop
+    @asyncio.coroutine
+    def test_on_startup_hook(self):
+        assert self.startup_loop is not None


### PR DESCRIPTION
## What do these changes do?

Set the loop before sending startup signal. Just like `web.run_app`.

## Are there changes in behavior for the user?

It will be more consistent between `run_app` and testing.

## Related issue number

#2060 

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `changes` folder
  * name it `<issue_id>.<type>` for example (588.bug)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
