### PR TITLE
Small docs improvements

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -189,6 +189,7 @@ Contents
    web_lowlevel
    abc
    multipart
+   multipart_reference
    streams
    api
    logging

--- a/docs/multipart.rst
+++ b/docs/multipart.rst
@@ -1,4 +1,4 @@
-.. module:: aiohttp.multipart
+.. module:: aiohttp
 
 .. _aiohttp-multipart:
 

--- a/docs/multipart_reference.rst
+++ b/docs/multipart_reference.rst
@@ -1,0 +1,20 @@
+.. module:: aiohttp
+
+Multipart reference
+===================
+
+.. class:: MultipartResponseWrapper
+
+   Wrapper around the :class:`MultipartBodyReader` to take care about
+   underlying connection and close it when it needs in.
+
+
+   .. method:: at_eof()
+
+      Returns ``True`` when all response data had been read.
+
+      :rtype: bool
+
+   .. comethod:: next()
+
+      Emits next multipart reader object.

--- a/docs/multipart_reference.rst
+++ b/docs/multipart_reference.rst
@@ -18,3 +18,9 @@ Multipart reference
    .. comethod:: next()
 
       Emits next multipart reader object.
+
+   .. comethod:: release()
+
+      Releases the connection gracefully, reading all the content
+      to the void.
+

--- a/docs/streams.rst
+++ b/docs/streams.rst
@@ -1,5 +1,3 @@
-.. module:: aiohttp.streams
-
 .. _aiohttp-streams:
 
 Streaming API


### PR DESCRIPTION
`multidict_reference.rst` is not finished.
My plan is publishing a template and asking people for finishing docs transition.
Getting rid of `yield from` campaign has proved the vitality of this approach.

Will make an issue for multipart docs just after merging the PR 