### PR TITLE
add TutorCruncher Socket and Morpheus to powered by

### DIFF
--- a/docs/powered_by.rst
+++ b/docs/powered_by.rst
@@ -14,3 +14,5 @@ make a Pull Request!
 * Skyscanner Hotels https://www.skyscanner.net/hotels
 * Ocean S.A. https://ocean.io/
 * GNS3 http://gns3.com
+* TutorCruncher socket https://tutorcruncher.com/features/tutorcruncher-socket/
+* Morpheus messaging microservice https://github.com/tutorcruncher/morpheus

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -122,6 +122,7 @@ lookups
 Mako
 manylinux
 metadata
+microservice
 middleware
 middlewares
 miltidict


### PR DESCRIPTION
Add to powered by:
* TutorCruncher socket - TutorCruncher's microservice for serving tutor listing for website integration.
* Morpheus - service for sending high volumes of emails and SMS, receiving webhooks, and displaying outbound message details and analytics to end users. One of its aims is to allow us to move off mandrill and onto SES by providing the extra functionality SES lacks.

Both projects are open source, socket is tightly linked to TutorCruncher's main API and is really open source for reference only. 

Morpheus is much less tightly linked to TutorCruncher and might one day become a useful tool for other SAAS/CRM platforms sending high volumes of emails and wanting to give users a comprehensive view of deliverability.