### PR TITLE
Fix incrorect base class of ClientConnectorSSLError

### DIFF
--- a/CHANGES/2563.bugfix
+++ b/CHANGES/2563.bugfix
@@ -1,0 +1,1 @@
+Change base class of ClientConnectorSSLError to ClientSSLError from ClientConnectorError.

--- a/aiohttp/client_exceptions.py
+++ b/aiohttp/client_exceptions.py
@@ -175,13 +175,13 @@ if ssl is not None:
     certificate_errors_bases = (ClientSSLError, ssl.CertificateError,)
 
     ssl_errors = (ssl.SSLError,)
-    ssl_error_bases = (ClientConnectorError, ssl.SSLError)
+    ssl_error_bases = (ClientSSLError, ssl.SSLError)
 else:  # pragma: no cover
     certificate_errors = tuple()
     certificate_errors_bases = (ClientSSLError, ValueError,)
 
     ssl_errors = tuple()
-    ssl_error_bases = (ClientConnectorError,)
+    ssl_error_bases = (ClientSSLError,)
 
 
 class ClientConnectorSSLError(*ssl_error_bases):

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -1504,7 +1504,7 @@ class TestHttpClientConnector(unittest.TestCase):
             self.loop.run_until_complete(session.request('get', url))
 
         self.assertIsInstance(ctx.value.os_error, ssl.SSLError)
-        self.assertTrue(ctx.value, aiohttp.ClientSSLError)
+        self.assertIsInstance(ctx.value, aiohttp.ClientSSLError)
 
         session.close()
         conn.close()


### PR DESCRIPTION

## What do these changes do?

Changes base class of `ClientConnectorSSLError` from `ClientConnectorError` to `ClientSSLError`.

## Are there changes in behavior for the user?

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bug)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
