### PR TITLE
aiohttp.wep.Application.make_handler access_log_class support

### DIFF
--- a/aiohttp/abc.py
+++ b/aiohttp/abc.py
@@ -152,7 +152,21 @@ class AbstractAccessLogger(ABC):
 
     def __init__(self, logger, log_format):
         self.logger = logger
+        self.log_format = log_format
 
     @abstractmethod
+    def _log(self, request, response, time):
+        """
+
+        :param request: Request object.
+        :param response: Response object.
+        :param float time: Time taken to serve the request.
+        """
+
     def log(self, request, response, time):
         """Emit log to logger"""
+
+        try:
+            self._log(request, response, time)
+        except Exception:
+            self.logger.exception("Error in logging")

--- a/aiohttp/abc.py
+++ b/aiohttp/abc.py
@@ -146,3 +146,13 @@ class AbstractPayloadWriter(ABC):
     @abstractmethod
     def drain(self):
         """Flush the write buffer."""
+
+
+class AbstractAccessLogger(ABC):
+
+    def __init__(self, logger, log_format):
+        self.logger = logger
+
+    @abstractmethod
+    def log(self, request, response, time):
+        """Emit log to logger"""

--- a/aiohttp/abc.py
+++ b/aiohttp/abc.py
@@ -155,18 +155,5 @@ class AbstractAccessLogger(ABC):
         self.log_format = log_format
 
     @abstractmethod
-    def _log(self, request, response, time):
-        """
-
-        :param request: Request object.
-        :param response: Response object.
-        :param float time: Time taken to serve the request.
-        """
-
     def log(self, request, response, time):
         """Emit log to logger"""
-
-        try:
-            self._log(request, response, time)
-        except Exception:
-            self.logger.exception("Error in logging")

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -513,31 +513,20 @@ class AccessLogger(AbstractAccessLogger):
         return ((key, method(request, response, time))
                 for key, method in self._methods)
 
-    def log(self, request, response, time):
-        """Log access.
+    def _log(self, request, response, time):
+        fmt_info = self._format_line(request, response, time)
 
-        :param message: Request object. May be None.
-        :param environ: Environment dict. May be None.
-        :param response: Response object.
-        :param transport: Tansport object. May be None
-        :param float time: Time taken to serve the request.
-        """
-        try:
-            fmt_info = self._format_line(request, response, time)
+        values = list()
+        extra = dict()
+        for key, value in fmt_info:
+            values.append(value)
 
-            values = list()
-            extra = dict()
-            for key, value in fmt_info:
-                values.append(value)
+            if key.__class__ is str:
+                extra[key] = value
+            else:
+                extra[key[0]] = {key[1]: value}
 
-                if key.__class__ is str:
-                    extra[key] = value
-                else:
-                    extra[key[0]] = {key[1]: value}
-
-            self.logger.info(self._log_format % tuple(values), extra=extra)
-        except Exception:
-            self.logger.exception("Error in logging")
+        self.logger.info(self._log_format % tuple(values), extra=extra)
 
 
 class reify:

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -23,6 +23,7 @@ from async_timeout import timeout
 from yarl import URL
 
 from . import hdrs
+from .abc import AbstractAccessLogger
 from .log import client_logger
 
 
@@ -346,7 +347,7 @@ def content_disposition_header(disptype, quote_fields=True, **params):
     return value
 
 
-class AccessLogger:
+class AccessLogger(AbstractAccessLogger):
     """Helper object to log access.
 
     Usage:
@@ -400,7 +401,7 @@ class AccessLogger:
         :param log_format: apache compatible log format
 
         """
-        self.logger = logger
+        super().__init__(logger, log_format=log_format)
 
         _compiled_format = AccessLogger._FORMAT_CACHE.get(log_format)
         if not _compiled_format:

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -513,20 +513,23 @@ class AccessLogger(AbstractAccessLogger):
         return ((key, method(request, response, time))
                 for key, method in self._methods)
 
-    def _log(self, request, response, time):
-        fmt_info = self._format_line(request, response, time)
+    def log(self, request, response, time):
+        try:
+            fmt_info = self._format_line(request, response, time)
 
-        values = list()
-        extra = dict()
-        for key, value in fmt_info:
-            values.append(value)
+            values = list()
+            extra = dict()
+            for key, value in fmt_info:
+                values.append(value)
 
-            if key.__class__ is str:
-                extra[key] = value
-            else:
-                extra[key[0]] = {key[1]: value}
+                if key.__class__ is str:
+                    extra[key] = value
+                else:
+                    extra[key[0]] = {key[1]: value}
 
-        self.logger.info(self._log_format % tuple(values), extra=extra)
+            self.logger.info(self._log_format % tuple(values), extra=extra)
+        except Exception:
+            self.logger.exception("Error in logging")
 
 
 class reify:

--- a/aiohttp/web.py
+++ b/aiohttp/web.py
@@ -237,8 +237,10 @@ class Application(MutableMapping):
                      **kwargs):
 
         if not issubclass(access_log_class, AbstractAccessLogger):
-            raise TypeError('access_log_class must be subclass of '
-                            'aiohttp.abc.AbstractAccessLogger')
+            raise TypeError(
+                'access_log_class must be subclass of '
+                'aiohttp.abc.AbstractAccessLogger, got {}'.format(
+                    access_log_class))
 
         self._set_loop(loop)
         self.freeze()

--- a/aiohttp/web.py
+++ b/aiohttp/web.py
@@ -14,7 +14,7 @@ from yarl import URL
 from . import (hdrs, web_exceptions, web_fileresponse, web_middlewares,
                web_protocol, web_request, web_response, web_server,
                web_urldispatcher, web_ws)
-from .abc import AbstractMatchInfo, AbstractRouter
+from .abc import AbstractAccessLogger, AbstractMatchInfo, AbstractRouter
 from .frozenlist import FrozenList
 from .http import HttpVersion  # noqa
 from .log import access_logger, web_logger
@@ -230,6 +230,14 @@ class Application(MutableMapping):
         return self._middlewares
 
     def make_handler(self, *, loop=None, **kwargs):
+        if 'access_log_class' in kwargs:
+            access_log_class = kwargs['access_log_class']
+
+            assert issubclass(access_log_class, AbstractAccessLogger), (
+                '{} must be subclass of '
+                'aiohttp.abc.AbstractAccessLogger'.format(access_log_class)
+            )
+
         self._set_loop(loop)
         self.freeze()
 

--- a/aiohttp/web_protocol.py
+++ b/aiohttp/web_protocol.py
@@ -61,6 +61,9 @@ class RequestHandler(asyncio.streams.FlowControlMixin, asyncio.Protocol):
     :param logger: custom logger object
     :type logger: aiohttp.log.server_logger
 
+    :param access_log_class: custom class for access_logger
+    :type access_log_class: aiohttp.abc.AbstractAccessLogger
+
     :param access_log: custom logging object
     :type access_log: aiohttp.log.server_logger
 

--- a/aiohttp/web_protocol.py
+++ b/aiohttp/web_protocol.py
@@ -83,7 +83,7 @@ class RequestHandler(asyncio.streams.FlowControlMixin, asyncio.Protocol):
                  tcp_keepalive=True,
                  slow_request_timeout=None,
                  logger=server_logger,
-                 access_log_factory=helpers.AccessLogger,
+                 access_log_class=helpers.AccessLogger,
                  access_log=access_logger,
                  access_log_format=helpers.AccessLogger.LOG_FORMAT,
                  debug=False,
@@ -139,7 +139,7 @@ class RequestHandler(asyncio.streams.FlowControlMixin, asyncio.Protocol):
         self.debug = debug
         self.access_log = access_log
         if access_log:
-            self.access_logger = access_log_factory(
+            self.access_logger = access_log_class(
                 access_log, access_log_format)
         else:
             self.access_logger = None

--- a/aiohttp/web_protocol.py
+++ b/aiohttp/web_protocol.py
@@ -83,6 +83,7 @@ class RequestHandler(asyncio.streams.FlowControlMixin, asyncio.Protocol):
                  tcp_keepalive=True,
                  slow_request_timeout=None,
                  logger=server_logger,
+                 access_log_factory=helpers.AccessLogger,
                  access_log=access_logger,
                  access_log_format=helpers.AccessLogger.LOG_FORMAT,
                  debug=False,
@@ -138,7 +139,7 @@ class RequestHandler(asyncio.streams.FlowControlMixin, asyncio.Protocol):
         self.debug = debug
         self.access_log = access_log
         if access_log:
-            self.access_logger = helpers.AccessLogger(
+            self.access_logger = access_log_factory(
                 access_log, access_log_format)
         else:
             self.access_logger = None

--- a/changes/2315.feature
+++ b/changes/2315.feature
@@ -1,0 +1,1 @@
+aiohttp.wep.Application.make_handler support access_log_factory

--- a/changes/2315.feature
+++ b/changes/2315.feature
@@ -1,1 +1,1 @@
-aiohttp.wep.Application.make_handler support access_log_factory
+aiohttp.wep.Application.make_handler support access_log_class

--- a/docs/abc.rst
+++ b/docs/abc.rst
@@ -35,7 +35,7 @@ Not Allowed*. :meth:`AbstractMatchInfo.handler` raises
 :attr:`~AbstractMatchInfo.http_exception` on call.
 
 
-.. class:: AbstractRouter
+.. class:: aiohttp.abc.AbstractRouter
 
    Abstract router, :class:`aiohttp.web.Application` accepts it as
    *router* parameter and returns as
@@ -54,7 +54,7 @@ Not Allowed*. :meth:`AbstractMatchInfo.handler` raises
       :return: :class:`AbstractMatchInfo` instance.
 
 
-.. class:: AbstractMatchInfo
+.. class:: aiohttp.abc.AbstractMatchInfo
 
    Abstract *match info*, returned by :meth:`AbstractRouter.resolve` call.
 
@@ -102,7 +102,7 @@ attribute.
 Abstract Cookie Jar
 -------------------
 
-.. class:: AbstractCookieJar
+.. class:: aiohttp.abc.AbstractCookieJar
 
    The cookie jar instance is available as :attr:`ClientSession.cookie_jar`.
 
@@ -146,3 +146,21 @@ Abstract Cookie Jar
 
       :return: :class:`http.cookies.SimpleCookie` with filtered
          cookies for given URL.
+
+Abstract Abstract Access Logger
+-------------------------------
+
+.. class:: aiohttp.abc.AbstractAccessLogger
+
+   An abstract class, base for all :class:`RequestHandler`
+   ``access_logger`` implementations
+
+   Method ``_log`` should be overridden.
+
+   .. method:: _log(request, response, time)
+
+      :param request: :class:`aiohttp.web.Request` object.
+
+      :param response: :class:`aiohttp.web.Response` object.
+
+      :param float time: Time taken to serve the request.

--- a/docs/abc.rst
+++ b/docs/abc.rst
@@ -155,9 +155,9 @@ Abstract Abstract Access Logger
    An abstract class, base for all :class:`RequestHandler`
    ``access_logger`` implementations
 
-   Method ``_log`` should be overridden.
+   Method ``log`` should be overridden.
 
-   .. method:: _log(request, response, time)
+   .. method:: log(request, response, time)
 
       :param request: :class:`aiohttp.web.Request` object.
 

--- a/docs/logging.rst
+++ b/docs/logging.rst
@@ -87,6 +87,20 @@ Default access log format is::
 
    '%a %l %u %t "%r" %s %b "%{Referrer}i" "%{User-Agent}i"'
 
+.. versionadded:: 2.3.0
+
+*access_log_class* introduced.
+
+Example of drop-in replacement for :class:`aiohttp.helpers.AccessLogger`::
+
+  from aiohttp.abc import AbstractAccessLogger
+
+  class AccessLogger(AbstractAccessLogger):
+
+      def _log(self, request, response, time):
+          self.logger.info(f'{request.remote} '
+                           f'"{request.method} {request.path}"" '
+                           f'done in {time}s: {request.status}')
 
 .. note::
 

--- a/docs/logging.rst
+++ b/docs/logging.rst
@@ -97,7 +97,7 @@ Example of drop-in replacement for :class:`aiohttp.helpers.AccessLogger`::
 
   class AccessLogger(AbstractAccessLogger):
 
-      def _log(self, request, response, time):
+      def log(self, request, response, time):
           self.logger.info(f'{request.remote} '
                            f'"{request.method} {request.path} '
                            f'done in {time}s: {response.status}')

--- a/docs/logging.rst
+++ b/docs/logging.rst
@@ -99,8 +99,8 @@ Example of drop-in replacement for :class:`aiohttp.helpers.AccessLogger`::
 
       def _log(self, request, response, time):
           self.logger.info(f'{request.remote} '
-                           f'"{request.method} {request.path}"" '
-                           f'done in {time}s: {request.status}')
+                           f'"{request.method} {request.path} '
+                           f'done in {time}s: {response.status}')
 
 .. note::
 

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -1347,6 +1347,9 @@ duplicated like one using :meth:`Application.copy`.
       :data:`aiohttp.log.server_logger`.
     :param access_log: Custom logging object. Default:
       :data:`aiohttp.log.access_logger`.
+    :param access_log_class: class for `access_logger`. Default:
+      :data:`aiohttp.helpers.AccessLogger`.
+      Must to be a subclass of :class:`aiohttp.abc.AbstractAccessLogger`.
     :param str access_log_format: Access log format string. Default:
       :attr:`helpers.AccessLogger.LOG_FORMAT`.
     :param bool debug: Switches debug mode. Default: ``False``.

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -259,16 +259,17 @@ def test_logger_no_transport():
 
 def test_logger_abc():
     class Logger(AbstractAccessLogger):
-        def _log(self, request, response, time):
+        def log(self, request, response, time):
             1 / 0
 
     mock_logger = mock.Mock()
     access_logger = Logger(mock_logger, None)
-    access_logger.log(None, None, None)
-    mock_logger.exception.assert_called_with("Error in logging")
+
+    with pytest.raises(ZeroDivisionError):
+        access_logger.log(None, None, None)
 
     class Logger(AbstractAccessLogger):
-        def _log(self, request, response, time):
+        def log(self, request, response, time):
             self.logger.info(self.log_format.format(
                 request=request,
                 response=response,

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -10,6 +10,7 @@ import pytest
 from yarl import URL
 
 from aiohttp import helpers
+from aiohttp.abc import AbstractAccessLogger
 
 
 # -------------------- coro guard --------------------------------
@@ -254,6 +255,30 @@ def test_logger_no_transport():
     access_logger = helpers.AccessLogger(mock_logger, "%a")
     access_logger.log(None, None, 0)
     mock_logger.info.assert_called_with("-", extra={'remote_address': '-'})
+
+
+def test_logger_abc():
+    class Logger(AbstractAccessLogger):
+        def _log(self, request, response, time):
+            1 / 0
+
+    mock_logger = mock.Mock()
+    access_logger = Logger(mock_logger, None)
+    access_logger.log(None, None, None)
+    mock_logger.exception.assert_called_with("Error in logging")
+
+    class Logger(AbstractAccessLogger):
+        def _log(self, request, response, time):
+            self.logger.info(self.log_format.format(
+                request=request,
+                response=response,
+                time=time
+            ))
+
+    mock_logger = mock.Mock()
+    access_logger = Logger(mock_logger, '{request} {response} {time}')
+    access_logger.log('request', 'response', 1)
+    mock_logger.info.assert_called_with('request response 1')
 
 
 class TestReify:

--- a/tests/test_web_application.py
+++ b/tests/test_web_application.py
@@ -4,7 +4,7 @@ from unittest import mock
 import pytest
 
 from aiohttp import helpers, log, web
-from aiohttp.abc import AbstractRouter
+from aiohttp.abc import AbstractAccessLogger, AbstractRouter
 
 
 def test_app_ctor(loop):
@@ -77,6 +77,29 @@ def test_app_make_handler_args(loop, mocker):
     srv.assert_called_with(app._handle,
                            request_factory=app._make_request,
                            loop=loop, debug=mock.ANY, test=True)
+
+
+def test_app_make_handler_access_log_class(loop, mocker):
+    class Logger:
+        pass
+
+    app = web.Application()
+
+    with pytest.raises(AssertionError):
+        app.make_handler(access_log_class=Logger, loop=loop)
+
+    class Logger(AbstractAccessLogger):
+
+        def _log(self, request, response, time):
+            self.logger.info('msg')
+
+    srv = mocker.patch('aiohttp.web.Server')
+
+    app.make_handler(access_log_class=Logger, loop=loop)
+    srv.assert_called_with(app._handle,
+                           access_log_class=Logger,
+                           request_factory=app._make_request,
+                           loop=loop, debug=mock.ANY)
 
 
 @asyncio.coroutine

--- a/tests/test_web_application.py
+++ b/tests/test_web_application.py
@@ -65,6 +65,7 @@ def test_app_make_handler_debug_exc(loop, mocker, debug):
     app.make_handler(loop=loop)
     srv.assert_called_with(app._handle,
                            request_factory=app._make_request,
+                           access_log_class=mock.ANY,
                            loop=loop,
                            debug=debug)
 
@@ -76,6 +77,7 @@ def test_app_make_handler_args(loop, mocker):
     app.make_handler(loop=loop)
     srv.assert_called_with(app._handle,
                            request_factory=app._make_request,
+                           access_log_class=mock.ANY,
                            loop=loop, debug=mock.ANY, test=True)
 
 
@@ -85,12 +87,12 @@ def test_app_make_handler_access_log_class(loop, mocker):
 
     app = web.Application()
 
-    with pytest.raises(AssertionError):
+    with pytest.raises(TypeError):
         app.make_handler(access_log_class=Logger, loop=loop)
 
     class Logger(AbstractAccessLogger):
 
-        def _log(self, request, response, time):
+        def log(self, request, response, time):
             self.logger.info('msg')
 
     srv = mocker.patch('aiohttp.web.Server')


### PR DESCRIPTION
## What do these changes do?

Adds support pluggable `aiohttp.helpers.AccessLogger` for `aiohttp.wep.Application.make_handler`

## Are there changes in behavior for the user?

No breaking changes.

## Related issue number

https://github.com/aio-libs/aiohttp/issues/2315

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `changes` folder
  * name it `<issue_id>.<type>` for example (588.bug)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
