### PR TITLE
Raise cancelled on closed

### DIFF
--- a/CHANGES/2499.bugfix
+++ b/CHANGES/2499.bugfix
@@ -1,1 +1,1 @@
-Fix writing to closed transport by raising asyncio.CancelledError
+Fix writing to closed transport by raising `asyncio.CancelledError`

--- a/CHANGES/2499.bugfix
+++ b/CHANGES/2499.bugfix
@@ -1,0 +1,1 @@
+Fix writing to closed transport by raising asyncio.CancelledError

--- a/aiohttp/http_writer.py
+++ b/aiohttp/http_writer.py
@@ -1,5 +1,6 @@
 """Http related parsers and protocol."""
 
+import asyncio
 import collections
 import socket
 import zlib
@@ -126,6 +127,9 @@ class PayloadWriter(AbstractPayloadWriter):
         size = len(chunk)
         self.buffer_size += size
         self.output_size += size
+
+        if self._transport.is_closing():
+            raise asyncio.CancelledError('Cannot write to closing transport')
         self._transport.write(chunk)
 
     def write(self, chunk, *, drain=True, LIMIT=64*1024):

--- a/tests/test_client_request.py
+++ b/tests/test_client_request.py
@@ -50,6 +50,7 @@ def transport(buf):
 
     transport.write.side_effect = write
     transport.write_eof.side_effect = write_eof
+    transport.is_closing.return_value = False
 
     return transport
 

--- a/tests/test_http_writer.py
+++ b/tests/test_http_writer.py
@@ -1,4 +1,5 @@
 """Tests for aiohttp/http_writer.py"""
+import asyncio
 import zlib
 from unittest import mock
 
@@ -20,6 +21,7 @@ def transport(buf):
         buf.extend(chunk)
 
     transport.write.side_effect = write
+    transport.is_closing.return_value = False
     return transport
 
 
@@ -147,3 +149,13 @@ def test_write_drain(stream, loop):
     msg.write(b'1', drain=True)
     assert msg.drain.called
     assert msg.buffer_size == 0
+
+
+def test_write_to_closing_transport(stream, loop):
+    msg = http.PayloadWriter(stream, loop)
+
+    msg.write(b'Before closing')
+    stream.transport.is_closing.return_value = True
+
+    with pytest.raises(asyncio.CancelledError):
+        msg.write(b'After closing')

--- a/tests/test_web_protocol.py
+++ b/tests/test_web_protocol.py
@@ -84,6 +84,7 @@ def transport(buf):
 
     transport.write.side_effect = write
     transport.drain.side_effect = helpers.noop
+    transport.is_closing.return_value = False
 
     return transport
 


### PR DESCRIPTION
## What do these changes do?

Add raising of asyncio.CancelledError to PayloadWriter write() method to avoid writing to closing transport.

## Are there changes in behavior for the user?

According to https://github.com/aio-libs/aiohttp/issues/2499#issuecomment-352364059 is was possible to catch this situation earlier by manually checking transport status of request. Thus, change should not broke any previously written code.

## Related issue number

Resolves #2499 

## Checklist

- [*] I think the code is well written
- [*] Unit tests for the changes exist
- [*] Add a new news fragment into the `CHANGES` folder
  