### PR TITLE
Websocket handshake cleanup

### DIFF
--- a/aiohttp/http.py
+++ b/aiohttp/http.py
@@ -9,7 +9,8 @@ from .http_parser import (HttpParser, HttpRequestParser, HttpResponseParser,
                           RawRequestMessage, RawResponseMessage)
 from .http_websocket import (WS_CLOSED_MESSAGE, WS_CLOSING_MESSAGE, WS_KEY,
                              WebSocketError, WebSocketReader, WebSocketWriter,
-                             WSCloseCode, WSMessage, WSMsgType, do_handshake)
+                             WSCloseCode, WSMessage, WSMsgType, ws_ext_gen,
+                             ws_ext_parse)
 from .http_writer import (HttpVersion, HttpVersion10, HttpVersion11,
                           PayloadWriter, StreamWriter)
 
@@ -27,7 +28,7 @@ __all__ = (
 
     # .http_websocket
     'WS_CLOSED_MESSAGE', 'WS_CLOSING_MESSAGE', 'WS_KEY',
-    'WebSocketReader', 'WebSocketWriter', 'do_handshake',
+    'WebSocketReader', 'WebSocketWriter', 'ws_ext_gen', 'ws_ext_parse',
     'WSMessage', 'WebSocketError', 'WSMsgType', 'WSCloseCode',
 )
 

--- a/aiohttp/http_websocket.py
+++ b/aiohttp/http_websocket.py
@@ -1,9 +1,6 @@
 """WebSocket protocol versions 13 and 8."""
 
-import base64
-import binascii
 import collections
-import hashlib
 import json
 import random
 import re
@@ -12,15 +9,13 @@ import zlib
 from enum import IntEnum
 from struct import Struct
 
-from . import hdrs
 from .helpers import NO_EXTENSIONS, noop
-from .http_exceptions import HttpBadRequest, HttpProcessingError
 from .log import ws_logger
 
 
 __all__ = ('WS_CLOSED_MESSAGE', 'WS_CLOSING_MESSAGE', 'WS_KEY',
-           'WebSocketReader', 'WebSocketWriter', 'do_handshake',
-           'WSMessage', 'WebSocketError', 'WSMsgType', 'WSCloseCode')
+           'WebSocketReader', 'WebSocketWriter', 'WSMessage',
+           'WebSocketError', 'WSMsgType', 'WSCloseCode')
 
 
 class WSCloseCode(IntEnum):
@@ -619,99 +614,3 @@ class WebSocketWriter:
                 PACK_CLOSE_CODE(code) + message, opcode=WSMsgType.CLOSE)
         finally:
             self._closing = True
-
-
-def do_handshake(method, headers, stream, protocols=(),
-                 write_buffer_size=DEFAULT_LIMIT, compress=True):
-    """Prepare WebSocket handshake.
-
-    It return HTTP response code, response headers, websocket parser,
-    websocket writer. It does not perform any IO.
-
-    `protocols` is a sequence of known protocols. On successful handshake,
-    the returned response headers contain the first protocol in this list
-    which the server also knows.
-
-    `write_buffer_size` max size of write buffer before `drain()` get called.
-
-    `compress` enable or disable server side deflate extension support.
-    """
-    # WebSocket accepts only GET
-    if method.upper() != hdrs.METH_GET:
-        raise HttpProcessingError(
-            code=405, headers=((hdrs.ALLOW, hdrs.METH_GET),))
-
-    if 'websocket' != headers.get(hdrs.UPGRADE, '').lower().strip():
-        raise HttpBadRequest(
-            message='No WebSocket UPGRADE hdr: {}\n Can '
-            '"Upgrade" only to "WebSocket".'.format(headers.get(hdrs.UPGRADE)))
-
-    if 'upgrade' not in headers.get(hdrs.CONNECTION, '').lower():
-        raise HttpBadRequest(
-            message='No CONNECTION upgrade hdr: {}'.format(
-                headers.get(hdrs.CONNECTION)))
-
-    # find common sub-protocol between client and server
-    protocol = None
-    if hdrs.SEC_WEBSOCKET_PROTOCOL in headers:
-        req_protocols = [str(proto.strip()) for proto in
-                         headers[hdrs.SEC_WEBSOCKET_PROTOCOL].split(',')]
-
-        for proto in req_protocols:
-            if proto in protocols:
-                protocol = proto
-                break
-        else:
-            # No overlap found: Return no protocol as per spec
-            ws_logger.warning(
-                'Client protocols %r don’t overlap server-known ones %r',
-                req_protocols, protocols)
-
-    # check supported version
-    version = headers.get(hdrs.SEC_WEBSOCKET_VERSION, '')
-    if version not in ('13', '8', '7'):
-        raise HttpBadRequest(
-            message='Unsupported version: {}'.format(version),
-            headers=((hdrs.SEC_WEBSOCKET_VERSION, '13'),))
-
-    # check client handshake for validity
-    key = headers.get(hdrs.SEC_WEBSOCKET_KEY)
-    try:
-        if not key or len(base64.b64decode(key)) != 16:
-            raise HttpBadRequest(
-                message='Handshake error: {!r}'.format(key))
-    except binascii.Error:
-        raise HttpBadRequest(
-            message='Handshake error: {!r}'.format(key)) from None
-
-    response_headers = [
-        (hdrs.UPGRADE, 'websocket'),
-        (hdrs.CONNECTION, 'upgrade'),
-        (hdrs.TRANSFER_ENCODING, 'chunked'),
-        (hdrs.SEC_WEBSOCKET_ACCEPT, base64.b64encode(
-            hashlib.sha1(key.encode() + WS_KEY).digest()).decode())]
-
-    notakeover = False
-    if compress:
-        extensions = headers.get(hdrs.SEC_WEBSOCKET_EXTENSIONS)
-        # Server side always get return with no exception.
-        # If something happened, just drop compress extension
-        compress, notakeover = ws_ext_parse(extensions, isserver=True)
-        if compress:
-            enabledext = ws_ext_gen(compress=compress, isserver=True,
-                                    server_notakeover=notakeover)
-            response_headers.append((hdrs.SEC_WEBSOCKET_EXTENSIONS,
-                                     enabledext))
-
-    if protocol:
-        response_headers.append((hdrs.SEC_WEBSOCKET_PROTOCOL, protocol))
-
-    # response code, headers, None, writer, protocol
-    return (101,
-            response_headers,
-            None,
-            WebSocketWriter(
-                stream, limit=write_buffer_size,
-                compress=compress, notakeover=notakeover),
-            protocol,
-            compress)

--- a/aiohttp/test_utils.py
+++ b/aiohttp/test_utils.py
@@ -459,6 +459,7 @@ def _create_app_mock():
     app = mock.Mock()
     app._debug = False
     app.on_response_prepare = Signal(app)
+    app.on_response_prepare.freeze()
     return app
 
 

--- a/aiohttp/web_ws.py
+++ b/aiohttp/web_ws.py
@@ -1,17 +1,21 @@
 import asyncio
+import base64
+import binascii
+import hashlib
 import json
 from collections import namedtuple
 
 import async_timeout
+from multidict import CIMultiDict
 
 from . import hdrs
 from .helpers import call_later, set_result
-from .http import (WS_CLOSED_MESSAGE, WS_CLOSING_MESSAGE, HttpProcessingError,
-                   WebSocketError, WebSocketReader, WSMessage, WSMsgType,
-                   do_handshake)
+from .http import (WS_CLOSED_MESSAGE, WS_CLOSING_MESSAGE, WS_KEY,
+                   WebSocketError, WebSocketReader, WebSocketWriter, WSMessage,
+                   WSMsgType, ws_ext_gen, ws_ext_parse)
+from .log import ws_logger
 from .streams import FlowControlDataQueue
-from .web_exceptions import (HTTPBadRequest, HTTPInternalServerError,
-                             HTTPMethodNotAllowed)
+from .web_exceptions import HTTPBadRequest, HTTPException, HTTPMethodNotAllowed
 from .web_response import StreamResponse
 
 
@@ -101,30 +105,92 @@ class WebSocketResponse(StreamResponse):
         await payload_writer.drain()
         return payload_writer
 
+    def _handshake(self, request):
+        headers = request.headers
+        if request.method != hdrs.METH_GET:
+            raise HTTPMethodNotAllowed(request.method, [hdrs.METH_GET])
+        if 'websocket' != headers.get(hdrs.UPGRADE, '').lower().strip():
+            raise HTTPBadRequest(
+                text=('No WebSocket UPGRADE hdr: {}\n Can '
+                      '"Upgrade" only to "WebSocket".')
+                .format(headers.get(hdrs.UPGRADE)))
+
+        if 'upgrade' not in headers.get(hdrs.CONNECTION, '').lower():
+            raise HTTPBadRequest(
+                text='No CONNECTION upgrade hdr: {}'.format(
+                    headers.get(hdrs.CONNECTION)))
+
+        # find common sub-protocol between client and server
+        protocol = None
+        if hdrs.SEC_WEBSOCKET_PROTOCOL in headers:
+            req_protocols = [str(proto.strip()) for proto in
+                             headers[hdrs.SEC_WEBSOCKET_PROTOCOL].split(',')]
+
+            for proto in req_protocols:
+                if proto in self._protocols:
+                    protocol = proto
+                    break
+            else:
+                # No overlap found: Return no protocol as per spec
+                ws_logger.warning(
+                    'Client protocols %r don’t overlap server-known ones %r',
+                    req_protocols, self._protocols)
+
+        # check supported version
+        version = headers.get(hdrs.SEC_WEBSOCKET_VERSION, '')
+        if version not in ('13', '8', '7'):
+            raise HTTPBadRequest(
+                text='Unsupported version: {}'.format(version))
+
+        # check client handshake for validity
+        key = headers.get(hdrs.SEC_WEBSOCKET_KEY)
+        try:
+            if not key or len(base64.b64decode(key)) != 16:
+                raise HTTPBadRequest(
+                    text='Handshake error: {!r}'.format(key))
+        except binascii.Error:
+            raise HTTPBadRequest(
+                text='Handshake error: {!r}'.format(key)) from None
+
+        accept_val = base64.b64encode(
+            hashlib.sha1(key.encode() + WS_KEY).digest()).decode()
+        response_headers = CIMultiDict({hdrs.UPGRADE: 'websocket',
+                                        hdrs.CONNECTION: 'upgrade',
+                                        hdrs.TRANSFER_ENCODING: 'chunked',
+                                        hdrs.SEC_WEBSOCKET_ACCEPT: accept_val})
+
+        notakeover = False
+        compress = self._compress
+        if compress:
+            extensions = headers.get(hdrs.SEC_WEBSOCKET_EXTENSIONS)
+            # Server side always get return with no exception.
+            # If something happened, just drop compress extension
+            compress, notakeover = ws_ext_parse(extensions, isserver=True)
+            if compress:
+                enabledext = ws_ext_gen(compress=compress, isserver=True,
+                                        server_notakeover=notakeover)
+                response_headers[hdrs.SEC_WEBSOCKET_EXTENSIONS] = enabledext
+
+        if protocol:
+            response_headers[hdrs.SEC_WEBSOCKET_PROTOCOL] = protocol
+        return (response_headers, protocol, compress, notakeover)
+
     def _pre_start(self, request):
         self._loop = request.loop
 
-        try:
-            status, headers, _, writer, protocol, compress = do_handshake(
-                request.method, request.headers, request._protocol.writer,
-                self._protocols, compress=self._compress)
-        except HttpProcessingError as err:
-            if err.code == 405:
-                raise HTTPMethodNotAllowed(
-                    request.method, [hdrs.METH_GET], body=b'')
-            elif err.code == 400:
-                raise HTTPBadRequest(text=err.message, headers=err.headers)
-            else:  # pragma: no cover
-                raise HTTPInternalServerError() from err
+        headers, protocol, compress, notakeover = self._handshake(
+            request)
 
         self._reset_heartbeat()
 
-        if self.status != status:
-            self.set_status(status)
-        for k, v in headers:
-            self.headers[k] = v
+        self.set_status(101)
+        self.headers.update(headers)
         self.force_close()
         self._compress = compress
+        writer = WebSocketWriter(request._protocol.writer,
+                                 compress=compress,
+                                 notakeover=notakeover)
+
         return protocol, writer
 
     def _post_start(self, request, protocol, writer):
@@ -139,10 +205,8 @@ class WebSocketResponse(StreamResponse):
         if self._writer is not None:
             raise RuntimeError('Already started')
         try:
-            _, _, _, _, protocol, _ = do_handshake(
-                request.method, request.headers, request._protocol.writer,
-                self._protocols)
-        except HttpProcessingError:
+            _, protocol, _, _ = self._handshake(request)
+        except HTTPException:
             return WebSocketReady(False, None)
         else:
             return WebSocketReady(True, protocol)

--- a/tests/test_websocket_handshake.py
+++ b/tests/test_websocket_handshake.py
@@ -1,30 +1,12 @@
 """Tests for http/websocket.py"""
 
 import base64
-import hashlib
 import os
-from unittest import mock
 
-import multidict
 import pytest
-from yarl import URL
 
-from aiohttp import http, http_exceptions
-from aiohttp.http import WS_KEY
-from aiohttp.http_websocket import do_handshake
-
-
-@pytest.fixture()
-def transport():
-    return mock.Mock()
-
-
-@pytest.fixture()
-def message():
-    headers = multidict.MultiDict()
-    return http.RawRequestMessage(
-        'GET', '/path', (1, 0), headers, [],
-        True, None, True, False, URL('/path'))
+from aiohttp import web
+from aiohttp.test_utils import make_mocked_request
 
 
 def gen_ws_headers(protocols='', compress=0, extension_text='',
@@ -50,158 +32,166 @@ def gen_ws_headers(protocols='', compress=0, extension_text='',
     return hdrs, key
 
 
-def test_not_get(message, transport):
-    with pytest.raises(http_exceptions.HttpProcessingError):
-        do_handshake('POST', message.headers, transport)
+async def test_not_get():
+    ws = web.WebSocketResponse()
+    req = make_mocked_request('POST', '/')
+    with pytest.raises(web.HTTPMethodNotAllowed):
+        await ws.prepare(req)
 
 
-def test_no_upgrade(message, transport):
-    with pytest.raises(http_exceptions.HttpBadRequest):
-        do_handshake(message.method, message.headers, transport)
+async def test_no_upgrade():
+    ws = web.WebSocketResponse()
+    req = make_mocked_request('GET', '/')
+    with pytest.raises(web.HTTPBadRequest):
+        await ws.prepare(req)
 
 
-def test_no_connection(message, transport):
-    message.headers.extend([('Upgrade', 'websocket'),
-                            ('Connection', 'keep-alive')])
-    with pytest.raises(http_exceptions.HttpBadRequest):
-        do_handshake(message.method, message.headers, transport)
+async def test_no_connection():
+    ws = web.WebSocketResponse()
+    req = make_mocked_request('GET', '/', headers={'Upgrade': 'websocket',
+                                                   'Connection': 'keep-alive'})
+    with pytest.raises(web.HTTPBadRequest):
+        await ws.prepare(req)
 
 
-def test_protocol_version(message, transport):
-    message.headers.extend([('Upgrade', 'websocket'),
-                            ('Connection', 'upgrade')])
-    with pytest.raises(http_exceptions.HttpBadRequest):
-        do_handshake(message.method, message.headers, transport)
-
-    message.headers.extend([('Upgrade', 'websocket'),
-                            ('Connection', 'upgrade'),
-                            ('Sec-Websocket-Version', '1')])
-
-    with pytest.raises(http_exceptions.HttpBadRequest):
-        do_handshake(message.method, message.headers, transport)
+async def test_protocol_version_unset():
+    ws = web.WebSocketResponse()
+    req = make_mocked_request('GET', '/', headers={'Upgrade': 'websocket',
+                                                   'Connection': 'upgrade'})
+    with pytest.raises(web.HTTPBadRequest):
+        await ws.prepare(req)
 
 
-def test_protocol_key(message, transport):
-    message.headers.extend([('Upgrade', 'websocket'),
-                            ('Connection', 'upgrade'),
-                            ('Sec-Websocket-Version', '13')])
-    with pytest.raises(http_exceptions.HttpBadRequest):
-        do_handshake(message.method, message.headers, transport)
+async def test_protocol_version_not_supported():
+    ws = web.WebSocketResponse()
+    req = make_mocked_request('GET', '/',
+                              headers={'Upgrade': 'websocket',
+                                       'Connection': 'upgrade',
+                                       'Sec-Websocket-Version': '1'})
+    with pytest.raises(web.HTTPBadRequest):
+        await ws.prepare(req)
 
-    message.headers.extend([('Upgrade', 'websocket'),
-                            ('Connection', 'upgrade'),
-                            ('Sec-Websocket-Version', '13'),
-                            ('Sec-Websocket-Key', '123')])
-    with pytest.raises(http_exceptions.HttpBadRequest):
-        do_handshake(message.method, message.headers, transport)
 
+async def test_protocol_key_not_present():
+    ws = web.WebSocketResponse()
+    req = make_mocked_request('GET', '/',
+                              headers={'Upgrade': 'websocket',
+                                       'Connection': 'upgrade',
+                                       'Sec-Websocket-Version': '13'})
+    with pytest.raises(web.HTTPBadRequest):
+        await ws.prepare(req)
+
+
+async def test_protocol_key_invalid():
+    ws = web.WebSocketResponse()
+    req = make_mocked_request('GET', '/',
+                              headers={'Upgrade': 'websocket',
+                                       'Connection': 'upgrade',
+                                       'Sec-Websocket-Version': '13',
+                                       'Sec-Websocket-Key': '123'})
+    with pytest.raises(web.HTTPBadRequest):
+        await ws.prepare(req)
+
+
+async def test_protocol_key_bad_size():
+    ws = web.WebSocketResponse()
     sec_key = base64.b64encode(os.urandom(2))
-    message.headers.extend([('Upgrade', 'websocket'),
-                            ('Connection', 'upgrade'),
-                            ('Sec-Websocket-Version', '13'),
-                            ('Sec-Websocket-Key', sec_key.decode())])
-    with pytest.raises(http_exceptions.HttpBadRequest):
-        do_handshake(message.method, message.headers, transport)
+    val = sec_key.decode()
+    req = make_mocked_request('GET', '/',
+                              headers={'Upgrade': 'websocket',
+                                       'Connection': 'upgrade',
+                                       'Sec-Websocket-Version': '13',
+                                       'Sec-Websocket-Key': val})
+    with pytest.raises(web.HTTPBadRequest):
+        await ws.prepare(req)
 
 
-def test_handshake(message, transport):
+async def test_handshake_ok():
     hdrs, sec_key = gen_ws_headers()
+    ws = web.WebSocketResponse()
+    req = make_mocked_request('GET', '/', headers=hdrs)
 
-    message.headers.extend(hdrs)
-    status, headers, parser, writer, protocol, _ = do_handshake(
-        message.method, message.headers, transport)
-    assert status == 101
-    assert protocol is None
+    await ws.prepare(req)
 
-    key = base64.b64encode(
-        hashlib.sha1(sec_key.encode() + WS_KEY).digest())
-    headers = dict(headers)
-    assert headers['Sec-Websocket-Accept'] == key.decode()
+    assert ws.ws_protocol is None
 
 
-def test_handshake_protocol(message, transport):
-    '''Tests if one protocol is returned by do_handshake'''
+async def test_handshake_protocol():
+    # Tests if one protocol is returned by handshake
     proto = 'chat'
 
-    message.headers.extend(gen_ws_headers(proto)[0])
-    _, resp_headers, _, _, protocol, _ = do_handshake(
-        message.method, message.headers, transport,
-        protocols=[proto])
+    ws = web.WebSocketResponse(protocols={'chat'})
+    req = make_mocked_request('GET', '/', headers=gen_ws_headers(proto)[0])
 
-    assert protocol == proto
+    await ws.prepare(req)
 
-    # also test if we reply with the protocol
-    resp_headers = dict(resp_headers)
-    assert resp_headers['Sec-Websocket-Protocol'] == proto
+    assert ws.ws_protocol == proto
 
 
-def test_handshake_protocol_agreement(message, transport):
-    '''Tests if the right protocol is selected given multiple'''
+async def test_handshake_protocol_agreement():
+    # Tests if the right protocol is selected given multiple
     best_proto = 'worse_proto'
     wanted_protos = ['best', 'chat', 'worse_proto']
     server_protos = 'worse_proto,chat'
 
-    message.headers.extend(gen_ws_headers(server_protos)[0])
-    _, resp_headers, _, _, protocol, _ = do_handshake(
-        message.method, message.headers, transport,
-        protocols=wanted_protos)
+    ws = web.WebSocketResponse(protocols=wanted_protos)
+    req = make_mocked_request('GET', '/',
+                              headers=gen_ws_headers(server_protos)[0])
 
-    assert protocol == best_proto
+    await ws.prepare(req)
+
+    assert ws.ws_protocol == best_proto
 
 
-def test_handshake_protocol_unsupported(log, message, transport):
-    '''Tests if a protocol mismatch handshake warns and returns None'''
+async def test_handshake_protocol_unsupported(log):
+    # Tests if a protocol mismatch handshake warns and returns None
     proto = 'chat'
-    message.headers.extend(gen_ws_headers('test')[0])
+    req = make_mocked_request('GET', '/',
+                              headers=gen_ws_headers('test')[0])
 
+    ws = web.WebSocketResponse(protocols=[proto])
     with log('aiohttp.websocket') as ctx:
-        _, _, _, _, protocol, _ = do_handshake(
-            message.method, message.headers, transport,
-            protocols=[proto])
+        await ws.prepare(req)
 
-        assert protocol is None
     assert (ctx.records[-1].msg ==
             'Client protocols %r don’t overlap server-known ones %r')
+    assert ws.ws_protocol is None
 
 
-def test_handshake_compress(message, transport):
+async def test_handshake_compress():
     hdrs, sec_key = gen_ws_headers(compress=15)
 
-    message.headers.extend(hdrs)
-    status, headers, parser, writer, protocol, compress = do_handshake(
-        message.method, message.headers, transport)
+    req = make_mocked_request('GET', '/', headers=hdrs)
 
-    headers = dict(headers)
-    assert 'Sec-Websocket-Extensions' in headers
-    assert headers['Sec-Websocket-Extensions'] == 'permessage-deflate'
+    ws = web.WebSocketResponse()
+    await ws.prepare(req)
 
-    assert compress == 15
+    assert ws.compress == 15
 
 
-def test_handshake_compress_server_notakeover(message, transport):
+def test_handshake_compress_server_notakeover():
     hdrs, sec_key = gen_ws_headers(compress=15, server_notakeover=True)
 
-    message.headers.extend(hdrs)
-    status, headers, parser, writer, protocol, compress = do_handshake(
-        message.method, message.headers, transport)
+    req = make_mocked_request('GET', '/', headers=hdrs)
 
-    headers = dict(headers)
+    ws = web.WebSocketResponse()
+    headers, _, compress, notakeover = ws._handshake(req)
+
+    assert compress == 15
+    assert notakeover is True
     assert 'Sec-Websocket-Extensions' in headers
     assert headers['Sec-Websocket-Extensions'] == (
         'permessage-deflate; server_no_context_takeover')
 
-    assert compress == 15
-    assert writer.notakeover is True
 
-
-def test_handshake_compress_client_notakeover(message, transport):
+def test_handshake_compress_client_notakeover():
     hdrs, sec_key = gen_ws_headers(compress=15, client_notakeover=True)
 
-    message.headers.extend(hdrs)
-    status, headers, parser, writer, protocol, compress = do_handshake(
-        message.method, message.headers, transport)
+    req = make_mocked_request('GET', '/', headers=hdrs)
 
-    headers = dict(headers)
+    ws = web.WebSocketResponse()
+    headers, _, compress, notakeover = ws._handshake(req)
+
     assert 'Sec-Websocket-Extensions' in headers
     assert headers['Sec-Websocket-Extensions'] == (
         'permessage-deflate'), hdrs
@@ -209,70 +199,66 @@ def test_handshake_compress_client_notakeover(message, transport):
     assert compress == 15
 
 
-def test_handshake_compress_wbits(message, transport):
+def test_handshake_compress_wbits():
     hdrs, sec_key = gen_ws_headers(compress=9)
 
-    message.headers.extend(hdrs)
-    status, headers, parser, writer, protocol, compress = do_handshake(
-        message.method, message.headers, transport)
+    req = make_mocked_request('GET', '/', headers=hdrs)
 
-    headers = dict(headers)
+    ws = web.WebSocketResponse()
+    headers, _, compress, notakeover = ws._handshake(req)
+
     assert 'Sec-Websocket-Extensions' in headers
     assert headers['Sec-Websocket-Extensions'] == (
         'permessage-deflate; server_max_window_bits=9')
     assert compress == 9
 
 
-def test_handshake_compress_wbits_error(message, transport):
+def test_handshake_compress_wbits_error():
     hdrs, sec_key = gen_ws_headers(compress=6)
 
-    message.headers.extend(hdrs)
+    req = make_mocked_request('GET', '/', headers=hdrs)
 
-    status, headers, parser, writer, protocol, compress = do_handshake(
-        message.method, message.headers, transport)
+    ws = web.WebSocketResponse()
+    headers, _, compress, notakeover = ws._handshake(req)
 
-    headers = dict(headers)
     assert 'Sec-Websocket-Extensions' not in headers
     assert compress == 0
 
 
-def test_handshake_compress_bad_ext(message, transport):
+def test_handshake_compress_bad_ext():
     hdrs, sec_key = gen_ws_headers(compress=15, extension_text='bad')
 
-    message.headers.extend(hdrs)
+    req = make_mocked_request('GET', '/', headers=hdrs)
 
-    status, headers, parser, writer, protocol, compress = do_handshake(
-        message.method, message.headers, transport)
+    ws = web.WebSocketResponse()
+    headers, _, compress, notakeover = ws._handshake(req)
 
-    headers = dict(headers)
     assert 'Sec-Websocket-Extensions' not in headers
     assert compress == 0
 
 
-def test_handshake_compress_multi_ext_bad(message, transport):
+def test_handshake_compress_multi_ext_bad():
     hdrs, sec_key = gen_ws_headers(compress=15,
                                    extension_text='bad, permessage-deflate')
 
-    message.headers.extend(hdrs)
+    req = make_mocked_request('GET', '/', headers=hdrs)
 
-    status, headers, parser, writer, protocol, compress = do_handshake(
-        message.method, message.headers, transport)
+    ws = web.WebSocketResponse()
+    headers, _, compress, notakeover = ws._handshake(req)
 
-    headers = dict(headers)
     assert 'Sec-Websocket-Extensions' in headers
     assert headers['Sec-Websocket-Extensions'] == 'permessage-deflate'
 
 
-def test_handshake_compress_multi_ext_wbits(message, transport):
+def test_handshake_compress_multi_ext_wbits():
     hdrs, sec_key = gen_ws_headers(compress=6,
                                    extension_text=', permessage-deflate')
 
-    message.headers.extend(hdrs)
+    req = make_mocked_request('GET', '/', headers=hdrs)
 
-    status, headers, parser, writer, protocol, compress = do_handshake(
-        message.method, message.headers, transport)
+    ws = web.WebSocketResponse()
+    headers, _, compress, notakeover = ws._handshake(req)
 
-    headers = dict(headers)
     assert 'Sec-Websocket-Extensions' in headers
     assert headers['Sec-Websocket-Extensions'] == 'permessage-deflate'
     assert compress == 15

--- a/tests/test_websocket_handshake.py
+++ b/tests/test_websocket_handshake.py
@@ -10,7 +10,8 @@ import pytest
 from yarl import URL
 
 from aiohttp import http, http_exceptions
-from aiohttp.http import WS_KEY, do_handshake
+from aiohttp.http import WS_KEY
+from aiohttp.http_websocket import do_handshake
 
 
 @pytest.fixture()


### PR DESCRIPTION
`do_handshake` is very private API, let's move the implementation into `web.WebSocketResponse` -- the only user of the function.