### PR TITLE
use pyloop as default for pytest --loop

### DIFF
--- a/aiohttp/pytest_plugin.py
+++ b/aiohttp/pytest_plugin.py
@@ -31,7 +31,7 @@ def pytest_addoption(parser):
         help='run tests faster by disabling extra checks')
     parser.addoption(
         '--loop', action='store', default='pyloop',
-        help='run tests with specific loop: pyloop, uvloop, tokio')
+        help='run tests with specific loop: pyloop, uvloop, tokio or all')
     parser.addoption(
         '--enable-loop-debug', action='store_true', default=False,
         help='enable event loop debug mode')

--- a/aiohttp/pytest_plugin.py
+++ b/aiohttp/pytest_plugin.py
@@ -30,7 +30,7 @@ def pytest_addoption(parser):
         '--fast', action='store_true', default=False,
         help='run tests faster by disabling extra checks')
     parser.addoption(
-        '--loop', action='append', default='pyloop',
+        '--loop', action='store', default='pyloop',
         help='run tests with specific loop: pyloop, uvloop, tokio')
     parser.addoption(
         '--enable-loop-debug', action='store_true', default=False,
@@ -122,17 +122,16 @@ def pytest_configure(config):
     if loops == 'all':
         loops = 'pyloop,uvloop?,tokio?'
 
-    for names in (name.split(',') for name in loops):
-        for name in names:
-            required = not name.endswith('?')
-            name = name.strip(' ?')
-            if name in factories:
-                LOOP_FACTORIES.append(factories[name])
-                LOOP_FACTORY_IDS.append(name)
-            elif required:
-                raise ValueError(
-                    "Unknown loop '%s', available loops: %s" % (
-                        name, list(factories.keys())))
+    for name in loops.split(','):
+        required = not name.endswith('?')
+        name = name.strip(' ?')
+        if name in factories:
+            LOOP_FACTORIES.append(factories[name])
+            LOOP_FACTORY_IDS.append(name)
+        elif required:
+            raise ValueError(
+                "Unknown loop '%s', available loops: %s" % (
+                    name, list(factories.keys())))
     asyncio.set_event_loop(None)
 
 

--- a/aiohttp/pytest_plugin.py
+++ b/aiohttp/pytest_plugin.py
@@ -30,7 +30,7 @@ def pytest_addoption(parser):
         '--fast', action='store_true', default=False,
         help='run tests faster by disabling extra checks')
     parser.addoption(
-        '--loop', action='append', default=[],
+        '--loop', action='append', default='pyloop',
         help='run tests with specific loop: pyloop, uvloop, tokio')
     parser.addoption(
         '--enable-loop-debug', action='store_true', default=False,
@@ -119,29 +119,20 @@ def pytest_configure(config):
     LOOP_FACTORIES.clear()
     LOOP_FACTORY_IDS.clear()
 
-    if loops:
-        for names in (name.split(',') for name in loops):
-            for name in names:
-                name = name.strip()
-                if name not in factories:
-                    raise ValueError(
-                        "Unknown loop '%s', available loops: %s" % (
-                            name, list(factories.keys())))
+    if loops == 'all':
+        loops = 'pyloop,uvloop?,tokio?'
 
+    for names in (name.split(',') for name in loops):
+        for name in names:
+            required = not name.endswith('?')
+            name = name.strip(' ?')
+            if name in factories:
                 LOOP_FACTORIES.append(factories[name])
                 LOOP_FACTORY_IDS.append(name)
-    else:
-        LOOP_FACTORIES.append(asyncio.new_event_loop)
-        LOOP_FACTORY_IDS.append('pyloop')
-
-        if uvloop is not None:  # pragma: no cover
-            LOOP_FACTORIES.append(uvloop.new_event_loop)
-            LOOP_FACTORY_IDS.append('uvloop')
-
-        if tokio is not None:
-            LOOP_FACTORIES.append(tokio.new_event_loop)
-            LOOP_FACTORY_IDS.append('tokio')
-
+            elif required:
+                raise ValueError(
+                    "Unknown loop '%s', available loops: %s" % (
+                        name, list(factories.keys())))
     asyncio.set_event_loop(None)
 
 

--- a/changes/2248.misc
+++ b/changes/2248.misc
@@ -1,0 +1,4 @@
+Test only python asyncio loop by default
+
+changed the default value for the pytest argument loop to `--loop pytest`
+then set aiohttp to use `--loop all`

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,6 +10,7 @@ max-line-length=79
 
 [tool:pytest]
 testpaths = tests
+addopts = --loop all
 
 [isort]
 known_third_party=jinja2


### PR DESCRIPTION
## What do these changes do?

Change the default loop for pytest tests to be the python asyncio loop.

## Are there changes in behavior for the user?

Yes, the default loop is now `pyloop` rather than all, all available loops can be used via `--loop all`

## Related issue number

#2248

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] ~~Documentation reflects the changes~~ no docs for this anyway
- [x] Add a new news fragment into the `changes` folder
  * name it `<issue_id>.<type>` for example (588.bug)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
