### PR TITLE
Rename PayloadWriter to StreamWriter

### DIFF
--- a/CHANGES/2654.feature
+++ b/CHANGES/2654.feature
@@ -1,0 +1,1 @@
+Rename PayloadWriter to StreamWriter

--- a/aiohttp/abc.py
+++ b/aiohttp/abc.py
@@ -119,8 +119,8 @@ class AbstractCookieJar(Sized, Iterable):
         """Return the jar's cookies filtered by their attributes."""
 
 
-class AbstractPayloadWriter(ABC):
-    """Abstract payload writer."""
+class AbstractStreamWriter(ABC):
+    """Abstract stream writer."""
 
     @abstractmethod
     async def write(self, chunk):

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -20,7 +20,7 @@ from .client_exceptions import (ClientConnectionError, ClientOSError,
                                 InvalidURL, ServerFingerprintMismatch)
 from .formdata import FormData
 from .helpers import PY_36, HeadersMixin, TimerNoop, noop, reify, set_result
-from .http import SERVER_SOFTWARE, HttpVersion10, HttpVersion11, PayloadWriter
+from .http import SERVER_SOFTWARE, HttpVersion10, HttpVersion11, StreamWriter
 from .log import client_logger
 from .streams import StreamReader
 
@@ -469,7 +469,7 @@ class ClientRequest:
             if self.url.raw_query_string:
                 path += '?' + self.url.raw_query_string
 
-        writer = PayloadWriter(conn.protocol, conn.transport, self.loop)
+        writer = StreamWriter(conn.protocol, conn.transport, self.loop)
 
         if self.compress:
             writer.enable_compression(self.compress)

--- a/aiohttp/http.py
+++ b/aiohttp/http.py
@@ -12,14 +12,14 @@ from .http_websocket import (WS_CLOSED_MESSAGE, WS_CLOSING_MESSAGE, WS_KEY,
                              WSCloseCode, WSMessage, WSMsgType, ws_ext_gen,
                              ws_ext_parse)
 from .http_writer import (HttpVersion, HttpVersion10, HttpVersion11,
-                          PayloadWriter)
+                          StreamWriter)
 
 
 __all__ = (
     'HttpProcessingError', 'RESPONSES', 'SERVER_SOFTWARE',
 
     # .http_writer
-    'PayloadWriter', 'HttpVersion', 'HttpVersion10', 'HttpVersion11',
+    'StreamWriter', 'HttpVersion', 'HttpVersion10', 'HttpVersion11',
 
     # .http_parser
     'HttpParser', 'HttpRequestParser', 'HttpResponseParser',

--- a/aiohttp/http_writer.py
+++ b/aiohttp/http_writer.py
@@ -4,18 +4,18 @@ import asyncio
 import collections
 import zlib
 
-from .abc import AbstractPayloadWriter
+from .abc import AbstractStreamWriter
 from .helpers import noop
 
 
-__all__ = ('PayloadWriter', 'HttpVersion', 'HttpVersion10', 'HttpVersion11')
+__all__ = ('StreamWriter', 'HttpVersion', 'HttpVersion10', 'HttpVersion11')
 
 HttpVersion = collections.namedtuple('HttpVersion', ['major', 'minor'])
 HttpVersion10 = HttpVersion(1, 0)
 HttpVersion11 = HttpVersion(1, 1)
 
 
-class PayloadWriter(AbstractPayloadWriter):
+class StreamWriter(AbstractStreamWriter):
 
     def __init__(self, protocol, transport, loop):
         self._protocol = protocol

--- a/aiohttp/payload.py
+++ b/aiohttp/payload.py
@@ -129,7 +129,7 @@ class Payload(ABC):
     async def write(self, writer):
         """Write payload.
 
-        writer is an AbstractPayloadWriter instance:
+        writer is an AbstractStreamWriter instance:
         """
 
 

--- a/aiohttp/web_fileresponse.py
+++ b/aiohttp/web_fileresponse.py
@@ -4,7 +4,7 @@ import pathlib
 
 from . import hdrs
 from .helpers import set_exception, set_result
-from .http_writer import PayloadWriter
+from .http_writer import StreamWriter
 from .log import server_logger
 from .web_exceptions import (HTTPNotModified, HTTPOk, HTTPPartialContent,
                              HTTPRequestRangeNotSatisfiable)
@@ -17,14 +17,14 @@ __all__ = ('FileResponse',)
 NOSENDFILE = bool(os.environ.get("AIOHTTP_NOSENDFILE"))
 
 
-class SendfilePayloadWriter(PayloadWriter):
+class SendfileStreamWriter(StreamWriter):
 
     def __init__(self, *args, **kwargs):
         self._sendfile_buffer = []
         super().__init__(*args, **kwargs)
 
     def _write(self, chunk):
-        # we overwrite PayloadWriter._write, so nothing can be appended to
+        # we overwrite StreamWriter._write, so nothing can be appended to
         # _buffer, and nothing is written to the transport directly by the
         # parent class
         self.output_size += len(chunk)
@@ -109,7 +109,7 @@ class FileResponse(StreamResponse):
                 transport.get_extra_info("socket") is None):
             writer = await self._sendfile_fallback(request, fobj, count)
         else:
-            writer = SendfilePayloadWriter(
+            writer = SendfileStreamWriter(
                 request.protocol,
                 transport,
                 request.loop

--- a/aiohttp/web_protocol.py
+++ b/aiohttp/web_protocol.py
@@ -9,7 +9,7 @@ from html import escape as html_escape
 
 from . import helpers, http
 from .helpers import CeilTimeout
-from .http import HttpProcessingError, HttpRequestParser, PayloadWriter
+from .http import HttpProcessingError, HttpRequestParser, StreamWriter
 from .log import access_logger, server_logger
 from .streams import EMPTY_PAYLOAD
 from .tcp_helpers import tcp_cork, tcp_keepalive, tcp_nodelay
@@ -230,14 +230,14 @@ class RequestHandler(asyncio.streams.FlowControlMixin, asyncio.Protocol):
                 # something happened during parsing
                 self._error_handler = self._loop.create_task(
                     self.handle_parse_error(
-                        PayloadWriter(self, self.transport, self._loop),
+                        StreamWriter(self, self.transport, self._loop),
                         400, exc, exc.message))
                 self.close()
             except Exception as exc:
                 # 500: internal error
                 self._error_handler = self._loop.create_task(
                     self.handle_parse_error(
-                        PayloadWriter(self, self.transport, self._loop),
+                        StreamWriter(self, self.transport, self._loop),
                         500, exc))
                 self.close()
             else:
@@ -360,7 +360,7 @@ class RequestHandler(asyncio.streams.FlowControlMixin, asyncio.Protocol):
                 now = loop.time()
 
             manager.requests_count += 1
-            writer = PayloadWriter(self, self.transport, loop)
+            writer = StreamWriter(self, self.transport, loop)
             request = self._request_factory(
                 message, payload, self, writer, handler)
             try:

--- a/tests/test_client_request.py
+++ b/tests/test_client_request.py
@@ -665,7 +665,7 @@ async def test_bytes_data(loop, conn):
 async def test_content_encoding(loop, conn):
     req = ClientRequest('post', URL('http://python.org/'), data='foo',
                         compress='deflate', loop=loop)
-    with mock.patch('aiohttp.client_reqrep.PayloadWriter') as m_writer:
+    with mock.patch('aiohttp.client_reqrep.StreamWriter') as m_writer:
         resp = req.send(conn)
     assert req.headers['TRANSFER-ENCODING'] == 'chunked'
     assert req.headers['CONTENT-ENCODING'] == 'deflate'
@@ -690,7 +690,7 @@ async def test_content_encoding_header(loop, conn):
     req = ClientRequest(
         'post', URL('http://python.org/'), data='foo',
         headers={'Content-Encoding': 'deflate'}, loop=loop)
-    with mock.patch('aiohttp.client_reqrep.PayloadWriter') as m_writer:
+    with mock.patch('aiohttp.client_reqrep.StreamWriter') as m_writer:
         resp = req.send(conn)
 
     assert not m_writer.return_value.enable_compression.called
@@ -729,7 +729,7 @@ async def test_chunked2(loop, conn):
 async def test_chunked_explicit(loop, conn):
     req = ClientRequest(
         'post', URL('http://python.org/'), chunked=True, loop=loop)
-    with mock.patch('aiohttp.client_reqrep.PayloadWriter') as m_writer:
+    with mock.patch('aiohttp.client_reqrep.StreamWriter') as m_writer:
         resp = req.send(conn)
 
     assert 'chunked' == req.headers['TRANSFER-ENCODING']

--- a/tests/test_http_writer.py
+++ b/tests/test_http_writer.py
@@ -34,14 +34,14 @@ def protocol(loop, transport):
 
 
 def test_payloadwriter_properties(transport, protocol, loop):
-    writer = http.PayloadWriter(protocol, transport, loop)
+    writer = http.StreamWriter(protocol, transport, loop)
     assert writer.protocol == protocol
     assert writer.transport == transport
 
 
 async def test_write_payload_eof(transport, protocol, loop):
     write = transport.write = mock.Mock()
-    msg = http.PayloadWriter(protocol, transport, loop)
+    msg = http.StreamWriter(protocol, transport, loop)
 
     msg.write(b'data1')
     msg.write(b'data2')
@@ -52,7 +52,7 @@ async def test_write_payload_eof(transport, protocol, loop):
 
 
 async def test_write_payload_chunked(buf, protocol, transport, loop):
-    msg = http.PayloadWriter(protocol, transport, loop)
+    msg = http.StreamWriter(protocol, transport, loop)
     msg.enable_chunking()
     msg.write(b'data')
     await msg.write_eof()
@@ -61,7 +61,7 @@ async def test_write_payload_chunked(buf, protocol, transport, loop):
 
 
 async def test_write_payload_chunked_multiple(buf, protocol, transport, loop):
-    msg = http.PayloadWriter(protocol, transport, loop)
+    msg = http.StreamWriter(protocol, transport, loop)
     msg.enable_chunking()
     msg.write(b'data1')
     msg.write(b'data2')
@@ -73,7 +73,7 @@ async def test_write_payload_chunked_multiple(buf, protocol, transport, loop):
 async def test_write_payload_length(protocol, transport, loop):
     write = transport.write = mock.Mock()
 
-    msg = http.PayloadWriter(protocol, transport, loop)
+    msg = http.StreamWriter(protocol, transport, loop)
     msg.length = 2
     msg.write(b'd')
     msg.write(b'ata')
@@ -86,7 +86,7 @@ async def test_write_payload_length(protocol, transport, loop):
 async def test_write_payload_chunked_filter(protocol, transport, loop):
     write = transport.write = mock.Mock()
 
-    msg = http.PayloadWriter(protocol, transport, loop)
+    msg = http.StreamWriter(protocol, transport, loop)
     msg.enable_chunking()
     msg.write(b'da')
     msg.write(b'ta')
@@ -101,7 +101,7 @@ async def test_write_payload_chunked_filter_mutiple_chunks(
         transport,
         loop):
     write = transport.write = mock.Mock()
-    msg = http.PayloadWriter(protocol, transport, loop)
+    msg = http.StreamWriter(protocol, transport, loop)
     msg.enable_chunking()
     msg.write(b'da')
     msg.write(b'ta')
@@ -121,7 +121,7 @@ COMPRESSED = b''.join([compressor.compress(b'data'), compressor.flush()])
 
 async def test_write_payload_deflate_compression(protocol, transport, loop):
     write = transport.write = mock.Mock()
-    msg = http.PayloadWriter(protocol, transport, loop)
+    msg = http.StreamWriter(protocol, transport, loop)
     msg.enable_compression('deflate')
     msg.write(b'data')
     await msg.write_eof()
@@ -137,7 +137,7 @@ async def test_write_payload_deflate_and_chunked(
         protocol,
         transport,
         loop):
-    msg = http.PayloadWriter(protocol, transport, loop)
+    msg = http.StreamWriter(protocol, transport, loop)
     msg.enable_compression('deflate')
     msg.enable_chunking()
 
@@ -149,7 +149,7 @@ async def test_write_payload_deflate_and_chunked(
 
 
 def test_write_drain(protocol, transport, loop):
-    msg = http.PayloadWriter(protocol, transport, loop)
+    msg = http.StreamWriter(protocol, transport, loop)
     msg.drain = mock.Mock()
     msg.write(b'1' * (64 * 1024 * 2), drain=False)
     assert not msg.drain.called
@@ -160,7 +160,7 @@ def test_write_drain(protocol, transport, loop):
 
 
 def test_write_to_closing_transport(protocol, transport, loop):
-    msg = http.PayloadWriter(protocol, transport, loop)
+    msg = http.StreamWriter(protocol, transport, loop)
 
     msg.write(b'Before closing')
     transport.is_closing.return_value = True
@@ -170,13 +170,13 @@ def test_write_to_closing_transport(protocol, transport, loop):
 
 
 async def test_drain(protocol, transport, loop):
-    msg = http.PayloadWriter(protocol, transport, loop)
+    msg = http.StreamWriter(protocol, transport, loop)
     await msg.drain()
     assert protocol._drain_helper.called
 
 
 async def test_drain_no_transport(protocol, transport, loop):
-    msg = http.PayloadWriter(protocol, transport, loop)
+    msg = http.StreamWriter(protocol, transport, loop)
     msg._protocol.transport = None
     await msg.drain()
     assert not protocol._drain_helper.called

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -163,7 +163,7 @@ class TestProxy(unittest.TestCase):
             "proxy_auth must be None or BasicAuth() tuple",
         )
 
-    @mock.patch('aiohttp.client_reqrep.PayloadWriter')
+    @mock.patch('aiohttp.client_reqrep.StreamWriter')
     def _test_connect_request_with_unicode_host(self, Request_mock):
         loop = mock.Mock()
         request = ClientRequest("CONNECT", URL("http://éé.com/"),

--- a/tests/test_web_protocol.py
+++ b/tests/test_web_protocol.py
@@ -74,7 +74,7 @@ def handle_with_error():
 
 @pytest.yield_fixture
 def writer(srv):
-    return http.PayloadWriter(srv, srv.transport, srv._loop)
+    return http.StreamWriter(srv, srv.transport, srv._loop)
 
 
 @pytest.yield_fixture

--- a/tests/test_web_sendfile.py
+++ b/tests/test_web_sendfile.py
@@ -2,7 +2,7 @@ from unittest import mock
 
 from aiohttp import hdrs
 from aiohttp.test_utils import make_mocked_coro, make_mocked_request
-from aiohttp.web_fileresponse import FileResponse, SendfilePayloadWriter
+from aiohttp.web_fileresponse import FileResponse, SendfileStreamWriter
 
 
 def test_static_handle_eof(loop):
@@ -12,7 +12,7 @@ def test_static_handle_eof(loop):
         in_fd = 31
         fut = loop.create_future()
         m_os.sendfile.return_value = 0
-        writer = SendfilePayloadWriter(mock.Mock(), mock.Mock(), fake_loop)
+        writer = SendfileStreamWriter(mock.Mock(), mock.Mock(), fake_loop)
         writer._sendfile_cb(fut, out_fd, in_fd, 0, 100, fake_loop, False)
         m_os.sendfile.assert_called_with(out_fd, in_fd, 0, 100)
         assert fut.done()
@@ -28,7 +28,7 @@ def test_static_handle_again(loop):
         in_fd = 31
         fut = loop.create_future()
         m_os.sendfile.side_effect = BlockingIOError()
-        writer = SendfilePayloadWriter(mock.Mock(), mock.Mock(), fake_loop)
+        writer = SendfileStreamWriter(mock.Mock(), mock.Mock(), fake_loop)
         writer._sendfile_cb(fut, out_fd, in_fd, 0, 100, fake_loop, False)
         m_os.sendfile.assert_called_with(out_fd, in_fd, 0, 100)
         assert not fut.done()
@@ -47,7 +47,7 @@ def test_static_handle_exception(loop):
         fut = loop.create_future()
         exc = OSError()
         m_os.sendfile.side_effect = exc
-        writer = SendfilePayloadWriter(mock.Mock(), mock.Mock(), fake_loop)
+        writer = SendfileStreamWriter(mock.Mock(), mock.Mock(), fake_loop)
         writer._sendfile_cb(fut, out_fd, in_fd, 0, 100, fake_loop, False)
         m_os.sendfile.assert_called_with(out_fd, in_fd, 0, 100)
         assert fut.done()
@@ -63,7 +63,7 @@ def test__sendfile_cb_return_on_cancelling(loop):
         in_fd = 31
         fut = loop.create_future()
         fut.cancel()
-        writer = SendfilePayloadWriter(mock.Mock(), mock.Mock(), fake_loop)
+        writer = SendfileStreamWriter(mock.Mock(), mock.Mock(), fake_loop)
         writer._sendfile_cb(fut, out_fd, in_fd, 0, 100, fake_loop, False)
         assert fut.done()
         assert not fake_loop.add_writer.called


### PR DESCRIPTION
## What do these changes do?

Rename the `PayloadWriter` class to `StreamWriter`, having consistency with the reader side which has a class called `StreamReader`.

## Are there changes in behavior for the user?

No

## Related issue number

#2109

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist