### PR TITLE
Change function "curl" to the working state

### DIFF
--- a/examples/curl.py
+++ b/examples/curl.py
@@ -6,16 +6,12 @@ import asyncio
 import aiohttp
 
 
-def curl(url):
-    session = aiohttp.ClientSession()
-    response = yield from session.request('GET', url)
-    print(repr(response))
-
-    chunk = yield from response.content.read()
-    print('Downloaded: %s' % len(chunk))
-
-    response.close()
-    yield from session.close()
+async def curl(url):
+    async with aiohttp.ClientSession() as session:
+        async with session.request('GET', url) as response:
+            print(repr(response))
+            chunk = await response.content.read()
+            print('Downloaded: %s' % len(chunk))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## What do these changes do?
The current state for curl example is not valid. It generates:
`chunk = yield from response.content.read()
Traceback (most recent call last):
  File "C:/Users/y.krylov/PycharmProjects/github/aiohttp/examples/curl.py", line 35, in <module>
    loop.run_until_complete(curl(options.url[0]))
  File "C:\Users\y.krylov\AppData\Local\Programs\Python\Python36\Lib\asyncio\base_events.py", line 467, in run_until_complete
    return future.result()
  File "C:/Users/y.krylov/PycharmProjects/github/aiohttp/examples/curl.py", line 14, in curl
    chunk = yield from response.content.read()
TypeError: cannot 'yield from' a coroutine object in a non-coroutine generator
`

And doesn’t show preferred  way of using ClientSession

## Environment
python 3.6.4
aiohttp 3.0.0a0

