### PR TITLE
Restricted YARL version to be less than 1.0

### DIFF
--- a/CHANGES/2662.bugfix
+++ b/CHANGES/2662.bugfix
@@ -1,0 +1,1 @@
+Restricted version of yarl to be less than 1.0

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ with codecs.open(os.path.join(os.path.abspath(os.path.dirname(
 
 
 install_requires = ['chardet', 'multidict>=3.0.0',
-                    'async_timeout>=1.2.0', 'yarl>=0.11']
+                    'async_timeout>=1.2.0', 'yarl>=0.11,<1.0']
 
 
 def read(f):


### PR DESCRIPTION
<!-- Thank you for your contribution!

## What do these changes do?

Adds restriction for yarl package to be less than 1.0 (I assume that minor changes won't change API)

## Are there changes in behavior for the user?

No

## Related issue number

2662

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
