### PR TITLE
allow custom port to TestServer

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -21,7 +21,7 @@
   * The format is &lt;Name&gt; &lt;Surname&gt;.
   * Please keep alphabetical order, the file is sorted by names. 
 - [ ] Add a new news fragment into the `CHANGES` folder
-  * name it `<issue_id>.<type>` for example (588.bug)
+  * name it `<issue_id>.<type>` for example (588.bugfix)
   * if you don't have an `issue_id` change it to the pr id after creating the pr
   * ensure type is one of the following:
     * `.feature`: Signifying a new feature.

--- a/CHANGES/2613.feature
+++ b/CHANGES/2613.feature
@@ -1,0 +1,1 @@
+Allow a custom port to be used by `TestServer` (and associated pytest fixtures)

--- a/aiohttp/pytest_plugin.py
+++ b/aiohttp/pytest_plugin.py
@@ -225,8 +225,8 @@ def test_server(loop):
     """
     servers = []
 
-    async def go(app, **kwargs):
-        server = TestServer(app)
+    async def go(app, *, port=None, **kwargs):
+        server = TestServer(app, port=port)
         await server.start_server(loop=loop, **kwargs)
         servers.append(server)
         return server
@@ -248,8 +248,8 @@ def raw_test_server(loop):
     """
     servers = []
 
-    async def go(handler, **kwargs):
-        server = RawTestServer(handler)
+    async def go(handler, port=None, **kwargs):
+        server = RawTestServer(handler, port=port)
         await server.start_server(loop=loop, **kwargs)
         servers.append(server)
         return server

--- a/aiohttp/pytest_plugin.py
+++ b/aiohttp/pytest_plugin.py
@@ -248,7 +248,7 @@ def raw_test_server(loop):
     """
     servers = []
 
-    async def go(handler, port=None, **kwargs):
+    async def go(handler, *, port=None, **kwargs):
         server = RawTestServer(handler, port=port)
         await server.start_server(loop=loop, **kwargs)
         servers.append(server)

--- a/aiohttp/test_utils.py
+++ b/aiohttp/test_utils.py
@@ -180,8 +180,7 @@ class TestClient:
 
     """
 
-    def __init__(self, server, *, cookie_jar=None, loop=None,
-                 **kwargs):
+    def __init__(self, server, *, cookie_jar=None, loop=None, **kwargs):
         if not isinstance(server, BaseTestServer):
             raise TypeError("server must be web.Application TestServer "
                             "instance, found type: %r" % type(server))

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -198,6 +198,19 @@ Pytest tooling has the following fixtures:
           client = await test_client(raw_server)
           resp = await client.get('/')
 
+.. data:: unused_port()
+
+   Function to return an unused port number for IPv4 TCP protocol::
+
+      async def test_f(test_client, unused_port):
+          port = unused_port()
+          app = web.Application()
+          # fill route table
+
+          client = await test_client(app, server_kwargs={'port': port})
+          ...
+
+
 .. _aiohttp-testing-unittest-example:
 
 .. _aiohttp-testing-unittest-style:

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -147,6 +147,8 @@ Pytest tooling has the following fixtures:
    *port* optional, port the server is run at, if
    not provided a random unused port is used.
 
+   .. versionadded:: 3.0
+
    *kwargs* are parameters passed to
                   :meth:`aiohttp.web.Application.make_handler`
 
@@ -181,13 +183,7 @@ Pytest tooling has the following fixtures:
 
    A fixture factory that creates
    :class:`~aiohttp.test_utils.RawTestServer` instance from given web
-   handler.
-
-   *handler* should be a coroutine which accepts a request and returns
-   response, e.g.
-
-   *port* optional, port the server is run at, if
-   not provided a random unused port is used.::
+   handler.::
 
       async def test_f(raw_test_server, test_client):
 
@@ -197,6 +193,14 @@ Pytest tooling has the following fixtures:
           raw_server = await raw_test_server(handler)
           client = await test_client(raw_server)
           resp = await client.get('/')
+
+   *handler* should be a coroutine which accepts a request and returns
+   response, e.g.
+
+   *port* optional, port the server is run at, if
+   not provided a random unused port is used.
+
+   .. versionadded:: 3.0
 
 .. data:: unused_port()
 
@@ -595,7 +599,9 @@ for accessing to the server.
       (``'127.0.0.1'``) by default.
 
    :param int port: optional port for TCP socket, if not provided a
-       random unused port is used.
+      random unused port is used.
+
+      .. versionadded:: 3.0
 
    .. attribute:: scheme
 
@@ -608,7 +614,7 @@ for accessing to the server.
 
    .. attribute:: port
 
-      A random *port* used to start a server.
+      *port* used to start the test server.
 
    .. attribute:: handler
 
@@ -654,6 +660,11 @@ for accessing to the server.
    :param str host: a host for TCP socket, IPv4 *local host*
       (``'127.0.0.1'``) by default.
 
+   :param int port: optional port for TCP socket, if not provided a
+      random unused port is used.
+
+      .. versionadded:: 3.0
+
 
 .. class:: TestServer(app, *, scheme="http", host='127.0.0.1')
 
@@ -667,6 +678,10 @@ for accessing to the server.
    :param str host: a host for TCP socket, IPv4 *local host*
       (``'127.0.0.1'``) by default.
 
+   :param int port: optional port for TCP socket, if not provided a
+      random unused port is used.
+
+      .. versionadded:: 3.0
 
    .. attribute:: app
 
@@ -712,7 +727,7 @@ Test Client
 
    .. attribute:: port
 
-      A random *port* used to start a server.
+      *port* used to start the server
 
    .. attribute:: server
 

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -128,7 +128,7 @@ app test client::
 
 Pytest tooling has the following fixtures:
 
-.. data:: test_server(app, **kwargs)
+.. data:: test_server(app, *, port=None, **kwargs)
 
    A fixture factory that creates
    :class:`~aiohttp.test_utils.TestServer`::
@@ -144,11 +144,14 @@ Pytest tooling has the following fixtures:
    *app* is the :class:`aiohttp.web.Application` used
                            to start server.
 
+   *port* optional, port the server is run at, if
+   not provided a random unused port is used.
+
    *kwargs* are parameters passed to
                   :meth:`aiohttp.web.Application.make_handler`
 
 
-.. data:: test_client(app, **kwargs)
+.. data:: test_client(app, server_kwargs=None, **kwargs)
           test_client(server, **kwargs)
           test_client(raw_server, **kwargs)
 
@@ -168,17 +171,23 @@ Pytest tooling has the following fixtures:
    :class:`aiohttp.test_utils.TestServer` or
    :class:`aiohttp.test_utils.RawTestServer` instance.
 
+   *server_kwargs* are parameters passed to the test server if an app
+   is passed, else ignored.
+
    *kwargs* are parameters passed to
    :class:`aiohttp.test_utils.TestClient` constructor.
 
-.. data:: raw_test_server(handler, **kwargs)
+.. data:: raw_test_server(handler, *, port=None, **kwargs)
 
    A fixture factory that creates
    :class:`~aiohttp.test_utils.RawTestServer` instance from given web
    handler.
 
    *handler* should be a coroutine which accepts a request and returns
-   response, e.g.::
+   response, e.g.
+
+   *port* optional, port the server is run at, if
+   not provided a random unused port is used.::
 
       async def test_f(raw_test_server, test_client):
 
@@ -563,7 +572,7 @@ Test server usually works in conjunction with
 :class:`aiohttp.test_utils.TestClient` which provides handy client methods
 for accessing to the server.
 
-.. class:: BaseTestServer(*, scheme='http', host='127.0.0.1')
+.. class:: BaseTestServer(*, scheme='http', host='127.0.0.1', port=None)
 
    Base class for test servers.
 
@@ -572,6 +581,8 @@ for accessing to the server.
    :param str host: a host for TCP socket, IPv4 *local host*
       (``'127.0.0.1'``) by default.
 
+   :param int port: optional port for TCP socket, if not provided a
+       random unused port is used.
 
    .. attribute:: scheme
 

--- a/tests/test_test_utils.py
+++ b/tests/test_test_utils.py
@@ -273,3 +273,18 @@ async def test_client_context_manager_response(method, app, loop):
             if method != 'head':
                 text = await resp.text()
                 assert "Hello, world" in text
+
+
+async def test_custom_port(loop, app, unused_port):
+    port = unused_port()
+    client = _TestClient(_TestServer(app, loop=loop, port=port), loop=loop)
+    await client.start_server()
+
+    assert client.server.port == port
+
+    resp = await client.get('/')
+    assert resp.status == 200
+    text = await resp.text()
+    assert _hello_world_str == text
+
+    await client.close()


### PR DESCRIPTION
## What do these changes do?

Allow the port to be set when creating test servers (and therefore test clients).

This is useful when you want you want the port of a test server to fixed for a sesssion but the test server to be ephemeral and be (re)created for all tests.

## Are there changes in behavior for the user?

Not unless they want to set the port

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] Add a new news fragment into the `CHANGES` folder
