### PR TITLE
Deprecated BaseRequest.has_body, replaced with 2 new attributes (#2005)

### DIFF
--- a/aiohttp/web_request.py
+++ b/aiohttp/web_request.py
@@ -16,6 +16,7 @@ from yarl import URL
 
 from . import hdrs, multipart
 from .helpers import HeadersMixin, SimpleCookie, reify, sentinel
+from .streams import EmptyStreamReader
 from .web_exceptions import HTTPRequestEntityTooLarge
 
 
@@ -457,8 +458,21 @@ class BaseRequest(collections.MutableMapping, HeadersMixin):
 
     @property
     def has_body(self):
-        """Return True if request has HTTP BODY, False otherwise."""
+        """Return True if request's HTTP BODY can be read, False otherwise."""
+        warnings.warn(
+            "Deprecated, use .can_read_body #2005",
+            DeprecationWarning, stacklevel=2)
         return not self._payload.at_eof()
+
+    @property
+    def can_read_body(self):
+        """Return True if request's HTTP BODY can be read, False otherwise."""
+        return not self._payload.at_eof()
+
+    @property
+    def body_exists(self):
+        """Return True if request has HTTP BODY, False otherwise."""
+        return type(self._payload) is not EmptyStreamReader
 
     @asyncio.coroutine
     def release(self):

--- a/changes/2005.feature
+++ b/changes/2005.feature
@@ -1,0 +1,3 @@
+- Deprecated BaseRequest.has_body in favour of BaseRequest.can_read_body
+- Added BaseRequest.body_exists attribute that stays static for the lifetime
+of the request

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -230,15 +230,33 @@ and :ref:`aiohttp-web-signals` handlers.
 
       Read-only property.
 
-   .. attribute:: has_body
+   .. attribute:: body_exists
 
       Return ``True`` if request has *HTTP BODY*, ``False`` otherwise.
 
       Read-only :class:`bool` property.
 
-      .. versionadded:: 0.16
+      .. versionadded:: 2.3
 
-   .. attribute:: content_type
+   .. attribute:: can_read_body
+
+      Return ``True`` if request's *HTTP BODY* can be read, ``False`` otherwise.
+
+      Read-only :class:`bool` property.
+
+      .. versionadded:: 2.3
+
+   .. attribute:: has_body
+
+      Return ``True`` if request's *HTTP BODY* can be read, ``False`` otherwise.
+
+      Read-only :class:`bool` property.
+
+      .. deprecated:: 2.3
+
+         Use :meth:`can_read_body` instead.
+
+ .. attribute:: content_type
 
       Read-only property with *content* part of *Content-Type* header.
 

--- a/tests/test_web_functional.py
+++ b/tests/test_web_functional.py
@@ -694,7 +694,8 @@ def test_empty_content_for_query_without_body(loop, test_client):
 
     @asyncio.coroutine
     def handler(request):
-        assert not request.has_body
+        assert not request.body_exists
+        assert not request.can_read_body
         return web.Response()
 
     app = web.Application()
@@ -710,7 +711,8 @@ def test_empty_content_for_query_with_body(loop, test_client):
 
     @asyncio.coroutine
     def handler(request):
-        assert request.has_body
+        assert request.body_exists
+        assert request.can_read_body
         body = yield from request.read()
         return web.Response(body=body)
 

--- a/tests/test_web_functional.py
+++ b/tests/test_web_functional.py
@@ -696,6 +696,7 @@ def test_empty_content_for_query_without_body(loop, test_client):
     def handler(request):
         assert not request.body_exists
         assert not request.can_read_body
+        assert not request.has_body
         return web.Response()
 
     app = web.Application()
@@ -713,6 +714,7 @@ def test_empty_content_for_query_with_body(loop, test_client):
     def handler(request):
         assert request.body_exists
         assert request.can_read_body
+        assert request.has_body
         body = yield from request.read()
         return web.Response(body=body)
 


### PR DESCRIPTION
#2005 
- Deprecated BaseRequest.has_body in favour of BaseRequest.can_read_body
- Added BaseRequest.body_exists attribute that stays static for the lifetime
of the request
