### PR TITLE
Fix regression: make response hashable again

### DIFF
--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -456,6 +456,9 @@ class StreamResponse(collections.MutableMapping, HeadersMixin):
     def __iter__(self):
         return iter(self._state)
 
+    def __hash__(self):
+        return hash(id(self))
+
 
 class Response(StreamResponse):
 

--- a/tests/test_web_response.py
+++ b/tests/test_web_response.py
@@ -77,6 +77,11 @@ def test_stream_response_ctor():
     assert resp.task is req.task
 
 
+def test_stream_response_hashable():
+    # should not raise exception
+    hash(StreamResponse())
+
+
 def test_stream_response_is_mutable_mapping():
     resp = StreamResponse()
     assert isinstance(resp, collections.MutableMapping)


### PR DESCRIPTION
Fixes https://github.com/aio-libs/aiohttp/pull/2575#issuecomment-348068011