### PR TITLE
Implement Application.add_subdomain (#1342)

### DIFF
--- a/aiohttp/web.py
+++ b/aiohttp/web.py
@@ -27,7 +27,7 @@ from .web_request import *  # noqa
 from .web_response import *  # noqa
 from .web_server import Server
 from .web_urldispatcher import *  # noqa
-from .web_urldispatcher import PrefixedSubAppResource
+from .web_urldispatcher import PrefixedSubAppResource, SubDomainResource
 from .web_ws import *  # noqa
 
 
@@ -190,6 +190,23 @@ class Application(MutableMapping):
             raise ValueError("Prefix cannot be empty")
 
         resource = PrefixedSubAppResource(prefix, subapp)
+        self.router.register_resource(resource)
+        self._reg_subapp_signals(subapp)
+        self._subapps.append(subapp)
+        if self._loop is not None:
+            subapp._set_loop(self._loop)
+        return resource
+
+    def add_subdomain(self, subdomain, subapp):
+        if self.frozen:
+            raise RuntimeError(
+                "Cannot add sub domain application to frozen application")
+        if subapp.frozen:
+            raise RuntimeError("Cannot add frozen application")
+        if subdomain == '':
+            raise ValueError("Subdomain cannot be empty")
+
+        resource = SubDomainResource(subdomain, subapp)
         self.router.register_resource(resource)
         self._reg_subapp_signals(subapp)
         self._subapps.append(subapp)

--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -672,6 +672,54 @@ class PrefixedSubAppResource(PrefixResource):
             prefix=self._prefix, app=self._app)
 
 
+class SubDomainResource(AbstractResource):
+
+    def __init__(self, subdomain, app):
+        super().__init__()
+        self._subdomain = subdomain
+        self._app = app
+
+    def add_prefix(self, prefix):
+        super().add_prefix(prefix)
+        for resource in self._app.router.resources():
+            resource.add_prefix(prefix)
+
+    def url_for(self, *args, **kwargs):
+        raise RuntimeError(".url_for() is not supported "
+                           "by subdomain sub-application root")
+
+    def url(self, **kwargs):
+        """Construct url for route with additional params."""
+        raise RuntimeError(".url() is not supported "
+                           "by subdomain sub-application root")
+
+    def get_info(self):
+        return {'app': self._app,
+                'subdomain': self._subdomain}
+
+    @asyncio.coroutine
+    def resolve(self, request):
+        if not request.headers['Host'] == self._subdomain:
+            return None, set()
+        match_info = yield from self._app.router.resolve(request)
+        match_info.add_app(self._app)
+        if isinstance(match_info.http_exception, HTTPMethodNotAllowed):
+            methods = match_info.http_exception.allowed_methods
+        else:
+            methods = set()
+        return (match_info, methods)
+
+    def __len__(self):
+        return len(self._app.router.routes())
+
+    def __iter__(self):
+        return iter(self._app.router.routes())
+
+    def __repr__(self):
+        return "<SubDomainResource {subdomain} -> {app!r}>".format(
+            subdomain=self._subdomain, app=self._app)
+
+
 class ResourceRoute(AbstractRoute):
     """A route with resource"""
 

--- a/tests/test_web_functional.py
+++ b/tests/test_web_functional.py
@@ -49,6 +49,32 @@ def test_simple_get(loop, test_client):
 
 
 @asyncio.coroutine
+def test_subdomain_simple(loop, test_client):
+
+    @asyncio.coroutine
+    def handler(request):
+        return web.Response(body=b'OK')
+
+    #  setup subdomain app
+    subdomain = web.Application()
+    subdomain.router.add_get('/to', handler)
+
+    # setup root app
+    app = web.Application()
+    app.add_subdomain('example.aiohttp.test', subdomain)
+
+    # run
+    client = yield from test_client(app)
+    headers = dict(Host='example.aiohttp.test')
+    resp = yield from client.get('/to', headers=headers)
+
+    # check
+    assert 200 == resp.status
+    txt = yield from resp.text()
+    assert 'OK' == txt
+
+
+@asyncio.coroutine
 def test_simple_get_with_text(loop, test_client):
 
     @asyncio.coroutine


### PR DESCRIPTION
## What do these changes do?

Implement basic subdomain support 

## Are there changes in behavior for the user?

Yes, one can add a subapp for a given domain as follow:

```python
    subdomain = web.Application()
    subdomain.router.add_get('/to', handler)

    # setup root app
    app = web.Application()
    app.add_subdomain('example.aiohttp.test', subdomain)
```

## Related issue number

#1342 

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [ ] Add a new news fragment into the `changes` folder
  * name it `<issue_id>.<type>` for example (588.bug)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
