### PR TITLE
Fix connector convert OSError to ClientConnectorError

### DIFF
--- a/CHANGES/2423.bugfix
+++ b/CHANGES/2423.bugfix
@@ -1,0 +1,1 @@
+Fix connector convert OSError to ClientConnectorError

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -777,7 +777,12 @@ class TCPConnector(BaseConnector):
         sslcontext = self._get_ssl_context(req)
         fingerprint, hashfunc = self._get_fingerprint_and_hashfunc(req)
 
-        hosts = await self._resolve_host(req.url.raw_host, req.port)
+        try:
+            hosts = await self._resolve_host(req.url.raw_host, req.port)
+        except OSError as exc:
+            # in case of proxy it is not ClientProxyConnectionError
+            # it is problem of resolving proxy ip itself
+            raise ClientConnectorError(req.connection_key, exc) from exc
 
         for hinfo in hosts:
             try:

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -18,7 +18,7 @@ import aiohttp
 from aiohttp import client, helpers, web
 from aiohttp.client import ClientRequest
 from aiohttp.connector import Connection, _DNSCacheTable
-from aiohttp.test_utils import unused_port
+from aiohttp.test_utils import make_mocked_coro, unused_port
 
 
 @pytest.fixture()
@@ -493,6 +493,19 @@ async def test_tcp_connector_dns_throttle_requests_cancelled_when_close(
 
         with pytest.raises(asyncio.futures.CancelledError):
             await f
+
+
+async def test_dns_error(loop):
+    connector = aiohttp.TCPConnector(loop=loop)
+    connector._resolve_host = make_mocked_coro(
+        raise_exception=OSError('dont take it serious'))
+
+    req = ClientRequest(
+        'GET', URL('http://www.python.org'),
+        loop=loop,
+    )
+    with pytest.raises(aiohttp.ClientConnectorError):
+        await connector.connect(req)
 
 
 def test_get_pop_empty_conns(loop):

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -215,7 +215,7 @@ class TestProxy(unittest.TestCase):
         Request_mock.assert_called_with(mock.ANY, mock.ANY, "xn--9caa.com:80",
                                         mock.ANY, loop=loop)
 
-    def test_proxy_connection_error(self):
+    def test_proxy_dns_error(self):
         connector = aiohttp.TCPConnector(loop=self.loop)
         connector._resolve_host = make_mocked_coro(
             raise_exception=OSError('dont take it serious'))


### PR DESCRIPTION
## What do these changes do?

Fix for https://github.com/aio-libs/aiohttp/issues/2423

## Are there changes in behavior for the user?

When dns request fails OSError converted ClientConnectorError

https://github.com/aio-libs/aiohttp/issues/2423

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `changes` folder
  * name it `<issue_id>.<type>` for example (588.bug)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
