### PR TITLE
Compatibility with yarl==1

### DIFF
--- a/aiohttp/web_runner.py
+++ b/aiohttp/web_runner.py
@@ -183,7 +183,7 @@ class AppRunner:
 
         # The loop over sites is intentional, an exception on gather()
         # leaves self._sites in unpredictable state.
-        # The loop guaranties than a site is eigher deleted on success or
+        # The loop guaranties that a site is either deleted on success or
         # still present on failure
         for site in list(self._sites):
             await site.stop()

--- a/tests/test_run_app.py
+++ b/tests/test_run_app.py
@@ -349,7 +349,7 @@ def test_run_app_preexisting_inet6_socket(patched_loop):
         patched_loop.create_server.assert_called_with(
             mock.ANY, sock=sock, backlog=128, ssl=None
         )
-        assert "http://:::{}".format(port) in printer.call_args[0][0]
+        assert "http://[::]:{}".format(port) in printer.call_args[0][0]
 
 
 @skip_if_no_unix_socks


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?
Refactores deprecated `yarl.quoting.unquote` to `yarl.URL(encoded=True)` as this is only public interface left.

Another possible workaround is to pull `yarl.quoting._Unquoter` to public interface.

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?
No

<!-- Outline any notable behaviour for the end users. -->

## Related issue number
#2662 

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
