### PR TITLE
Slow request body copy

### DIFF
--- a/CHANGES/2126.feature
+++ b/CHANGES/2126.feature
@@ -1,0 +1,1 @@
+Speed up the `PayloadWriter.write` method for large request bodies.

--- a/aiohttp/http_writer.py
+++ b/aiohttp/http_writer.py
@@ -154,8 +154,7 @@ class PayloadWriter(AbstractPayloadWriter):
 
         if self._drain_waiter is not None:
             waiter, self._drain_waiter = self._drain_waiter, None
-            if not waiter.done():
-                waiter.set_result(None)
+            waiter.set_result(None)
 
     async def get_transport(self):
         if self._transport is None:

--- a/aiohttp/web_fileresponse.py
+++ b/aiohttp/web_fileresponse.py
@@ -18,17 +18,16 @@ NOSENDFILE = bool(os.environ.get("AIOHTTP_NOSENDFILE"))
 
 class SendfilePayloadWriter(PayloadWriter):
 
-    def set_transport(self, transport):
-        self._transport = transport
-
-        if self._drain_waiter is not None:
-            waiter, self._drain_maiter = self._drain_maiter, None
-            if not waiter.done():
-                waiter.set_result(None)
+    def __init__(self, *args, **kwargs):
+        self.__buffer = []
+        super().__init__(*args, **kwargs)
 
     def _write(self, chunk):
+        # we overwrite PayloadWriter._write, so nothing can be appended to
+        # _buffer, and nothing is written to the transport directly by the
+        # parent class
         self.output_size += len(chunk)
-        self._buffer.append(chunk)
+        self.__buffer.append(chunk)
 
     def _sendfile_cb(self, fut, out_fd, in_fd,
                      offset, count, loop, registered):
@@ -54,13 +53,9 @@ class SendfilePayloadWriter(PayloadWriter):
             fut.set_result(None)
 
     async def sendfile(self, fobj, count):
-        if self._transport is None:
-            if self._drain_waiter is None:
-                self._drain_waiter = self.loop.create_future()
+        transport = await self.get_transport()
 
-            await self._drain_waiter
-
-        out_socket = self._transport.get_extra_info("socket").dup()
+        out_socket = transport.get_extra_info('socket').dup()
         out_socket.setblocking(False)
         out_fd = out_socket.fileno()
         in_fd = fobj.fileno()
@@ -74,13 +69,12 @@ class SendfilePayloadWriter(PayloadWriter):
             await fut
         except Exception:
             server_logger.debug('Socket error')
-            self._transport.close()
+            transport.close()
         finally:
             out_socket.close()
 
         self.output_size += count
-        self._transport = None
-        self._stream.release()
+        await super().write_eof()
 
     async def write_eof(self, chunk=b''):
         pass

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -2462,7 +2462,7 @@ async def test_handle_keepalive_on_closed_connection(loop):
     await r.read()
     assert 1 == len(connector._conns)
 
-    with pytest.raises(aiohttp.ServerDisconnectedError):
+    with pytest.raises(aiohttp.ClientConnectionError):
         await session.request('GET', url)
     assert 0 == len(connector._conns)
 

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -1799,6 +1799,26 @@ async def test_bad_payload_content_length(loop, test_client):
     resp.close()
 
 
+async def test_payload_content_length_by_chunks(loop, test_client):
+
+    async def handler(request):
+        resp = web.StreamResponse(headers={'content-length': '3'})
+        await resp.prepare(request)
+        await resp.write(b'answer')
+        await resp.write(b'two')
+        request.transport.close()
+        return resp
+
+    app = web.Application()
+    app.router.add_get('/', handler)
+    client = await test_client(app)
+
+    resp = await client.get('/')
+    data = await resp.read()
+    assert data == b'ans'
+    resp.close()
+
+
 async def test_chunked(loop, test_client):
 
     async def handler(request):

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -1694,6 +1694,27 @@ async def test_encoding_gzip(loop, test_client):
     resp.close()
 
 
+async def test_encoding_gzip_write_by_chunks(loop, test_client):
+
+    async def handler(request):
+        resp = web.StreamResponse()
+        resp.enable_compression(web.ContentCoding.gzip)
+        await resp.prepare(request)
+        await resp.write(b'0')
+        await resp.write(b'0')
+        return resp
+
+    app = web.Application()
+    app.router.add_get('/', handler)
+    client = await test_client(app)
+
+    resp = await client.get('/')
+    assert 200 == resp.status
+    txt = await resp.text()
+    assert txt == '00'
+    resp.close()
+
+
 async def test_encoding_gzip_nochunk(loop, test_client):
 
     async def handler(request):

--- a/tests/test_http_writer.py
+++ b/tests/test_http_writer.py
@@ -1,5 +1,6 @@
 """Tests for aiohttp/http_writer.py"""
 
+import asyncio
 import zlib
 from unittest import mock
 
@@ -148,3 +149,19 @@ def test_write_drain(stream, loop):
     msg.write(b'1', drain=True)
     assert msg.drain.called
     assert msg.buffer_size == 0
+
+
+async def test_multiple_drains(stream, loop):
+    stream.available = False
+    msg = http.PayloadWriter(stream, loop)
+    fut1 = loop.create_task(msg.drain())
+    fut2 = loop.create_task(msg.drain())
+
+    assert not fut1.done()
+    assert not fut2.done()
+
+    msg.set_transport(stream.transport)
+
+    await asyncio.sleep(0)
+    assert fut1.done()
+    assert fut2.done()

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -80,8 +80,9 @@ async def test_raw_server_cancelled_in_write_eof(raw_test_server, test_client):
     server = await raw_test_server(handler, logger=logger)
     cli = await test_client(server)
 
-    with pytest.raises(client.ServerDisconnectedError):
-        await cli.get('/path/to')
+    resp = await cli.get('/path/to')
+    with pytest.raises(client.ClientPayloadError):
+        await resp.read()
 
     logger.debug.assert_called_with('Ignored premature client disconnection ')
 


### PR DESCRIPTION
When sending a request with a large body (e.g.`session.post('…', data=b'0' * 2_000_000_000)`,) `PayloadWriter._write` is taking very long (5+ seconds for a 2G body).

This is especially problematic because this locks the event loop and nothing else gets executed (so if you are running this in a request handler, the whole server becomes unresponsive).

As far as I understand this, there is no need to actually copy the data before passing it to the underlying asyncio transport: its `write` method handles fragmented chunks and we spare a big `''.join(buffer)`.

This leads to a x2 speed up for the actual write, what ever the actual body size is (I tested with bodies from 2KB to 2GB)

## What do these changes do?

When the asyncio transport is open, leave the buffering to the OS and write data directly to it.
I have also factorised some code, to keep the `_buffer` / `_transport` variables in a clear state (exactly one of them is None at all time)

## Are there changes in behavior for the user?

The headers are not buffered until the first byte of the body is ready if the transport is already there. I'm not sure why this was done, I can't find anything related to that in the git history. @fafhrd91, since this is your code, any idea why sending the headers was buffered even when the transport is ready?

Also, see the changed test: some user might get a ClientPayloadError instead of a ServerDisconnectedError since the headers are now sent even if write_eof raises. This is mostly a side effect of the tests: in real life I would expect users already receiving a bit of both `ClientPayloadError` and `ServerDisconnectedError` for this use case (depending on when exactly the connection was cut off).