### PR TITLE
Move documentation to docs.aiohttp.org

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,7 +21,7 @@ Async http client/server framework
    :alt: Latest PyPI package version
 
 .. image:: https://readthedocs.org/projects/aiohttp/badge/?version=latest
-   :target: http://aiohttp.readthedocs.io/en/latest/
+   :target: http://docs.aiohttp.org/
    :alt: Latest Read The Docs
 
 .. image:: https://badges.gitter.im/Join%20Chat.svg

--- a/aiohttp/worker.py
+++ b/aiohttp/worker.py
@@ -226,7 +226,7 @@ class GunicornWebWorker(base.Worker):
                 "Gunicorn's style options in form of `%(name)s` are not "
                 "supported for the log formatting. Please use aiohttp's "
                 "format specification to configure access log formatting: "
-                "http://aiohttp.readthedocs.io/en/stable/logging.html"
+                "http://docs.aiohttp.org/en/stable/logging.html"
                 "#format-specification"
             )
         else:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -156,6 +156,7 @@ html_theme = 'alabaster'
 html_theme_options = {
     'logo': 'aiohttp-icon-128x128.png',
     'description': 'http client/server for asyncio',
+    'canonical_url': 'http://docs.aiohttp.org/en/stable/',
     'github_user': 'aio-libs',
     'github_repo': 'aiohttp',
     'github_button': True,


### PR DESCRIPTION
http://docs.aiohttp.org/en/stable/ already exists BTW