### PR TITLE
Allow overriding ClientSession class in TestClient

### DIFF
--- a/aiohttp/test_utils.py
+++ b/aiohttp/test_utils.py
@@ -374,7 +374,7 @@ class AioHTTPTestCase(unittest.TestCase):
         Use .get_application() coroutine instead
 
         """
-        pass  # pragma: no cover
+        raise RuntimeError("Did you forget to define get_application()?")
 
     def setUp(self):
         self.loop = setup_test_loop()

--- a/aiohttp/test_utils.py
+++ b/aiohttp/test_utils.py
@@ -186,7 +186,8 @@ class TestClient:
 
     """
 
-    def __init__(self, server, *, cookie_jar=None, loop=None, **kwargs):
+    def __init__(self, server, *, cookie_jar=None, loop=None,
+                 session_class=ClientSession, **kwargs):
         if not isinstance(server, BaseTestServer):
             raise TypeError("server must be web.Application TestServer "
                             "instance, found type: %r" % type(server))
@@ -194,7 +195,7 @@ class TestClient:
         self._loop = loop
         if cookie_jar is None:
             cookie_jar = aiohttp.CookieJar(unsafe=True, loop=loop)
-        self._session = ClientSession(loop=loop,
+        self._session = session_class(loop=loop,
                                       cookie_jar=cookie_jar,
                                       **kwargs)
         self._closed = False

--- a/changes/2042.feature
+++ b/changes/2042.feature
@@ -1,0 +1,1 @@
+Allow overriding ClientSession class in TestClient

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -263,6 +263,13 @@ functionality, the AioHTTPTestCase is provided::
        This async method can be overridden to return the :class:`TestClient`
        object used in the test.
 
+       For example, if you need to test your own class
+       :class:`aiohttp.ClientSession` you can override it in this way::
+
+           async def get_client(self, server):
+               return _TestClient(server, session_class=MyClientSession,
+                                  loop=self.loop)
+
        :return: :class:`TestClient` instance.
 
        .. versionadded:: 2.3.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,7 @@ import sys
 import pytest
 
 
-pytest_plugins = 'aiohttp.pytest_plugin'
+pytest_plugins = ['aiohttp.pytest_plugin', 'pytester']
 
 
 _LoggingWatcher = collections.namedtuple("_LoggingWatcher",

--- a/tests/test_test_utils.py
+++ b/tests/test_test_utils.py
@@ -20,6 +20,10 @@ _hello_world_bytes = _hello_world_str.encode('utf-8')
 _hello_world_gz = gzip.compress(_hello_world_bytes)
 
 
+class CustomClientSession(aiohttp.ClientSession):
+    pass
+
+
 def _create_example_app():
     @asyncio.coroutine
     def hello(request):
@@ -307,3 +311,16 @@ def test_server_make_url_yarl_compatibility(loop):
             make_url('http://foo.com')
         with pytest.raises(AssertionError):
             make_url(URL('http://foo.com'))
+
+
+def test_custom_client_session(test_client, loop):
+    app = _create_example_app()
+    with _TestClient(_TestServer(app, loop=loop),
+                     session_class=CustomClientSession, loop=loop) as client:
+        assert isinstance(client.session, CustomClientSession)
+
+
+def test_no_custom_client_session(test_client, loop):
+    app = _create_example_app()
+    with _TestClient(_TestServer(app, loop=loop), loop=loop) as client:
+        assert isinstance(client.session, aiohttp.ClientSession)

--- a/tests/test_test_utils.py
+++ b/tests/test_test_utils.py
@@ -324,3 +324,17 @@ def test_no_custom_client_session(test_client, loop):
     app = _create_example_app()
     with _TestClient(_TestServer(app, loop=loop), loop=loop) as client:
         assert isinstance(client.session, aiohttp.ClientSession)
+
+
+def test_testcase_no_app(testdir, loop):
+    testdir.makepyfile(
+        """
+        from aiohttp.test_utils import AioHTTPTestCase
+
+
+        class InvalidTestCase(AioHTTPTestCase):
+            def test_noop(self):
+                pass
+        """)
+    result = testdir.runpytest()
+    result.stdout.fnmatch_lines(["*RuntimeError*"])


### PR DESCRIPTION
## What do these changes do?

It adds a keyword argument to the TestClient class to override the default ClientSession used.

## Are there changes in behavior for the user?

None.

## Related issue number

#2032 #2074 

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `changes` folder
  * name it `<issue_id>.<type>` for example (588.bug)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
