### PR TITLE
Fix wrap oserrors.

### DIFF
--- a/CHANGES/2423.bugfix
+++ b/CHANGES/2423.bugfix
@@ -1,0 +1,1 @@
+Fix connector convert OSError to ClientConnectorError

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -1295,6 +1295,8 @@ def test_tcp_connector(test_client, loop):
     assert r.status == 200
 
 
+@pytest.mark.skipif(not hasattr(socket, 'AF_UNIX'),
+                    reason="requires unix socket")
 def test_unix_connector_not_found(loop):
     connector = aiohttp.UnixConnector('/' + uuid.uuid4().hex, loop=loop)
 
@@ -1306,6 +1308,8 @@ def test_unix_connector_not_found(loop):
         loop.run_until_complete(connector.connect(req))
 
 
+@pytest.mark.skipif(not hasattr(socket, 'AF_UNIX'),
+                    reason="requires unix socket")
 def test_unix_connector_permission(loop):
     loop.create_unix_connection = make_mocked_coro(
         raise_exception=PermissionError())

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -9,6 +9,7 @@ import socket
 import ssl
 import tempfile
 import unittest
+import uuid
 from unittest import mock
 
 import pytest
@@ -18,7 +19,7 @@ import aiohttp
 from aiohttp import client, helpers, web
 from aiohttp.client import ClientRequest
 from aiohttp.connector import Connection, _DNSCacheTable
-from aiohttp.test_utils import unused_port
+from aiohttp.test_utils import make_mocked_coro, unused_port
 
 
 @pytest.fixture()
@@ -505,6 +506,19 @@ def test_tcp_connector_dns_throttle_requests_cancelled_when_close(
 
         with pytest.raises(asyncio.futures.CancelledError):
             yield from f
+
+
+def test_dns_error(loop):
+    connector = aiohttp.TCPConnector(loop=loop)
+    connector._resolve_host = make_mocked_coro(
+        raise_exception=OSError('dont take it serious'))
+
+    req = ClientRequest(
+        'GET', URL('http://www.python.org'),
+        loop=loop,
+    )
+    with pytest.raises(aiohttp.ClientConnectorError):
+        loop.run_until_complete(connector.connect(req))
 
 
 def test_get_pop_empty_conns(loop):
@@ -1279,6 +1293,30 @@ def test_tcp_connector(test_client, loop):
 
     r = yield from client.get('/')
     assert r.status == 200
+
+
+def test_unix_connector_not_found(loop):
+    connector = aiohttp.UnixConnector('/' + uuid.uuid4().hex, loop=loop)
+
+    req = ClientRequest(
+        'GET', URL('http://www.python.org'),
+        loop=loop,
+    )
+    with pytest.raises(aiohttp.ClientConnectorError):
+        loop.run_until_complete(connector.connect(req))
+
+
+def test_unix_connector_permission(loop):
+    loop.create_unix_connection = make_mocked_coro(
+        raise_exception=PermissionError())
+    connector = aiohttp.UnixConnector('/' + uuid.uuid4().hex, loop=loop)
+
+    req = ClientRequest(
+        'GET', URL('http://www.python.org'),
+        loop=loop,
+    )
+    with pytest.raises(aiohttp.ClientConnectorError):
+        loop.run_until_complete(connector.connect(req))
 
 
 def test_default_use_dns_cache(loop):

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -215,7 +215,7 @@ class TestProxy(unittest.TestCase):
         Request_mock.assert_called_with(mock.ANY, mock.ANY, "xn--9caa.com:80",
                                         mock.ANY, loop=loop)
 
-    def test_proxy_connection_error(self):
+    def test_proxy_dns_error(self):
         connector = aiohttp.TCPConnector(loop=self.loop)
         connector._resolve_host = make_mocked_coro(
             raise_exception=OSError('dont take it serious'))


### PR DESCRIPTION
## What do these changes do?

Fix wrap `OSError` to `ClientConnectorError`

## Are there changes in behavior for the user?

`ClientConnectorError` raised instead of `OSError`

## Related issue number

https://github.com/aio-libs/aiohttp/issues/2423

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `changes` folder
  * name it `<issue_id>.<type>` for example (588.bug)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
