### PR TITLE
Polish quoting

### DIFF
--- a/CHANGES/2668.bugfix
+++ b/CHANGES/2668.bugfix
@@ -1,0 +1,1 @@
+Do percent encoding for `.url_for()` parameters

--- a/CHANGES/2668.removal
+++ b/CHANGES/2668.removal
@@ -1,0 +1,1 @@
+Forbid non-strings in `resource.url_for()` parameters.

--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -343,7 +343,7 @@ class PlainResource(Resource):
         return {'path': self._path}
 
     def url_for(self):
-        return URL(self._path)
+        return URL(self._path, encoded=True)
 
     def __repr__(self):
         name = "'" + self.name + "' " if self.name is not None else ""
@@ -378,7 +378,7 @@ class DynamicResource(Resource):
             if '{' in part or '}' in part:
                 raise ValueError("Invalid path '{}'['{}']".format(path, part))
 
-            path = URL(part).raw_path
+            path = URL.build(path=part).raw_path
             formatter += path
             pattern += re.escape(path)
 
@@ -404,8 +404,8 @@ class DynamicResource(Resource):
         if match is None:
             return None
         else:
-            return {key: URL(value, encoded=True).path for key, value in
-                    match.groupdict().items()}
+            return {key: URL.build(path=value, encoded=True).path
+                    for key, value in match.groupdict().items()}
 
     def raw_match(self, path):
         return self._formatter == path
@@ -415,7 +415,8 @@ class DynamicResource(Resource):
                 'pattern': self._pattern}
 
     def url_for(self, **parts):
-        url = self._formatter.format_map(parts)
+        url = self._formatter.format_map({k: URL.build(path=v).raw_path
+                                          for k, v in parts.items()})
         return URL(url)
 
     def __repr__(self):
@@ -430,7 +431,7 @@ class PrefixResource(AbstractResource):
         assert not prefix or prefix.startswith('/'), prefix
         assert prefix in ('', '/') or not prefix.endswith('/'), prefix
         super().__init__(name=name)
-        self._prefix = URL(prefix).raw_path
+        self._prefix = URL.build(path=prefix).raw_path
 
     def add_prefix(self, prefix):
         assert prefix.startswith('/')
@@ -483,7 +484,7 @@ class StaticResource(PrefixResource):
         while filename.startswith('/'):
             filename = filename[1:]
         filename = '/' + filename
-        url = self._prefix + URL(filename).raw_path
+        url = self._prefix + URL.build(path=filename).raw_path
         url = URL(url)
         if append_version is True:
             try:
@@ -534,8 +535,8 @@ class StaticResource(PrefixResource):
         if method not in allowed_methods:
             return None, allowed_methods
 
-        match_dict = {'filename': URL(path[len(self._prefix)+1:],
-                                      encoded=True).path}
+        match_dict = {'filename': URL.build(path=path[len(self._prefix)+1:],
+                                            encoded=True).path}
         return (UrlMappingMatchInfo(match_dict, self._routes[method]),
                 allowed_methods)
 
@@ -850,7 +851,7 @@ class UrlDispatcher(AbstractRouter, collections.abc.Mapping):
             if resource.name == name and resource.raw_match(path):
                 return resource
         if not ('{' in path or '}' in path or ROUTE_RE.search(path)):
-            url = URL(path)
+            url = URL.build(path=path)
             resource = PlainResource(url.raw_path, name=name)
             self.register_resource(resource)
             return resource

--- a/tests/test_urldispatch.py
+++ b/tests/test_urldispatch.py
@@ -593,7 +593,7 @@ def test_route_dynamic_with_regex(router):
     handler = make_handler()
     route = router.add_route('GET', r'/{one}/{two:.+}', handler)
 
-    url = route.url_for(one=1, two=2)
+    url = route.url_for(one='1', two='2')
     assert '/1/2' == str(url)
 
 

--- a/tests/test_urldispatch.py
+++ b/tests/test_urldispatch.py
@@ -597,6 +597,14 @@ def test_route_dynamic_with_regex(router):
     assert '/1/2' == str(url)
 
 
+def test_route_dynamic_quoting(router):
+    handler = make_handler()
+    route = router.add_route('GET', r'/{arg}', handler)
+
+    url = route.url_for(arg='1 2/текст')
+    assert '/1%202/%D1%82%D0%B5%D0%BA%D1%81%D1%82' == str(url)
+
+
 async def test_regular_match_info(router):
     handler = make_handler()
     router.add_route('GET', '/get/{name}', handler)


### PR DESCRIPTION
Forbid non-strings (integers for example) in `url_for` parameters.