### PR TITLE
Added check install idna-ssl or not on Python3.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -63,8 +63,11 @@ with codecs.open(os.path.join(os.path.abspath(os.path.dirname(
 
 
 install_requires = ['chardet', 'multidict>=4.0.0',
-                    'async_timeout>=1.2.0', 'yarl>=1.0.0',
-                    'idna-ssl>=1.0.0']
+                    'async_timeout>=1.2.0', 'yarl>=1.0.0']
+
+
+if sys.version_info < (3, 7):
+    install_requires.append('idna-ssl>=1.0.0')
 
 
 def read(f):


### PR DESCRIPTION
## What do these changes do?

idna_ssl is not installed on Python3.7 as dependency 

otherwise on Python3.7 will be

```bash
idna-ssl requires Python '<3.7.0' but the running Python is 3.7.0
```