### PR TITLE
Fix bug while installing in non utf-8 environment

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ if sys.version_info < (3, 7):
 
 
 def read(f):
-    return open(os.path.join(os.path.dirname(__file__), f)).read().strip()
+    return open(os.path.join(os.path.dirname(__file__), f), 'r', encoding='utf-8').read().strip()
 
 
 class PyTest(TestCommand):


### PR DESCRIPTION
## What do these changes do

Set explicit encoding while opening file in setup.py

## Are there changes in behavior for the user ?

Enable installation in non-utf8 environment

## Issue / error description

I get this error since last release (v3.0.0)

```
Traceback (most recent call last):
    File "<string>", line 1, in <module>
    File "/tmp/pip-build-it7otfyc/aiohttp/setup.py", line 95, in <module>
    long_description='\n\n'.join((read('README.rst'), read('CHANGES.rst'))),
    File "/tmp/pip-build-it7otfyc/aiohttp/setup.py", line 76, in read
    return open(os.path.join(os.path.dirname(__file__), f)).read().strip()
    File "/usr/lib/python3.6/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xef in position 3650: ordinal not in range(128)
```