### PR TITLE
Fix default `access_log_format` to correct value

### DIFF
--- a/CHANGES/2649.bugfix
+++ b/CHANGES/2649.bugfix
@@ -1,0 +1,1 @@
+Fix default value of `access_log_format` argument in `web.run_app`

--- a/aiohttp/web.py
+++ b/aiohttp/web.py
@@ -40,8 +40,7 @@ def run_app(app, *, host=None, port=None, path=None, sock=None,
             shutdown_timeout=60.0, ssl_context=None,
             print=print, backlog=128, access_log_class=helpers.AccessLogger,
             access_log_format=helpers.AccessLogger.LOG_FORMAT,
-            access_log=access_logger,
-            handle_signals=True):
+            access_log=access_logger, handle_signals=True):
     """Run an app locally"""
     loop = asyncio.get_event_loop()
 

--- a/aiohttp/web.py
+++ b/aiohttp/web.py
@@ -39,7 +39,8 @@ __all__ = (web_protocol.__all__ +
 def run_app(app, *, host=None, port=None, path=None, sock=None,
             shutdown_timeout=60.0, ssl_context=None,
             print=print, backlog=128, access_log_class=helpers.AccessLogger,
-            access_log_format=None, access_log=access_logger,
+            access_log_format=helpers.AccessLogger.LOG_FORMAT,
+            access_log=access_logger,
             handle_signals=True):
     """Run an app locally"""
     loop = asyncio.get_event_loop()

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -2271,7 +2271,7 @@ Utilities
                       sock=None, shutdown_timeout=60.0, \
                       ssl_context=None, print=print, backlog=128, \
                       access_log_class=aiohttp.helpers.AccessLogger, \
-                      access_log_format=None, \
+                      access_log_format=aiohttp.helpers.AccessLogger.LOG_FORMAT, \
                       access_log=aiohttp.log.access_logger, \
                       handle_signals=True)
 


### PR DESCRIPTION
## What do these changes do?

Fixing wrong default value of access log format

## Are there changes in behavior for the user?

Should not affect anything

## Related issue number

#2649 

## Checklist

- [x] I think the code is well written
- [x] Documentation reflects the changes
- [x] Add a new news fragment into the `CHANGES` folder
  