### PR TITLE
Forbid synchronous context managers

### DIFF
--- a/CHANGES/2362.feature
+++ b/CHANGES/2362.feature
@@ -1,0 +1,2 @@
+Forbid synchronous context managers for `ClientSession` and test
+server/client.

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -711,7 +711,7 @@ class ClientSession:
         self._connector = None
 
     def __enter__(self):
-        raise RuntimeError("Use async with instead")
+        raise TypeError("Use async with instead")
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         # __exit__ should exist in pair with __enter__ but never executed

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -711,11 +711,11 @@ class ClientSession:
         self._connector = None
 
     def __enter__(self):
-        warnings.warn("Use async with instead", DeprecationWarning)
-        return self
+        raise RuntimeError("Use async with instead")
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        self.close()
+        # __exit__ should exist in pair with __enter__ but never executed
+        pass  # pragma: no cover
 
     @asyncio.coroutine
     def __aenter__(self):

--- a/aiohttp/test_utils.py
+++ b/aiohttp/test_utils.py
@@ -118,11 +118,11 @@ class BaseTestServer(ABC):
         pass  # pragma: no cover
 
     def __enter__(self):
-        self._loop.run_until_complete(self.start_server(loop=self._loop))
-        return self
+        raise RuntimeError("Use async with instead")
 
     def __exit__(self, exc_type, exc_value, traceback):
-        self._loop.run_until_complete(self.close())
+        # __exit__ should exist in pair with __enter__ but never executed
+        pass  # pragma: no cover
 
     async def __aenter__(self):
         await self.start_server(loop=self._loop)
@@ -317,11 +317,11 @@ class TestClient:
             self._closed = True
 
     def __enter__(self):
-        self._loop.run_until_complete(self.start_server())
-        return self
+        raise RuntimeError("Use async with instead")
 
     def __exit__(self, exc_type, exc_value, traceback):
-        self._loop.run_until_complete(self.close())
+        # __exit__ should exist in pair with __enter__ but never executed
+        pass  # pragma: no cover
 
     async def __aenter__(self):
         await self.start_server()

--- a/aiohttp/test_utils.py
+++ b/aiohttp/test_utils.py
@@ -118,7 +118,7 @@ class BaseTestServer(ABC):
         pass  # pragma: no cover
 
     def __enter__(self):
-        raise RuntimeError("Use async with instead")
+        raise TypeError("Use async with instead")
 
     def __exit__(self, exc_type, exc_value, traceback):
         # __exit__ should exist in pair with __enter__ but never executed
@@ -317,7 +317,7 @@ class TestClient:
             self._closed = True
 
     def __enter__(self):
-        raise RuntimeError("Use async with instead")
+        raise TypeError("Use async with instead")
 
     def __exit__(self, exc_type, exc_value, traceback):
         # __exit__ should exist in pair with __enter__ but never executed

--- a/tests/test_client_session.py
+++ b/tests/test_client_session.py
@@ -351,7 +351,7 @@ def test_del(connector, loop):
 
 
 def test_context_manager(connector, loop):
-    with pytest.raises(RuntimeError):
+    with pytest.raises(TypeError):
         with ClientSession(loop=loop, connector=connector) as session:
             pass
 

--- a/tests/test_client_session.py
+++ b/tests/test_client_session.py
@@ -2,7 +2,6 @@ import asyncio
 import contextlib
 import gc
 import re
-import types
 from http.cookies import SimpleCookie
 from unittest import mock
 
@@ -352,11 +351,11 @@ def test_del(connector, loop):
 
 
 def test_context_manager(connector, loop):
-    with pytest.warns(DeprecationWarning):
+    with pytest.raises(RuntimeError):
         with ClientSession(loop=loop, connector=connector) as session:
             pass
 
-    assert session.closed
+        assert session.closed
 
 
 def test_borrow_connector_loop(connector, create_session, loop):
@@ -384,19 +383,6 @@ async def test_reraise_os_error(create_session):
     e = ctx.value
     assert e.errno == err.errno
     assert e.strerror == err.strerror
-
-
-async def test_request_ctx_manager_props(loop):
-    await asyncio.sleep(0, loop=loop)  # to make it a task
-    with pytest.warns(DeprecationWarning):
-        with aiohttp.ClientSession(loop=loop) as client:
-            ctx_mgr = client.get('http://example.com')
-
-            next(ctx_mgr)
-            assert isinstance(ctx_mgr.gi_frame, types.FrameType)
-            assert not ctx_mgr.gi_running
-            assert isinstance(ctx_mgr.gi_code, types.CodeType)
-            await asyncio.sleep(0.1, loop=loop)
 
 
 async def test_cookie_jar_usage(loop, test_client):

--- a/tests/test_test_utils.py
+++ b/tests/test_test_utils.py
@@ -23,10 +23,6 @@ def _create_example_app():
     async def hello(request):
         return web.Response(body=_hello_world_bytes)
 
-    async def gzip_hello(request):
-        return web.Response(body=_hello_world_gz,
-                            headers={'Content-Encoding': 'gzip'})
-
     async def websocket_handler(request):
 
         ws = web.WebSocketResponse()
@@ -47,7 +43,6 @@ def _create_example_app():
 
     app = web.Application()
     app.router.add_route('*', '/', hello)
-    app.router.add_route('*', '/gzip_hello', gzip_hello)
     app.router.add_route('*', '/websocket', websocket_handler)
     app.router.add_route('*', '/cookie', cookie_handler)
     return app
@@ -73,64 +68,18 @@ def test_client(loop, app):
     loop.run_until_complete(client.close())
 
 
-def test_full_server_scenario():
-    with loop_context() as loop:
-        app = _create_example_app()
-        with _TestClient(_TestServer(app, loop=loop), loop=loop) as client:
-
-            async def test_get_route():
-                nonlocal client
-                resp = await client.request("GET", "/")
-                assert resp.status == 200
-                text = await resp.text()
-                assert _hello_world_str == text
-
-            loop.run_until_complete(test_get_route())
+def test_with_test_server_fails(loop):
+    app = _create_example_app()
+    with pytest.raises(RuntimeError):
+        with _TestServer(app, loop=loop):
+            pass
 
 
-def test_auto_gzip_decompress():
-    with loop_context() as loop:
-        app = _create_example_app()
-        with _TestClient(_TestServer(app, loop=loop), loop=loop) as client:
-
-            async def test_get_route():
-                nonlocal client
-                resp = await client.request("GET", "/gzip_hello")
-                assert resp.status == 200
-                data = await resp.read()
-                assert data == _hello_world_bytes
-
-            loop.run_until_complete(test_get_route())
-
-
-def test_noauto_gzip_decompress():
-    with loop_context() as loop:
-        app = _create_example_app()
-        with _TestClient(_TestServer(app, loop=loop), loop=loop,
-                         auto_decompress=False) as client:
-
-            async def test_get_route():
-                nonlocal client
-                resp = await client.request("GET", "/gzip_hello")
-                assert resp.status == 200
-                data = await resp.read()
-                assert data == _hello_world_gz
-
-            loop.run_until_complete(test_get_route())
-
-
-def test_server_with_create_test_teardown():
-    with loop_context() as loop:
-        app = _create_example_app()
-        with _TestClient(_TestServer(app, loop=loop), loop=loop) as client:
-
-            async def test_get_route():
-                resp = await client.request("GET", "/")
-                assert resp.status == 200
-                text = await resp.text()
-                assert _hello_world_str == text
-
-            loop.run_until_complete(test_get_route())
+def test_with_test_client_fails(loop):
+    app = _create_example_app()
+    with pytest.raises(RuntimeError):
+        with _TestClient(_TestServer(app, loop=loop), loop=loop):
+            pass
 
 
 def test_test_client_close_is_idempotent():
@@ -255,29 +204,26 @@ def test_make_mocked_request_transport():
     assert req.transport is transport
 
 
-def test_test_client_props(loop):
+async def test_test_client_props(loop):
     app = _create_example_app()
     client = _TestClient(_TestServer(app, host='localhost', loop=loop),
                          loop=loop)
     assert client.host == 'localhost'
     assert client.port is None
-    with client:
+    async with client:
         assert isinstance(client.port, int)
         assert client.server is not None
     assert client.port is None
 
 
-def test_test_server_context_manager(loop):
+async def test_test_server_context_manager(loop):
     app = _create_example_app()
-    with _TestServer(app, loop=loop) as server:
-        async def go():
-            client = aiohttp.ClientSession(loop=loop)
-            resp = await client.head(server.make_url('/'))
-            assert resp.status == 200
-            resp.close()
-            client.close()
-
-        loop.run_until_complete(go())
+    async with _TestServer(app, loop=loop) as server:
+        client = aiohttp.ClientSession(loop=loop)
+        resp = await client.head(server.make_url('/'))
+        assert resp.status == 200
+        resp.close()
+        client.close()
 
 
 def test_client_unsupported_arg():
@@ -285,9 +231,9 @@ def test_client_unsupported_arg():
         _TestClient('string')
 
 
-def test_server_make_url_yarl_compatibility(loop):
+async def test_server_make_url_yarl_compatibility(loop):
     app = _create_example_app()
-    with _TestServer(app, loop=loop) as server:
+    async with _TestServer(app, loop=loop) as server:
         make_url = server.make_url
         assert make_url(URL('/foo')) == make_url('/foo')
         with pytest.raises(AssertionError):

--- a/tests/test_test_utils.py
+++ b/tests/test_test_utils.py
@@ -70,14 +70,14 @@ def test_client(loop, app):
 
 def test_with_test_server_fails(loop):
     app = _create_example_app()
-    with pytest.raises(RuntimeError):
+    with pytest.raises(TypeError):
         with _TestServer(app, loop=loop):
             pass
 
 
 def test_with_test_client_fails(loop):
     app = _create_example_app()
-    with pytest.raises(RuntimeError):
+    with pytest.raises(TypeError):
         with _TestClient(_TestServer(app, loop=loop), loop=loop):
             pass
 


### PR DESCRIPTION
for ClientSession and test client/server.

Fixes #2540
