### PR TITLE
Calling str() on all headers values on http_writer.writer_headers method

### DIFF
--- a/CHANGES/2398.bugfix
+++ b/CHANGES/2398.bugfix
@@ -1,0 +1,1 @@
+Calling str() on all headers values on http_writer.writer_headers method

--- a/aiohttp/http_writer.py
+++ b/aiohttp/http_writer.py
@@ -244,7 +244,7 @@ class PayloadWriter(AbstractPayloadWriter):
         """Write request/response status and headers."""
         # status + headers
         headers = status_line + ''.join(
-            [k + SEP + v + END for k, v in headers.items()])
+            [k + SEP + str(v) + END for k, v in headers.items()])
         headers = headers.encode('utf-8') + b'\r\n'
 
         size = len(headers)


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Before submit your Pull Request, make sure you picked
     the right branch:

     - If you propose a new feature or improvement, select "master"
       as a target branch;
     - If this is a bug fix or documentation amendment, select
       the latest release branch (which looks like "0.xx") -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

Just call str() on all values passed to write_headers method.

## Are there changes in behavior for the user?

Now users could pass a dict with any value to be written on the response headers.
<!-- Outline any notable behaviour for the end users. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [ ] Add a new news fragment into the `changes` folder
  * name it `<issue_id>.<type>` for example (588.bug)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
