### PR TITLE
Fix missing ' in client documentation

### DIFF
--- a/docs/client.rst
+++ b/docs/client.rst
@@ -56,7 +56,7 @@ Any of session's request methods like `request`, `get`, `post` etc accept
 `json` parameter::
 
   async with aiohttp.ClientSession() as session:
-      async with session.post(json={'test': 'object})
+      async with session.post(json={'test': 'object'})
 
 
 By default session uses python's standard `json` module for serialization.
@@ -66,7 +66,7 @@ parameter::
   import ujson
 
   async with aiohttp.ClientSession(json_serialize=ujson.dumps) as session:
-      async with session.post(json={'test': 'object})
+      async with session.post(json={'test': 'object'})
 
 
 Passing Parameters In URLs


### PR DESCRIPTION
## What do these changes do?

Fix a (very) small mistake in the documentation.
