### PR TITLE
Fix stacklevel in _CoroGuard's warning

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -77,6 +77,7 @@ Gregory Haynes
 Günther Jena
 Hu Bo
 Hugo Herter
+Hynek Schlawack
 Igor Davydenko
 Igor Pavlov
 Ingmar Steen

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -106,6 +106,11 @@ if not PY_35:
 
 
 class _CoroGuard(_BaseCoroMixin):
+    """Only to be used with func:`deprecated_noop`.
+
+    Otherwise the stack information in the raised warning doesn't line up with
+    the user's code anymore.
+    """
     __slots__ = ('_msg', '_awaited')
 
     def __init__(self, coro, msg):
@@ -126,7 +131,7 @@ class _CoroGuard(_BaseCoroMixin):
     def __del__(self):
         self._coro = None
         if not self._awaited:
-            warnings.warn(self._msg, DeprecationWarning)
+            warnings.warn(self._msg, DeprecationWarning, stacklevel=2)
 
 
 coroutines = asyncio.coroutines

--- a/changes/2106.bugfix
+++ b/changes/2106.bugfix
@@ -1,0 +1,1 @@
+Warnings about unawaited coroutines now correctly point to the user's code.

--- a/tests/test_client_session.py
+++ b/tests/test_client_session.py
@@ -64,8 +64,11 @@ def test_close_coro(create_session, loop):
 def test_close_deprecated(create_session):
     session = create_session()
 
-    with pytest.warns(DeprecationWarning):
+    with pytest.warns(DeprecationWarning) as ctx:
         session.close()
+
+    # Assert the warning points at us and not at _CoroGuard.
+    assert ctx.list[0].filename == __file__
 
 
 def test_init_headers_simple_dict(create_session):

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -17,7 +17,12 @@ from aiohttp import helpers
 def test_warn():
     with pytest.warns(DeprecationWarning) as ctx:
         helpers.deprecated_noop('Text')
-    assert str(ctx.list[0].message) == 'Text'
+
+    w = ctx.list[0]
+
+    assert str(w.message) == 'Text'
+    # Assert the warning points at us and not at _CoroGuard.
+    assert w.filename == __file__
 
 
 @asyncio.coroutine


### PR DESCRIPTION
## What do these changes do?

_CoroGuard’s warnings point to the user's code now.

## Are there changes in behavior for the user?

They get useful warnings now.

## Related issue number

Fixes #2106.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [n/a] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `changes` folder
  * name it `<issue_id>.<type>` for example (588.bug)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."