### PR TITLE
Add note about `aiohttp.request` usage problem

### DIFF
--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -676,6 +676,9 @@ certification chaining.
               assert resp.status == 200
               print(await resp.text())
 
+   .. note:: 
+      This usage may raise warning ```Unclosed client session``` under 
+      version 2.x and will be fixed in version 3.0.
 
 .. _aiohttp-client-reference-connectors:
 


### PR DESCRIPTION
## What do these changes do?

Add note about `aiohttp.request`'s example which would cause `Unclosed client session`

## Related issue number

[#2635](https://github.com/aio-libs/aiohttp/issues/2635)