### PR TITLE
Correct request.app context (for handlers not just middlewares)

### DIFF
--- a/CHANGES/2577.bugfix
+++ b/CHANGES/2577.bugfix
@@ -1,0 +1,1 @@
+Correct `request.app` context (for handlers not just middlewares).

--- a/aiohttp/web.py
+++ b/aiohttp/web.py
@@ -268,8 +268,7 @@ class Application(MutableMapping):
                               'see #2252'.format(m),
                               DeprecationWarning, stacklevel=2)
                 yield m, False
-        if self._middlewares:
-            yield _fix_request_current_app(self), True
+        yield _fix_request_current_app(self), True
 
     async def _handle(self, request):
         match_info = await self._router.resolve(request)

--- a/tests/test_web_functional.py
+++ b/tests/test_web_functional.py
@@ -1290,32 +1290,46 @@ async def test_subapp_on_cleanup(loop, test_server):
     assert [app, subapp1, subapp2] == order
 
 
-@pytest.mark.parametrize('route,expected', [
-    ('/sub/', ['app see root', 'subapp see sub']),
-    ('/', ['app see root']),
+@pytest.mark.parametrize('route,expected,middlewares', [
+    ('/sub/', ['A: root', 'C: sub', 'D: sub'], 'AC'),
+    ('/', ['A: root', 'B: root'], 'AC'),
+    ('/sub/', ['A: root', 'D: sub'], 'A'),
+    ('/', ['A: root', 'B: root'], 'A'),
+    ('/sub/', ['C: sub', 'D: sub'], 'C'),
+    ('/', ['B: root'], 'C'),
+    ('/sub/', ['D: sub'], ''),
+    ('/', ['B: root'], ''),
 ])
-async def test_subapp_middleware_context(loop, test_client, route, expected):
+async def test_subapp_middleware_context(
+        loop, test_client, route, expected, middlewares):
     values = []
 
     def show_app_context(appname):
         @web.middleware
         async def middleware(request, handler):
-            values.append('{} see {}'.format(appname, request.app['my_value']))
+            values.append('{}: {}'.format(
+                appname, request.app['my_value']))
             return await handler(request)
         return middleware
 
-    async def handler(request):
-        return web.Response(text='Ok')
+    def make_handler(appname):
+        async def handler(request):
+            values.append('{}: {}'.format(
+                appname, request.app['my_value']))
+            return web.Response(text='Ok')
+        return handler
 
     app = web.Application()
     app['my_value'] = 'root'
-    app.middlewares.append(show_app_context('app'))
-    app.router.add_get('/', handler)
+    if 'A' in middlewares:
+        app.middlewares.append(show_app_context('A'))
+    app.router.add_get('/', make_handler('B'))
 
     subapp = web.Application()
     subapp['my_value'] = 'sub'
-    subapp.middlewares.append(show_app_context('subapp'))
-    subapp.router.add_get('/', handler)
+    if 'C' in middlewares:
+        subapp.middlewares.append(show_app_context('C'))
+    subapp.router.add_get('/', make_handler('D'))
     app.add_subapp('/sub/', subapp)
 
     client = await test_client(app)


### PR DESCRIPTION
This is an update to #2550 
`_fix_request_current_app` middleware was added if application had any middlewares.
Now it is yielded unconditionally to set proper context for handlers as well.
