### PR TITLE
benchmarking script to time the different asyncio write options

### DIFF
--- a/tools/bench-asyncio-write.py
+++ b/tools/bench-asyncio-write.py
@@ -1,0 +1,118 @@
+import asyncio
+import atexit
+import math
+import os
+import signal
+
+PORT = 8888
+
+server = os.fork()
+if server == 0:
+    loop = asyncio.get_event_loop()
+    coro = asyncio.start_server(lambda *_: None, port=PORT)
+    loop.run_until_complete(coro)
+    loop.run_forever()
+else:
+    atexit.register(os.kill, server, signal.SIGTERM)
+
+
+async def write_joined_bytearray(writer, chunks):
+    body = bytearray(chunks[0])
+    for c in chunks[1:]:
+        body += c
+    writer.write(body)
+
+async def write_joined_list(writer, chunks):
+    body = b''.join(chunks)
+    writer.write(body)
+
+async def write_separately(writer, chunks):
+    for c in chunks:
+        writer.write(c)
+
+
+def fm_size(s, _fms=('', 'K', 'M', 'G')):
+    i = 0
+    while s >= 1024:
+        s /= 1024
+        i += 1
+    return '{:.0f}{}B'.format(s, _fms[i])
+def fm_time(s, _fms=('', 'm', 'µ', 'n')):
+    if s == 0:
+        return '0'
+    i = 0
+    while s < 1:
+        s *= 1000
+        i += 1
+    return '{:.2f}{}s'.format(s, _fms[i])
+
+
+writes = [
+    ("b''.join", write_joined_list),
+    ('bytearray', write_joined_bytearray),
+    ('multiple writes', write_separately),
+]
+
+bodies = (
+    [],
+    [10 * 2 ** 0 ],
+    [10 * 2 ** 7],
+    [10 * 2 ** 17],
+    [10 * 2 ** 27],
+    [50 * 2 ** 27],
+    [ 1 * 2 ** 0  for _ in range(10)],
+    [ 1 * 2 ** 7  for _ in range(10)],
+    [ 1 * 2 ** 17 for _ in range(10)],
+    [ 1 * 2 ** 27 for _ in range(10)],
+    [10 * 2 ** 27 for _ in range(5)],
+)
+
+jobs = [(
+    # always start with a 256B headers chunk
+    '{} / {}'.format(fm_size(sum(j) if j else 0), len(j)),
+    [b'0' * s for s in [256] + list(j)],
+) for j in bodies]
+
+async def time(loop, fn, *args):
+    spent = []
+    while not spent or sum(spent) < .2:
+        s = loop.time()
+        await fn(*args)
+        e = loop.time()
+        spent.append(e - s)
+    mean = sum(spent) / len(spent)
+    sd = sum((x - mean) ** 2 for x in spent) / len(spent)
+    return len(spent), mean, math.sqrt(sd)
+
+async def main(loop):
+    _, writer = await asyncio.open_connection(port=PORT)
+    print('Loop:', loop)
+    print('Transport:', writer._transport)
+    res = [
+        ('size/chunks', 'Write option', 'Mean', 'Std dev', 'loops', 'Variation'),
+    ]
+    res.append([':---', ':---', '---:', '---:', '---:', '---:'])
+
+    async def bench(job_title, w, body, base=None):
+        it, mean, sd = await time(loop, w[1], writer, c)
+        res.append((
+            job_title,
+            w[0],
+            fm_time(mean),
+            fm_time(sd),
+            str(it),
+            '{:.2%}'.format(mean / base - 1) if base is not None else '',
+        ))
+        return mean
+
+    for t, c in jobs:
+        print('Doing', t)
+        base = await bench(t, writes[0], c)
+        for w in writes[1:]:
+            await bench('', w, c, base)
+    with open('bench.md', 'w') as f:
+        for l in res:
+            f.write('| {} |\n'.format(' | '.join(l)))
+
+loop = asyncio.get_event_loop()
+loop.run_until_complete(main(loop))


### PR DESCRIPTION
As discussed in #2126, I tried putting together a small benchmarking script to test the different write options in `http_writer` and their impacts on different workloads.

The script is in the PR (just a convenient way to link the file, i'm not sure at all it should be merged)
My results are bellow, I'm running a `_UnixSelectorEventLoop`: it would be interesting to get results from other configs.

The use cases I used are:
 - No body (only a few bytes representing the headers)
 - A very small body (10B) in 2 chunks (headers + body)
 - A 1KB body, in 2 or 10 chunks
 - A 1MB body, in 2 or 10 chunks
 - A 1GB body, in 2 or 10 chunks
The really useful numbers here are the 2 chunks: this is what is happening when you have a server writing the headers first, then the body in one go.

The current implementation is waiting to join the headers with the first chunk of the body, so it correspond to the `b''.join` lines.
With #2126, the headers would be send in a separate `Transport.write` call, so it corresponds to the `multiple writes` lines.
The `bytearray` lines are just for comparaison, trying to see where it would be preferable to b''.join

At lastly, the "10 chunks" lines are just to see how fast performance is degrading. If I understand things correctly, the `http_writer.PayloadWriter` class only does buffering until the transport is set. So, keeping aside the headers chunk, we only get multiple chunks here when http pipelining is happening **and** the user application does a lot a separate `write` in the handler. So imo, the only use case that really matters is 2 chunks, one for the headers, and one for the body. @fafhrd91 can you confirm this?


Here what i take from those results:
 - With a body size bellow a 1MB, the tests are inconclusive, the std dev is way too high. I think we can assume the second syscall does not impact the results in anyway but I might be missing something.
 - Above 1MB, the `multiple write` option is of course faster, since it is avoiding a ~large copy.
 - The 10 chunks lines shows that the multiple writes option is slower until the body exceed 1MB. For smaller body, this (very specific) use case is 3x slower in the #2126 against the current implementation.


| size/chunks | Write option | Mean | Std dev | loops | Variation |
| :--- | :--- | ---: | ---: | ---: | ---: |
| 0B / 0 | b''.join | 5.45µs | 7.94µs | 36706 |  |
|  | bytearray | 5.60µs | 5.87µs | 35695 | 2.83% |
|  | multiple writes | 4.55µs | 5.88µs | 43916 | -16.42% |
| 10B / 1 | b''.join | 4.55µs | 7.44µs | 43920 |  |
|  | bytearray | 5.76µs | 8.92µs | 34750 | 26.39% |
|  | multiple writes | 6.54µs | 8.94µs | 30564 | 43.70% |
| 1KB / 1 | b''.join | 6.65µs | 26.31µs | 30092 |  |
|  | bytearray | 7.91µs | 24.50µs | 25283 | 19.02% |
|  | multiple writes | 7.45µs | 7.64µs | 26835 | 12.14% |
| 1MB / 1 | b''.join | 1.18ms | 616.71µs | 170 |  |
|  | bytearray | 1.15ms | 503.26µs | 175 | -3.10% |
|  | multiple writes | 984.20µs | 441.12µs | 204 | -16.76% |
| 1GB / 1 | b''.join | 2.25s | 0 | 1 |  |
|  | bytearray | 1.80s | 0 | 1 | -19.76% |
|  | multiple writes | 665.09ms | 0 | 1 | -70.42% |
| 6GB / 1 | b''.join | 21.27s | 0 | 1 |  |
|  | bytearray | 19.76s | 0 | 1 | -7.09% |
|  | multiple writes | 8.87s | 0 | 1 | -58.30% |
| 10B / 10 | b''.join | 5.60µs | 8.49µs | 35704 |  |
|  | bytearray | 7.32µs | 24.33µs | 27317 | 30.71% |
|  | multiple writes | 22.90µs | 4.34µs | 8733 | 308.88% |
| 1KB / 10 | b''.join | 6.84µs | 8.46µs | 29240 |  |
|  | bytearray | 9.92µs | 8.33µs | 20160 | 45.04% |
|  | multiple writes | 25.34µs | 21.29µs | 7894 | 270.46% |
| 1MB / 10 | b''.join | 1.17ms | 619.23µs | 171 |  |
|  | bytearray | 1.79ms | 540.51µs | 112 | 52.41% |
|  | multiple writes | 1.05ms | 441.37µs | 192 | -10.81% |
| 1GB / 10 | b''.join | 3.25s | 0 | 1 |  |
|  | bytearray | 1.93s | 0 | 1 | -40.65% |
|  | multiple writes | 689.35ms | 0 | 1 | -78.77% |
| 6GB / 5 | b''.join | 22.15s | 0 | 1 |  |
|  | bytearray | 19.55s | 0 | 1 | -11.77% |
|  | multiple writes | 8.59s | 0 | 1 | -61.22% |

