### PR TITLE
Content-Disposition fast access in ClientResponse

### DIFF
--- a/CHANGES/2455.feature
+++ b/CHANGES/2455.feature
@@ -1,0 +1,1 @@
+Content-Disposition fast access in ClientResponse

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -9,16 +9,17 @@ import warnings
 from collections import namedtuple
 from hashlib import md5, sha1, sha256
 from http.cookies import CookieError, Morsel, SimpleCookie
+from types import MappingProxyType
 
 from multidict import CIMultiDict, CIMultiDictProxy, MultiDict, MultiDictProxy
 from yarl import URL
 
-from . import hdrs, helpers, http, payload
+from . import hdrs, helpers, http, multipart, payload
 from .client_exceptions import (ClientConnectionError, ClientOSError,
                                 ClientResponseError, ContentTypeError,
                                 InvalidURL)
 from .formdata import FormData
-from .helpers import HeadersMixin, TimerNoop, noop
+from .helpers import HeadersMixin, TimerNoop, noop, reify
 from .http import SERVER_SOFTWARE, HttpVersion10, HttpVersion11, PayloadWriter
 from .log import client_logger
 from .streams import FlowControlStreamReader
@@ -31,6 +32,10 @@ except ImportError:  # pragma: no cover
 
 
 __all__ = ('ClientRequest', 'ClientResponse', 'RequestInfo')
+
+
+ContentDisposition = collections.namedtuple(
+    'ContentDisposition', ('type', 'parameters', 'filename'))
 
 
 RequestInfo = collections.namedtuple(
@@ -527,6 +532,7 @@ class ClientResponse(HeadersMixin):
         self._request_info = request_info
         self._timer = timer if timer is not None else TimerNoop()
         self._auto_decompress = auto_decompress
+        self._cache = {}  # reqired for @reify method decorator
 
     @property
     def url(self):
@@ -549,6 +555,16 @@ class ClientResponse(HeadersMixin):
     @property
     def request_info(self):
         return self._request_info
+
+    @reify
+    def content_disposition(self):
+        raw = self._headers.get(hdrs.CONTENT_DISPOSITION)
+        if raw is None:
+            return None
+        disposition_type, params = multipart.parse_content_disposition(raw)
+        params = MappingProxyType(params)
+        filename = multipart.content_disposition_filename(params)
+        return ContentDisposition(disposition_type, params, filename)
 
     def _post_init(self, loop, session):
         self._loop = loop

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -1109,12 +1109,19 @@ Response object
 
    .. attribute:: charset
 
-   Read-only property that specifies the *encoding* for the request's BODY.
+      Read-only property that specifies the *encoding* for the request's BODY.
 
       The value is parsed from the *Content-Type* HTTP header.
 
       Returns :class:`str` like ``'utf-8'`` or ``None`` if no *Content-Type*
       header present in HTTP headers or it has no charset information.
+
+   .. attribute:: content_disposition
+
+      Read-only property that specified the *Content-Disposition* HTTP header.
+
+      Instance of :class:`ContentDisposition` or ``None`` if no *Content-Disposition*
+      header present in HTTP headers.
 
    .. attribute:: history
 
@@ -1561,6 +1568,21 @@ All exceptions are available as members of *aiohttp* module.
 
       Invalid URL, :class:`yarl.URL` instance.
 
+.. class:: ContentDisposition
+
+    Represent Content-Disposition header
+
+    .. attribute:: value
+
+    A :class:`str` instance. Value of Content-Disposition header itself, e.g. ``attachment``.
+
+    .. attribute:: filename
+
+    A :class:`str` instance. Content filename extracted from parameters. May be ``None``.
+
+    .. attribute:: parameters
+
+    Read-only mapping contains all parameters.
 
 Response errors
 ^^^^^^^^^^^^^^^

--- a/tests/test_client_response.py
+++ b/tests/test_client_response.py
@@ -458,6 +458,42 @@ def test_charset_no_charset():
     assert response.charset is None
 
 
+def test_content_disposition_full():
+    response = ClientResponse('get', URL('http://def-cl-resp.org'))
+    response.headers = {'Content-Disposition':
+                        'attachment; filename="archive.tar.gz"; foo=bar'}
+
+    assert 'attachment' == response.content_disposition.type
+    assert 'bar' == response.content_disposition.parameters["foo"]
+    assert 'archive.tar.gz' == response.content_disposition.filename
+    with pytest.raises(TypeError):
+        response.content_disposition.parameters["foo"] = "baz"
+
+
+def test_content_disposition_no_parameters():
+    response = ClientResponse('get', URL('http://def-cl-resp.org'))
+    response.headers = {'Content-Disposition': 'attachment'}
+
+    assert 'attachment' == response.content_disposition.type
+    assert response.content_disposition.filename is None
+    assert {} == response.content_disposition.parameters
+
+
+def test_content_disposition_no_header():
+    response = ClientResponse('get', URL('http://def-cl-resp.org'))
+    response.headers = {}
+
+    assert response.content_disposition is None
+
+
+def test_content_disposition_cache():
+    response = ClientResponse('get', URL('http://def-cl-resp.org'))
+    response.headers = {'Content-Disposition': 'attachment'}
+    cd = response.content_disposition
+    ClientResponse.headers = {'Content-Disposition': 'spam'}
+    assert cd is response.content_disposition
+
+
 def test_response_request_info():
     url = 'http://def-cl-resp.org'
     headers = {'Content-Type': 'application/json;charset=cp1251'}


### PR DESCRIPTION
Add content_disposition and content_disposition_dict properties

Partially implements #1670

## What do these changes do?

Improves ClientResponse ergonomics

## Are there changes in behavior for the user?

All changes are documented.

## Related issue number

#1670

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bug)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
