### PR TITLE
[Doc] on_startup & on_shutdown signals example with aiopg engine

### DIFF
--- a/changes/2131.doc
+++ b/changes/2131.doc
@@ -1,0 +1,1 @@
+Add example usage of on_startup and on_shutdown signals by creating and disposing an aiopg connection engine.

--- a/docs/web.rst
+++ b/docs/web.rst
@@ -977,6 +977,32 @@ This can be accomplished by subscribing to the
     app.on_response_prepare.append(on_prepare)
 
 
+Additionally, the :attr:`~aiohttp.web.Application.on_startup` and
+:attr:`~aiohttp.web.Application.on_shutdown` signals can be subscribed to for
+application component setup and tear down accordingly.
+
+The following example will properly initialize and dispose an aiopg connection
+engine::
+
+    from aiopg.sa import create_engine
+
+    async def create_aiopg(app):
+        app['pg_engine'] = await create_engine(
+            user='postgre',
+            database='postgre',
+            host='localhost',
+            port=5432,
+            password=''
+        )
+
+    async def dispose_aiopg(app):
+        app['pg_engine'].close()
+        await app['pg_engine'].wait_closed()
+
+    app.on_startup.append(create_aiopg)
+    app.on_shutdown.append(dispose_aiopg)
+
+
 Signal handlers should not return a value but may modify incoming mutable
 parameters.
 

--- a/docs/web.rst
+++ b/docs/web.rst
@@ -978,7 +978,7 @@ This can be accomplished by subscribing to the
 
 
 Additionally, the :attr:`~aiohttp.web.Application.on_startup` and
-:attr:`~aiohttp.web.Application.on_shutdown` signals can be subscribed to for
+:attr:`~aiohttp.web.Application.on_cleanup` signals can be subscribed to for
 application component setup and tear down accordingly.
 
 The following example will properly initialize and dispose an aiopg connection
@@ -1000,7 +1000,7 @@ engine::
         await app['pg_engine'].wait_closed()
 
     app.on_startup.append(create_aiopg)
-    app.on_shutdown.append(dispose_aiopg)
+    app.on_cleanup.append(dispose_aiopg)
 
 
 Signal handlers should not return a value but may modify incoming mutable


### PR DESCRIPTION
## What do these changes do?

Add a documentation example usage of `on_startup` and `on_shutdown` signals by properly creating and disposing an aiopg connection engine.

## Are there changes in behavior for the user?

No, just documentation.

## Related issue number

Relates to #2131.

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `changes` folder
  * name it `<issue_id>.<type>` for example (588.bug)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
