### PR TITLE
small optimization of BytesIOPayload.size

### DIFF
--- a/aiohttp/payload.py
+++ b/aiohttp/payload.py
@@ -254,7 +254,10 @@ class BytesIOPayload(IOBasePayload):
 
     @property
     def size(self):
-        return len(self._value.getbuffer()) - self._value.tell()
+        p = self._value.tell()
+        l = self._value.seek(0, os.SEEK_END)
+        self._value.seek(p)
+        return l - p
 
 
 class BufferedReaderPayload(IOBasePayload):


### PR DESCRIPTION
When posting a large body that you have as a `bytes` object, as per #2127 , the body should be passed as a `io.BytesIO` object.

But when this BytesIO is initialised on a bytes object that might be used somewhere else, calling `getbuffer` needs to copy the underlying data to return a writable memoryview.

```
python -m timeit -s "import io; a = b'0' * 2 ** 30" 'io.BytesIO(a).getbuffer()'
10 loops, best of 3: 627 msec per loop
python -m timeit -s "import io; a = b'0' * 2 ** 30" 'io.BytesIO(a).getvalue()'
1000000 loops, best of 3: 0.247 usec per loop
python -m timeit -s "import io; a = b'0' * 2 ** 30" 'io.BytesIO(a)'
10000000 loops, best of 3: 0.186 usec per loop
```
(the instantiating the BytesIO in the loop to avoid the caching done by BytesIO)

This is problematic beyond wasting 500ms when making a request: the event loop is actually locked during this memory copy, so an underlying aiohttp server won't be able to process any other pending requests.


**But**, calling `getvalue` instead of getbuffer will make some (weird) use-cases way worse than now:
```
python -m timeit -s "import io; d = io.BytesIO(b'0' * 2 ** 30)" i = d.getbuffer()" 'd.getvalue()'
10 loops, best of 3: 624 msec per loop
```

Calling `seek(0, SEEK_END)` avoid all this