### PR TITLE
Fix typo in ClientWebSocketResponse.closed doc

### DIFF
--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -1238,7 +1238,7 @@ manually.
 
    .. attribute:: closed
 
-      Read-only property, ``True`` if :meth:`close` has been called of
+      Read-only property, ``True`` if :meth:`close` has been called or
       :const:`~aiohttp.WSMsgType.CLOSE` message has been received from peer.
 
    .. attribute:: protocol


### PR DESCRIPTION
## What do these changes do?

Fix a small typo in the client reference docs, for `ClientWebSocketResponse.closed` 

"of" -> "on"

## Are there changes in behavior for the user?

No.

## Related issue number

No tracked issue.