### PR TITLE
Patch aiohttp classes module

### DIFF
--- a/aiohttp/__init__.py
+++ b/aiohttp/__init__.py
@@ -4,6 +4,7 @@ __version__ = '2.3.0a0'
 
 from . import hdrs  # noqa
 from .client import *  # noqa
+from .client_exceptions import * # noqa
 from .formdata import *  # noqa
 from .helpers import *  # noqa
 from .http import (HttpVersion, HttpVersion10, HttpVersion11,  # noqa
@@ -15,14 +16,16 @@ from .payload import *  # noqa
 from .payload_streamer import *  # noqa
 from .resolver import *  # noqa
 
+from .helpers import _patch_module
+
 try:
     from .worker import GunicornWebWorker, GunicornUVLoopWebWorker  # noqa
     workers = ('GunicornWebWorker', 'GunicornUVLoopWebWorker')
 except ImportError:
     workers = ()
 
-
 __all__ = (client.__all__ +  # noqa
+           client_exceptions.__all__ + # noqa
            formdata.__all__ +  # noqa
            helpers.__all__ +  # noqa
            multipart.__all__ +  # noqa
@@ -33,3 +36,6 @@ __all__ = (client.__all__ +  # noqa
             'WSMsgType', 'WSCloseCode',
             'WebSocketError', 'WSMessage', 'CookieJar',
            ) + workers)
+
+
+_patch_module('aiohttp')

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -6,6 +6,7 @@ import binascii
 import cgi
 import datetime
 import functools
+import importlib
 import os
 import re
 import sys
@@ -811,3 +812,26 @@ class DummyCookieJar(AbstractCookieJar):
 
     def filter_cookies(self, request_url):
         return None
+
+
+def _patch_module(namespace, *, skip_list=()):
+    mod = importlib.import_module(namespace)
+    names = mod.__all__
+    for name in names:
+        obj = getattr(mod, name)
+        try:
+            module = obj.__module__
+        except:
+            pass
+        else:
+            if not module.startswith('aiohttp'):
+                continue
+            if module == 'aiohttp':
+                # Already patched by top level import aiohttp
+                continue
+            if name.endswith(skip_list):
+                continue
+            try:
+                obj.__module__ = namespace
+            except:
+                pass

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -814,7 +814,7 @@ class DummyCookieJar(AbstractCookieJar):
         return None
 
 
-def _patch_module(namespace, *, skip_list=()):
+def _patch_module(namespace):
     mod = importlib.import_module(namespace)
     names = mod.__all__
     for name in names:
@@ -829,9 +829,4 @@ def _patch_module(namespace, *, skip_list=()):
             if module == 'aiohttp':
                 # Already patched by top level import aiohttp
                 continue
-            if name.endswith(skip_list):
-                continue
-            try:
-                obj.__module__ = namespace
-            except:
-                pass
+            obj.__module__ = namespace

--- a/aiohttp/web.py
+++ b/aiohttp/web.py
@@ -16,6 +16,7 @@ from . import (hdrs, web_exceptions, web_fileresponse, web_middlewares,
                web_urldispatcher, web_ws)
 from .abc import AbstractMatchInfo, AbstractRouter
 from .frozenlist import FrozenList
+from .helpers import _patch_module
 from .http import HttpVersion  # noqa
 from .log import access_logger, web_logger
 from .signals import FuncSignal, PostSignal, PreSignal, Signal
@@ -521,6 +522,9 @@ def main(argv):
     app = func(extra_argv)
     run_app(app, host=args.hostname, port=args.port, path=args.path)
     arg_parser.exit(message="Stopped\n")
+
+
+_patch_module('aiohttp.web')
 
 
 if __name__ == "__main__":  # pragma: no branch


### PR DESCRIPTION
The PR fixes `__module__` attribute for aiohttp classes.

You know people don't import our classes properly: the use `from aiohttp.client.ClientSession` instead of `aiohttp.Session` etc. I saw it very many times.
It prevents us for deep refactoring (extracting source code into new file is a potential source of backward compatibility problems for our users).

The proposal pins module names to expected by us: `aiohttp` for client usage and `aiohttp.web` for server. 

I raised the issue many times proposing mangling modules by underscore etc.
Patching the module looks like robust and it's an easy change.
I'll check tomorrow how it works for PyCharm IDE.