### PR TITLE
Speed up Signals when there are no receivers.

### DIFF
--- a/aiohttp/_frozenlist.pyx
+++ b/aiohttp/_frozenlist.pyx
@@ -4,9 +4,11 @@ from collections.abc import MutableSequence
 cdef class FrozenList:
 
     cdef readonly bint frozen
+    cdef readonly bint _receivers 
     cdef list _items
 
     def __init__(self, items=None):
+        self._receivers = False
         self.frozen = False
         if items is not None:
             items = list(items)
@@ -17,6 +19,9 @@ cdef class FrozenList:
     cdef object _check_frozen(self):
         if self.frozen:
             raise RuntimeError("Cannot modify frozen list.")
+
+    cdef object _fast_len(self):
+        return len(self._items)
 
     def freeze(self):
         self.frozen = True
@@ -33,7 +38,7 @@ cdef class FrozenList:
         del self._items[index]
 
     def __len__(self):
-        return self._items.__len__()
+        return self._fast_len()
 
     def __iter__(self):
         return self._items.__iter__()

--- a/aiohttp/_frozenlist.pyx
+++ b/aiohttp/_frozenlist.pyx
@@ -18,7 +18,7 @@ cdef class FrozenList:
         if self.frozen:
             raise RuntimeError("Cannot modify frozen list.")
 
-    cdef object _fast_len(self):
+    cdef inline object _fast_len(self):
         return len(self._items)
 
     def freeze(self):

--- a/aiohttp/_frozenlist.pyx
+++ b/aiohttp/_frozenlist.pyx
@@ -4,11 +4,9 @@ from collections.abc import MutableSequence
 cdef class FrozenList:
 
     cdef readonly bint frozen
-    cdef readonly bint _receivers 
     cdef list _items
 
     def __init__(self, items=None):
-        self._receivers = False
         self.frozen = False
         if items is not None:
             items = list(items)

--- a/changes/2229.feature
+++ b/changes/2229.feature
@@ -1,0 +1,1 @@
+Speed up Signals when there are no receivers


### PR DESCRIPTION
## What do these changes do?

Reduce the footprint of the `send()` method by a 10% when there are
no receivers connected.

Before
```bash
$ python ../test_aiohttp_signals.py
Signals per second: 2296186.5549501474
```

After
```bash
$ python ../test_aiohttp_signals.py
Signals per second: 2759791.7854124783
```

Script used [1]

[1] https://gist.github.com/pfreixes/baea4ecc7b5380d534d60a8c1e8da32f 

## Are there changes in behavior for the user?

No

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Add a new news fragment into the `changes` folder
  * name it `<issue_id>.<type>` for example (588.bug)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
