### PR TITLE
Drop aiohttp.Timeout

### DIFF
--- a/CHANGES/2348.removal
+++ b/CHANGES/2348.removal
@@ -1,0 +1,1 @@
+Drop `aiohttp.Timeout` and use `async_timeout.timeout` instead.

--- a/aiohttp/client_ws.py
+++ b/aiohttp/client_ws.py
@@ -3,8 +3,10 @@
 import asyncio
 import json
 
+import async_timeout
+
 from .client_exceptions import ClientError
-from .helpers import PY_352, Timeout, call_later, create_future
+from .helpers import PY_352, call_later, create_future
 from .http import (WS_CLOSED_MESSAGE, WS_CLOSING_MESSAGE, WebSocketError,
                    WSMessage, WSMsgType)
 
@@ -153,7 +155,7 @@ class ClientWebSocketResponse:
 
             while True:
                 try:
-                    with Timeout(self._timeout, loop=self._loop):
+                    with async_timeout.timeout(self._timeout, loop=self._loop):
                         msg = yield from self._reader.read()
                 except asyncio.CancelledError:
                     self._close_code = 1006
@@ -188,7 +190,7 @@ class ClientWebSocketResponse:
             try:
                 self._waiting = create_future(self._loop)
                 try:
-                    with Timeout(
+                    with async_timeout.timeout(
                             timeout or self._receive_timeout,
                             loop=self._loop):
                         msg = yield from self._reader.read()

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -20,7 +20,7 @@ from pathlib import Path
 from urllib.parse import quote
 from urllib.request import getproxies
 
-from async_timeout import timeout
+import async_timeout
 from yarl import URL
 
 from . import hdrs
@@ -31,11 +31,10 @@ from .log import client_logger
 PY_352 = sys.version_info >= (3, 5, 2)
 
 
-__all__ = ('BasicAuth', 'Timeout')
+__all__ = ('BasicAuth',)
 
 
 sentinel = object()
-Timeout = timeout
 NO_EXTENSIONS = bool(os.environ.get('AIOHTTP_NO_EXTENSIONS'))
 
 CHAR = set(chr(i) for i in range(0, 128))
@@ -711,7 +710,7 @@ class TimerContext:
             self._cancelled = True
 
 
-class CeilTimeout(Timeout):
+class CeilTimeout(async_timeout.timeout):
 
     def __enter__(self):
         if self._timeout is not None:

--- a/aiohttp/web_ws.py
+++ b/aiohttp/web_ws.py
@@ -2,8 +2,10 @@ import asyncio
 import json
 from collections import namedtuple
 
+import async_timeout
+
 from . import hdrs
-from .helpers import PY_352, Timeout, call_later, create_future
+from .helpers import PY_352, call_later, create_future
 from .http import (WS_CLOSED_MESSAGE, WS_CLOSING_MESSAGE, HttpProcessingError,
                    WebSocketError, WebSocketReader, WSMessage, WSMsgType,
                    do_handshake)
@@ -234,7 +236,7 @@ class WebSocketResponse(StreamResponse):
                 return True
 
             try:
-                with Timeout(self._timeout, loop=self._loop):
+                with async_timeout.timeout(self._timeout, loop=self._loop):
                     msg = yield from self._reader.read()
             except asyncio.CancelledError:
                 self._close_code = 1006
@@ -275,7 +277,7 @@ class WebSocketResponse(StreamResponse):
             try:
                 self._waiting = create_future(self._loop)
                 try:
-                    with Timeout(
+                    with async_timeout.timeout(
                             timeout or self._receive_timeout, loop=self._loop):
                         msg = yield from self._reader.read()
                     self._reset_heartbeat()


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Before submit your Pull Request, make sure you picked
     the right branch:

     - If you propose a new feature or improvement, select "master"
       as a target branch;
     - If this is a bug fix or documentation amendment, select
       the latest release branch (which looks like "0.xx") -->

## What do these changes do?
Drop `aiohttp.Timeout` and use `async_timeout.timeout` instead.
<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?
No.
<!-- Outline any notable behaviour for the end users. -->

## Related issue number
https://github.com/aio-libs/aiohttp/issues/2348

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] Add a new news fragment into the `changes` folder
