### PR TITLE
Add deprecation warning when HTTPException is returned instead of raised

### DIFF
--- a/CHANGES/2415.removal
+++ b/CHANGES/2415.removal
@@ -1,0 +1,1 @@
+Add DeprecationWarning for returning HTTPException

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -140,6 +140,7 @@ Nicolas Braem
 Nikolay Novik
 Olaf Conradi
 Pahaz Blinov
+Panagiotis Kolokotronis
 Pankaj Pandey
 Pau Freixes
 Paul Colomiets

--- a/aiohttp/web_protocol.py
+++ b/aiohttp/web_protocol.py
@@ -3,6 +3,7 @@ import asyncio.streams
 import http.server
 import socket
 import traceback
+import warnings
 from collections import deque
 from contextlib import suppress
 from html import escape as html_escape
@@ -426,6 +427,14 @@ class RequestHandler(asyncio.streams.FlowControlMixin, asyncio.Protocol):
                 # log access
                 if self.access_log:
                     self.log_access(request, resp, loop.time() - now)
+
+                # Deprication warning (See #2415)
+                if isinstance(resp, HTTPException):
+                    warnings.warn(
+                        "returning HTTPException object is deprecated (#2415) "
+                        "and will be removed, "
+                        "please raise the exception instead",
+                        DeprecationWarning)
 
                 # check payload
                 if not payload.is_eof():

--- a/docs/web_quickstart.rst
+++ b/docs/web_quickstart.rst
@@ -590,6 +590,11 @@ The exceptions are also a subclass of :class:`Response`, allowing you to either
 ``raise`` or ``return`` them in a
 :ref:`request handler <aiohttp-web-handler>` for the same effect.
 
+.. warning::
+
+   Returning :class:`~HTTPException` or its subclasses is deprecated and will
+   be removed in subsequent aiohttp versions.
+
 The following snippets are the same::
 
     async def handler(request):

--- a/tests/test_web_functional.py
+++ b/tests/test_web_functional.py
@@ -1576,3 +1576,16 @@ async def test_iter_any(test_server, loop):
     async with aiohttp.ClientSession(loop=loop) as session:
         async with session.post(server.make_url('/'), data=data) as resp:
             assert resp.status == 200
+
+
+async def test_return_http_exception_deprecated(loop, test_client):
+
+    async def handler(request):
+        return web.HTTPForbidden()
+
+    app = web.Application()
+    app.router.add_route('GET', '/', handler)
+    client = await test_client(app)
+
+    with pytest.warns(DeprecationWarning):
+        await client.get('/')


### PR DESCRIPTION
## What do these changes do?

Add DeprecationWarning when an HTTPException is returned instead of being raised.

## Are there changes in behavior for the user?

If user's handler (view function) returns an HTTPException, a DeprecationWarning will be displayed.

## Related issue number

Discussion in #2415

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bug)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
