### PR TITLE
Use custom classes to pass client signals parameters #2686

### DIFF
--- a/CHANGES/2686.feature
+++ b/CHANGES/2686.feature
@@ -1,0 +1,1 @@
+Use custom classes to pass client signals parameters

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -660,14 +660,14 @@ class TCPConnector(BaseConnector):
 
             if traces:
                 for trace in traces:
-                    await trace.send_dns_resolvehost_start()
+                    await trace.send_dns_resolvehost_start(host)
 
             res = (await self._resolver.resolve(
                 host, port, family=self._family))
 
             if traces:
                 for trace in traces:
-                    await trace.send_dns_resolvehost_end()
+                    await trace.send_dns_resolvehost_end(host)
 
             return res
 
@@ -678,26 +678,26 @@ class TCPConnector(BaseConnector):
 
             if traces:
                 for trace in traces:
-                    await trace.send_dns_cache_hit()
+                    await trace.send_dns_cache_hit(host)
 
             return self._cached_hosts.next_addrs(key)
 
         if key in self._throttle_dns_events:
             if traces:
                 for trace in traces:
-                    await trace.send_dns_cache_hit()
+                    await trace.send_dns_cache_hit(host)
             await self._throttle_dns_events[key].wait()
         else:
             if traces:
                 for trace in traces:
-                    await trace.send_dns_cache_miss()
+                    await trace.send_dns_cache_miss(host)
             self._throttle_dns_events[key] = \
                 EventResultOrError(self._loop)
             try:
 
                 if traces:
                     for trace in traces:
-                        await trace.send_dns_resolvehost_start()
+                        await trace.send_dns_resolvehost_start(host)
 
                 addrs = await \
                     asyncio.shield(self._resolver.resolve(host,
@@ -706,7 +706,7 @@ class TCPConnector(BaseConnector):
                                    loop=self._loop)
                 if traces:
                     for trace in traces:
-                        await trace.send_dns_resolvehost_end()
+                        await trace.send_dns_resolvehost_end(host)
 
                 self._cached_hosts.add(key, addrs)
                 self._throttle_dns_events[key].set()

--- a/aiohttp/tracing.py
+++ b/aiohttp/tracing.py
@@ -14,7 +14,8 @@ __all__ = (
     'TraceConnectionQueuedEndParams', 'TraceConnectionCreateStartParams',
     'TraceConnectionCreateEndParams', 'TraceConnectionReuseconnParams',
     'TraceDnsResolveHostStartParams', 'TraceDnsResolveHostEndParams',
-    'TraceDnsCacheHitParams', 'TraceDnsCacheMissParams'
+    'TraceDnsCacheHitParams', 'TraceDnsCacheMissParams',
+    'TraceRequestRedirectParams'
 )
 
 

--- a/docs/client_advanced.rst
+++ b/docs/client_advanced.rst
@@ -225,10 +225,10 @@ disabled. The following snippet shows how the start and the end
 signals of a request flow can be followed::
 
     async def on_request_start(
-            session, trace_config_ctx, method, host, port, headers):
+            session, trace_config_ctx, params):
         print("Starting request")
 
-    async def on_request_end(session, trace_config_ctx, resp):
+    async def on_request_end(session, trace_config_ctx, params):
         print("Ending request")
 
     trace_config = aiohttp.TraceConfig()
@@ -259,10 +259,10 @@ share the state through to the different signals that belong to the
 same request and to the same :class:`TraceConfig` class, perhaps::
 
     async def on_request_start(
-            session, trace_config_ctx, method, host, port, headers):
+            session, trace_config_ctx, params):
         trace_config_ctx.start = session.loop.time()
 
-    async def on_request_end(session, trace_config_ctx, resp):
+    async def on_request_end(session, trace_config_ctx, params):
         elapsed = session.loop.time() - trace_config_ctx.start
         print("Request took {}".format(elapsed))
 
@@ -280,7 +280,7 @@ factory. This param is useful to pass data that is only available at
 request time, perhaps::
 
     async def on_request_start(
-            session, trace_config_ctx, method, host, port, headers):
+            session, trace_config_ctx, params):
         print(trace_config_ctx.trace_request_ctx)
 
 

--- a/docs/tracing_reference.rst
+++ b/docs/tracing_reference.rst
@@ -31,8 +31,8 @@ the request flow.
       Property that gives access to the signals that will be executed when a
       request starts, based on the :class:`aiohttp.signals.Signal` implementation.
 
-      The coroutines listening will receive as a param the ``session``,
-      ``trace_config_ctx`` and :class:`aiohttp.TraceRequestStartParams` params.
+      The signal handler signature is ``async def on_request_start(session, context, params): ...``
+      where ``params`` is :class:`aiohttp.TraceRequestStartParams` instance
 
       .. versionadded:: 3.0
 
@@ -41,8 +41,8 @@ the request flow.
       Property that gives access to the signals that will be executed when a
       redirect happens during a request flow.
 
-      The coroutines that are listening will receive the ``session``,
-      ``trace_config_ctx`` and :class:`aiohttp.TraceRequestRedirectParams` params.
+      The signal handler signature is ``async def on_request_start(session, context, params): ...``
+      where ``params`` is :class:`aiohttp.TraceRequestRedirectParams` instance
 
       .. versionadded:: 3.0
 
@@ -51,8 +51,8 @@ the request flow.
       Property that gives access to the signals that will be executed when a
       request ends.
 
-      The coroutines that are listening will receive the ``session``,
-      ``trace_config_ctx`` and :class:`aiohttp.TraceRequestEndParams` params.
+      The signal handler signature is ``async def on_request_start(session, context, params): ...``
+      where ``params`` is :class:`aiohttp.TraceRequestEndParams` instance
 
       .. versionadded:: 3.0
 
@@ -61,8 +61,8 @@ the request flow.
       Property that gives access to the signals that will be executed when a
       request finishes with an exception.
 
-      The coroutines listening will receive the ``session``,
-      ``trace_config_ctx`` and :class:`aiohttp.TraceRequestExceptionParams` params.
+      The signal handler signature is ``async def on_request_start(session, context, params): ...``
+      where ``params`` is :class:`aiohttp.TraceRequestExceptionParams` instance
 
       .. versionadded:: 3.0
 
@@ -71,8 +71,8 @@ the request flow.
       Property that gives access to the signals that will be executed when a
       request has been queued waiting for an available connection.
 
-      The coroutines that are listening will receive the ``session``,
-      ``trace_config_ctx`` and :class:`aiohttp.TraceConnectionQueuedStartParams` params.
+      The signal handler signature is ``async def on_request_start(session, context, params): ...``
+      where ``params`` is :class:`aiohttp.TraceConnectionQueuedStartParams` instance
 
       .. versionadded:: 3.0
 
@@ -81,8 +81,8 @@ the request flow.
       Property that gives access to the signals that will be executed when a
       request that was queued already has an available connection.
 
-      The coroutines that are listening will receive the ``session``,
-      ``trace_config_ctx`` and :class:`aiohttp.TraceConnectionQueuedEndParams` params.
+      The signal handler signature is ``async def on_request_start(session, context, params): ...``
+      where ``params`` is :class:`aiohttp.TraceConnectionQueuedEndParams` instance
 
       .. versionadded:: 3.0
 
@@ -91,8 +91,8 @@ the request flow.
       Property that gives access to the signals that will be executed when a
       request creates a new connection.
 
-      The coroutines listening will receive the ``session``,
-      ``trace_config_ctx`` and :class:`aiohttp.TraceConnectionCreateStartParams` params.
+      The signal handler signature is ``async def on_request_start(session, context, params): ...``
+      where ``params`` is :class:`aiohttp.TraceConnectionCreateStartParams` instance
 
       .. versionadded:: 3.0
 
@@ -101,8 +101,8 @@ the request flow.
       Property that gives access to the signals that will be executed when a
       request that created a new connection finishes its creation.
 
-      The coroutines listening will receive the ``session``,
-      ``trace_config_ctx`` and :class:`aiohttp.TraceConnectionCreateEndParams` params.
+      The signal handler signature is ``async def on_request_start(session, context, params): ...``
+      where ``params`` is :class:`aiohttp.TraceConnectionCreateEndParams` instance
 
       .. versionadded:: 3.0
 
@@ -111,8 +111,8 @@ the request flow.
       Property that gives access to the signals that will be executed when a
       request reuses a connection.
 
-      The coroutines listening will receive the ``session``,
-      ``trace_config_ctx`` and :class:`aiohttp.TraceConnectionReuseconnParams` params.
+      The signal handler signature is ``async def on_request_start(session, context, params): ...``
+      where ``params`` is :class:`aiohttp.TraceConnectionReuseconnParams` instance
 
       .. versionadded:: 3.0
 
@@ -121,8 +121,8 @@ the request flow.
       Property that gives access to the signals that will be executed when a
       request starts to resolve the domain related with the request.
 
-      The coroutines listening will receive the ``session``,
-      ``trace_config_ctx`` and :class:`aiohttp.TraceDnsResolveHostStartParams` params.
+      The signal handler signature is ``async def on_request_start(session, context, params): ...``
+      where ``params`` is :class:`aiohttp.TraceDnsResolveHostStartParams` instance
 
       .. versionadded:: 3.0
 
@@ -131,8 +131,8 @@ the request flow.
       Property that gives access to the signals that will be executed when a
       request finishes to resolve the domain related with the request.
 
-      The coroutines listening will receive the ``session``,
-      ``trace_config_ctx`` and :class:`aiohttp.TraceDnsResolveHostEndParams` params.
+      The signal handler signature is ``async def on_request_start(session, context, params): ...``
+      where ``params`` is :class:`aiohttp.TraceDnsResolveHostEndParams` instance
 
       .. versionadded:: 3.0
 
@@ -142,8 +142,8 @@ the request flow.
       request was able to use a cached DNS resolution for the domain related
       with the request.
 
-      The coroutines listening will receive the ``session``,
-      ``trace_config_ctx`` and :class:`aiohttp.TraceDnsCacheHitParams` params.
+      The signal handler signature is ``async def on_request_start(session, context, params): ...``
+      where ``params`` is :class:`aiohttp.TraceDnsCacheHitParams` instance
 
       .. versionadded:: 3.0
 
@@ -153,8 +153,8 @@ the request flow.
       request was not able to use a cached DNS resolution for the domain related
       with the request.
 
-      The coroutines listening will receive the ``session``,
-      ``trace_config_ctx`` and :class:`aiohttp.TraceDnsCacheMissParams` params.
+      The signal handler signature is ``async def on_request_start(session, context, params): ...``
+      where ``params`` is :class:`aiohttp.TraceDnsCacheMissParams` instance
 
       .. versionadded:: 3.0
 

--- a/docs/tracing_reference.rst
+++ b/docs/tracing_reference.rst
@@ -29,10 +29,10 @@ the request flow.
    .. attribute:: on_request_start
 
       Property that gives access to the signals that will be executed when a
-      request starts, based on the :class:`~signals.Signal` implementation.
+      request starts, based on the :class:`aiohttp.signals.Signal` implementation.
 
       The coroutines listening will receive as a param the ``session``,
-      ``trace_config_ctx``, ``method``, ``url`` and ``headers``.
+      ``trace_config_ctx`` and :class:`aiohttp.TraceRequestStartParams` params.
 
       .. versionadded:: 3.0
 
@@ -42,7 +42,7 @@ the request flow.
       redirect happens during a request flow.
 
       The coroutines that are listening will receive the ``session``,
-      ``trace_config_ctx``, ``method``, ``url``, ``headers`` and ``resp`` params.
+      ``trace_config_ctx`` and :class:`aiohttp.TraceRequestRedirectParams` params.
 
       .. versionadded:: 3.0
 
@@ -52,7 +52,7 @@ the request flow.
       request ends.
 
       The coroutines that are listening will receive the ``session``,
-      ``trace_config_ctx``, ``method``, ``url``, ``headers`` and ``resp`` params
+      ``trace_config_ctx`` and :class:`aiohttp.TraceRequestEndParams` params.
 
       .. versionadded:: 3.0
 
@@ -62,7 +62,7 @@ the request flow.
       request finishes with an exception.
 
       The coroutines listening will receive the ``session``,
-      ``trace_config_ctx``, ``method``, ``url``, ``headers`` and ``exception`` params.
+      ``trace_config_ctx`` and :class:`aiohttp.TraceRequestExceptionParams` params.
 
       .. versionadded:: 3.0
 
@@ -71,8 +71,8 @@ the request flow.
       Property that gives access to the signals that will be executed when a
       request has been queued waiting for an available connection.
 
-      The coroutines that are listening will receive the ``session`` and
-      ``trace_config_ctx`` params.
+      The coroutines that are listening will receive the ``session``,
+      ``trace_config_ctx`` and :class:`aiohttp.TraceConnectionQueuedStartParams` params.
 
       .. versionadded:: 3.0
 
@@ -81,8 +81,8 @@ the request flow.
       Property that gives access to the signals that will be executed when a
       request that was queued already has an available connection.
 
-      The coroutines that are listening will receive the ``session`` and
-      ``trace_config_ctx`` params.
+      The coroutines that are listening will receive the ``session``,
+      ``trace_config_ctx`` and :class:`aiohttp.TraceConnectionQueuedEndParams` params.
 
       .. versionadded:: 3.0
 
@@ -91,8 +91,8 @@ the request flow.
       Property that gives access to the signals that will be executed when a
       request creates a new connection.
 
-      The coroutines listening will receive the ``session`` and
-      ``trace_config_ctx`` params.
+      The coroutines listening will receive the ``session``,
+      ``trace_config_ctx`` and :class:`aiohttp.TraceConnectionCreateStartParams` params.
 
       .. versionadded:: 3.0
 
@@ -101,8 +101,8 @@ the request flow.
       Property that gives access to the signals that will be executed when a
       request that created a new connection finishes its creation.
 
-      The coroutines listening will receive the ``session`` and
-      ``trace_config_ctx`` params.
+      The coroutines listening will receive the ``session``,
+      ``trace_config_ctx`` and :class:`aiohttp.TraceConnectionCreateEndParams` params.
 
       .. versionadded:: 3.0
 
@@ -111,8 +111,8 @@ the request flow.
       Property that gives access to the signals that will be executed when a
       request reuses a connection.
 
-      The coroutines listening will receive the ``session`` and
-      ``trace_config_ctx`` params.
+      The coroutines listening will receive the ``session``,
+      ``trace_config_ctx`` and :class:`aiohttp.TraceConnectionReuseconnParams` params.
 
       .. versionadded:: 3.0
 
@@ -121,8 +121,8 @@ the request flow.
       Property that gives access to the signals that will be executed when a
       request starts to resolve the domain related with the request.
 
-      The coroutines listening will receive the ``session`` and
-      ``trace_config_ctx`` params.
+      The coroutines listening will receive the ``session``,
+      ``trace_config_ctx`` and :class:`aiohttp.TraceDnsResolveHostStartParams` params.
 
       .. versionadded:: 3.0
 
@@ -131,8 +131,8 @@ the request flow.
       Property that gives access to the signals that will be executed when a
       request finishes to resolve the domain related with the request.
 
-      The coroutines listening will receive the ``session`` and ``trace_config_ctx``
-      params.
+      The coroutines listening will receive the ``session``,
+      ``trace_config_ctx`` and :class:`aiohttp.TraceDnsResolveHostEndParams` params.
 
       .. versionadded:: 3.0
 
@@ -142,8 +142,8 @@ the request flow.
       request was able to use a cached DNS resolution for the domain related
       with the request.
 
-      The coroutines listening will receive the ``session`` and
-      ``trace_config_ctx`` params.
+      The coroutines listening will receive the ``session``,
+      ``trace_config_ctx`` and :class:`aiohttp.TraceDnsCacheHitParams` params.
 
       .. versionadded:: 3.0
 
@@ -153,7 +153,120 @@ the request flow.
       request was not able to use a cached DNS resolution for the domain related
       with the request.
 
-      The coroutines listening will receive the ``session`` and
-      ``trace_config_ctx`` params.
+      The coroutines listening will receive the ``session``,
+      ``trace_config_ctx`` and :class:`aiohttp.TraceDnsCacheMissParams` params.
 
       .. versionadded:: 3.0
+
+.. class:: TraceRequestStartParams
+
+   .. attribute:: method 
+
+       Method that will be used  to make the request.
+
+   .. attribute:: url
+
+       URL that will be used  for the request.
+
+   .. attribute:: headers
+
+       Headers that will be used for the request, can be mutated.
+
+.. class:: TraceRequestEndParams
+
+   .. attribute:: method 
+
+       Method used to make the request.
+
+   .. attribute:: url
+
+       URL used for the request.
+
+   .. attribute:: headers
+
+       Headers used for the request.
+
+   .. attribute:: resp
+
+       Response :class:`ClientReponse`.
+
+
+.. class:: TraceRequestExceptionParams
+
+   .. attribute:: method 
+
+       Method used to make the request.
+
+   .. attribute:: url
+
+       URL used for the request.
+
+   .. attribute:: headers
+
+       Headers used for the request.
+
+   .. attribute:: exception
+
+       Exception raised during the request.
+
+.. class:: TraceRequestRedirectParams
+
+   .. attribute:: method 
+
+       Method used to get this redirect request.
+
+   .. attribute:: url
+
+       URL used for this redirect request.
+
+   .. attribute:: headers
+
+       Headers used for this redirect.
+
+   .. attribute:: resp
+
+       Response :class:`ClientReponse` got from the redirect.
+
+.. class:: TraceConnectionQueuedStartParams
+
+       There are no attributes right now.
+
+.. class:: TraceConnectionQueuedEndParams
+
+       There are no attributes right now.
+
+.. class:: TraceConnectionCreateStartParams
+
+       There are no attributes right now.
+
+.. class:: TraceConnectionCreateEndParams
+
+       There are no attributes right now.
+
+.. class:: TraceConnectionReuseconnParams
+
+       There are no attributes right now.
+
+.. class:: TraceDnsResolveHostStartParams
+
+   .. attribute:: Host
+
+       Host that will be resolved.
+
+.. class:: TraceDnsResolveHostEndParams
+
+   .. attribute:: Host
+
+       Host that has been resolved.
+
+.. class:: TraceDnsCacheHitParams
+
+   .. attribute:: Host
+
+       Host found in the cache.
+
+.. class:: TraceDnsCacheMissParams
+
+   .. attribute:: Host
+
+       Host didn't find the cache.

--- a/tests/test_client_session.py
+++ b/tests/test_client_session.py
@@ -479,18 +479,22 @@ async def test_request_tracing(loop):
             on_request_start.assert_called_once_with(
                 session,
                 trace_config_ctx,
-                hdrs.METH_GET,
-                URL("http://example.com"),
-                CIMultiDict()
+                aiohttp.TraceRequestStartParams(
+                    hdrs.METH_GET,
+                    URL("http://example.com"),
+                    CIMultiDict()
+                )
             )
 
             on_request_end.assert_called_once_with(
                 session,
                 trace_config_ctx,
-                hdrs.METH_GET,
-                URL("http://example.com"),
-                CIMultiDict(),
-                resp
+                aiohttp.TraceRequestEndParams(
+                    hdrs.METH_GET,
+                    URL("http://example.com"),
+                    CIMultiDict(),
+                    resp
+                )
             )
             assert not on_request_redirect.called
 
@@ -524,10 +528,12 @@ async def test_request_tracing_exception(loop):
         on_request_exception.assert_called_once_with(
             session,
             mock.ANY,
-            hdrs.METH_GET,
-            URL("http://example.com"),
-            CIMultiDict(),
-            error
+            aiohttp.TraceRequestExceptionParams(
+                hdrs.METH_GET,
+                URL("http://example.com"),
+                CIMultiDict(),
+                error
+            )
         )
         assert not on_request_end.called
 
@@ -544,11 +550,8 @@ async def test_request_tracing_interpose_headers(loop):
     async def new_headers(
             session,
             trace_config_ctx,
-            method,
-            url,
-            headers,
-            trace_request_ctx=None):
-        headers['foo'] = 'bar'
+            data):
+        data.headers['foo'] = 'bar'
 
     trace_config = aiohttp.TraceConfig()
     trace_config.on_request_start.append(new_headers)

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -666,14 +666,17 @@ async def test_tcp_connector_dns_tracing(loop, dns_response):
         on_dns_resolvehost_start.assert_called_once_with(
             session,
             trace_config_ctx,
+            aiohttp.TraceDnsResolveHostStartParams('localhost')
         )
-        on_dns_resolvehost_start.assert_called_once_with(
+        on_dns_resolvehost_end.assert_called_once_with(
             session,
             trace_config_ctx,
+            aiohttp.TraceDnsResolveHostEndParams('localhost')
         )
         on_dns_cache_miss.assert_called_once_with(
             session,
             trace_config_ctx,
+            aiohttp.TraceDnsCacheMissParams('localhost')
         )
         assert not on_dns_cache_hit.called
 
@@ -685,6 +688,7 @@ async def test_tcp_connector_dns_tracing(loop, dns_response):
         on_dns_cache_hit.assert_called_once_with(
             session,
             trace_config_ctx,
+            aiohttp.TraceDnsCacheHitParams('localhost')
         )
 
 
@@ -738,21 +742,25 @@ async def test_tcp_connector_dns_tracing_cache_disabled(loop, dns_response):
         on_dns_resolvehost_start.assert_has_calls([
             mock.call(
                 session,
-                trace_config_ctx
+                trace_config_ctx,
+                aiohttp.TraceDnsResolveHostStartParams('localhost')
             ),
             mock.call(
                 session,
-                trace_config_ctx
+                trace_config_ctx,
+                aiohttp.TraceDnsResolveHostStartParams('localhost')
             )
         ])
         on_dns_resolvehost_end.assert_has_calls([
             mock.call(
                 session,
-                trace_config_ctx
+                trace_config_ctx,
+                aiohttp.TraceDnsResolveHostEndParams('localhost')
             ),
             mock.call(
                 session,
-                trace_config_ctx
+                trace_config_ctx,
+                aiohttp.TraceDnsResolveHostEndParams('localhost')
             )
         ])
 
@@ -793,11 +801,13 @@ async def test_tcp_connector_dns_tracing_throttle_requests(loop, dns_response):
         await asyncio.sleep(0, loop=loop)
         on_dns_cache_hit.assert_called_once_with(
             session,
-            trace_config_ctx
+            trace_config_ctx,
+            aiohttp.TraceDnsCacheHitParams('localhost')
         )
         on_dns_cache_miss.assert_called_once_with(
             session,
-            trace_config_ctx
+            trace_config_ctx,
+            aiohttp.TraceDnsCacheMissParams('localhost')
         )
 
 
@@ -933,11 +943,13 @@ async def test_connect_tracing(loop):
     await conn.connect(req, traces=traces)
     on_connection_create_start.assert_called_with(
         session,
-        trace_config_ctx
+        trace_config_ctx,
+        aiohttp.TraceConnectionCreateStartParams()
     )
     on_connection_create_end.assert_called_with(
         session,
-        trace_config_ctx
+        trace_config_ctx,
+        aiohttp.TraceConnectionCreateEndParams()
     )
 
 
@@ -1333,11 +1345,13 @@ async def test_connect_queued_operation_tracing(loop, key):
         )
         on_connection_queued_start.assert_called_with(
             session,
-            trace_config_ctx
+            trace_config_ctx,
+            aiohttp.TraceConnectionQueuedStartParams()
         )
         on_connection_queued_end.assert_called_with(
             session,
-            trace_config_ctx
+            trace_config_ctx,
+            aiohttp.TraceConnectionQueuedEndParams()
         )
         connection2.release()
 
@@ -1381,7 +1395,8 @@ async def test_connect_reuseconn_tracing(loop, key):
 
     on_connection_reuseconn.assert_called_with(
         session,
-        trace_config_ctx
+        trace_config_ctx,
+        aiohttp.TraceConnectionReuseconnParams()
     )
     conn.close()
 

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -5,6 +5,21 @@ from unittest.mock import Mock
 import pytest
 
 from aiohttp.tracing import Trace, TraceConfig
+from aiohttp.tracing import (
+    TraceRequestStartParams,
+    TraceRequestEndParams,
+    TraceRequestExceptionParams,
+    TraceRequestRedirectParams,
+    TraceConnectionQueuedStartParams,
+    TraceConnectionQueuedEndParams,
+    TraceConnectionCreateStartParams,
+    TraceConnectionCreateEndParams,
+    TraceConnectionReuseconnParams,
+    TraceDnsResolveHostStartParams,
+    TraceDnsResolveHostEndParams,
+    TraceDnsCacheHitParams,
+    TraceDnsCacheMissParams
+)
 
 
 class TestTraceConfig:
@@ -45,23 +60,74 @@ class TestTraceConfig:
 
 class TestTrace:
 
-    @pytest.mark.parametrize('signal', [
-        'request_start',
-        'request_end',
-        'request_exception',
-        'request_redirect',
-        'connection_queued_start',
-        'connection_queued_end',
-        'connection_create_start',
-        'connection_create_end',
-        'connection_reuseconn',
-        'dns_resolvehost_start',
-        'dns_resolvehost_end',
-        'dns_cache_hit',
-        'dns_cache_miss'
+    @pytest.mark.parametrize('signal,params,param_obj', [
+        (
+            'request_start',
+            (Mock(), Mock(), Mock()),
+            TraceRequestStartParams
+        ),
+        (
+            'request_end',
+            (Mock(), Mock(), Mock(), Mock()),
+            TraceRequestEndParams
+        ),
+        (
+            'request_exception',
+            (Mock(), Mock(), Mock(), Mock()),
+            TraceRequestExceptionParams
+        ),
+        (
+            'request_redirect',
+            (Mock(), Mock(), Mock(), Mock()),
+            TraceRequestRedirectParams
+        ),
+        (
+            'connection_queued_start',
+            (),
+            TraceConnectionQueuedStartParams
+        ),
+        (
+            'connection_queued_end',
+            (),
+            TraceConnectionQueuedEndParams
+        ),
+        (
+            'connection_create_start',
+            (),
+            TraceConnectionCreateStartParams
+        ),
+        (
+            'connection_create_end',
+            (),
+            TraceConnectionCreateEndParams
+        ),
+        (
+            'connection_reuseconn',
+            (),
+            TraceConnectionReuseconnParams
+        ),
+        (
+            'dns_resolvehost_start',
+            (Mock(),),
+            TraceDnsResolveHostStartParams
+        ),
+        (
+            'dns_resolvehost_end',
+            (Mock(),),
+            TraceDnsResolveHostEndParams
+        ),
+        (
+            'dns_cache_hit',
+            (Mock(),),
+            TraceDnsCacheHitParams
+        ),
+        (
+            'dns_cache_miss',
+            (Mock(),),
+            TraceDnsCacheMissParams
+        )
     ])
-    async def test_send(self, loop, signal):
-        param = Mock()
+    async def test_send(self, loop, signal, params, param_obj):
         session = Mock()
         trace_request_ctx = Mock()
         callback = Mock(side_effect=asyncio.coroutine(Mock()))
@@ -74,10 +140,10 @@ class TestTrace:
             trace_config,
             trace_config.trace_config_ctx(trace_request_ctx=trace_request_ctx)
         )
-        await getattr(trace, "send_%s" % signal)(param)
+        await getattr(trace, "send_%s" % signal)(*params)
 
         callback.assert_called_once_with(
             session,
             SimpleNamespace(trace_request_ctx=trace_request_ctx),
-            param,
+            param_obj(*params)
         )

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -4,22 +4,19 @@ from unittest.mock import Mock
 
 import pytest
 
-from aiohttp.tracing import Trace, TraceConfig
-from aiohttp.tracing import (
-    TraceRequestStartParams,
-    TraceRequestEndParams,
-    TraceRequestExceptionParams,
-    TraceRequestRedirectParams,
-    TraceConnectionQueuedStartParams,
-    TraceConnectionQueuedEndParams,
-    TraceConnectionCreateStartParams,
-    TraceConnectionCreateEndParams,
-    TraceConnectionReuseconnParams,
-    TraceDnsResolveHostStartParams,
-    TraceDnsResolveHostEndParams,
-    TraceDnsCacheHitParams,
-    TraceDnsCacheMissParams
-)
+from aiohttp.tracing import (Trace, TraceConfig,
+                             TraceConnectionCreateEndParams,
+                             TraceConnectionCreateStartParams,
+                             TraceConnectionQueuedEndParams,
+                             TraceConnectionQueuedStartParams,
+                             TraceConnectionReuseconnParams,
+                             TraceDnsCacheHitParams, TraceDnsCacheMissParams,
+                             TraceDnsResolveHostEndParams,
+                             TraceDnsResolveHostStartParams,
+                             TraceRequestEndParams,
+                             TraceRequestExceptionParams,
+                             TraceRequestRedirectParams,
+                             TraceRequestStartParams)
 
 
 class TestTraceConfig:


### PR DESCRIPTION
## What do these changes do?

This will allow Aiohttp development add new parameters in the future without
break the signals signature.

## Are there changes in behavior for the user?

Yes

## Related issue number

#2686

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes