### PR TITLE
Drop encoding param

### DIFF
--- a/CHANGES/2606.removal
+++ b/CHANGES/2606.removal
@@ -1,0 +1,1 @@
+Drop deprecated `encoding` parameter from client API

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -154,7 +154,6 @@ class ClientSession:
                        auth=None,
                        allow_redirects=True,
                        max_redirects=10,
-                       encoding=None,
                        compress=None,
                        chunked=None,
                        expect100=False,
@@ -171,12 +170,6 @@ class ClientSession:
         # NOTE: timeout clamps existing connect and read timeouts.  We cannot
         # set the default to None because we need to detect if the user wants
         # to use the existing timeouts by setting timeout to None.
-
-        if encoding is not None:
-            warnings.warn(
-                "encoding parameter is not supported, "
-                "please use FormData(charset='utf-8') instead",
-                DeprecationWarning)
 
         if self.closed:
             raise RuntimeError('Session is closed')
@@ -793,7 +786,6 @@ def request(method, url, *,
             auth=None,
             allow_redirects=True,
             max_redirects=10,
-            encoding=None,
             version=http.HttpVersion11,
             compress=None,
             chunked=None,
@@ -854,7 +846,6 @@ def request(method, url, *,
                          auth=auth,
                          allow_redirects=allow_redirects,
                          max_redirects=max_redirects,
-                         encoding=encoding,
                          compress=compress,
                          chunked=chunked,
                          expect100=expect100,

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -2004,19 +2004,6 @@ async def test_redirect_without_location_header(loop, test_client):
     assert data == body
 
 
-async def test_encoding_deprecated(loop, test_client):
-
-    async def handler_redirect(request):
-        return web.Response(status=301)
-
-    app = web.Application()
-    app.router.add_route('GET', '/redirect', handler_redirect)
-    client = await test_client(app)
-
-    with pytest.warns(DeprecationWarning):
-        await client.get('/', encoding='utf-8')
-
-
 async def test_chunked_deprecated(loop, test_client):
 
     async def handler_redirect(request):


### PR DESCRIPTION
It was deprecated in aiohttp 2.0 and actually ignored