### PR TITLE
Fix docs (#2085)

### DIFF
--- a/changes/2085.doc
+++ b/changes/2085.doc
@@ -1,0 +1,1 @@
+Fix mistake about access log disabling.

--- a/docs/logging.rst
+++ b/docs/logging.rst
@@ -38,7 +38,7 @@ instance to override default logger.
 
 .. note::
 
-   Use ``app.make_handler(access_log=None)`` for disabling access logs.
+   Use ``web.run_app(app, access_log=None)`` for disabling access logs.
 
 
 Other parameter called *access_log_format* may be used for specifying log


### PR DESCRIPTION
## What do these changes do?

Fix document mistake about access log disabling.

## Are there changes in behavior for the user?

No

## Related issue number

#2085 

## Checklist
- [x] Documentation reflects the changes
- [x] Add a new news fragment into the `changes` folder