### PR TITLE
Per message deflate

### DIFF
--- a/CHANGES/2551.feature
+++ b/CHANGES/2551.feature
@@ -1,2 +1,2 @@
-Optional configurable per message deflate for `ClientWebSocketResponse` and
-`WebSocketResponse`
+Add optional configurable per message compression for
+`ClientWebSocketResponse` and `WebSocketResponse`.

--- a/CHANGES/2551.feature
+++ b/CHANGES/2551.feature
@@ -1,0 +1,2 @@
+Optional configurable per message deflate for `ClientWebSocketResponse` and
+`WebSocketResponse`

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -33,6 +33,7 @@ Andrew Svetlov
 Andrii Soldatenko
 Antoine Pietri
 Anton Kasyanov
+Anton Zhdan-Pushkin
 Arthur Darcet
 Ben Bader
 Benedikt Reinartz

--- a/aiohttp/client_ws.py
+++ b/aiohttp/client_ws.py
@@ -123,7 +123,7 @@ class ClientWebSocketResponse:
                             type(data))
         await self._writer.send(data, binary=True, compress=compress)
 
-    async def send_json(self, data, *, dumps=json.dumps, compress=None):
+    async def send_json(self, data, compress=None, *, dumps=json.dumps):
         await self.send_str(dumps(data), compress=compress)
 
     async def close(self, *, code=1000, message=b''):

--- a/aiohttp/client_ws.py
+++ b/aiohttp/client_ws.py
@@ -112,19 +112,19 @@ class ClientWebSocketResponse:
     async def pong(self, message='b'):
         await self._writer.pong(message)
 
-    async def send_str(self, data):
+    async def send_str(self, data, compress=None):
         if not isinstance(data, str):
             raise TypeError('data argument must be str (%r)' % type(data))
-        await self._writer.send(data, binary=False)
+        await self._writer.send(data, binary=False, compress=compress)
 
-    async def send_bytes(self, data):
+    async def send_bytes(self, data, compress=None):
         if not isinstance(data, (bytes, bytearray, memoryview)):
             raise TypeError('data argument must be byte-ish (%r)' %
                             type(data))
-        await self._writer.send(data, binary=True)
+        await self._writer.send(data, binary=True, compress=compress)
 
-    async def send_json(self, data, *, dumps=json.dumps):
-        await self.send_str(dumps(data))
+    async def send_json(self, data, *, dumps=json.dumps, compress=None):
+        await self.send_str(dumps(data), compress=compress)
 
     async def close(self, *, code=1000, message=b''):
         # we need to break `receive()` cycle first,

--- a/aiohttp/web_ws.py
+++ b/aiohttp/web_ws.py
@@ -256,7 +256,7 @@ class WebSocketResponse(StreamResponse):
                             type(data))
         await self._writer.send(data, binary=True, compress=compress)
 
-    async def send_json(self, data, *, dumps=json.dumps, compress=None):
+    async def send_json(self, data, compress=None, *, dumps=json.dumps):
         await self.send_str(dumps(data), compress=compress)
 
     async def write_eof(self):

--- a/aiohttp/web_ws.py
+++ b/aiohttp/web_ws.py
@@ -241,23 +241,23 @@ class WebSocketResponse(StreamResponse):
             raise RuntimeError('Call .prepare() first')
         await self._writer.pong(message)
 
-    async def send_str(self, data):
+    async def send_str(self, data, compress=None):
         if self._writer is None:
             raise RuntimeError('Call .prepare() first')
         if not isinstance(data, str):
             raise TypeError('data argument must be str (%r)' % type(data))
-        await self._writer.send(data, binary=False)
+        await self._writer.send(data, binary=False, compress=compress)
 
-    async def send_bytes(self, data):
+    async def send_bytes(self, data, compress=None):
         if self._writer is None:
             raise RuntimeError('Call .prepare() first')
         if not isinstance(data, (bytes, bytearray, memoryview)):
             raise TypeError('data argument must be byte-ish (%r)' %
                             type(data))
-        await self._writer.send(data, binary=True)
+        await self._writer.send(data, binary=True, compress=compress)
 
-    async def send_json(self, data, *, dumps=json.dumps):
-        await self.send_str(dumps(data))
+    async def send_json(self, data, *, dumps=json.dumps, compress=None):
+        await self.send_str(dumps(data), compress=compress)
 
     async def write_eof(self):
         if self._eof_sent:

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -1228,11 +1228,14 @@ manually.
 
          The method is converted into :term:`coroutine`
 
-   .. comethod:: send_str(data)
+   .. comethod:: send_str(data, compress=None)
 
       Send *data* to peer as :const:`~aiohttp.WSMsgType.TEXT` message.
 
       :param str data: data to send.
+
+      :param int compress: sets specific level of compression for
+                           single message
 
       :raise TypeError: if data is not :class:`str`
 
@@ -1240,11 +1243,14 @@ manually.
 
          The method is converted into :term:`coroutine`
 
-   .. comethod:: send_bytes(data)
+   .. comethod:: send_bytes(data, compress=None)
 
       Send *data* to peer as :const:`~aiohttp.WSMsgType.BINARY` message.
 
       :param data: data to send.
+
+      :param int compress: sets specific level of compression for
+                           single message
 
       :raise TypeError: if data is not :class:`bytes`,
                         :class:`bytearray` or :class:`memoryview`.
@@ -1253,11 +1259,14 @@ manually.
 
          The method is converted into :term:`coroutine`
 
-   .. comethod:: send_json(data, *, dumps=json.dumps)
+   .. comethod:: send_json(data, compress=None, *, dumps=json.dumps)
 
       Send *data* to peer as JSON string.
 
       :param data: data to send.
+
+      :param int compress: sets specific level of compression for
+                           single message
 
       :param callable dumps: any :term:`callable` that accepts an object and
                              returns a JSON string

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -1235,13 +1235,15 @@ manually.
       :param str data: data to send.
 
       :param int compress: sets specific level of compression for
-                           single message
+                           single message, 
+                           ``None`` for not overridding per-socket setting.
 
       :raise TypeError: if data is not :class:`str`
 
       .. versionchanged:: 3.0
 
-         The method is converted into :term:`coroutine`
+         The method is converted into :term:`coroutine`,
+         *compress* parameter added.
 
    .. comethod:: send_bytes(data, compress=None)
 
@@ -1250,14 +1252,16 @@ manually.
       :param data: data to send.
 
       :param int compress: sets specific level of compression for
-                           single message
+                           single message,
+                           ``None`` for not overridding per-socket setting.
 
       :raise TypeError: if data is not :class:`bytes`,
                         :class:`bytearray` or :class:`memoryview`.
 
       .. versionchanged:: 3.0
 
-         The method is converted into :term:`coroutine`
+         The method is converted into :term:`coroutine`,
+         *compress* parameter added.
 
    .. comethod:: send_json(data, compress=None, *, dumps=json.dumps)
 
@@ -1266,7 +1270,8 @@ manually.
       :param data: data to send.
 
       :param int compress: sets specific level of compression for
-                           single message
+                           single message,
+                           ``None`` for not overridding per-socket setting.
 
       :param callable dumps: any :term:`callable` that accepts an object and
                              returns a JSON string
@@ -1281,7 +1286,8 @@ manually.
 
       .. versionchanged:: 3.0
 
-         The method is converted into :term:`coroutine`
+         The method is converted into :term:`coroutine`,
+         *compress* parameter added.
 
    .. comethod:: close(*, code=1000, message=b'')
 

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -1236,7 +1236,7 @@ manually.
 
       :param int compress: sets specific level of compression for
                            single message, 
-                           ``None`` for not overridding per-socket setting.
+                           ``None`` for not overriding per-socket setting.
 
       :raise TypeError: if data is not :class:`str`
 
@@ -1253,7 +1253,7 @@ manually.
 
       :param int compress: sets specific level of compression for
                            single message,
-                           ``None`` for not overridding per-socket setting.
+                           ``None`` for not overriding per-socket setting.
 
       :raise TypeError: if data is not :class:`bytes`,
                         :class:`bytearray` or :class:`memoryview`.
@@ -1271,7 +1271,7 @@ manually.
 
       :param int compress: sets specific level of compression for
                            single message,
-                           ``None`` for not overridding per-socket setting.
+                           ``None`` for not overriding per-socket setting.
 
       :param callable dumps: any :term:`callable` that accepts an object and
                              returns a JSON string

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -989,11 +989,14 @@ WebSocketResponse
 
          The method is converted into :term:`coroutine`
 
-   .. comethod:: send_str(data)
+   .. comethod:: send_str(data, compress=None)
 
       Send *data* to peer as :const:`~aiohttp.WSMsgType.TEXT` message.
 
       :param str data: data to send.
+
+      :param int compress: sets specific level of compression for
+                           single message
 
       :raise RuntimeError: if connection is not started or closing
 
@@ -1003,11 +1006,14 @@ WebSocketResponse
 
          The method is converted into :term:`coroutine`
 
-   .. comethod:: send_bytes(data)
+   .. comethod:: send_bytes(data, compress=None)
 
       Send *data* to peer as :const:`~aiohttp.WSMsgType.BINARY` message.
 
       :param data: data to send.
+
+      :param int compress: sets specific level of compression for
+                           single message
 
       :raise RuntimeError: if connection is not started or closing
 
@@ -1018,11 +1024,14 @@ WebSocketResponse
 
          The method is converted into :term:`coroutine`
 
-   .. comethod:: send_json(data, *, dumps=json.dumps)
+   .. comethod:: send_json(data, compress=None, *, dumps=json.dumps)
 
       Send *data* to peer as JSON string.
 
       :param data: data to send.
+
+      :param int compress: sets specific level of compression for
+                           single message
 
       :param callable dumps: any :term:`callable` that accepts an object and
                              returns a JSON string

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -996,7 +996,8 @@ WebSocketResponse
       :param str data: data to send.
 
       :param int compress: sets specific level of compression for
-                           single message
+                           single message,
+                           ``None`` for not overridding per-socket setting.                           
 
       :raise RuntimeError: if connection is not started or closing
 
@@ -1004,7 +1005,8 @@ WebSocketResponse
 
       .. versionchanged:: 3.0
 
-         The method is converted into :term:`coroutine`
+         The method is converted into :term:`coroutine`,
+         *compress* parameter added.
 
    .. comethod:: send_bytes(data, compress=None)
 
@@ -1013,7 +1015,8 @@ WebSocketResponse
       :param data: data to send.
 
       :param int compress: sets specific level of compression for
-                           single message
+                           single message,
+                           ``None`` for not overridding per-socket setting.
 
       :raise RuntimeError: if connection is not started or closing
 
@@ -1022,7 +1025,8 @@ WebSocketResponse
 
       .. versionchanged:: 3.0
 
-         The method is converted into :term:`coroutine`
+         The method is converted into :term:`coroutine`,
+         *compress* parameter added.
 
    .. comethod:: send_json(data, compress=None, *, dumps=json.dumps)
 
@@ -1031,7 +1035,8 @@ WebSocketResponse
       :param data: data to send.
 
       :param int compress: sets specific level of compression for
-                           single message
+                           single message,
+                           ``None`` for not overridding per-socket setting.
 
       :param callable dumps: any :term:`callable` that accepts an object and
                              returns a JSON string
@@ -1045,7 +1050,8 @@ WebSocketResponse
 
       .. versionchanged:: 3.0
 
-         The method is converted into :term:`coroutine`
+         The method is converted into :term:`coroutine`,
+         *compress* parameter added.
 
    .. comethod:: close(*, code=1000, message=b'')
 

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -997,7 +997,7 @@ WebSocketResponse
 
       :param int compress: sets specific level of compression for
                            single message,
-                           ``None`` for not overridding per-socket setting.                           
+                           ``None`` for not overriding per-socket setting.                           
 
       :raise RuntimeError: if connection is not started or closing
 
@@ -1016,7 +1016,7 @@ WebSocketResponse
 
       :param int compress: sets specific level of compression for
                            single message,
-                           ``None`` for not overridding per-socket setting.
+                           ``None`` for not overriding per-socket setting.
 
       :raise RuntimeError: if connection is not started or closing
 
@@ -1036,7 +1036,7 @@ WebSocketResponse
 
       :param int compress: sets specific level of compression for
                            single message,
-                           ``None`` for not overridding per-socket setting.
+                           ``None`` for not overriding per-socket setting.
 
       :param callable dumps: any :term:`callable` that accepts an object and
                              returns a JSON string

--- a/tests/test_client_ws.py
+++ b/tests/test_client_ws.py
@@ -10,6 +10,7 @@ import aiohttp
 from aiohttp import client, hdrs
 from aiohttp.http import WS_KEY
 from aiohttp.log import ws_logger
+from aiohttp.test_utils import make_mocked_coro
 
 
 @pytest.fixture
@@ -512,6 +513,39 @@ async def test_ws_connect_deflate(loop, ws_key, key_data):
 
     assert res.compress == 15
     assert res.client_notakeover is False
+
+
+async def test_ws_connect_deflate_per_message(loop, ws_key, key_data):
+    resp = mock.Mock()
+    resp.status = 101
+    resp.headers = {
+        hdrs.UPGRADE: hdrs.WEBSOCKET,
+        hdrs.CONNECTION: hdrs.UPGRADE,
+        hdrs.SEC_WEBSOCKET_ACCEPT: ws_key,
+        hdrs.SEC_WEBSOCKET_EXTENSIONS: 'permessage-deflate',
+    }
+    with mock.patch('aiohttp.client.WebSocketWriter') as WebSocketWriter:
+        with mock.patch('aiohttp.client.os') as m_os:
+            with mock.patch('aiohttp.client.ClientSession.get') as m_req:
+                m_os.urandom.return_value = key_data
+                m_req.return_value = loop.create_future()
+                m_req.return_value.set_result(resp)
+                writer = WebSocketWriter.return_value = mock.Mock()
+                send = writer.send = make_mocked_coro()
+
+                session = aiohttp.ClientSession(loop=loop)
+                resp = await session.ws_connect('http://test.org')
+
+                await resp.send_str('string', compress=-1)
+                send.assert_called_with('string', binary=False, compress=-1)
+
+                await resp.send_bytes(b'bytes', compress=15)
+                send.assert_called_with(b'bytes', binary=True, compress=15)
+
+                await resp.send_json([{}], compress=-9)
+                send.assert_called_with('[{}]', binary=False, compress=-9)
+
+                await session.close()
 
 
 async def test_ws_connect_deflate_server_not_support(loop, ws_key, key_data):

--- a/tests/test_websocket_writer.py
+++ b/tests/test_websocket_writer.py
@@ -60,7 +60,7 @@ def test_close(stream, writer):
     stream.transport.write.assert_called_with(b'\x88\x05\x03\xf4msg')
 
 
-def test_send_text_masked(stream, writer):
+def test_send_text_masked(stream):
     writer = WebSocketWriter(stream,
                              use_mask=True,
                              random=random.Random(123))
@@ -68,7 +68,7 @@ def test_send_text_masked(stream, writer):
     stream.transport.write.assert_called_with(b'\x81\x84\rg\xb3fy\x02\xcb\x12')
 
 
-def test_send_compress_text(stream, writer):
+def test_send_compress_text(stream):
     writer = WebSocketWriter(stream, compress=15)
     writer.send(b'text')
     stream.transport.write.assert_called_with(b'\xc1\x06*I\xad(\x01\x00')
@@ -76,9 +76,19 @@ def test_send_compress_text(stream, writer):
     stream.transport.write.assert_called_with(b'\xc1\x05*\x01b\x00\x00')
 
 
-def test_send_compress_text_notakeover(stream, writer):
+def test_send_compress_text_notakeover(stream):
     writer = WebSocketWriter(stream, compress=15, notakeover=True)
     writer.send(b'text')
     stream.transport.write.assert_called_with(b'\xc1\x06*I\xad(\x01\x00')
     writer.send(b'text')
+    stream.transport.write.assert_called_with(b'\xc1\x06*I\xad(\x01\x00')
+
+
+def test_send_compress_text_per_message(stream):
+    writer = WebSocketWriter(stream)
+    writer.send(b'text', compress=15)
+    stream.transport.write.assert_called_with(b'\xc1\x06*I\xad(\x01\x00')
+    writer.send(b'text')
+    stream.transport.write.assert_called_with(b'\x81\x04text')
+    writer.send(b'text', compress=15)
     stream.transport.write.assert_called_with(b'\xc1\x06*I\xad(\x01\x00')


### PR DESCRIPTION
## What do these changes do?

This PR allows to pass optional argument `compress` to `send_str`, `send_bytes` and `sent_json` methods of `ClientWebSocketResponse` and `WebSocketResponse`.

## Are there changes in behavior for the user?

Argument is optional and default behavior (`compress=None`) did not changed so older code is not affected.

## Related issue number

Resolves #2551

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] Add a new news fragment into the `CHANGES` folder

