### PR TITLE
Improve startup cleanup signals

### DIFF
--- a/aiohttp/web.py
+++ b/aiohttp/web.py
@@ -420,9 +420,10 @@ def run_app(app, *, host=None, port=None, path=None, sock=None,
         loop = asyncio.get_event_loop()
 
     app._set_loop(loop)
-    loop.run_until_complete(app.startup())
 
     try:
+        loop.run_until_complete(app.startup())
+
         make_handler_kwargs = dict()
         if access_log_format is not None:
             make_handler_kwargs['access_log_format'] = access_log_format

--- a/changes/2092.feature
+++ b/changes/2092.feature
@@ -1,0 +1,1 @@
+Cleanup signal is sent even if an error occur during startup signal

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -1299,6 +1299,14 @@ duplicated like one using :meth:`Application.copy`.
           async def on_cleanup(app):
               pass
 
+      .. versionchanged:: 2.3.0
+
+         The cleanup signal is sent even if an error occurs during the
+         processing of the startup signal. An error during startup will
+         probably leave your application partially initialized. If you are
+         using the :class:`Application` dictionary, you must check first that
+         the key exists before cleaning up anything.
+
       .. seealso:: :ref:`aiohttp-web-graceful-shutdown` and :attr:`on_shutdown`.
 
    .. method:: make_handler(loop=None, **kwargs)

--- a/tests/test_run_app.py
+++ b/tests/test_run_app.py
@@ -566,3 +566,16 @@ def test_startup_cleanup_signals_even_on_failure(loop, mocker):
 
     app.startup.assert_called_once_with()
     app.cleanup.assert_called_once_with()
+
+
+def test_exception_during_startup_prevents_running(loop, mocker):
+    skip_if_no_dict(loop)
+
+    app = web.Application()
+    app.on_startup.append(mock.Mock(side_effect=RuntimeError()))
+    mocker.spy(app, 'cleanup')
+
+    with pytest.raises(RuntimeError):
+        web.run_app(app, loop=loop, host=(), print=stopper(loop))
+
+    app.cleanup.assert_called_once_with()


### PR DESCRIPTION
## What do these changes do?

1. cleanup signal is sent even if startup signal failed
2. ~helpers to create and manage background tasks~

## Are there changes in behavior for the user?

1. The cleanup hooks will be called more often at the end of the process. You now try to connect to a database in a startup hook and get your client session cleaned automatically in the cleanup even if the database connection failed.
2. ~You no longer need to use the dict methods of Application to create tasks to manage background processes, you can use the helper `add_task` and provide a coroutine. The coroutine will be called with the app argument. When the application finishes, the tasks will be cancelled and awaited properly (except if a task raise SystemExit or any not Exception based exception).~

## Related issue number

#2092 

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `changes` folder
  * name it `<issue_id>.<type>` for example (588.bug)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
