### PR TITLE
Fix issue with IndexError being raised by the StreamReader.iter_chunks() generator

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -104,6 +104,7 @@ Kirill Klenov
 Kirill Malovitsa
 Kyrylo Perevozchikov
 Lars P. Søndergaard
+Loïc Lajeanne
 Louis-Philippe Huberdeau
 Lu Gong
 Lubomir Gelo

--- a/aiohttp/streams.py
+++ b/aiohttp/streams.py
@@ -323,12 +323,13 @@ class StreamReader(AsyncStreamReaderMixin):
         if self._exception is not None:
             raise self._exception
 
-        if not self._buffer:
-            if self._eof:
-                return b""
+        if not self._buffer and not self._eof:
             yield from self._wait('readchunk')
 
-        return self._read_nowait_chunk(-1)
+        if self._buffer:
+            return self._read_nowait_chunk(-1)
+        else:
+            return b""
 
     @asyncio.coroutine
     def readexactly(self, n):

--- a/aiohttp/streams.py
+++ b/aiohttp/streams.py
@@ -323,7 +323,9 @@ class StreamReader(AsyncStreamReaderMixin):
         if self._exception is not None:
             raise self._exception
 
-        if not self._buffer and not self._eof:
+        if not self._buffer:
+            if self._eof:
+                return b""
             yield from self._wait('readchunk')
 
         return self._read_nowait_chunk(-1)

--- a/changes/2112.bugfix
+++ b/changes/2112.bugfix
@@ -1,0 +1,1 @@
+Fix issue with IndexError being raised by the StreamReader.iter_chunks() generator.

--- a/tests/test_streams.py
+++ b/tests/test_streams.py
@@ -547,7 +547,6 @@ class TestStreamReader(unittest.TestCase):
         self.assertRaises(RuntimeError, stream.read_nowait)
 
     def test_readchunk(self):
-
         stream = self._make_one()
 
         def cb():
@@ -564,6 +563,18 @@ class TestStreamReader(unittest.TestCase):
 
         data = self.loop.run_until_complete(stream.readchunk())
         self.assertEqual(b'', data)
+
+    def test_readchunk_wait_eof(self):
+        stream = self._make_one()
+
+        def cb():
+            yield from asyncio.sleep(0.1, loop=self.loop)
+            stream.feed_eof()
+
+        asyncio.Task(cb(), loop=self.loop)
+        data = self.loop.run_until_complete(stream.readchunk())
+        self.assertEqual(b"", data)
+        self.assertTrue(stream.is_eof())
 
     def test___repr__(self):
         stream = self._make_one()

--- a/tests/test_streams.py
+++ b/tests/test_streams.py
@@ -562,7 +562,7 @@ class TestStreamReader(unittest.TestCase):
         data = self.loop.run_until_complete(stream.readchunk())
         self.assertEqual(b'chunk2', data)
 
-        data = self.loop.run_until_complete(stream.read())
+        data = self.loop.run_until_complete(stream.readchunk())
         self.assertEqual(b'', data)
 
     def test___repr__(self):


### PR DESCRIPTION
## What do these changes do?

Make `StreamReader.readchunk` method return `b""` when ~~buffer is empty~~ eof is reached

## Are there changes in behavior for the user?

Fixes the `IndexError` raised when using `iter_chunks()`

## Related issue number

#2112

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `changes` folder
  * name it `<issue_id>.<type>` for example (588.bug)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
