### PR TITLE
Add support to Flask-style decorators with class-based Views

### DIFF
--- a/CHANGES/2472.feature
+++ b/CHANGES/2472.feature
@@ -1,0 +1,1 @@
+Added support to Flask-style decorators with class-based Views.

--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -33,7 +33,7 @@ __all__ = ('UrlDispatcher', 'UrlMappingMatchInfo',
            'AbstractResource', 'Resource', 'PlainResource', 'DynamicResource',
            'AbstractRoute', 'ResourceRoute',
            'StaticResource', 'View', 'RouteDef', 'RouteTableDef',
-           'head', 'get', 'post', 'patch', 'put', 'delete', 'route')
+           'head', 'get', 'post', 'patch', 'put', 'delete', 'route', 'view')
 
 HTTP_METHOD_RE = re.compile(r"^[0-9A-Za-z!#\$%&'\*\+\-\.\^_`\|~]+$")
 ROUTE_RE = re.compile(r'(\{[_a-zA-Z][^{}]*(?:\{[^{}]*\}[^{}]*)*\})')
@@ -926,6 +926,12 @@ class UrlDispatcher(AbstractRouter, collections.abc.Mapping):
         """
         return self.add_route(hdrs.METH_DELETE, path, handler, **kwargs)
 
+    def add_view(self, path, handler, **kwargs):
+        """
+        Shortcut for add_route with ANY methods for a class-based view
+        """
+        return self.add_route(hdrs.METH_ANY, path, handler, **kwargs)
+
     def freeze(self):
         super().freeze()
         for resource in self._resources:
@@ -968,6 +974,10 @@ def patch(path, handler, **kwargs):
 
 def delete(path, handler, **kwargs):
     return route(hdrs.METH_DELETE, path, handler, **kwargs)
+
+
+def view(path, handler, **kwargs):
+    return route(hdrs.METH_ANY, path, handler, **kwargs)
 
 
 class RouteTableDef(Sequence):
@@ -1013,3 +1023,6 @@ class RouteTableDef(Sequence):
 
     def delete(self, path, **kwargs):
         return self.route(hdrs.METH_DELETE, path, **kwargs)
+
+    def view(self, path, **kwargs):
+        return self.route(hdrs.METH_ANY, path, **kwargs)

--- a/docs/web_quickstart.rst
+++ b/docs/web_quickstart.rst
@@ -282,7 +282,7 @@ retrieved by :attr:`View.request` property.
 After implementing the view (``MyView`` from example above) should be
 registered in application's router::
 
-   app.router.add_route('*', '/path/to', MyView)
+   app.router.add_view('/path/to', MyView)
 
 Example will process GET and POST requests for */path/to* but raise
 *405 Method not allowed* exception for unimplemented HTTP methods.
@@ -345,6 +345,20 @@ Route decorators are closer to Flask approach::
    @routes.post('/post')
    async def handle_post(request):
        ...
+
+   app.router.add_routes(routes)
+
+It is also possible to use decorators with class-based views::
+
+   routes = web.RouteTableDef()
+
+   @routes.view("/view")
+   class MyView(web.View):
+       async def get(self):
+           ...
+
+       async def post(self):
+           ...
 
    app.router.add_routes(routes)
 

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -1583,6 +1583,11 @@ Router is any object that implements :class:`AbstractRouter` interface.
       Shortcut for adding a DELETE handler. Calls the :meth:`add_route` with \
       ``method`` equals to ``'DELETE'``.
 
+   .. method:: add_view(path, handler, **kwargs)
+
+      Shortcut for adding a class-based view handler. Calls the \
+      :meth:`add_routre` with ``method`` equals to ``'*'``.
+
    .. method:: add_static(prefix, path, *, name=None, expect_handler=None, \
                           chunk_size=256*1024, \
                           response_factory=StreamResponse, \
@@ -2081,6 +2086,11 @@ The definition is created by functions like :func:`get` or
 
    .. versionadded:: 2.3
 
+.. function:: view(path, handler, *, name=None, expect_handler=None)
+
+   Return :class:`RouteDef` for processing ``ANY`` requests. See
+   :meth:`UrlDispatcher.add_view` for information about parameters.
+
 .. function:: route(method, path, handler, *, name=None, expect_handler=None)
 
    Return :class:`RouteDef` for processing ``POST`` requests. See
@@ -2110,6 +2120,15 @@ A routes table definition used for describing routes by decorators
        ...
 
    app.router.add_routes(routes)
+
+
+   @routes.view("/view")
+   class MyView(web.View):
+       async def get(self):
+           ...
+
+       async def post(self):
+           ...
 
 .. class:: RouteTableDef()
 
@@ -2156,6 +2175,13 @@ A routes table definition used for describing routes by decorators
       Add a new :class:`RouteDef` item for registering ``DELETE`` web-handler.
 
       See :meth:`UrlDispatcher.add_delete` for information about parameters.
+
+   .. decoratormethod:: view(path, *, name=None, expect_handler=None)
+
+      Add a new :class:`RouteDef` item for registering ``ANY`` methods
+      against a class-based view.
+
+      See :meth:`UrlDispatcher.add_view` for information about parameters.
 
    .. decoratormethod:: route(method, path, *, name=None, expect_handler=None)
 
@@ -2217,7 +2243,7 @@ View
                resp = await post_response(self.request)
                return resp
 
-       app.router.add_route('*', '/view', MyView)
+       app.router.add_view('/view', MyView)
 
    The view raises *405 Method Not allowed*
    (:class:`HTTPMethodNowAllowed`) if requested web verb is not

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -1588,6 +1588,8 @@ Router is any object that implements :class:`AbstractRouter` interface.
       Shortcut for adding a class-based view handler. Calls the \
       :meth:`add_routre` with ``method`` equals to ``'*'``.
 
+      .. versionadded:: 3.0
+
    .. method:: add_static(prefix, path, *, name=None, expect_handler=None, \
                           chunk_size=256*1024, \
                           response_factory=StreamResponse, \
@@ -2091,6 +2093,8 @@ The definition is created by functions like :func:`get` or
    Return :class:`RouteDef` for processing ``ANY`` requests. See
    :meth:`UrlDispatcher.add_view` for information about parameters.
 
+   .. versionadded:: 3.0
+
 .. function:: route(method, path, handler, *, name=None, expect_handler=None)
 
    Return :class:`RouteDef` for processing ``POST`` requests. See
@@ -2182,6 +2186,8 @@ A routes table definition used for describing routes by decorators
       against a class-based view.
 
       See :meth:`UrlDispatcher.add_view` for information about parameters.
+
+      .. versionadded:: 3.0
 
    .. decoratormethod:: route(method, path, *, name=None, expect_handler=None)
 

--- a/tests/test_web_urldispatcher.py
+++ b/tests/test_web_urldispatcher.py
@@ -378,3 +378,88 @@ def test_resource_raw_match():
 
     resource = app.router.add_static("/static", ".")
     assert not resource.raw_match("/static")
+
+
+async def test_add_view(loop, test_client):
+    app = web.Application()
+
+    class MyView(web.View):
+        async def get(self):
+            return web.Response()
+
+        async def post(self):
+            return web.Response()
+
+    app.router.add_view("/a", MyView)
+
+    client = await test_client(app)
+
+    r = await client.get("/a")
+    assert r.status == 200
+    await r.release()
+
+    r = await client.post("/a")
+    assert r.status == 200
+    await r.release()
+
+    r = await client.put("/a")
+    assert r.status == 405
+    await r.release()
+
+
+async def test_decorate_view(loop, test_client):
+    routes = web.RouteTableDef()
+
+    @routes.view("/a")
+    class MyView(web.View):
+        async def get(self):
+            return web.Response()
+
+        async def post(self):
+            return web.Response()
+
+    app = web.Application()
+    app.router.add_routes(routes)
+
+    client = await test_client(app)
+
+    r = await client.get("/a")
+    assert r.status == 200
+    await r.release()
+
+    r = await client.post("/a")
+    assert r.status == 200
+    await r.release()
+
+    r = await client.put("/a")
+    assert r.status == 405
+    await r.release()
+
+
+async def test_web_view(loop, test_client):
+    app = web.Application()
+
+    class MyView(web.View):
+        async def get(self):
+            return web.Response()
+
+        async def post(self):
+            return web.Response()
+
+    app.router.add_routes([
+        web.view("/a", MyView)
+    ])
+
+    client = await test_client(app)
+
+    r = await client.get("/a")
+    assert r.status == 200
+    await r.release()
+
+    r = await client.post("/a")
+    assert r.status == 200
+    await r.release()
+
+    r = await client.put("/a")
+    assert r.status == 405
+    await r.release()


### PR DESCRIPTION
## What do these changes do?

Add support to Flask-style decorators with class-based Views

## Are there changes in behavior for the user?

Users will be able to register routing in class-based wiew with either

```
app.router.add_routes([web.view("/a", MyView)])

routes = web.RouteTableDef()
@routes.view("/a")
class MyView(web.view)
    pass

app.router.add_view("/a", MyView)
```

## Related issue number

#2472 

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bug)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
