### PR TITLE
Force use of IPv4 during tests

### DIFF
--- a/changes/2104.bugfix
+++ b/changes/2104.bugfix
@@ -1,0 +1,2 @@
+Force use of IPv4 during test, this will make tests run in a Docker container
+

--- a/tests/test_run_app.py
+++ b/tests/test_run_app.py
@@ -261,7 +261,7 @@ def test_run_app_nondefault_host_port(loop, unused_port, mocker):
     skip_if_no_dict(loop)
 
     port = unused_port()
-    host = 'localhost'
+    host = '127.0.0.1'
 
     mocker.spy(loop, 'create_server')
 


### PR DESCRIPTION
## What do these changes do?

Force test to run using IPv4 only.

## Are there changes in behavior for the user?

None.

## Related issue number

#2104 

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `changes` folder
  * name it `<issue_id>.<type>` for example (588.bug)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
