### PR TITLE
Fix connection for multiple dns hosts

### DIFF
--- a/CHANGES/2424.bugfix
+++ b/CHANGES/2424.bugfix
@@ -1,0 +1,1 @@
+Fix connection attempts for multiple dns hosts

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -828,8 +828,14 @@ class TCPConnector(BaseConnector):
             has_cert = transp.get_extra_info('sslcontext')
             if has_cert and fingerprint:
                 sock = transp.get_extra_info('socket')
+                if not hasattr(sock, 'getpeercert'):
+                    # Workaround for asyncio 3.5.0
+                    # Starting from 3.5.1 version
+                    # there is 'ssl_object' extra info in transport
+                    sock = transp._ssl_protocol._sslpipe.ssl_object
                 # gives DER-encoded cert as a sequence of bytes (or None)
                 cert = sock.getpeercert(binary_form=True)
+                assert cert
                 got = hashfunc(cert).digest()
                 expected = fingerprint
                 if got != expected:

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -848,8 +848,6 @@ class TCPConnector(BaseConnector):
 
             return transp, proto
         else:
-            assert last_exc is not None
-
             raise last_exc
 
     @asyncio.coroutine


### PR DESCRIPTION
## What do these changes do?

Fix for `aiohttp.connector.TCPConnector._create_direct_connection` tries to use all of dns hosts from dns response to connect one by one

## Related issue number

https://github.com/aio-libs/aiohttp/issues/2424

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bug)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
