### PR TITLE
handle custom content types

### DIFF
--- a/CHANGES/2594.bugfix
+++ b/CHANGES/2594.bugfix
@@ -1,0 +1,1 @@
+Fixes content type check in client by ignoring content type parameters like encoding etc.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -25,6 +25,7 @@ Alexey Popravka
 Alexey Stepanov
 Amin Etesamian
 Amy Boyle
+Andreas Würl
 Andrei Ursulenko
 Andrej Antonov
 Andrew Leech

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -795,8 +795,11 @@ class ClientResponse(HeadersMixin):
             await self.read()
 
         if content_type:
-            ctype = self.headers.get(hdrs.CONTENT_TYPE, '').lower()
-            if content_type not in ctype:
+            ctype_header = self.headers.get(hdrs.CONTENT_TYPE, '')
+            ctype = helpers.strip_mimetype_parameters(ctype_header.lower())
+
+            if helpers.strip_mimetype_parameters(
+                    content_type.lower()) not in ctype:
                 raise ContentTypeError(
                     self.request_info,
                     self.history,

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -188,6 +188,10 @@ def parse_mimetype(mimetype):
                     parameters=params)
 
 
+def strip_mimetype_parameters(mimetype):
+    return mimetype.split(";")[0]
+
+
 def guess_filename(obj, default=None):
     name = getattr(obj, 'name', None)
     if name and isinstance(name, str) and name[0] != '<' and name[-1] != '>':

--- a/tests/test_client_response.py
+++ b/tests/test_client_response.py
@@ -341,6 +341,26 @@ async def test_json(loop, session):
     assert response._connection is None
 
 
+async def test_json_custom(loop, session):
+    response = ClientResponse('get', URL('http://def-cl-resp.org'))
+    response._post_init(loop, session)
+
+    def side_effect(*args, **kwargs):
+        fut = loop.create_future()
+        fut.set_result('{"тест": "пройден"}'.encode('cp1251'))
+        return fut
+
+    response.headers = {
+        'Content-Type': 'application/vnd.aiohttp-test+json;charset=cp1251'}
+    content = response.content = mock.Mock()
+    content.read.side_effect = side_effect
+
+    res = await response.json(
+        content_type='application/vnd.aiohttp-test+json; charset=utf-8')
+    assert res == {'тест': 'пройден'}
+    assert response._connection is None
+
+
 async def test_json_custom_loader(loop, session):
     response = ClientResponse('get', URL('http://def-cl-resp.org'))
     response._post_init(loop, session)


### PR DESCRIPTION
## What do these changes do?

When using a custom content type like `application/vnd.aiohttp-test+json` the client now ignores content type parameters (e. g. an encoding setting) when checking for matching types.

## Are there changes in behavior for the user?

Nothing expected here. Clients which include the parameters in `content_type` (as a workaround) should still work.

## Related issue number

#2206 is somehow related

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bug)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
