### PR TITLE
fixed ValueError for AF_INET6 sockets

### DIFF
--- a/CHANGES/2431.bugfix
+++ b/CHANGES/2431.bugfix
@@ -1,0 +1,1 @@
+fixed ValueError for AF_INET6 sockets

--- a/CHANGES/2431.bugfix
+++ b/CHANGES/2431.bugfix
@@ -1,1 +1,1 @@
-fixed ValueError for AF_INET6 sockets
+fixed ValueError for AF_INET6 sockets if a preexisting INET6 socket to the `aiohttp.web.run_app` function.

--- a/aiohttp/web.py
+++ b/aiohttp/web.py
@@ -421,7 +421,7 @@ def _make_server_creators(handler, *, loop, ssl_context,
         if hasattr(socket, 'AF_UNIX') and sock.family == socket.AF_UNIX:
             uris.append('{}://unix:{}:'.format(scheme, sock.getsockname()))
         else:
-            host, port = sock.getsockname()
+            host, port = sock.getsockname()[:2]
             uris.append(str(base_url.with_host(host).with_port(port)))
     return server_creations, uris
 

--- a/tests/test_run_app.py
+++ b/tests/test_run_app.py
@@ -42,15 +42,15 @@ skip_if_no_unix_socks = pytest.mark.skipif(
 )
 del _has_unix_domain_socks, _abstract_path_failed
 
-has_ipv6 = socket.has_ipv6
-if has_ipv6:
+HAS_IPV6 = socket.has_ipv6
+if HAS_IPV6:
     # The socket.has_ipv6 flag may be True if Python was built with IPv6
     # support, but the target system still may not have it.
     # So let's ensure that we really have IPv6 support.
     try:
         socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
     except OSError:
-        has_ipv6 = False
+        HAS_IPV6 = False
 
 
 # tokio event loop does not allow to override attributes
@@ -461,7 +461,7 @@ def test_run_app_preexisting_inet_socket(loop, mocker):
         assert "http://0.0.0.0:{}".format(port) in printer.call_args[0][0]
 
 
-@pytest.mark.skipif(not has_ipv6, reason="IPv6 is not available")
+@pytest.mark.skipif(not HAS_IPV6, reason="IPv6 is not available")
 def test_run_app_preexisting_inet6_socket(loop, mocker):
     skip_if_no_dict(loop)
 


### PR DESCRIPTION
## What do these changes do?

There is an issue if you pass a preexisting INET6 socket to the aiohttp.web.run_app function.
```
Traceback (most recent call last):
  File "test_aiohttp.py", line 26, in <module>
    web.run_app(app, sock=sock1)
  File "/usr/lib/python3.6/site-packages/aiohttp/web.py", line 435, in run_app
    backlog=backlog)
  File "/usr/lib/python3.6/site-packages/aiohttp/web.py", line 407, in _make_server_creators
    host, port = sock.getsockname()
ValueError: too many values to unpack (expected 2)
```

## Are there changes in behavior for the user?

It's a bugfix.

## Related issue number

There is no tracked issue.

## Checklist


- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `changes` folder
  * name it `<issue_id>.<type>` for example (588.bug)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
