### PR TITLE
Detect content encoding if invalid charset was specified

### DIFF
--- a/CHANGES/2549.feature
+++ b/CHANGES/2549.feature
@@ -1,0 +1,2 @@
+Make the `aiohttp.ClientResponse.get_encoding` method public with
+the processing of invalid charsets while detecting content encoding.

--- a/CHANGES/2549.feature
+++ b/CHANGES/2549.feature
@@ -1,2 +1,2 @@
 Make the `aiohttp.ClientResponse.get_encoding` method public with
-the processing of invalid charsets while detecting content encoding.
+the processing of invalid charset while detecting content encoding.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -122,6 +122,7 @@ Ludovic Gasc
 Lukasz Marcin Dobrzanski
 Makc Belousow
 Manuel Miranda
+Marat Sharafutdinov
 Marco Paolini
 Mariano Anaya
 Martin Melka

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -757,7 +757,7 @@ class ClientResponse(HeadersMixin):
 
         return self._content
 
-    def _get_encoding(self):
+    def get_encoding(self):
         ctype = self.headers.get(hdrs.CONTENT_TYPE, '').lower()
         mimetype = helpers.parse_mimetype(ctype)
 
@@ -784,7 +784,7 @@ class ClientResponse(HeadersMixin):
             await self.read()
 
         if encoding is None:
-            encoding = self._get_encoding()
+            encoding = self.get_encoding()
 
         return self._content.decode(encoding, errors=errors)
 
@@ -809,7 +809,7 @@ class ClientResponse(HeadersMixin):
             return None
 
         if encoding is None:
-            encoding = self._get_encoding()
+            encoding = self.get_encoding()
 
         return loads(stripped.decode(encoding))
 

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -1,4 +1,5 @@
 import asyncio
+import codecs
 import collections
 import io
 import json
@@ -761,6 +762,11 @@ class ClientResponse(HeadersMixin):
         mimetype = helpers.parse_mimetype(ctype)
 
         encoding = mimetype.parameters.get('charset')
+        if encoding:
+            try:
+                codecs.lookup(encoding)
+            except LookupError:
+                encoding = None
         if not encoding:
             if mimetype.type == 'application' and mimetype.subtype == 'json':
                 # RFC 7159 states that the default encoding is UTF-8.

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -1162,6 +1162,12 @@ Response object
        A namedtuple with request URL and headers from :class:`ClientRequest`
        object, :class:`aiohttp.RequestInfo` instance.
 
+   .. method:: get_encoding()
+
+      Automatically detect content encoding using ``charset`` info in
+      ``Content-Type`` HTTP header. If this info is not exists or there
+      are no appropriate codecs for encoding then :term:`cchardet` /
+      :term:`chardet` is used.
 
 
 ClientWebSocketResponse

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -1168,6 +1168,8 @@ Response object
       ``Content-Type`` HTTP header. If this info is not exists or there
       are no appropriate codecs for encoding then :term:`cchardet` /
       :term:`chardet` is used.
+      
+      .. versionadded:: 3.0
 
 
 ClientWebSocketResponse

--- a/tests/test_client_response.py
+++ b/tests/test_client_response.py
@@ -256,12 +256,12 @@ async def test_text_custom_encoding(loop, session):
         'Content-Type': 'application/json'}
     content = response.content = mock.Mock()
     content.read.side_effect = side_effect
-    response._get_encoding = mock.Mock()
+    response.get_encoding = mock.Mock()
 
     res = await response.text(encoding='cp1251')
     assert res == '{"тест": "пройден"}'
     assert response._connection is None
-    assert not response._get_encoding.called
+    assert not response.get_encoding.called
 
 
 async def test_text_detect_encoding(loop, session):
@@ -300,7 +300,7 @@ async def test_text_detect_encoding_if_invalid_charset(loop, session):
     res = await response.text()
     assert res == '{"тест": "пройден"}'
     assert response._connection is None
-    assert response._get_encoding() == 'windows-1251'
+    assert response.get_encoding() == 'windows-1251'
 
 
 async def test_text_after_read(loop, session):
@@ -392,12 +392,12 @@ async def test_json_override_encoding(loop, session):
         'Content-Type': 'application/json;charset=utf8'}
     content = response.content = mock.Mock()
     content.read.side_effect = side_effect
-    response._get_encoding = mock.Mock()
+    response.get_encoding = mock.Mock()
 
     res = await response.json(encoding='cp1251')
     assert res == {'тест': 'пройден'}
     assert response._connection is None
-    assert not response._get_encoding.called
+    assert not response.get_encoding.called
 
 
 @pytest.mark.xfail
@@ -418,7 +418,7 @@ def test_get_encoding_unknown(loop, session):
     response.headers = {'Content-Type': 'application/json'}
     with mock.patch('aiohttp.client_reqrep.chardet') as m_chardet:
         m_chardet.detect.return_value = {'encoding': None}
-        assert response._get_encoding() == 'utf-8'
+        assert response.get_encoding() == 'utf-8'
 
 
 def test_raise_for_status_2xx():

--- a/tests/test_client_response.py
+++ b/tests/test_client_response.py
@@ -300,7 +300,7 @@ async def test_text_detect_encoding_if_invalid_charset(loop, session):
     res = await response.text()
     assert res == '{"тест": "пройден"}'
     assert response._connection is None
-    assert response.get_encoding() == 'windows-1251'
+    assert response.get_encoding().lower() == 'windows-1251'
 
 
 async def test_text_after_read(loop, session):


### PR DESCRIPTION
<!-- Thank you for your contribution!

     Before submit your Pull Request, make sure you picked
     the right branch:

     - If you propose a new feature or improvement, select "master"
       as a target branch;
     - If this is a bug fix or documentation amendment, select the latest
       [release branch](https://github.com/aio-libs/aiohttp/branches) (which
       looks like "X.Y" e.g. "2.3") -->

## What do these changes do?

1. Add processing of invalid charsets while detecting content encoding
2. Make the `aiohttp.ClientResponse.get_encoding` method public

## Are there changes in behavior for the user?

Autodetection of content encoding is now working even if content provided with invalid charset (such charset is taken as if it was not provided).

## Related issue number

There are no any opened issues that will be resolved by merging this change.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bug)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
