### PR TITLE
Fix typo from `pyenv` to `pyvenv`

### DIFF
--- a/docs/deployment.rst
+++ b/docs/deployment.rst
@@ -214,7 +214,7 @@ Create a directory for your application::
   >> mkdir myapp
   >> cd myapp
 
-`Ubuntu` has a bug in pyenv, so to create virtualenv you need to do some
+`Ubuntu` has a bug in pyvenv, so to create virtualenv you need to do some
 extra manipulation::
 
   >> pyvenv-3.4 --without-pip venv

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -190,6 +190,7 @@ pyenv
 pyflakes
 pytest
 Pytest
+pyvenv
 Quickstart
 quote’s
 readonly


### PR DESCRIPTION
## What do these changes do?

Fix a typo, [`pyenv`](https://github.com/pyenv/pyenv) is different from [`pyvenv`](https://docs.python.org/3/library/venv.html?highlight=pyvenv)

## Related issue number

N/A, trivial update
