### PR TITLE
Call shutdown_asyncgens before loop closing

### DIFF
--- a/aiohttp/web.py
+++ b/aiohttp/web.py
@@ -464,6 +464,7 @@ def run_app(app, *, host=None, port=None, path=None, sock=None,
     finally:
         loop.run_until_complete(app.cleanup())
     if not user_supplied_loop:
+        loop.run_until_complete(loop.shutdown_asyncgens())
         loop.close()
 
 

--- a/aiohttp/web.py
+++ b/aiohttp/web.py
@@ -464,7 +464,8 @@ def run_app(app, *, host=None, port=None, path=None, sock=None,
     finally:
         loop.run_until_complete(app.cleanup())
     if not user_supplied_loop:
-        loop.run_until_complete(loop.shutdown_asyncgens())
+        if hasattr(loop, 'shutdown_asyncgens'):
+            loop.run_until_complete(loop.shutdown_asyncgens())
         loop.close()
 
 

--- a/aiohttp/worker.py
+++ b/aiohttp/worker.py
@@ -48,7 +48,8 @@ class GunicornWebWorker(base.Worker):
         try:
             self.loop.run_until_complete(self._runner)
         finally:
-            self.loop.run_until_complete(self.loop.shutdown_asyncgens())
+            if hasattr(self.loop, 'shutdown_asyncgens'):
+                self.loop.run_until_complete(self.loop.shutdown_asyncgens())
             self.loop.close()
 
         sys.exit(self.exit_code)

--- a/aiohttp/worker.py
+++ b/aiohttp/worker.py
@@ -48,6 +48,7 @@ class GunicornWebWorker(base.Worker):
         try:
             self.loop.run_until_complete(self._runner)
         finally:
+            self.loop.run_until_complete(self.loop.shutdown_asyncgens())
             self.loop.close()
 
         sys.exit(self.exit_code)

--- a/changes/2227.feature
+++ b/changes/2227.feature
@@ -1,0 +1,1 @@
+Call `shutdown_asyncgens` before event loop closing on Python 3.6.


### PR DESCRIPTION
`shutdown_asyncgens` call is required on python 3.6

https://docs.python.org/3/library/asyncio-eventloop.html#asyncio.AbstractEventLoop.shutdown_asyncgens