### PR TITLE
Add deferredssl

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -93,6 +93,7 @@ Jeroen van der Heijden
 Jesus Cea
 Jinkyu Yi
 Joel Watts
+Jon Nabozny
 Joongi Kim
 Josep Cugat
 Julia Tsemusheva

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -3,6 +3,12 @@ import functools
 import sys
 import traceback
 import warnings
+
+try:
+    import ssl
+except ImportError:
+    ssl = None
+    
 from collections import defaultdict, namedtuple
 from hashlib import md5, sha1, sha256
 from itertools import cycle, islice
@@ -19,10 +25,6 @@ from .helpers import SimpleCookie, is_ip_address, noop, sentinel
 from .locks import EventResultOrError
 from .resolver import DefaultResolver
 
-try:
-    import ssl
-except ImportError:
-    ssl = None
 
 __all__ = ('BaseConnector', 'TCPConnector', 'UnixConnector')
 

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -1,6 +1,5 @@
 import asyncio
 import functools
-import ssl
 import sys
 import traceback
 import warnings
@@ -20,6 +19,10 @@ from .helpers import SimpleCookie, is_ip_address, noop, sentinel
 from .locks import EventResultOrError
 from .resolver import DefaultResolver
 
+try:
+    import ssl
+except ImportError:
+    ssl = None
 
 __all__ = ('BaseConnector', 'TCPConnector', 'UnixConnector')
 
@@ -626,6 +629,9 @@ class TCPConnector(BaseConnector):
 
         Lazy property, creates context on demand.
         """
+        if ssl is None:
+            raise RuntimeError('SSL is not supported.')
+
         if self._ssl_context is None:
             if not self._verify_ssl:
                 sslcontext = ssl.SSLContext(ssl.PROTOCOL_SSLv23)

--- a/aiohttp/worker.py
+++ b/aiohttp/worker.py
@@ -5,8 +5,12 @@ import os
 import re
 import signal
 import socket
-import ssl
 import sys
+
+try:
+    import ssl
+except ImportError:
+    ssl = None
 
 from gunicorn.config import AccessLogFormat as GunicornAccessLogFormat
 from gunicorn.workers import base
@@ -200,6 +204,9 @@ class GunicornWebWorker(base.Worker):
 
         See ssl.SSLSocket.__init__ for more details.
         """
+        if ssl is None:
+            raise RuntimeError('SSL is not supported.')
+
         ctx = ssl.SSLContext(cfg.ssl_version)
         ctx.load_cert_chain(cfg.certfile, cfg.keyfile)
         ctx.verify_mode = cfg.cert_reqs

--- a/changes/2221.feature
+++ b/changes/2221.feature
@@ -1,0 +1,7 @@
+Add deferredssl 
+
+Wraps ssl in a deferred wrapper.
+aiohttp does not require SSL to function. The codepaths involved with
+SSL will only be hit upon SSL usage. Using a wrapper allows installs
+that don't use SSL to function (without erroring on import) and still
+allows full function on SSL enabled systems.


### PR DESCRIPTION
Wraps ssl in a deferred wrapper.
aiohttp does not require SSL to function. The codepaths involved with
SSL will only be hit upon SSL usage. Using a wrapper allows installs
that don't use SSL to function (without erroring on import) and still
allows full function on SSL enabled systems.

<!-- Thank you for your contribution!

     Before submit your Pull Request, make sure you picked
     the right branch:

     - If you propose a new feature or improvement, select "master"
       as a target branch;
     - If this is a bug fix or documentation amendment, select
       the latest release branch (which looks like "0.xx") -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [ ] Add a new news fragment into the `changes` folder
  * name it `<issue_id>.<type>` for example (588.bug)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
