### PR TITLE
Support reuse_port and reuse_address options

### DIFF
--- a/CHANGES/2679.feature
+++ b/CHANGES/2679.feature
@@ -1,0 +1,1 @@
+New options *reuse_port*, *reuse_address* are added to `run_app` and `TCPSite`.

--- a/aiohttp/web.py
+++ b/aiohttp/web.py
@@ -41,7 +41,8 @@ def run_app(app, *, host=None, port=None, path=None, sock=None,
             shutdown_timeout=60.0, ssl_context=None,
             print=print, backlog=128, access_log_class=helpers.AccessLogger,
             access_log_format=helpers.AccessLogger.LOG_FORMAT,
-            access_log=access_logger, handle_signals=True):
+            access_log=access_logger, handle_signals=True,
+            reuse_address=None, reuse_port=None):
     """Run an app locally"""
     loop = asyncio.get_event_loop()
 
@@ -60,17 +61,23 @@ def run_app(app, *, host=None, port=None, path=None, sock=None,
                 sites.append(TCPSite(runner, host, port,
                                      shutdown_timeout=shutdown_timeout,
                                      ssl_context=ssl_context,
-                                     backlog=backlog))
+                                     backlog=backlog,
+                                     reuse_address=reuse_address,
+                                     reuse_port=reuse_port))
             else:
                 for h in host:
                     sites.append(TCPSite(runner, h, port,
                                          shutdown_timeout=shutdown_timeout,
                                          ssl_context=ssl_context,
-                                         backlog=backlog))
+                                         backlog=backlog,
+                                         reuse_address=reuse_address,
+                                         reuse_port=reuse_port))
         elif path is None and sock is None or port is not None:
             sites.append(TCPSite(runner, port=port,
                                  shutdown_timeout=shutdown_timeout,
-                                 ssl_context=ssl_context, backlog=backlog))
+                                 ssl_context=ssl_context, backlog=backlog,
+                                 reuse_address=reuse_address,
+                                 reuse_port=reuse_port))
 
         if path is not None:
             if isinstance(path, (str, bytes, bytearray, memoryview)):

--- a/aiohttp/web_runner.py
+++ b/aiohttp/web_runner.py
@@ -58,7 +58,8 @@ class TCPSite(BaseSite):
 
     def __init__(self, app, host=None, port=None, *,
                  shutdown_timeout=60.0, ssl_context=None,
-                 backlog=128):
+                 backlog=128, reuse_address=None,
+                 reuse_port=None):
         super().__init__(app, shutdown_timeout=shutdown_timeout,
                          ssl_context=ssl_context, backlog=backlog)
         if host is None:
@@ -67,6 +68,8 @@ class TCPSite(BaseSite):
         if port is None:
             port = 8443 if self._ssl_context else 8080
         self._port = port
+        self._reuse_address = reuse_address
+        self._reuse_port = reuse_port
 
     @property
     def name(self):
@@ -78,7 +81,9 @@ class TCPSite(BaseSite):
         loop = asyncio.get_event_loop()
         self._server = await loop.create_server(
             self._runner.server, self._host, self._port,
-            ssl=self._ssl_context, backlog=self._backlog)
+            ssl=self._ssl_context, backlog=self._backlog,
+            reuse_address=self._reuse_address,
+            reuse_port=self._reuse_port)
 
 
 class UnixSite(BaseSite):

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -2326,7 +2326,8 @@ application on specific TCP or Unix socket, e.g.::
 
 .. class:: TCPSite(app, host=None, port=None, *, \
                    shutdown_timeout=60.0, ssl_context=None, \
-                   backlog=128)
+                   backlog=128, reuse_address=None,
+                   reuse_port=None)
 
    Serve an application on TCP socket.
 
@@ -2349,6 +2350,17 @@ application on specific TCP or Unix socket, e.g.::
                        connections, see :meth:`socket.listen` for details.
 
                        ``128`` by default.
+
+   :param bool reuse_address: tells the kernel to reuse a local socket in
+                              TIME_WAIT state, without waiting for its
+                              natural timeout to expire. If not specified
+                              will automatically be set to True on UNIX.
+
+   :param bool reuse_port: tells the kernel to allow this endpoint to be
+                           bound to the same port as other existing
+                           endpoints are bound to, so long as they all set
+                           this flag when being created. This option is not
+                           supported on Windows.
 
 .. class:: UnixSite(app, path, *, \
                    shutdown_timeout=60.0, ssl_context=None, \
@@ -2431,7 +2443,9 @@ Utilities
                       access_log_class=aiohttp.helpers.AccessLogger, \
                       access_log_format=aiohttp.helpers.AccessLogger.LOG_FORMAT, \
                       access_log=aiohttp.log.access_logger, \
-                      handle_signals=True)
+                      handle_signals=True, \
+                      reuse_address=None, \
+                      reuse_port=None)
 
    A utility function for running an application, serving it until
    keyboard interrupt and performing a
@@ -2504,9 +2518,23 @@ Utilities
    :param bool handle_signals: override signal TERM handling to gracefully
                                exit the application.
 
+   :param bool reuse_address: tells the kernel to reuse a local socket in
+                              TIME_WAIT state, without waiting for its
+                              natural timeout to expire. If not specified
+                              will automatically be set to True on UNIX.
+
+   :param bool reuse_port: tells the kernel to allow this endpoint to be
+                           bound to the same port as other existing
+                           endpoints are bound to, so long as they all set
+                           this flag when being created. This option is not
+                           supported on Windows.
+
    .. versionadded:: 3.0
 
       Support *access_log_class* parameter.
+      
+      Support *reuse_address*, *reuse_port* parameter.
+
 
 Constants
 ---------


### PR DESCRIPTION
## What do these changes do?

This pull request add supports for `reuse_port` and `reuse_address` socket options for TCP servers.

## Are there changes in behavior for the user?

Users can specify reuse_address, reuse_port options on run_app, or on a TCPSite creation.
When these options are not specified (or None is specified), the behavior is not changed.

## Related issue number
#2679 

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
