### PR TITLE
Add automatically a SafeChildWatcher to the test loop

### DIFF
--- a/aiohttp/test_utils.py
+++ b/aiohttp/test_utils.py
@@ -5,6 +5,7 @@ import contextlib
 import functools
 import gc
 import socket
+import sys
 import unittest
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
@@ -440,6 +441,11 @@ def setup_test_loop(loop_factory=asyncio.new_event_loop):
     """
     loop = loop_factory()
     asyncio.set_event_loop(None)
+    if sys.platform != "win32":
+        policy = asyncio.get_event_loop_policy()
+        watcher = asyncio.SafeChildWatcher()
+        watcher.attach_loop(loop)
+        policy.set_child_watcher(watcher)
     return loop
 
 

--- a/changes/2058.feature
+++ b/changes/2058.feature
@@ -1,0 +1,1 @@
+Add automatically a SafeChildWatcher to the test loop

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -1,0 +1,16 @@
+import asyncio
+import platform
+import threading
+
+import pytest
+
+
+@pytest.mark.skipif(platform.system() == "Windows",
+                    reason="the test is not valid for Windows")
+@asyncio.coroutine
+def test_subprocess_co(loop):
+    assert isinstance(threading.current_thread(), threading._MainThread)
+    proc = yield from asyncio.create_subprocess_shell(
+        "exit 0", loop=loop, stdin=asyncio.subprocess.DEVNULL,
+        stdout=asyncio.subprocess.DEVNULL, stderr=asyncio.subprocess.DEVNULL)
+    yield from proc.wait()


### PR DESCRIPTION
The fact that on Unix system we don't create automatically a child
watcher makes all call to asyncio.create_subprocess_* to fail.

## What do these changes do?

It adds a default child watcher to the test loop.

## Are there changes in behavior for the user?

Any `asyncio.create_subprocess_*` call in the application or during a test will work because the ChildWatcher exist (on Unix).

No change for Windows.

## Related issue number

#2058 #2059 

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `changes` folder
  * name it `<issue_id>.<type>` for example (588.bug)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
