### PR TITLE
Implement trust_env

### DIFF
--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -42,7 +42,6 @@ else:
 
 
 __all__ = ('BasicAuth', 'create_future', 'parse_mimetype',
-           'proxies_from_env', 'ProxyInfo',
            'Timeout', 'ensure_future', 'noop')
 
 

--- a/changes/1198.feature
+++ b/changes/1198.feature
@@ -1,1 +1,0 @@
-Implement `proxy_form_env()` function.

--- a/changes/1998.feature
+++ b/changes/1998.feature
@@ -1,0 +1,1 @@
+Implement `trust_env=True` param in ClientSession.

--- a/docs/client.rst
+++ b/docs/client.rst
@@ -626,24 +626,12 @@ If your HTTP server uses UNIX domain sockets you can use
 Proxy support
 -------------
 
-aiohttp supports proxy. You have to use
-:attr:`proxy`::
+aiohttp supports HTTP/HTTPS proxies. You have to use
+*proxy* parameter::
 
    async with aiohttp.ClientSession() as session:
        async with session.get("http://python.org",
                               proxy="http://some.proxy.com") as resp:
-           print(resp.status)
-
-Contrary to the ``requests`` library, it won't read environment
-variables by default. But you can do so by passing
-:func:`proxies_from_env` result into :class:`aiohttp.ClientSession`
-constructor.  The function extracts proxy configuration from
-``HTTP_PROXY`` or ``HTTPS_PROXY`` *environment variables* (both are case
-insensitive)::
-
-   async with aiohttp.ClientSession() as session:
-       async with session.get("http://python.org",
-                              proxies=aiohttp.proxies_from_env()) as resp:
            print(resp.status)
 
 It also supports proxy authorization::
@@ -660,6 +648,16 @@ Authentication credentials can be passed in proxy URL::
    session.get("http://python.org",
                proxy="http://user:pass@some.proxy.com")
 
+Contrary to the ``requests`` library, it won't read environment
+variables by default. But you can do so by passing
+``trust_env=True`` into :class:`aiohttp.ClientSession`
+constructor for extracting proxy configuration from
+*HTTP_PROXY* or *HTTPS_PROXY* *environment variables* (both are case
+insensitive)::
+
+   async with aiohttp.ClientSession() as session:
+       async with session.get("http://python.org", trust_env=True) as resp:
+           print(resp.status)
 
 Response Status Codes
 ---------------------

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -143,16 +143,9 @@ The client session supports the context manager protocol for self closing.
 
       .. versionadded:: 2.3
 
-   :param dict proxies: A proxies dictionary or ``None`` if no proxies
-      are provided.
-
-      The dictionary is a *protocol* -> *proxy_info* mapping where
-      *protocol* is ``'http'`` or ``'https'``, *proxy_info* is
-      :class:`aiohttp.ProxyInfo` structure.
-
-      The main intended usage is configuring proxies by *environment
-      variables*: `client =
-      aiohttp.ClientSession(proxies=aiohttp.proxies_from_env())`.
+   :param bool from_env: Get proxies information from *HTTP_PROXY* /
+                         *HTTPS_PROXY* environment variables if the
+                         parameter is ``True`` (``False`` by default).
 
       .. versionadded:: 2.3
 
@@ -1367,36 +1360,6 @@ RequestInfo
    .. attribute:: headers
 
       HTTP headers for request, :class:`multidict.CIMultiDict` instance.
-
-
-Proxy Support
-^^^^^^^^^^^^^
-
-.. class:: ProxyInfo
-
-   A structure for storing information about HTTP proxy configuration.
-
-   .. attribute:: proxy
-
-      :class:`yarl.URL` to proxy.
-
-   .. attribute:: proxy_auth
-
-      :class:`aiohttp.BasicAuth` with proxy credentials or ``None`` if
-      no login/password are needed.
-
-   .. versionadded:: 2.3.0
-
-
-.. function:: proxies_from_env()
-
-   Extract proxy information from *environment variables*
-   (``HTTP_PROXY`` and ``HTTTPS_PROXY``, names are case insensitive).
-
-   Return a :class:`dict` for passing into
-   :class:`aiohttp.ClientSession` as *proxes* parameter.
-
-   .. versionadded:: 2.3.0
 
 
 BasicAuth

--- a/tests/test_proxy_functional.py
+++ b/tests/test_proxy_functional.py
@@ -64,10 +64,10 @@ def proxy_test_server(raw_test_server, loop, monkeypatch):
 @pytest.fixture()
 def get_request(loop):
     @asyncio.coroutine
-    def _request(method='GET', *, url, proxies=None, **kwargs):
+    def _request(method='GET', *, url, trust_env=False, **kwargs):
         connector = aiohttp.TCPConnector(verify_ssl=False, loop=loop)
         client = aiohttp.ClientSession(connector=connector,
-                                       proxies=proxies)
+                                       trust_env=trust_env)
         try:
             resp = yield from client.request(method, url, **kwargs)
             yield from resp.release()
@@ -513,7 +513,7 @@ def test_proxy_from_env_http(proxy_test_server, get_request, mocker):
     proxy = yield from proxy_test_server()
     mocker.patch.dict(os.environ, {'http_proxy': str(proxy.url)})
 
-    yield from get_request(url=url, proxies=aiohttp.proxies_from_env())
+    yield from get_request(url=url, trust_env=True)
 
     assert len(proxy.requests_list) == 1
     assert proxy.request.method == 'GET'
@@ -532,7 +532,7 @@ def test_proxy_from_env_http_with_auth(proxy_test_server, get_request, mocker):
                                        .with_user(auth.login)
                                        .with_password(auth.password))})
 
-    yield from get_request(url=url, proxies=aiohttp.proxies_from_env())
+    yield from get_request(url=url, trust_env=True)
 
     assert len(proxy.requests_list) == 1
     assert proxy.request.method == 'GET'
@@ -547,7 +547,7 @@ def xtest_proxy_from_env_https(proxy_test_server, get_request, mocker):
     proxy = yield from proxy_test_server()
     mocker.patch.dict(os.environ, {'https_proxy': str(proxy.url)})
 
-    yield from get_request(url=url, proxies=aiohttp.proxies_from_env())
+    yield from get_request(url=url, trust_env=True)
 
     assert len(proxy.requests_list) == 2
     assert proxy.request.method == 'GET'
@@ -567,7 +567,7 @@ def xtest_proxy_from_env_https_with_auth(proxy_test_server,
                                        .with_user(auth.login)
                                        .with_password(auth.password))})
 
-    yield from get_request(url=url, proxies=aiohttp.proxies_from_env())
+    yield from get_request(url=url, trust_env=True)
 
     assert len(proxy.requests_list) == 2
 


### PR DESCRIPTION
Replace `proxies_from_env` with `trust_env` boolean flag.
The flag could be reused for supporting `.netrc` file in future as well as other possible config files.

The main motivation for the change is: bool flag is easier to use than `proxies=aiohttp.proxies_from_env()`

`proxies_from_env()` is not released yet, the change doesn't raise backward incompatibility. 