### PR TITLE
Fix parsing the Forwarded header

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -172,6 +172,7 @@ Thomas Grainger
 Tolga Tezel
 Vaibhav Sagar
 Vamsi Krishna Avula
+Vasiliy Faronov
 Vasyl Baran
 Vikas Kawadia
 Vitalik Verhovodov

--- a/aiohttp/web_request.py
+++ b/aiohttp/web_request.py
@@ -27,7 +27,7 @@ FileField = collections.namedtuple(
 _TCHAR = string.digits + string.ascii_letters + r"!#$%&'*+.^_`|~-"
 # '-' at the end to prevent interpretation as range in a char class
 
-_TOKEN = r'[{tchar}]*'.format(tchar=_TCHAR)
+_TOKEN = r'[{tchar}]+'.format(tchar=_TCHAR)
 
 _QDTEXT = r'[{}]'.format(
     r''.join(chr(c) for c in (0x09, 0x20, 0x21) + tuple(range(0x23, 0x7F))))
@@ -39,12 +39,8 @@ _QUOTED_PAIR = r'\\[\t !-~]'
 _QUOTED_STRING = r'"(?:{quoted_pair}|{qdtext})*"'.format(
     qdtext=_QDTEXT, quoted_pair=_QUOTED_PAIR)
 
-_FORWARDED_PARAMS = (
-    r'[bB][yY]|[fF][oO][rR]|[hH][oO][sS][tT]|[pP][rR][oO][tT][oO]')
-
 _FORWARDED_PAIR = (
-    r'^({forwarded_params})=({token}|{quoted_string})$'.format(
-        forwarded_params=_FORWARDED_PARAMS,
+    r'({token})=({token}|{quoted_string})'.format(
         token=_TOKEN,
         quoted_string=_QUOTED_STRING))
 
@@ -208,37 +204,45 @@ class BaseRequest(collections.MutableMapping, HeadersMixin):
 
         Returns a tuple containing one or more immutable dicts
         """
-        def _parse_forwarded(forwarded_headers):
-            for field_value in forwarded_headers:
-                # by=...;for=..., For=..., BY=...
-                for forwarded_elm in field_value.split(','):
-                    # by=...;for=...
-                    fvparams = dict()
-                    forwarded_pairs = (
-                        _FORWARDED_PAIR_RE.findall(pair)
-                        for pair in forwarded_elm.strip().split(';'))
-                    for forwarded_pair in forwarded_pairs:
-                        # by=...
-                        if len(forwarded_pair) != 1:
-                            # non-compliant syntax
-                            break
-                        param, value = forwarded_pair[0]
-                        if param.lower() in fvparams:
-                            # duplicate param in field-value
-                            break
-                        if value and value[0] == '"':
-                            # quoted string: replace quotes and escape
-                            # sequences
-                            value = _QUOTED_PAIR_REPLACE_RE.sub(
-                                r'\1', value[1:-1])
-                        fvparams[param.lower()] = value
+        elems = []
+        for field_value in self._message.headers.getall(hdrs.FORWARDED, ()):
+            length = len(field_value)
+            pos = 0
+            need_separator = False
+            elem = {}
+            elems.append(types.MappingProxyType(elem))
+            while 0 <= pos < length:
+                match = _FORWARDED_PAIR_RE.match(field_value, pos)
+                if match is not None:           # got a valid forwarded-pair
+                    if need_separator:
+                        # bad syntax here, skip to next comma
+                        pos = field_value.find(',', pos)
                     else:
-                        yield types.MappingProxyType(fvparams)
-                        continue
-                    yield dict()
-
-        return tuple(
-            _parse_forwarded(self._message.headers.getall(hdrs.FORWARDED, ())))
+                        (name, value) = match.groups()
+                        if value[0] == '"':
+                            # quoted string: remove quotes and unescape
+                            value = _QUOTED_PAIR_REPLACE_RE.sub(r'\1',
+                                                                value[1:-1])
+                        elem[name.lower()] = value
+                        pos += len(match.group(0))
+                        need_separator = True
+                elif field_value[pos] == ',':      # next forwarded-element
+                    need_separator = False
+                    elem = {}
+                    elems.append(types.MappingProxyType(elem))
+                    pos += 1
+                elif field_value[pos] == ';':      # next forwarded-pair
+                    need_separator = False
+                    pos += 1
+                elif field_value[pos] in ' \t':
+                    # Allow whitespace even between forwarded-pairs, though
+                    # RFC 7239 doesn't. This simplifies code and is in line
+                    # with Postel's law.
+                    pos += 1
+                else:
+                    # bad syntax here, skip to next comma
+                    pos = field_value.find(',', pos)
+        return tuple(elems)
 
     @reify
     def _scheme(self):

--- a/changes/2170.bugfix
+++ b/changes/2170.bugfix
@@ -1,0 +1,1 @@
+Fix parsing the Forwarded header according to RFC 7239.


### PR DESCRIPTION
## What do these changes do?

Parse the `Forwarded` header more carefully, while staying about as fast, simple, and robust in the face of potential injection attacks. (Speed was measured with IPython’s `%timeit` on my laptop on a few typical and pathological header values.)

## Are there changes in behavior for the user?

Most valid `Forwarded` headers that used to be parsed incorrectly by aiohttp are now parsed correctly. In particular:

- commas and semicolons are allowed inside quoted-strings;
- empty forwarded-pairs (as in ``for=_1;;by=_2``) are allowed;
- non-standard parameters are allowed (although this alone could be easily done in the previous parser).

Valid headers containing obs-text are still not parsed correctly, as this was an intentional decision in the previous parser (see comments) that I did not change.

Also, the previous parser used to bail out of (invalid) forwarded-elements containing duplicate parameter names. No rationale was given in the code, and I don’t think this is important, so the new parser doesn't enforce this.

## Related issue number

#2170

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `changes` folder
  * name it `<issue_id>.<type>` for example (588.bug)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
