### PR TITLE
Enable Read The Docs build sphinx rst using py 3.6

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,5 @@
+build:
+  image: latest
+python:
+  version: 3.6
+  pip_install: true


### PR DESCRIPTION
It's just a minor improvement which instructs RTD to use python3.6-enabled container for building docs.