### PR TITLE
Pytest async fixtures

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -188,6 +188,7 @@ Will McGugan
 Willem de Groot
 Wilson Ong
 Yannick Koechlin
+Yannick Péroux
 Yegor Roganov
 Young-Ho Cha
 Yuriy Shatrov

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -243,7 +243,7 @@ def isasyncgenfunction(obj):
         return inspect.isasyncgenfunction(obj)
     return False
 
-  
+
 def parse_mimetype(mimetype):
     """Parses a MIME type into its components.
 

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -6,6 +6,7 @@ import binascii
 import cgi
 import datetime
 import functools
+import inspect
 import os
 import re
 import sys
@@ -821,3 +822,9 @@ class DummyCookieJar(AbstractCookieJar):
 
     def filter_cookies(self, request_url):
         return None
+
+
+def isasyncgenfunction(obj):
+    if hasattr(inspect, 'isasyncgenfunction'):
+        return inspect.isasyncgenfunction(obj)
+    return False

--- a/changes/2223.feature
+++ b/changes/2223.feature
@@ -1,0 +1,1 @@
+Accept coroutine fixtures in pytest plugin

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -3,6 +3,8 @@ import sys
 
 import pytest
 
+from aiohttp.pytest_plugin import LOOP_FACTORIES
+
 
 pytest_plugins = 'pytester'
 
@@ -180,3 +182,116 @@ async def test_bad():
     stdout, _ = capsys.readouterr()
     assert ("test_warning_checks.py:__LINE__:coroutine 'foobar' was "
             "never awaited" in re.sub('\d{2,}', '__LINE__', stdout))
+
+
+def test_aiohttp_plugin_async_fixture(testdir, capsys):
+    testdir.makepyfile("""\
+import asyncio
+import pytest
+
+from aiohttp import web
+
+
+pytest_plugins = 'aiohttp.pytest_plugin'
+
+
+@asyncio.coroutine
+def hello(request):
+    return web.Response(body=b'Hello, world')
+
+
+def create_app(loop):
+    app = web.Application()
+    app.router.add_route('GET', '/', hello)
+    return app
+
+
+@pytest.fixture
+@asyncio.coroutine
+def cli(test_client):
+    client = yield from test_client(create_app)
+    return client
+
+
+@pytest.fixture
+@asyncio.coroutine
+def foo():
+    return 42
+
+
+@pytest.fixture
+@asyncio.coroutine
+def bar(request):
+    # request should be accessible in async fixtures if needed
+    return request.function
+
+
+@asyncio.coroutine
+def test_hello(cli):
+    resp = yield from cli.get('/')
+    assert resp.status == 200
+
+
+def test_foo(loop, foo):
+    assert foo == 42
+
+
+def test_foo_without_loop(foo):
+    # will raise an error because there is no loop
+    pass
+
+
+def test_bar(loop, bar):
+    assert bar is test_bar
+""")
+    nb_loops = len(LOOP_FACTORIES)
+    result = testdir.runpytest('-p', 'no:sugar')
+    result.assert_outcomes(passed=3 * nb_loops, error=1)
+    result.stdout.fnmatch_lines(
+        "*Asynchronous fixtures must depend on the 'loop' fixture "
+        "or be used in tests depending from it."
+    )
+
+
+@pytest.mark.skipif(sys.version_info < (3, 6), reason='old python')
+def test_aiohttp_plugin_async_gen_fixture(testdir):
+    testdir.makepyfile("""\
+import asyncio
+import pytest
+from unittest import mock
+
+from aiohttp import web
+
+
+pytest_plugins = 'aiohttp.pytest_plugin'
+
+canary = mock.Mock()
+
+
+async def hello(request):
+    return web.Response(body=b'Hello, world')
+
+
+def create_app(loop):
+    app = web.Application()
+    app.router.add_route('GET', '/', hello)
+    return app
+
+
+@pytest.fixture
+async def cli(test_client):
+    yield await test_client(create_app)
+    canary()
+
+
+async def test_hello(cli):
+    resp = await cli.get('/')
+    assert resp.status == 200
+
+
+def test_finalized():
+    assert canary.called is True
+""")
+    nb_loops = len(LOOP_FACTORIES)
+    result = testdir.runpytest('-p', 'no:sugar')
+    result.assert_outcomes(passed=1 * nb_loops + 1)


### PR DESCRIPTION
## What do these changes do?

With this PR, pytest fixtures can be coroutines. For example, in order to create a client, you can use:

```python
@pytest.fixture
async def cli(test_client):
    return await test_client(setup_app)
```

This is not a killer feature as you could already do the same thing using `loop.run_until_complete`, but I find it more idiomatic.

The main gotcha is that in order for an async fixture to work, it must use the `loop` fixture, or be called in a test using it. The previous example works because `test_client` uses the `loop` fixture.
I don't think this is a big issue because I can't think of any case where one would want an asynchronous fixture without using the loop.

## Are there changes in behavior for the user?

None.

## Related issue number

#2223

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `changes` folder
  * name it `<issue_id>.<type>` for example (588.bug)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
