### PR TITLE
Fix proxy headers use default headers

### DIFF
--- a/CHANGES/2272.bugfix
+++ b/CHANGES/2272.bugfix
@@ -1,0 +1,1 @@
+Fix proxy headers use default headers

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -160,6 +160,7 @@ SeongSoo Cho
 Sergey Ninua
 Sergey Skripnick
 Serhii Kostel
+Sijun Ye
 Simon Kennedy
 Sin-Woo Bang
 Stanislas Plum

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -108,12 +108,8 @@ class ClientSession:
         self._auto_decompress = auto_decompress
         self._trust_env = trust_env
 
-        # Convert to list of tuples
-        if headers:
-            headers = CIMultiDict(headers)
-        else:
-            headers = CIMultiDict()
-        self._default_headers = headers
+        # Convert headers to MultiDict
+        self._default_headers = CIMultiDict(headers or {})
         if skip_auto_headers is not None:
             self._skip_auto_headers = frozenset([istr(i)
                                                  for i in skip_auto_headers])
@@ -192,7 +188,7 @@ class ClientSession:
 
         # Merge with default headers and transform to CIMultiDict
         headers = self._prepare_headers(headers)
-        proxy_headers = self._prepare_headers(proxy_headers)
+        proxy_headers = CIMultiDict(proxy_headers or {})
 
         try:
             url = URL(url)


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Before submit your Pull Request, make sure you picked
     the right branch:

     - If you propose a new feature or improvement, select "master"
       as a target branch;
     - If this is a bug fix or documentation amendment, select the latest
       [release branch](https://github.com/aio-libs/aiohttp/branches) (which
       looks like "X.Y" e.g. "2.3") -->

## What do these changes do?

Fix proxy headers use default headers, PR https://github.com/aio-libs/aiohttp/pull/2272 caused `ClientHttpProxyError(Proxy Authentication Required)` use proxy when `Authorization` in default headers.

## Are there changes in behavior for the user?

no.

## Related issue number

https://github.com/aio-libs/aiohttp/pull/2272

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bug)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
