### PR TITLE
Skip middleware code when there are no user middlewares installed

### DIFF
--- a/CHANGES/2629.feature
+++ b/CHANGES/2629.feature
@@ -1,0 +1,1 @@
+Fixes performance issue introduced by #2577. When there are no middlewares installed by the user, no additional and useless code is executed.

--- a/aiohttp/web_app.py
+++ b/aiohttp/web_app.py
@@ -116,12 +116,19 @@ class Application(MutableMapping):
         self._on_startup.freeze()
         self._on_shutdown.freeze()
         self._on_cleanup.freeze()
-        self._run_middlewares = len(self.middlewares) > 0
         self._middlewares_handlers = tuple(self._prepare_middleware())
+
+        # If current app and any subapp do not have middlewares avoid run all
+        # of the code footprint that it implies, which have a middleware
+        # hardcoded per app that sets up the current_app attribute. If no
+        # middlewares are configured the handler will receive the proper
+        # current_app without needing all of this code.
+        self._run_middlewares = True if self.middlewares else False
 
         for subapp in self._subapps:
             subapp.freeze()
-            self._run_middlewares |= len(subapp._middlewares) > 0
+            self._run_middlewares =\
+                self._run_middlewares or subapp._run_middlewares
 
     @property
     def debug(self):

--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -195,6 +195,7 @@ def test_app_delitem():
 def test_app_freeze():
     app = web.Application()
     subapp = mock.Mock()
+    subapp._middlewares = ()
     app._subapps.append(subapp)
 
     app.freeze()
@@ -210,3 +211,27 @@ def test_equality():
 
     assert app1 == app1
     assert app1 != app2
+
+def test_app_run_middlewares():
+
+    root = web.Application()
+    sub = web.Application()
+    root.add_subapp('/sub', sub)
+    root.freeze()
+    assert root._run_middlewares == False
+
+    @web.middleware
+    async def middleware(request, handler):
+        return await handler(request)
+
+    root = web.Application(middlewares=[middleware])
+    sub = web.Application()
+    root.add_subapp('/sub', sub)
+    root.freeze()
+    assert root._run_middlewares == True
+
+    root = web.Application()
+    sub = web.Application(middlewares=[middleware])
+    root.add_subapp('/sub', sub)
+    root.freeze()
+    assert root._run_middlewares == True

--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -212,13 +212,14 @@ def test_equality():
     assert app1 == app1
     assert app1 != app2
 
+
 def test_app_run_middlewares():
 
     root = web.Application()
     sub = web.Application()
     root.add_subapp('/sub', sub)
     root.freeze()
-    assert root._run_middlewares == False
+    assert root._run_middlewares is False
 
     @web.middleware
     async def middleware(request, handler):
@@ -228,10 +229,10 @@ def test_app_run_middlewares():
     sub = web.Application()
     root.add_subapp('/sub', sub)
     root.freeze()
-    assert root._run_middlewares == True
+    assert root._run_middlewares is True
 
     root = web.Application()
     sub = web.Application(middlewares=[middleware])
     root.add_subapp('/sub', sub)
     root.freeze()
-    assert root._run_middlewares == True
+    assert root._run_middlewares is True


### PR DESCRIPTION
## What do these changes do?

Fixes performance issue introduced by #2577, boosting from 8K req/sec
to almost 9K req/sec.

If there are no middlewares installed by the user the attribute
`request._match_info.current_app` already looks at to the right app,
this is by design.

## Are there changes in behavior for the user?

No