### PR TITLE
Add GNS3 to powered by

### DIFF
--- a/docs/powered_by.rst
+++ b/docs/powered_by.rst
@@ -13,3 +13,4 @@ make a Pull Request!
 * KeepSafe https://www.getkeepsafe.com/
 * Skyscanner Hotels https://www.skyscanner.net/hotels
 * Ocean S.A. https://ocean.io/
+* GNS3 http://gns3.com


### PR DESCRIPTION
This PR add GNS3 to powered by aiohttp.

It's the foundation of the GNS3 server which allow user to emulate network. It's use by students to pass certification  and by network engineer for simulating operations.

Because it's a popular open source project in the world of the network engineers, you can be sure any big organisation has somewhere a GNS3 installation with aiohttp.

And thanks to high quality open source project like aiohttp. We can provide a free tool that enable student around the world to learn networking for almost no money except the certification cost.

So thanks to everyone !