### PR TITLE
run_app: make print=None disable printing

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -29,6 +29,7 @@ Andrew Leech
 Andrew Lytvyn
 Andrew Svetlov
 Andrii Soldatenko
+Antoine Pietri
 Anton Kasyanov
 Arthur Darcet
 Ben Bader

--- a/aiohttp/web.py
+++ b/aiohttp/web.py
@@ -447,8 +447,9 @@ def run_app(app, *, host=None, port=None, path=None, sock=None,
                 pass
 
         try:
-            print("======== Running on {} ========\n"
-                  "(Press CTRL+C to quit)".format(', '.join(uris)))
+            if print:
+                print("======== Running on {} ========\n"
+                      "(Press CTRL+C to quit)".format(', '.join(uris)))
             loop.run_forever()
         except (GracefulExit, KeyboardInterrupt):  # pragma: no cover
             pass

--- a/changes/2260.feature
+++ b/changes/2260.feature
@@ -1,0 +1,1 @@
+run_app: Make print=None disable printing

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -2400,7 +2400,8 @@ Utilities
                        ``None`` for HTTP connection.
 
    :param print: a callable compatible with :func:`print`. May be used
-                 to override STDOUT output or suppress it.
+                 to override STDOUT output or suppress it. Passing `None`
+                 disables output.
 
    :param int backlog: the number of unaccepted connections that the
                        system will allow before refusing new

--- a/tests/test_run_app.py
+++ b/tests/test_run_app.py
@@ -214,7 +214,7 @@ def test_run_app_mixed_bindings(mocker, run_app_kwargs, expected_server_calls,
     loop = mocker.MagicMock()
     mocker.patch('asyncio.gather')
 
-    web.run_app(app, loop=loop, print=lambda *args: None, **run_app_kwargs)
+    web.run_app(app, loop=loop, print=None, **run_app_kwargs)
 
     assert loop.create_unix_server.mock_calls == expected_unix_server_calls
     assert loop.create_server.mock_calls == expected_server_calls


### PR DESCRIPTION
run_app currently takes a callable compatible with `print()`. If you want to disable output completely (which happens all the time when you're writing test suites or similar), you have to call run_app with `print=lambda *_, **__: None`, which is not very pretty and confusing.

This behavior is annoying, so this change makes print=None a special case that disables output completely.

This change is backwards-compatible.