### PR TITLE
Raise ContentTypeError by json() when headers does not …

### DIFF
--- a/aiohttp/client_exceptions.py
+++ b/aiohttp/client_exceptions.py
@@ -40,7 +40,7 @@ class ClientResponseError(ClientError):
 
 
 class ContentTypeError(ClientResponseError):
-    """ ContentType found is not valid """
+    """ContentType found is not valid."""
 
 
 class WSServerHandshakeError(ClientResponseError):

--- a/aiohttp/client_exceptions.py
+++ b/aiohttp/client_exceptions.py
@@ -13,7 +13,7 @@ __all__ = (
     'ServerFingerprintMismatch',
 
     'ClientResponseError', 'ClientPayloadError',
-    'ClientResponseContentTypeError',
+    'ContentTypeError',
 
     'ClientHttpProxyError', 'WSServerHandshakeError')
 
@@ -39,7 +39,7 @@ class ClientResponseError(ClientError):
         super().__init__("%s, message='%s'" % (code, message))
 
 
-class ClientResponseContentTypeError(ClientResponseError):
+class ContentTypeError(ClientResponseError):
     """ ContentType found is not valid """
 
 

--- a/aiohttp/client_exceptions.py
+++ b/aiohttp/client_exceptions.py
@@ -13,6 +13,8 @@ __all__ = (
     'ServerFingerprintMismatch',
 
     'ClientResponseError', 'ClientPayloadError',
+    'ClientResponseContentTypeError',
+
     'ClientHttpProxyError', 'WSServerHandshakeError')
 
 
@@ -35,6 +37,10 @@ class ClientResponseError(ClientError):
         self.history = history
 
         super().__init__("%s, message='%s'" % (code, message))
+
+
+class ClientResponseContentTypeError(ClientResponseError):
+    """ ContentType found is not valid """
 
 
 class WSServerHandshakeError(ClientResponseError):

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -13,6 +13,7 @@ from yarl import URL
 
 from . import hdrs, helpers, http, payload
 from .client_exceptions import (ClientConnectionError, ClientOSError,
+                                ClientResponseContentTypeError,
                                 ClientResponseError)
 from .formdata import FormData
 from .helpers import PY_35, HeadersMixin, SimpleCookie, TimerNoop, noop
@@ -722,7 +723,7 @@ class ClientResponse(HeadersMixin):
         if content_type:
             ctype = self.headers.get(hdrs.CONTENT_TYPE, '').lower()
             if content_type not in ctype:
-                raise ClientResponseError(
+                raise ClientResponseContentTypeError(
                     self.request_info,
                     self.history,
                     message=('Attempt to decode JSON with '

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -13,8 +13,7 @@ from yarl import URL
 
 from . import hdrs, helpers, http, payload
 from .client_exceptions import (ClientConnectionError, ClientOSError,
-                                ClientResponseContentTypeError,
-                                ClientResponseError)
+                                ClientResponseError, ContentTypeError)
 from .formdata import FormData
 from .helpers import PY_35, HeadersMixin, SimpleCookie, TimerNoop, noop
 from .http import SERVER_SOFTWARE, HttpVersion10, HttpVersion11, PayloadWriter
@@ -723,7 +722,7 @@ class ClientResponse(HeadersMixin):
         if content_type:
             ctype = self.headers.get(hdrs.CONTENT_TYPE, '').lower()
             if content_type not in ctype:
-                raise ClientResponseContentTypeError(
+                raise ContentTypeError(
                     self.request_info,
                     self.history,
                     message=('Attempt to decode JSON with '

--- a/changes/2136.feature
+++ b/changes/2136.feature
@@ -1,2 +1,2 @@
-json() raises a ClientResponseContentTypeError exception if the content-type
+json() raises a ContentTypeError exception if the content-type
 does not meet the requirements instead of raising a generic ClientResponseError.

--- a/changes/2136.feature
+++ b/changes/2136.feature
@@ -1,0 +1,2 @@
+json() raises a ClientResponseContentTypeError exception if the content-type
+does not meet the requirements instead of raising a generic ClientResponseError.

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -1115,7 +1115,7 @@ Response object
       *cchardet* is not available.
 
       if response's `content-type` does not match `content_type` parameter
-      :exc:`aiohttp.ClientResponseContentTypeError` get raised.
+      :exc:`aiohttp.ContentTypeError` get raised.
       To disable content type check pass ``None`` value.
 
       :param str encoding: text encoding used for *BODY* decoding, or

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -1050,6 +1050,9 @@ Response object
       Close underlying connection if data reading gets an error,
       release connection otherwise.
 
+      Raise an :exc:`aiohttp.ClientResponseError` if the data can't
+      be read.
+
       :return bytes: read *BODY*.
 
       .. seealso:: :meth:`close`, :meth:`release`.
@@ -1104,15 +1107,16 @@ Response object
                       content_type='application/json')
 
       Read response's body as *JSON*, return :class:`dict` using
-      specified *encoding* and *loader*.
+      specified *encoding* and *loader*. If data is not still available
+      a ``read`` call will be done, 
 
       If *encoding* is ``None`` content encoding is autocalculated
       using :term:`cchardet` or :term:`chardet` as fallback if
       *cchardet* is not available.
 
       if response's `content-type` does not match `content_type` parameter
-      :exc:`aiohttp.ClientResponseError` get raised. To disable content type
-      check pass ``None`` value.
+      :exc:`aiohttp.ClientResponseContentTypeError` get raised.
+      To disable content type check pass ``None`` value.
 
       :param str encoding: text encoding used for *BODY* decoding, or
                            ``None`` for encoding autodetection

--- a/tests/test_client_response.py
+++ b/tests/test_client_response.py
@@ -352,17 +352,26 @@ def test_json_custom_loader(loop, session):
 
 
 @asyncio.coroutine
-def test_json_no_content(loop, session):
+def test_json_invalid_content_type(loop, session):
     response = ClientResponse('get', URL('http://def-cl-resp.org'))
     response._post_init(loop, session)
     response.headers = {
         'Content-Type': 'data/octet-stream'}
     response._content = b''
 
-    with pytest.raises(aiohttp.ClientResponseError) as info:
+    with pytest.raises(aiohttp.ClientResponseContentTypeError) as info:
         yield from response.json()
 
     assert info.value.request_info == response.request_info
+
+
+@asyncio.coroutine
+def test_json_no_content(loop, session):
+    response = ClientResponse('get', URL('http://def-cl-resp.org'))
+    response._post_init(loop, session)
+    response.headers = {
+        'Content-Type': 'data/octet-stream'}
+    response._content = b''
 
     res = yield from response.json(content_type=None)
     assert res is None

--- a/tests/test_client_response.py
+++ b/tests/test_client_response.py
@@ -359,7 +359,7 @@ def test_json_invalid_content_type(loop, session):
         'Content-Type': 'data/octet-stream'}
     response._content = b''
 
-    with pytest.raises(aiohttp.ClientResponseContentTypeError) as info:
+    with pytest.raises(aiohttp.ContentTypeError) as info:
         yield from response.json()
 
     assert info.value.request_info == response.request_info


### PR DESCRIPTION
## What do these changes do?

Basically, avoid having a nocive fall back as the following one

```python
try:
    resp = await req.json()
except ClieintResponseError:
    logging.warning("Invalid content-type")
    resp = loads(await req.read())
```

The `ClieintResponseError` can be raised by many reasons, and the case presented the fallback can be misleading having as a  result twice `ClieintResponseError` because the source of the problem wasn't related to the content type.

With an ad-hoc exception, the client can code a more specific fallback case taking into account the differents source of problems with a cleaner interface, for example:

```python
try:
    resp = await req.json()
except ContentTypeError:
    logging.warning("Invalid content-type by servcie ....")
    resp = loads(await req.read())
except ClieintResponseError:
    logging.exception("something went wrong")
    raise
```

Thanks to the current `json()` implementation once we have had a `ContentTypeError` exception is not possible to have a `ClieintResponseError`. Therefore, the developer can handle the errors as the previous example.

For backward compatibility the `ContentTypeError` inherits from `ClieintResponseError`.


## Are there changes in behavior for the user?

No

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `changes` folder
  * name it `<issue_id>.<type>` for example (588.bug)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
