### PR TITLE
Fix location of DummyCookieJar in docs

### DIFF
--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -101,7 +101,7 @@ The client session supports the context manager protocol for self closing.
       proxy mode.
 
       If no cookie processing is needed, a
-      :class:`aiohttp.helpers.DummyCookieJar` instance can be
+      :class:`aiohttp.DummyCookieJar` instance can be
       provided.
 
    :param callable json_serialize: Json *serializer* callable.


### PR DESCRIPTION
Trivial doc fix. DummyCookieJar can't be imported from aiohttp.helpers.