### PR TITLE
 Fix web.FileResponse overriding user supplied Content-Type

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -49,6 +49,7 @@ Daniel García
 Daniel Nelson
 Danny Song
 David Michael Brown
+Denilson Amorim
 Denis Matiychuk
 Dima Veselov
 Dimitar Dimitrov

--- a/aiohttp/web_fileresponse.py
+++ b/aiohttp/web_fileresponse.py
@@ -182,9 +182,13 @@ class FileResponse(StreamResponse):
             self._length_check = False
             return (yield from super().prepare(request))
 
-        ct, encoding = mimetypes.guess_type(str(filepath))
-        if not ct:
-            ct = 'application/octet-stream'
+        if hdrs.CONTENT_TYPE not in self.headers:
+            ct, encoding = mimetypes.guess_type(str(filepath))
+            if not ct:
+                ct = 'application/octet-stream'
+        else:
+            ct = self.headers[hdrs.CONTENT_TYPE]
+            encoding = 'gzip' if gzip else None
 
         status = HTTPOk.status_code
         file_size = st.st_size

--- a/changes/2317.bugfix
+++ b/changes/2317.bugfix
@@ -1,0 +1,1 @@
+Fix web.FileResponse overriding user supplied Content-Type

--- a/tests/test_web_sendfile_functional.py
+++ b/tests/test_web_sendfile_functional.py
@@ -123,6 +123,54 @@ def test_static_file_with_content_type(loop, test_client, sender):
 
 
 @asyncio.coroutine
+def test_static_file_custom_content_type(loop, test_client, sender):
+    filepath = (pathlib.Path(__file__).parent / 'hello.txt.gz')
+
+    @asyncio.coroutine
+    def handler(request):
+        resp = sender(filepath, chunk_size=16)
+        resp.content_type = 'application/pdf'
+        return resp
+
+    app = web.Application()
+    app.router.add_get('/', handler)
+    client = yield from test_client(lambda loop: app)
+
+    resp = yield from client.get('/')
+    assert resp.status == 200
+    body = yield from resp.read()
+    with filepath.open('rb') as f:
+        content = f.read()
+        assert content == body
+    assert resp.headers['Content-Type'] == 'application/pdf'
+    assert resp.headers.get('Content-Encoding') is None
+    resp.close()
+
+
+@asyncio.coroutine
+def test_static_file_custom_content_type_compress(loop, test_client, sender):
+    filepath = (pathlib.Path(__file__).parent / 'hello.txt')
+
+    @asyncio.coroutine
+    def handler(request):
+        resp = sender(filepath, chunk_size=16)
+        resp.content_type = 'application/pdf'
+        return resp
+
+    app = web.Application()
+    app.router.add_get('/', handler)
+    client = yield from test_client(lambda loop: app)
+
+    resp = yield from client.get('/')
+    assert resp.status == 200
+    body = yield from resp.read()
+    assert b'hello aiohttp\n' == body
+    assert resp.headers['Content-Type'] == 'application/pdf'
+    assert resp.headers.get('Content-Encoding') == 'gzip'
+    resp.close()
+
+
+@asyncio.coroutine
 def test_static_file_with_content_encoding(loop, test_client, sender):
     filepath = pathlib.Path(__file__).parent / 'hello.txt.gz'
 


### PR DESCRIPTION

## What do these changes do?

If the user modifies either the `web.FileResponse.content_type` property, or the `Content-Type` header, the choice is now respected instead of guessing the content type from the file extension.

## Are there changes in behavior for the user?

No notable changes should happen.

## Related issue number

Fixes #2317 

## Checklist

- [X] I think the code is well written
- [X] Unit tests for the changes exist
- [ ] Documentation reflects the changes **(no need I guess)**
- [X] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
- [X] Add a new news fragment into the `changes` folder
