### PR TITLE
Hint testcase getapplication

### DIFF
--- a/aiohttp/test_utils.py
+++ b/aiohttp/test_utils.py
@@ -373,7 +373,7 @@ class AioHTTPTestCase(unittest.TestCase):
         Use .get_application() coroutine instead
 
         """
-        pass  # pragma: no cover
+        raise RuntimeError("Did you forget to define get_application()?")
 
     def setUp(self):
         self.loop = setup_test_loop()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,7 @@ import sys
 import pytest
 
 
-pytest_plugins = 'aiohttp.pytest_plugin'
+pytest_plugins = ['aiohttp.pytest_plugin', 'pytester']
 
 
 _LoggingWatcher = collections.namedtuple("_LoggingWatcher",

--- a/tests/test_test_utils.py
+++ b/tests/test_test_utils.py
@@ -307,3 +307,17 @@ def test_server_make_url_yarl_compatibility(loop):
             make_url('http://foo.com')
         with pytest.raises(AssertionError):
             make_url(URL('http://foo.com'))
+
+
+def test_testcase_no_app(testdir, loop):
+    testdir.makepyfile(
+        """
+        from aiohttp.test_utils import AioHTTPTestCase
+
+
+        class InvalidTestCase(AioHTTPTestCase):
+            def test_noop(self):
+                pass
+        """)
+    result = testdir.runpytest()
+    result.stdout.fnmatch_lines(["*RuntimeError*"])


### PR DESCRIPTION
## What do these changes do?

It raises a RuntimeError when executing test if the developer forgets to redefine `get_application`

## Are there changes in behavior for the user?

None.

## Related issue number

#2032 #2074 #2142

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `changes` folder
  * name it `<issue_id>.<type>` for example (588.bug)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
