### PR TITLE
add more details to ClientConnectorError

### DIFF
--- a/aiohttp/client_exceptions.py
+++ b/aiohttp/client_exceptions.py
@@ -64,6 +64,25 @@ class ClientConnectorError(ClientOSError):
     Raised in :class:`aiohttp.connector.TCPConnector` if
         connection to proxy can not be established.
     """
+    def __init__(self, connection_key, os_error):
+        self._conn_key = connection_key
+        super().__init__(os_error.errno, os_error.strerror)
+
+    @property
+    def host(self):
+        return self._conn_key.host
+
+    @property
+    def port(self):
+        return self._conn_key.port
+
+    @property
+    def ssl(self):
+        return self._conn_key.ssl
+
+    def __str__(self):
+        return ('Cannot connect to host {0.host}:{0.port} ssl:{0.ssl} [{1}]'
+                .format(self._conn_key, self.strerror))
 
 
 class ClientProxyConnectionError(ClientConnectorError):

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -4,7 +4,7 @@ import ssl
 import sys
 import traceback
 import warnings
-from collections import defaultdict
+from collections import defaultdict, namedtuple
 from hashlib import md5, sha1, sha256
 from itertools import cycle, islice
 from time import monotonic
@@ -126,6 +126,9 @@ class _TransportPlaceholder:
 
     def close(self):
         pass
+
+
+ConnectionKey = namedtuple('ConnectionKey', ['host', 'port', 'ssl'])
 
 
 class BaseConnector(object):
@@ -300,11 +303,11 @@ class BaseConnector(object):
             if self._loop.is_closed():
                 return noop()
 
-            # cacnel cleanup task
+            # cancel cleanup task
             if self._cleanup_handle:
                 self._cleanup_handle.cancel()
 
-            # cacnel cleanup close task
+            # cancel cleanup close task
             if self._cleanup_closed_handle:
                 self._cleanup_closed_handle.cancel()
 
@@ -338,7 +341,7 @@ class BaseConnector(object):
     @asyncio.coroutine
     def connect(self, req):
         """Get from pool or create new connection."""
-        key = (req.host, req.port, req.ssl)
+        key = ConnectionKey(req.host, req.port, req.ssl)
 
         if self._limit:
             # total calc available connections
@@ -377,10 +380,7 @@ class BaseConnector(object):
             try:
                 proto = yield from self._create_connection(req)
             except OSError as exc:
-                raise ClientConnectorError(
-                    exc.errno,
-                    'Cannot connect to host {0[0]}:{0[1]} ssl:{0[2]} [{1}]'
-                    .format(key, exc.strerror)) from exc
+                raise ClientConnectorError(key, exc) from exc
             finally:
                 self._acquired.remove(placeholder)
                 self._acquired_per_host[key].remove(placeholder)
@@ -731,10 +731,7 @@ class TCPConnector(BaseConnector):
             except OSError as e:
                 exc = e
         else:
-            raise ClientConnectorError(
-                exc.errno,
-                'Can not connect to %s:%s [%s]' %
-                (req.host, req.port, exc.strerror)) from exc
+            raise ClientConnectorError(req, exc) from exc
 
     @asyncio.coroutine
     def _create_proxy_connection(self, req):
@@ -748,7 +745,7 @@ class TCPConnector(BaseConnector):
             transport, proto = yield from self._create_direct_connection(
                 proxy_req)
         except OSError as exc:
-            raise ClientProxyConnectionError(*exc.args) from exc
+            raise ClientProxyConnectionError(proxy_req, exc) from exc
 
         auth = proxy_req.headers.pop(hdrs.AUTHORIZATION, None)
         if auth is not None:

--- a/changes/2094.misc
+++ b/changes/2094.misc
@@ -1,0 +1,1 @@
+add more details to ``ClientConnectorError`` exceptions about the original error.

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -499,19 +499,22 @@ def test_connect(loop):
 
 
 @asyncio.coroutine
-def test_connect_oserr(loop):
+def test_connect_connection_error(loop):
     conn = aiohttp.BaseConnector(loop=loop)
     conn._create_connection = mock.Mock()
     conn._create_connection.return_value = helpers.create_future(loop)
     err = OSError(1, 'permission error')
     conn._create_connection.return_value.set_exception(err)
 
-    with pytest.raises(aiohttp.ClientOSError) as ctx:
+    with pytest.raises(aiohttp.ClientConnectorError) as ctx:
         req = mock.Mock()
         yield from conn.connect(req)
     assert 1 == ctx.value.errno
-    assert ctx.value.strerror.startswith('Cannot connect to')
-    assert ctx.value.strerror.endswith('[permission error]')
+    assert str(ctx.value).startswith('Cannot connect to')
+    assert str(ctx.value).endswith('[permission error]')
+    assert ctx.value.host == req.host
+    assert ctx.value.port == req.port
+    assert ctx.value.ssl == req.ssl
 
 
 def test_ctor_cleanup():


### PR DESCRIPTION
## What do these changes do?
see #2094, this should provide more details on `ClientConnectorError` exceptions allowing them to be more easily processed programmatically without resorting to parsing the error message.

## Are there changes in behavior for the user?

Should have minimal effect on users unless they're referring to `exc.strerror` which has changed here.

## Related issue number

#2094

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes (no specific docs for `ClientConnectorError` fields)
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `changes` folder
  * name it `<issue_id>.<type>` for example (588.bug)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
