### PR TITLE
Root app middleware receives wrong app context

### DIFF
--- a/CHANGES/2550.bugfix
+++ b/CHANGES/2550.bugfix
@@ -1,0 +1,1 @@
+Make `request.app` point to proper application instance when using nested applications (with middlewares).

--- a/aiohttp/web.py
+++ b/aiohttp/web.py
@@ -22,6 +22,7 @@ from .signals import Signal
 from .web_exceptions import *  # noqa
 from .web_fileresponse import *  # noqa
 from .web_middlewares import *  # noqa
+from .web_middlewares import _fix_request_current_app
 from .web_protocol import *  # noqa
 from .web_request import *  # noqa
 from .web_response import *  # noqa
@@ -267,6 +268,8 @@ class Application(MutableMapping):
                               'see #2252'.format(m),
                               DeprecationWarning, stacklevel=2)
                 yield m, False
+        if self._middlewares:
+            yield _fix_request_current_app(self), True
 
     async def _handle(self, request):
         match_info = await self._router.resolve(request)

--- a/aiohttp/web.py
+++ b/aiohttp/web.py
@@ -301,8 +301,9 @@ class Application(MutableMapping):
             ("Handler {!r} should return response instance, "
              "got {!r} [middlewares {!r}]").format(
                  match_info.handler, type(resp),
-                 [middleware for middleware in app.middlewares
-                  for app in match_info.apps])
+                 [middleware
+                  for app in match_info.apps
+                  for middleware in app.middlewares])
         return resp
 
     def __call__(self):

--- a/aiohttp/web_middlewares.py
+++ b/aiohttp/web_middlewares.py
@@ -78,3 +78,12 @@ def normalize_path_middleware(
         return await handler(request)
 
     return impl
+
+
+def _fix_request_current_app(app):
+
+    @middleware
+    async def impl(request, handler):
+        with request.match_info.set_current_app(app):
+            return await handler(request)
+    return impl

--- a/aiohttp/web_request.py
+++ b/aiohttp/web_request.py
@@ -609,10 +609,10 @@ class Request(BaseRequest):
         """Result of route resolving."""
         return self._match_info
 
-    @reify
+    @property
     def app(self):
         """Application instance."""
-        return self._match_info.apps[-1]
+        return self._match_info.current_app
 
     async def _prepare_hook(self, response):
         match_info = self._match_info

--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -10,6 +10,7 @@ import re
 import warnings
 from collections import namedtuple
 from collections.abc import Container, Iterable, Sequence, Sized
+from contextlib import contextmanager
 from functools import wraps
 from pathlib import Path
 from types import MappingProxyType
@@ -170,6 +171,7 @@ class UrlMappingMatchInfo(dict, AbstractMatchInfo):
         super().__init__(match_dict)
         self._route = route
         self._apps = ()
+        self._current_app = None
         self._frozen = False
 
     @property
@@ -198,7 +200,25 @@ class UrlMappingMatchInfo(dict, AbstractMatchInfo):
     def add_app(self, app):
         if self._frozen:
             raise RuntimeError("Cannot change apps stack after .freeze() call")
+        if self._current_app is None:
+            self._current_app = app
         self._apps = (app,) + self._apps
+
+    @property
+    def current_app(self):
+        return self._current_app
+
+    @contextmanager
+    def set_current_app(self, app):
+        assert app in self._apps, (
+            "Expected one of the following apps {!r}, got {!r}"
+            .format(self._apps, app))
+        prev = self._current_app
+        self._current_app = app
+        try:
+            yield
+        finally:
+            self._current_app = prev
 
     def freeze(self):
         self._frozen = True


### PR DESCRIPTION
## Long story short

When handling request to sub-application root application's middlewares see wrong
`request.app` instance — sub-app instead of the one they attached to.

This PR demonstrates it (adds failing test) but has no fix yet.