### PR TITLE
Limit protocol upgrades to supported protocols

### DIFF
--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -327,6 +327,12 @@ class HttpParser:
             elif v == 'upgrade':
                 upgrade = True
 
+        # restrict connection upgrade to supported protocols
+        upgrade_to = headers.get(hdrs.UPGRADE)
+        if upgrade_to:
+            v = conn.lower()
+            upgrade = upgrade and v in {'websocket'}
+
         # encoding
         enc = headers.get(hdrs.CONTENT_ENCODING)
         if enc:


### PR DESCRIPTION

## What do these changes do?

Fix issue #2277 by limiting connection upgrades to supported protocols. Currently only websocket as h2 and h2c are not supported.

There are no unit tests on this change as all my attempts caused the test to be skipped. Could use some help.

## Are there changes in behavior for the user?

Responses will be obtained when the server advertises connection upgrades to http2 without the client requesting it.

## Related issue number

#2277 

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bug)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
