### PR TITLE
ssl.SSLError explicit support

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -178,6 +178,7 @@ Vaibhav Sagar
 Vamsi Krishna Avula
 Vasiliy Faronov
 Vasyl Baran
+Victor Kovtun
 Vikas Kawadia
 Vitalik Verhovodov
 Vitaly Haritonsky

--- a/aiohttp/client_exceptions.py
+++ b/aiohttp/client_exceptions.py
@@ -3,6 +3,12 @@
 import asyncio
 
 
+try:
+    import ssl
+except ImportError:  # pragma: no cover
+    ssl = None
+
+
 __all__ = (
     'ClientError',
 
@@ -72,7 +78,12 @@ class ClientConnectorError(ClientOSError):
     """
     def __init__(self, connection_key, os_error):
         self._conn_key = connection_key
+        self._os_error = os_error
         super().__init__(os_error.errno, os_error.strerror)
+
+    @property
+    def os_error(self):
+        return self._os_error
 
     @property
     def host(self):
@@ -150,3 +161,12 @@ class InvalidURL(ClientError, ValueError):
 
     def __repr__(self):
         return '<{} {}>'.format(self.__class__.__name__, self.url)
+
+
+if ssl is not None:
+    class ClientConnectorSSLError(ClientConnectorError, ssl.SSLError):
+        """Response ssl error."""
+else:
+    class ClientConnectorSSLError(ClientConnectorError):
+        """Dummy wrapper for ClientConnectorSSLError
+        when ssl module is not available."""

--- a/aiohttp/client_exceptions.py
+++ b/aiohttp/client_exceptions.py
@@ -100,7 +100,7 @@ class ClientConnectorError(ClientOSError):
 
     def __str__(self):
         return ('Cannot connect to host {0.host}:{0.port} ssl:{0.ssl} [{1}]'
-                .format(self._conn_key, self.strerror))
+                .format(self, self.strerror))
 
 
 class ClientProxyConnectionError(ClientConnectorError):
@@ -164,10 +164,10 @@ class InvalidURL(ClientError, ValueError):
         return '<{} {}>'.format(self.__class__.__name__, self.url)
 
 
+ssl_error_bases = [ClientConnectorError]
 if ssl is not None:
-    class ClientConnectorSSLError(ClientConnectorError, ssl.SSLError):
-        """Response ssl error."""
-else:
-    class ClientConnectorSSLError(ClientConnectorError):
-        """Dummy wrapper for ClientConnectorSSLError
-        when ssl module is not available."""
+    ssl_error_bases.append(ssl.SSLError)
+
+
+class ClientConnectorSSLError(*ssl_error_bases):
+    """Response ssl error."""

--- a/aiohttp/client_exceptions.py
+++ b/aiohttp/client_exceptions.py
@@ -14,6 +14,7 @@ __all__ = (
 
     'ClientConnectionError',
     'ClientOSError', 'ClientConnectorError', 'ClientProxyConnectionError',
+    'ClientConnectorSSLError',
 
     'ServerConnectionError', 'ServerTimeoutError', 'ServerDisconnectedError',
     'ServerFingerprintMismatch',

--- a/aiohttp/client_exceptions.py
+++ b/aiohttp/client_exceptions.py
@@ -14,6 +14,8 @@ __all__ = (
 
     'ClientConnectionError',
     'ClientOSError', 'ClientConnectorError', 'ClientProxyConnectionError',
+
+    'ClientSSLError',
     'ClientConnectorSSLError', 'ClientConnectorCertificateError',
 
     'ServerConnectionError', 'ServerTimeoutError', 'ServerDisconnectedError',
@@ -164,15 +166,19 @@ class InvalidURL(ClientError, ValueError):
         return '<{} {}>'.format(self.__class__.__name__, self.url)
 
 
+class ClientSSLError(ClientConnectorError):
+    """Base error for ssl.*Errors."""
+
+
 if ssl is not None:
     certificate_errors = (ssl.CertificateError,)
-    certificate_errors_bases = (ClientConnectorError, ssl.CertificateError,)
+    certificate_errors_bases = (ClientSSLError, ssl.CertificateError,)
 
     ssl_errors = (ssl.SSLError,)
     ssl_error_bases = (ClientConnectorError, ssl.SSLError)
-else:
+else:  # pragma: no cover
     certificate_errors = tuple()
-    certificate_errors_bases = (ClientConnectorError, ValueError,)
+    certificate_errors_bases = (ClientSSLError, ValueError,)
 
     ssl_errors = tuple()
     ssl_error_bases = (ClientConnectorError,)

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -6,6 +6,7 @@ import ssl
 import sys
 import traceback
 import warnings
+from collections import namedtuple
 from hashlib import md5, sha1, sha256
 from http.cookies import CookieError, Morsel
 
@@ -44,6 +45,9 @@ HASHFUNC_BY_DIGESTLEN = {
 
 
 _SSL_OP_NO_COMPRESSION = getattr(ssl, "OP_NO_COMPRESSION", 0)
+
+
+ConnectionKey = namedtuple('ConnectionKey', ['host', 'port', 'ssl'])
 
 
 class ClientRequest:
@@ -127,6 +131,10 @@ class ClientRequest:
         self.update_body_from_data(data)
         self.update_transfer_encoding()
         self.update_expect_continue(expect100)
+
+    @property
+    def connection_key(self):
+        return ConnectionKey(self.host, self.port, self.ssl)
 
     @property
     def host(self):

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -395,9 +395,10 @@ class BaseConnector(object):
                     proto.close()
                     raise ClientConnectionError("Connector is closed.")
             except ClientConnectorSSLError as exc:
-                raise ClientConnectorSSLError(key, exc.os_error)
+                raise ClientConnectorSSLError(
+                    key, exc.os_error) from exc.os_error
             except ClientConnectorError as exc:
-                raise ClientConnectorError(key, exc.os_error)
+                raise ClientConnectorError(key, exc.os_error) from exc.os_error
             except OSError as exc:
                 raise ClientConnectorError(key, exc) from exc
             finally:

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -10,9 +10,10 @@ from time import monotonic
 from types import MappingProxyType
 
 from . import hdrs, helpers
-from .client_exceptions import (ClientConnectorCertificateError,
-                                ClientConnectionError, ClientConnectorError,
-                                ClientConnectorSSLError, ClientHttpProxyError,
+from .client_exceptions import (ClientConnectionError,
+                                ClientConnectorCertificateError,
+                                ClientConnectorError, ClientConnectorSSLError,
+                                ClientHttpProxyError,
                                 ClientProxyConnectionError,
                                 ServerFingerprintMismatch, certificate_errors,
                                 ssl_errors)

--- a/changes/2294.feature
+++ b/changes/2294.feature
@@ -1,0 +1,1 @@
+Added `aiohttp.ClientConnectorSSLError` when connection fails due `ssl.SSLError`

--- a/docs/client.rst
+++ b/docs/client.rst
@@ -542,7 +542,7 @@ same thing as the previous example, but add another call to
                              '/path/to/client/private/device.jey')
   r = await session.get('https://example.com', ssl_context=sslcontext)
 
-There is explicit error when ssl verification fails
+There is explicit errors when ssl verification fails
 
 :class:`aiohttp.ClientConnectorSSLError`::
 
@@ -556,6 +556,20 @@ There is explicit error when ssl verification fails
   try:
       await session.get('https://wrong.host.badssl.com/')
   except aiohttp.ClientConnectorCertificateError as e:
+      assert isinstance(e, ssl.CertificateError)
+
+If you need to skip both ssl related errors
+
+:class:`aiohttp.ClientSSLError`::
+
+  try:
+      await session.get('https://expired.badssl.com/')
+  except aiohttp.ClientSSLError as e:
+      assert isinstance(e, ssl.SSLError)
+
+  try:
+      await session.get('https://wrong.host.badssl.com/')
+  except aiohttp.ClientSSLError as e:
       assert isinstance(e, ssl.CertificateError)
 
 You may also verify certificates via *SHA256* fingerprint::

--- a/docs/client.rst
+++ b/docs/client.rst
@@ -543,12 +543,20 @@ same thing as the previous example, but add another call to
   r = await session.get('https://example.com', ssl_context=sslcontext)
 
 There is explicit error when ssl verification fails
+
 :class:`aiohttp.ClientConnectorSSLError`::
 
   try:
       await session.get('https://expired.badssl.com/')
   except aiohttp.ClientConnectorSSLError as e:
       assert isinstance(e, ssl.SSLError)
+
+:class:`aiohttp.ClientConnectorCertificateError`::
+
+  try:
+      await session.get('https://wrong.host.badssl.com/')
+  except aiohttp.ClientConnectorCertificateError as e:
+      assert isinstance(e, ssl.CertificateError)
 
 You may also verify certificates via *SHA256* fingerprint::
 

--- a/docs/client.rst
+++ b/docs/client.rst
@@ -542,6 +542,13 @@ same thing as the previous example, but add another call to
                              '/path/to/client/private/device.jey')
   r = await session.get('https://example.com', ssl_context=sslcontext)
 
+There is explicit error when ssl verification fails
+:class:`aiohttp.ClientConnectorSSLError`::
+
+  try:
+      await session.get('https://expired.badssl.com/')
+  except aiohttp.ClientConnectorSSLError as e:
+      assert isinstance(e, ssl.SSLError)
 
 You may also verify certificates via *SHA256* fingerprint::
 
@@ -808,7 +815,7 @@ For a ``ClientSession`` with SSL, the application must wait a short duration bef
     # Wait 250 ms for the underlying SSL connections to close
     loop.run_until_complete(asyncio.sleep(0.250))
     loop.close()
-    
+
 Note that the appropriate amount of time to wait will vary from application to application.
 
 All if this will eventually become obsolete when the asyncio internals are changed so that aiohttp itself can wait on the underlying connection to close. Please follow issue `#1925 <https://github.com/aio-libs/aiohttp/issues/1925>`_ for the progress on this.

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -1642,6 +1642,12 @@ Connection errors
 
    Derived from :exc:`ClientOSError`
 
+.. class:: ClientConnectorSSLError
+
+   Response ssl error.
+
+   Derived from :exc:`ClientConnectorError` and :exc:`ssl.SSLError`
+
 .. class:: ClientProxyConnectionError
 
    Derived from :exc:`ClientConnectonError`
@@ -1691,6 +1697,8 @@ Hierarchy of exceptions
     * :exc:`ClientOSError`
 
       * :exc:`ClientConnectorError`
+
+         * :exc:`ClientConnectorSSLError`
 
          * :exc:`ClientProxyConnectionError`
 

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -1626,7 +1626,6 @@ Connection errors
 
    These exceptions related to low-level connection problems.
 
-
    Derived from :exc:`ClientError`
 
 .. class:: ClientOSError
@@ -1650,17 +1649,21 @@ Connection errors
 
    Derived from :exc:`ClientConnectonError`
 
+.. class:: ClientSSLError
+
+   Derived from :exc:`ClientConnectonError`
+
 .. class:: ClientConnectorSSLError
 
    Response ssl error.
 
-   Derived from :exc:`ClientConnectorError` and :exc:`ssl.SSLError`
+   Derived from :exc:`ClientSSLError` and :exc:`ssl.SSLError`
 
 .. class:: ClientConnectorCertificateError
 
    Response certificate error.
 
-   Derived from :exc:`ClientConnectorError` and :exc:`ssl.CertificateError`
+   Derived from :exc:`ClientSSLError` and :exc:`ssl.CertificateError`
 
 .. class:: ServerDisconnectedError
 
@@ -1703,7 +1706,11 @@ Hierarchy of exceptions
 
       * :exc:`ClientConnectorError`
 
-         * :exc:`ClientConnectorSSLError`
+         * :exc:`ClientSSLError`
+
+           * :exc:`ClientConnectorCertificateError`
+
+           * :exc:`ClientConnectorSSLError`
 
          * :exc:`ClientProxyConnectionError`
 

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -1642,12 +1642,6 @@ Connection errors
 
    Derived from :exc:`ClientOSError`
 
-.. class:: ClientConnectorSSLError
-
-   Response ssl error.
-
-   Derived from :exc:`ClientConnectorError` and :exc:`ssl.SSLError`
-
 .. class:: ClientProxyConnectionError
 
    Derived from :exc:`ClientConnectonError`
@@ -1656,6 +1650,17 @@ Connection errors
 
    Derived from :exc:`ClientConnectonError`
 
+.. class:: ClientConnectorSSLError
+
+   Response ssl error.
+
+   Derived from :exc:`ClientConnectorError` and :exc:`ssl.SSLError`
+
+.. class:: ClientConnectorCertificateError
+
+   Response certificate error.
+
+   Derived from :exc:`ClientConnectorError` and :exc:`ssl.CertificateError`
 
 .. class:: ServerDisconnectedError
 

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -1239,7 +1239,7 @@ class TestHttpClientConnector(unittest.TestCase):
         self.handler = app.make_handler(loop=self.loop, tcp_keepalive=False)
         srv = yield from self.loop.create_server(
             self.handler, '127.0.0.1', port, ssl=ssl_context)
-        scheme = 's' if ssl is not None else ''
+        scheme = 's' if ssl_context is not None else ''
         url = "http{}://127.0.0.1:{}".format(scheme, port) + path
         self.addCleanup(srv.close)
         return app, srv, url
@@ -1332,7 +1332,8 @@ class TestHttpClientConnector(unittest.TestCase):
         )
 
         port = unused_port()
-        conn = aiohttp.TCPConnector(loop=self.loop)
+        conn = aiohttp.TCPConnector(loop=self.loop,
+                                    local_addr=('127.0.0.1', port))
 
         session = aiohttp.ClientSession(connector=conn)
 

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -1342,7 +1342,7 @@ class TestHttpClientConnector(unittest.TestCase):
 
         r.release()
         first_conn = next(iter(conn._conns.values()))[0][0]
-        self.assertIs(
+        self.assertEqual(
             first_conn.transport._sock.getsockname(), ('127.0.0.1', port))
         r.close()
         session.close()

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -357,6 +357,7 @@ def test_tcp_connector_certificate_error(loop):
 
     assert isinstance(ctx.value, ssl.CertificateError)
     assert isinstance(ctx.value.certificate_error, ssl.CertificateError)
+    assert isinstance(ctx.value, aiohttp.ClientSSLError)
     assert str(ctx.value) == ('Cannot connect to host 127.0.0.1:443 ssl:True '
                               '[CertificateError: ()]')
 
@@ -1261,6 +1262,7 @@ class TestHttpClientConnector(unittest.TestCase):
             self.loop.run_until_complete(session.request('get', url))
 
         self.assertIsInstance(ctx.value.os_error, ssl.SSLError)
+        self.assertTrue(ctx.value, aiohttp.ClientSSLError)
 
         session.close()
         conn.close()

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -570,50 +570,6 @@ def test_connect(loop):
 
 
 @asyncio.coroutine
-def test_connect_connection_error(loop):
-    conn = aiohttp.BaseConnector(loop=loop)
-    conn._create_connection = mock.Mock()
-    conn._create_connection.return_value = helpers.create_future(loop)
-    os_error = OSError(1, 'permission error')
-    conn._create_connection.return_value.set_exception(os_error)
-
-    with pytest.raises(aiohttp.ClientConnectorError) as ctx:
-        req = mock.Mock()
-        yield from conn.connect(req)
-    assert 1 == ctx.value.errno
-    assert str(ctx.value).startswith('Cannot connect to')
-    assert str(ctx.value).endswith('[permission error]')
-    assert ctx.value.host == req.host
-    assert ctx.value.port == req.port
-    assert ctx.value.ssl == req.ssl
-    assert ctx.value.os_error is os_error
-
-
-@asyncio.coroutine
-def test_connect_connection_error_re_raise(loop):
-    conn = aiohttp.BaseConnector(loop=loop)
-    conn._create_connection = mock.Mock()
-    conn._create_connection.return_value = helpers.create_future(loop)
-    os_error = OSError(1, 'permission error')
-
-    with pytest.raises(aiohttp.ClientConnectorError) as ctx:
-        raise aiohttp.ClientConnectorError(conn, os_error) from os_error
-
-    conn._create_connection.return_value.set_exception(ctx.value)
-
-    with pytest.raises(aiohttp.ClientConnectorError) as ctx:
-        req = mock.Mock()
-        yield from conn.connect(req)
-    assert 1 == ctx.value.errno
-    assert str(ctx.value).startswith('Cannot connect to')
-    assert str(ctx.value).endswith('[permission error]')
-    assert ctx.value.host == req.host
-    assert ctx.value.port == req.port
-    assert ctx.value.ssl == req.ssl
-    assert ctx.value.os_error is os_error
-
-
-@asyncio.coroutine
 def test_close_during_connect(loop):
     proto = mock.Mock()
     proto.is_connected.return_value = True

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -1315,8 +1315,13 @@ class TestHttpClientConnector(unittest.TestCase):
 
         r.release()
         first_conn = next(iter(conn._conns.values()))[0][0]
-        self.assertIs(
-            first_conn.transport._sslcontext, sslcontext)
+
+        try:
+            _sslcontext = first_conn.transport._ssl_protocol._sslcontext
+        except AttributeError:
+            _sslcontext = first_conn.transport._sslcontext
+
+        self.assertIs(_sslcontext, sslcontext)
         r.close()
 
         session.close()


### PR DESCRIPTION
## What do these changes do?

Explicit `ssl.SSLError` support and `ssl.CertificateError`

## Are there changes in behavior for the user?

Right now `Connector` wraps any `OSError` to `ClientConnectorError `
https://github.com/aio-libs/aiohttp/blob/0b807a849564f5fefec5630b4a478789a9de1d22/aiohttp/connector.py#L813
Later `connect` wraps it one more time https://github.com/aio-libs/aiohttp/blob/0b807a849564f5fefec5630b4a478789a9de1d22/aiohttp/connector.py#L393 at this point real `OSError` is lost and 2 times `raise from`

Not sure is there any reason to catch  `OSError` in `connect`

If explicitly re raise `ClientConnectorError` only `tests.test_connector.test_connect_connection_error` fails,  but it seems mocked wrong, cuz there is no way to raise `OSError` from `_create_connection` it is already re raised to `ClientConnectorError` in `_create_direct_connection`

For first, can we remove catching `OSError` from `connect`? It makes no sense as for me

## Related issue number

https://github.com/aio-libs/aiohttp/issues/2294

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `changes` folder
  * name it `<issue_id>.<type>` for example (588.bug)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
