### PR TITLE
Properly close sessions in _SessionRequestContextManager

### DIFF
--- a/CHANGES/2441.bugfix
+++ b/CHANGES/2441.bugfix
@@ -1,0 +1,1 @@
+_SessionRequestContextManager closes the session properly now.

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -724,16 +724,16 @@ class _SessionRequestContextManager(_RequestContextManager):
     def __iter__(self):
         try:
             return (yield from self._coro)
-        except:
-            self._session.close()
+        except BaseException:
+            yield from self._session.close()
             raise
 
     if PY_35:
         def __await__(self):
             try:
                 return (yield from self._coro)
-            except:
-                self._session.close()
+            except BaseException:
+                yield from self._session.close()
                 raise
 
 


### PR DESCRIPTION
## What do these changes do?

Fix a bunch of `DeprecationWarning: ClientSession.close() is a coroutine self._session.close()`.

Also changed bare except to BaseException which is equivalent but won’t raise a warning on current flake8s.  I’m aware current master catches Exception, but that seems like backward-combat violation in a point release.

## Are there changes in behavior for the user?

Less warnings.  I have a bit of a hard time writing tests because the test suite doesn’t work on my machine…

## Related issue number

Didn’t find any.

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `changes` folder
  * name it `<issue_id>.<type>` for example (588.bug)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."