### PR TITLE
Added get_client and get_server methods to AioHTTPTestCase

### DIFF
--- a/aiohttp/test_utils.py
+++ b/aiohttp/test_utils.py
@@ -384,9 +384,20 @@ class AioHTTPTestCase(unittest.TestCase):
 
         self.loop.run_until_complete(self.client.start_server())
 
+        self.loop.run_until_complete(self.setUpAsync())
+
+    @asyncio.coroutine
+    def setUpAsync(self):
+        pass
+
     def tearDown(self):
+        self.loop.run_until_complete(self.tearDownAsync())
         self.loop.run_until_complete(self.client.close())
         teardown_test_loop(self.loop)
+
+    @asyncio.coroutine
+    def tearDownAsync(self):
+        pass
 
     @asyncio.coroutine
     def get_server(self, app):

--- a/changes/2032.feature
+++ b/changes/2032.feature
@@ -1,1 +1,1 @@
-Added `get_client` and `get_server` methods to AioHTTPTestCase
+Added `get_client`, `get_server`, `setUpAsync` and `tearDownAsync` methods to AioHTTPTestCase

--- a/changes/2032.feature
+++ b/changes/2032.feature
@@ -1,0 +1,1 @@
+Added `get_client` and `get_server` methods to AioHTTPTestCase

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -278,6 +278,16 @@ functionality, the AioHTTPTestCase is provided::
 
        :return: :class:`aiohttp.web.Application` instance.
 
+    .. comethod:: setUpAsync()
+
+       This async method do nothing by default and can be overriden to execute
+       asynchronous code during the setUp stage of the TestCase.
+
+    .. comethod:: tearDownAsync()
+
+       This async method do nothing by default and can be overriden to execute
+       asynchronous code during the tearDown stage of the TestCase.
+
     .. method:: setUp()
 
        Standard test initialization method.

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -243,6 +243,10 @@ functionality, the AioHTTPTestCase is provided::
 
        an aiohttp test client, :class:`TestClient` instance.
 
+    .. attribute:: server
+
+       an aiohttp test server, :class:`TestServer` instance.
+
     .. attribute:: loop
 
        The event loop in which the application and server are running.
@@ -251,6 +255,20 @@ functionality, the AioHTTPTestCase is provided::
 
        The application returned by :meth:`get_app`
        (:class:`aiohttp.web.Application` instance).
+
+    .. comethod:: get_client()
+
+       This async method can be overridden to return the :class:`TestClient`
+       object used in the test.
+
+       :return: :class:`TestClient` instance.
+
+    .. comethod:: get_server()
+
+       This async method can be overridden to return the :class:`TestServer`
+       object used in the test.
+
+       :return: :class:`TestServer` instance.
 
     .. comethod:: get_application()
 

--- a/tests/test_py35/test_test_utils_35.py
+++ b/tests/test_py35/test_test_utils_35.py
@@ -27,7 +27,7 @@ async def test_server_context_manager(app, loop):
     "head", "get", "post", "options", "post", "put", "patch", "delete"
 ])
 async def test_client_context_manager_response(method, app, loop):
-    async with _TestClient(app, loop=loop) as client:
+    async with _TestClient(_TestServer(app), loop=loop) as client:
         async with getattr(client, method)('/') as resp:
             assert resp.status == 200
             if method != 'head':


### PR DESCRIPTION
This change is needed if we want a clear distinction in the
unittest.TestCase between "app" (the application) and "server" the
actual test server. This will also allow a developer to override these
methods to use their own TestServer and TestClient.

## What do these changes do?

1. It transform the method `_get_client()` of AioHTTPTestCase to a public method (inviting the developer to override it)
2. It adds a method `get_server()` to AioHTTPTestCase that will, by default, instantiate the default TestServer
3. It replaces the flexible first parameter of TestClient which was `app_or_server` to `server` only
4. It removes the now unrelevant parameter host an port of TestClient

## Are there changes in behavior for the user?

1. (breaking change) You can no longer return a BaseTestServer instance from `get_application`. `get_application` must only return an Application instance.
2. If you want a different TestServer you must override `get_server`.
2. You can now override `get_client` method because it is now a public method (you always could but... now it's more obvious that you actually should).
3. (breaking change) `_get_client` has change of name.

## Related issue number

#2032 

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `changes` folder
  * name it `<issue_id>.<type>` for example (588.bug)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
