### PR TITLE
Drop a chapter about 2.0 release from README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,33 +21,6 @@ Async http client/server framework
     :target: https://gitter.im/aio-libs/Lobby
     :alt: Chat on Gitter
 
-aiohttp 2.0 release!
-====================
-
-For this release we completely refactored low-level implementation of
-http handling.  Finally `uvloop` gives performance
-improvement. Overall performance improvement should be around 70-90%
-compared to 1.x version.
-
-We took opportunity to refactor long standing api design problems
-across whole package.  Client exceptions handling has been cleaned up
-and now much more straight forward. Client payload management
-simplified and allows to extend with any custom type. Client
-connection pool implementation has been redesigned as well, now there
-is no need for actively releasing response objects, aiohttp handles
-connection release automatically.
-
-Another major change, we moved aiohttp development to public
-organization https://github.com/aio-libs
-
-With this amount of api changes we had to make backward incompatible
-changes. Please check this migration document
-https://aiohttp.readthedocs.io/en/latest/migration_to_2xx.html
-
-Please report problems or annoyance with with api to
-https://github.com/aio-libs/aiohttp
-
-
 Features
 ========
 


### PR DESCRIPTION
aiohttp 2.0 was released long time ago, no need a chapter about migration from 1.x anymore