### PR TITLE
Added proxy parameters for ClientSession

### DIFF
--- a/CHANGES/2580.feature
+++ b/CHANGES/2580.feature
@@ -1,0 +1,1 @@
+Added proxy parameters for ClientSession.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -74,6 +74,7 @@ Erich Healy
 Eugene Chernyshov
 Eugene Naydenov
 Evert Lammerts
+Fan Yu
 Frederik Gladhorn
 Frederik Peter Aalund
 Gabriel Tremblay

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -165,13 +165,13 @@ class ClientSession:
                        chunked=None,
                        expect100=False,
                        read_until_eof=True,
-                       proxy=NotImplemented,
-                       proxy_auth=NotImplemented,
+                       proxy=sentinel,
+                       proxy_auth=sentinel,
                        timeout=sentinel,
                        verify_ssl=None,
                        fingerprint=None,
                        ssl_context=None,
-                       proxy_headers=NotImplemented,
+                       proxy_headers=sentinel,
                        trace_request_ctx=None):
 
         # NOTE: timeout clamps existing connect and read timeouts.  We cannot
@@ -203,13 +203,13 @@ class ClientSession:
 
         # Merge with session proxy
         proxy = self._proxy_info['proxy'] \
-            if proxy == NotImplemented else proxy
+            if proxy is sentinel else proxy
 
         proxy_auth = self._proxy_info['auth'] \
-            if proxy_auth == NotImplemented else proxy_auth
+            if proxy_auth is sentinel else proxy_auth
 
         proxy_headers = self._proxy_info['headers'] \
-            if proxy_headers == NotImplemented else proxy_headers
+            if proxy_headers is sentinel else proxy_headers
 
         # Merge with default headers and transform to CIMultiDict
         headers = self._prepare_headers(headers)

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -59,7 +59,8 @@ class ClientSession:
                  cookie_jar=None, connector_owner=True, raise_for_status=False,
                  read_timeout=sentinel, conn_timeout=None,
                  auto_decompress=True, trust_env=False,
-                 trace_configs=None):
+                 trace_configs=None,
+                 proxy=None, proxy_auth=None, proxy_headers=None):
 
         implicit_loop = False
         if loop is None:
@@ -110,6 +111,11 @@ class ClientSession:
         self._raise_for_status = raise_for_status
         self._auto_decompress = auto_decompress
         self._trust_env = trust_env
+        self._proxy_info = {
+            'proxy': proxy,
+            'auth': proxy_auth,
+            'headers': proxy_headers,
+        }
 
         # Convert to list of tuples
         if headers:
@@ -159,13 +165,13 @@ class ClientSession:
                        chunked=None,
                        expect100=False,
                        read_until_eof=True,
-                       proxy=None,
-                       proxy_auth=None,
+                       proxy=NotImplemented,
+                       proxy_auth=NotImplemented,
                        timeout=sentinel,
                        verify_ssl=None,
                        fingerprint=None,
                        ssl_context=None,
-                       proxy_headers=None,
+                       proxy_headers=NotImplemented,
                        trace_request_ctx=None):
 
         # NOTE: timeout clamps existing connect and read timeouts.  We cannot
@@ -194,6 +200,16 @@ class ClientSession:
         redirects = 0
         history = []
         version = self._version
+
+        # Merge with session proxy
+        proxy = self._proxy_info['proxy'] \
+            if proxy == NotImplemented else proxy
+
+        proxy_auth = self._proxy_info['auth'] \
+            if proxy_auth == NotImplemented else proxy_auth
+
+        proxy_headers = self._proxy_info['headers'] \
+            if proxy_headers == NotImplemented else proxy_headers
 
         # Merge with default headers and transform to CIMultiDict
         headers = self._prepare_headers(headers)

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -47,7 +47,8 @@ The client session supports the context manager protocol for self closing.
                          conn_timeout=None, \
                          raise_for_status=False, \
                          connector_owner=True, \
-                         auto_decompress=True, proxies=None)
+                         auto_decompress=True, \
+                         proxy=None, proxy_auth=None, proxy_headers=None)
 
    The class for creating client sessions and making requests.
 

--- a/tests/test_proxy_session.py
+++ b/tests/test_proxy_session.py
@@ -1,0 +1,126 @@
+import asyncio
+import os
+from unittest import mock
+
+import pytest
+from yarl import URL
+
+import aiohttp
+from aiohttp import web
+
+
+@pytest.fixture
+def proxy_test_server(raw_test_server, loop, monkeypatch):
+    """Handle all proxy requests and imitate remote server response."""
+
+    _patch_ssl_transport(monkeypatch)
+
+    default_response = dict(
+        status=200,
+        headers=None,
+        body=None)
+
+    proxy_mock = mock.Mock()
+
+    async def proxy_handler(request):
+        proxy_mock.request = request
+        proxy_mock.requests_list.append(request)
+
+        response = default_response.copy()
+        if isinstance(proxy_mock.return_value, dict):
+            response.update(proxy_mock.return_value)
+
+        headers = response['headers']
+        if not headers:
+            headers = {}
+
+        if request.method == 'CONNECT':
+            response['body'] = None
+
+        response['headers'] = headers
+
+        resp = web.Response(**response)
+        await resp.prepare(request)
+        await resp.write_eof()
+        return resp
+
+    async def proxy_server():
+        proxy_mock.request = None
+        proxy_mock.auth = None
+        proxy_mock.requests_list = []
+
+        server = await raw_test_server(proxy_handler)
+
+        proxy_mock.server = server
+        proxy_mock.url = server.make_url('/')
+
+        return proxy_mock
+
+    return proxy_server
+
+
+@pytest.fixture()
+def get_request(loop):
+    async def _request(method='GET', *, url, trust_env=False, **kwargs):
+        connector = aiohttp.TCPConnector(verify_ssl=False, loop=loop)
+        client = aiohttp.ClientSession(connector=connector,
+                                       trust_env=trust_env)
+        try:
+            resp = await client.request(method, url, **kwargs)
+            await resp.release()
+            return resp
+        finally:
+            await client.close()
+    return _request
+
+
+def _patch_ssl_transport(monkeypatch):
+    """Make ssl transport substitution to prevent ssl handshake."""
+    def _make_ssl_transport_dummy(self, rawsock, protocol, sslcontext,
+                                  waiter=None, **kwargs):
+        return self._make_socket_transport(rawsock, protocol, waiter,
+                                           extra=kwargs.get('extra'),
+                                           server=kwargs.get('server'))
+
+    monkeypatch.setattr(
+        "asyncio.selector_events.BaseSelectorEventLoop._make_ssl_transport",
+        _make_ssl_transport_dummy)
+
+
+async def test_session_proxy_http(proxy_test_server, loop):
+    url = 'http://aiohttp.io/path'
+    proxy = await proxy_test_server()
+    proxy.return_value = dict(body=b'test')
+
+    conn = aiohttp.TCPConnector(loop=loop)
+    sess = aiohttp.ClientSession(connector=conn, loop=loop, proxy=proxy.url)
+
+    resp = await sess.get(url)
+    assert (await resp.read()) == b'test'
+
+
+async def test_session_proxy_http_auth(proxy_test_server, loop):
+    url = 'http://aiohttp.io/path'
+    proxy = await proxy_test_server()
+
+    conn = aiohttp.TCPConnector(loop=loop)
+    sess = aiohttp.ClientSession(connector=conn, loop=loop, proxy=proxy.url)
+    await sess.get(url)
+    assert 'Authorization' not in proxy.request.headers
+    assert 'Proxy-Authorization' not in proxy.request.headers
+
+    conn = aiohttp.TCPConnector(loop=loop)
+    auth = aiohttp.BasicAuth('user', 'pass')
+    sess = aiohttp.ClientSession(connector=conn, loop=loop,
+                                 proxy_auth=auth, proxy=proxy.url)
+    await sess.get(url)
+    assert 'Authorization' not in proxy.request.headers
+    assert 'Proxy-Authorization' in proxy.request.headers
+
+    conn = aiohttp.TCPConnector(loop=loop)
+    auth = aiohttp.BasicAuth('user', 'pass')
+    sess = aiohttp.ClientSession(connector=conn, loop=loop,
+                                 auth=auth, proxy_auth=auth, proxy=proxy.url)
+    await sess.get(url)
+    assert 'Authorization' in proxy.request.headers
+    assert 'Proxy-Authorization' in proxy.request.headers

--- a/tests/test_proxy_session.py
+++ b/tests/test_proxy_session.py
@@ -1,9 +1,6 @@
-import asyncio
-import os
 from unittest import mock
 
 import pytest
-from yarl import URL
 
 import aiohttp
 from aiohttp import web


### PR DESCRIPTION
## What do these changes do?

Added proxy parameters for ClientSession

## Are there changes in behavior for the user?

New parameters of ClientSession\():
* proxy
* proxy_auth
* proxy_headers

```python
async with ClientSession(proxy=proxy) as session:
    async with session.get('http://test.com') as resp:
        print(await resp.text())
```

## Related issue number

#2580 

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bug)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
