### PR TITLE
Document encoding detection behavior for unknown encodings.

### DIFF
--- a/CHANGES/2732.doc
+++ b/CHANGES/2732.doc
@@ -1,0 +1,1 @@
+Document behavior when cchardet detects encodings that are unknown to Python.

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -1170,6 +1170,9 @@ Response object
 
       :return str: decoded *BODY*
 
+      :raise LookupError: if the encoding detected by chardet or cchardet is
+                          unknown by Python (e.g. VISCII).
+
       .. note::
 
          If response has no ``charset`` info in ``Content-Type`` HTTP
@@ -1222,6 +1225,10 @@ Response object
       ``Content-Type`` HTTP header. If this info is not exists or there
       are no appropriate codecs for encoding then :term:`cchardet` /
       :term:`chardet` is used.
+
+      Beware that it is not always safe to use the result of this function to
+      decode a response. Some encodings detected by cchardet are not known by
+      Python (e.g. VISCII).
 
       .. versionadded:: 3.0
 


### PR DESCRIPTION
Closes #2732

## What do these changes do?

Document that sometimes, cchardet might detect encodings that Python doesn't know. In such cases, `.text()` function might raise a `LookupError`, and `get_encoding` may return values that are unsafe to pass to `bytes.decode()` or to `.text()` functions.

## Are there changes in behavior for the user?

No.

## Related issue number

#2732 

## Checklist

- NA I think the code is well written
- NA Unit tests for the changes exist
- NA Documentation reflects the changes
- [X] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [X] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
