### PR TITLE
Add drain() method to ClientWebSocketResponse.

### DIFF
--- a/CHANGES/2484.feature
+++ b/CHANGES/2484.feature
@@ -1,0 +1,1 @@
+Add `drain` method to the `ClientWebSocketResponse` class.

--- a/aiohttp/client_ws.py
+++ b/aiohttp/client_ws.py
@@ -126,6 +126,9 @@ class ClientWebSocketResponse:
     async def send_json(self, data, *, dumps=json.dumps):
         await self.send_str(dumps(data))
 
+    async def drain(self):
+        await self._writer.drain()
+
     async def close(self, *, code=1000, message=b''):
         # we need to break `receive()` cycle first,
         # `close()` may be called from different task

--- a/aiohttp/http_websocket.py
+++ b/aiohttp/http_websocket.py
@@ -610,6 +610,10 @@ class WebSocketWriter:
         else:
             return self._send_frame(message, WSMsgType.TEXT)
 
+    def drain(self):
+        """Flush the write buffer."""
+        return self.stream.drain()
+
     def close(self, code=1000, message=b''):
         """Close the websocket, sending the specified code and message."""
         if isinstance(message, str):

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -1333,6 +1333,11 @@ manually.
 
          The method is converted into :term:`coroutine`
 
+   .. comethod:: drain()
+
+      A :ref:`coroutine<coroutine>` to let the write buffer of the
+      underlying transport a chance to be flushed.
+
    .. comethod:: close(*, code=1000, message=b'')
 
       A :ref:`coroutine<coroutine>` that initiates closing handshake by sending


### PR DESCRIPTION
## What do these changes do?

These changes add a drain() method to the ClientWebSocketResponse class, analogous to the drain() method of the WebSocketResponse class.

## Are there changes in behavior for the user?

There should be no changes in existing applications, only newly added functionality.

## Related issue number

I am not aware of a related issue number.

## Checklist

- [X] I think the code is well written
- [X] Unit tests for the changes exist
- [X] Documentation reflects the changes
- [X] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
- [X] Add a new news fragment into the `CHANGES` folder
