### PR TITLE
Fix wrap ssl errors for proxy connector.

### DIFF
--- a/CHANGES/2408.bugfix
+++ b/CHANGES/2408.bugfix
@@ -1,0 +1,1 @@
+Fix ClientConnectorSSLError and ClientProxyConnectionError for proxy connector


### PR DESCRIPTION
## What do these changes do?

Fix wrapping ssl related errors for proxy connector

## Are there changes in behavior for the user?

`ssl.SSLError` wrapped to `aiohttp.ClientConnectorSSLError` and
`ssl.CertificateError` wrapped to `aiohttp.ClientConnectorCertificateError`

## Related issue number

https://github.com/aio-libs/aiohttp/issues/2408

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bug)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
