### PR TITLE
Implement dynamic prefix for subapps

### DIFF
--- a/CHANGES/2756.feature
+++ b/CHANGES/2756.feature
@@ -1,1 +1,1 @@
-Allow use of variables in subapp prefixes.
+Allow use of variables in sub-application prefixes.

--- a/CHANGES/2756.feature
+++ b/CHANGES/2756.feature
@@ -1,0 +1,1 @@
+Allow use of variables in subapp prefixes.

--- a/aiohttp/abc.py
+++ b/aiohttp/abc.py
@@ -62,6 +62,10 @@ class AbstractMatchInfo(ABC):
         """Add application to the nested apps stack."""
 
     @abstractmethod
+    def add_map(self, match_dict):
+        """Add matched variables to the nested apps stack."""
+
+    @abstractmethod
     def freeze(self):
         """Freeze the match info.
 

--- a/aiohttp/web_app.py
+++ b/aiohttp/web_app.py
@@ -13,7 +13,9 @@ from .web_middlewares import _fix_request_current_app
 from .web_request import Request
 from .web_response import StreamResponse
 from .web_server import Server
-from .web_urldispatcher import PrefixedSubAppResource, UrlDispatcher
+from .web_urldispatcher import (DynamicSubAppResource,
+                                PrefixedSubAppResource,
+                                UrlDispatcher, ROUTE_RE)
 
 
 __all__ = ('Application', 'CleanupError')
@@ -190,7 +192,10 @@ class Application(MutableMapping):
         if prefix in ('', '/'):
             raise ValueError("Prefix cannot be empty")
 
-        resource = PrefixedSubAppResource(prefix, subapp)
+        if not ('{' in prefix or '}' in prefix or ROUTE_RE.search(prefix)):
+            resource = PrefixedSubAppResource(prefix, subapp)
+        else:
+            resource = DynamicSubAppResource(prefix, subapp)
         self.router.register_resource(resource)
         self._reg_subapp_signals(subapp)
         self._subapps.append(subapp)

--- a/aiohttp/web_app.py
+++ b/aiohttp/web_app.py
@@ -180,7 +180,7 @@ class Application(MutableMapping):
         reg_handler('on_shutdown')
         reg_handler('on_cleanup')
 
-    def add_subapp(self, prefix, subapp):
+    def add_subapp(self, prefix, subapp, *, name=None):
         if self.frozen:
             raise RuntimeError(
                 "Cannot add sub application to frozen application")
@@ -192,9 +192,9 @@ class Application(MutableMapping):
             raise ValueError("Prefix cannot be empty")
 
         if not ('{' in prefix or '}' in prefix or ROUTE_RE.search(prefix)):
-            resource = PrefixedSubAppResource(prefix, subapp)
+            resource = PrefixedSubAppResource(prefix, subapp, name=name)
         else:
-            resource = DynamicSubAppResource(prefix, subapp)
+            resource = DynamicSubAppResource(prefix, subapp, name=name)
         self.router.register_resource(resource)
         self._reg_subapp_signals(subapp)
         self._subapps.append(subapp)

--- a/aiohttp/web_app.py
+++ b/aiohttp/web_app.py
@@ -13,9 +13,8 @@ from .web_middlewares import _fix_request_current_app
 from .web_request import Request
 from .web_response import StreamResponse
 from .web_server import Server
-from .web_urldispatcher import (DynamicSubAppResource,
-                                PrefixedSubAppResource,
-                                UrlDispatcher, ROUTE_RE)
+from .web_urldispatcher import (ROUTE_RE, DynamicSubAppResource,
+                                PrefixedSubAppResource, UrlDispatcher)
 
 
 __all__ = ('Application', 'CleanupError')

--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -690,11 +690,6 @@ class PrefixedSubAppResource(PrefixResource):
         for subresource in app.router.resources():
             subresource.add_prefix(self)
 
-    def add_prefix(self, resource):
-        super().add_prefix(resource)
-        for subresource in self._app.router.resources():
-            subresource.add_prefix(self)
-
     def get_info(self):
         return {'app': self._app,
                 'prefix': self._prefix}
@@ -732,18 +727,12 @@ class DynamicSubAppResource(DynamicResource):
         assert len(prefix) > 1
         super().__init__(prefix, name=name)
         self._app = app
-        self._prefix = prefix
         for subresource in app.router.resources():
-            subresource.add_prefix(self)
-
-    def add_prefix(self, resource):
-        super().add_prefix(resource)
-        for subresource in self._app.router.resources():
             subresource.add_prefix(self)
 
     def get_info(self):
         info = {'app': self._app,
-                'prefix': self._prefix}
+                'prefix': self._formatter}
         if self._name:
             info['name'] = self._name
         return info
@@ -791,9 +780,9 @@ class DynamicSubAppResource(DynamicResource):
     def __repr__(self):
         if self._name:
             return "<DynamicSubAppResource {name} {prefix} -> {app!r}>".format(
-                name=self._name, prefix=self._prefix, app=self._app)
+                name=self._name, prefix=self._formatter, app=self._app)
         return "<DynamicSubAppResource {prefix} -> {app!r}>".format(
-            prefix=self._prefix, app=self._app)
+            prefix=self._formatter, app=self._app)
 
 
 class ResourceRoute(AbstractRoute):

--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -106,7 +106,7 @@ class AbstractResource(Sized, Iterable):
         Return (UrlMappingMatchInfo, allowed_methods) pair."""
 
     @abc.abstractmethod
-    def add_prefix(self, prefix):
+    def add_prefix(self, resource):
         """Add a prefix to processed URLs.
 
         Required for subapplications support.
@@ -365,16 +365,18 @@ class PlainResource(Resource):
         super().__init__(name=name)
         assert not path or path.startswith('/')
         self._path = path
+        self._parent = None
 
     def freeze(self):
         if not self._path:
             self._path = '/'
 
-    def add_prefix(self, prefix):
-        assert prefix.startswith('/')
-        assert not prefix.endswith('/')
-        assert len(prefix) > 1
-        self._path = prefix + self._path
+    def add_prefix(self, resource):
+        self._parent = resource
+        # assert prefix.startswith('/')
+        # assert not prefix.endswith('/')
+        # assert len(prefix) > 1
+        # self._path = prefix + self._path
 
     def _match(self, path):
         # string comparison is about 10 times faster than regexp matching
@@ -389,8 +391,9 @@ class PlainResource(Resource):
     def get_info(self):
         return {'path': self._path}
 
-    def url_for(self):
-        return URL.build(path=self._path, encoded=True)
+    def url_for(self, **kwargs):
+        prefix = self._parent.url_for(**kwargs).path if self._parent else ''
+        return URL.build(path=prefix + self._path, encoded=True)
 
     def __repr__(self):
         name = "'" + self.name + "' " if self.name is not None else ""
@@ -438,13 +441,15 @@ class DynamicResource(Resource):
         assert formatter.startswith('/')
         self._pattern = compiled
         self._formatter = formatter
+        self._parent = None
 
-    def add_prefix(self, prefix):
-        assert prefix.startswith('/')
-        assert not prefix.endswith('/')
-        assert len(prefix) > 1
-        self._pattern = re.compile(re.escape(prefix)+self._pattern.pattern)
-        self._formatter = prefix + self._formatter
+    def add_prefix(self, resource):
+        self._parent = resource
+        # assert prefix.startswith('/')
+        # assert not prefix.endswith('/')
+        # assert len(prefix) > 1
+        # self._pattern = re.compile(re.escape(prefix)+self._pattern.pattern)
+        # self._formatter = prefix + self._formatter
 
     def _match(self, path):
         match = self._pattern.fullmatch(path)
@@ -462,9 +467,10 @@ class DynamicResource(Resource):
                 'pattern': self._pattern}
 
     def url_for(self, **parts):
+        prefix = self._parent.url_for(**parts).path if self._parent else ''
         url = self._formatter.format_map({k: URL.build(path=v).raw_path
                                           for k, v in parts.items()})
-        return URL.build(path=url)
+        return URL.build(path=prefix + url)
 
     def __repr__(self):
         name = "'" + self.name + "' " if self.name is not None else ""
@@ -478,16 +484,23 @@ class PrefixResource(AbstractResource):
         assert not prefix or prefix.startswith('/'), prefix
         assert prefix in ('', '/') or not prefix.endswith('/'), prefix
         super().__init__(name=name)
-        self._prefix = URL.build(path=prefix).raw_path
+        self._parent = None
+        self._prefix = prefix
+        # self._path_prefix = URL.build(path=prefix).raw_path
 
-    def add_prefix(self, prefix):
-        assert prefix.startswith('/')
-        assert not prefix.endswith('/')
-        assert len(prefix) > 1
-        self._prefix = prefix + self._prefix
+    def add_prefix(self, resource):
+        self._parent = resource
+        # assert prefix.startswith('/')
+        # assert not prefix.endswith('/')
+        # assert len(prefix) > 1
+        # self._parent = prefix + self._parent
 
     def raw_match(self, prefix):
         return False
+
+    def url_for(self, **parts):
+        prefix = self._parent.url_for(**parts).path if self._parent else ''
+        return URL.build(path=prefix + self._prefix, encoded=True)
 
     # TODO: impl missing abstract methods
 
@@ -523,7 +536,7 @@ class StaticResource(PrefixResource):
                         'HEAD': ResourceRoute('HEAD', self._handle, self,
                                               expect_handler=expect_handler)}
 
-    def url_for(self, *, filename, append_version=None):
+    def url_for(self, *, filename, append_version=None, **kwargs):
         if append_version is None:
             append_version = self._append_version
         if isinstance(filename, Path):
@@ -533,7 +546,8 @@ class StaticResource(PrefixResource):
         filename = '/' + filename
 
         # filename is not encoded
-        url = URL.build(path=self._prefix + filename)
+        prefix = self._parent.url_for(**kwargs).path if self._parent else ''
+        url = URL.build(path=prefix + self._prefix + filename)
 
         if append_version is True:
             try:
@@ -680,26 +694,24 @@ class PrefixedSubAppResource(PrefixResource):
     def __init__(self, prefix, app):
         super().__init__(prefix)
         self._app = app
-        for resource in app.router.resources():
-            resource.add_prefix(prefix)
+        for subresource in app.router.resources():
+            subresource.add_prefix(self)
 
-    def add_prefix(self, prefix):
-        super().add_prefix(prefix)
-        for resource in self._app.router.resources():
-            resource.add_prefix(prefix)
-
-    def url_for(self, *args, **kwargs):
-        raise RuntimeError(".url_for() is not supported "
-                           "by sub-application root")
+    def add_prefix(self, resource):
+        super().add_prefix(resource)
+        for subresource in self._app.router.resources():
+            subresource.add_prefix(resource)
 
     def get_info(self):
         return {'app': self._app,
                 'prefix': self._prefix}
 
     async def resolve(self, request):
-        if not request.url.raw_path.startswith(self._prefix):
+        if not request.url.path.startswith(self._prefix):
             return None, set()
-        match_info = await self._app.router.resolve(request)
+        subpath = request.url.path[len(self._prefix):]
+        subrequest = request.clone(rel_url=request.url.with_path(subpath))
+        match_info = await self._app.router.resolve(subrequest)
         match_info.add_app(self._app)
         match_info.add_map({})
         if isinstance(match_info.http_exception, HTTPMethodNotAllowed):
@@ -726,10 +738,6 @@ class DynamicSubAppResource(DynamicResource):
         self._app = app
         self._prefix = prefix
 
-    def url_for(self, *args, **kwargs):
-        raise RuntimeError(".url_for() is not supported "
-                           "by sub-application root")
-
     def get_info(self):
         return {'app': self._app,
                 'prefix': self._prefix}
@@ -745,11 +753,11 @@ class DynamicSubAppResource(DynamicResource):
             return mdict, match.end()
 
     async def resolve(self, request):
-        mdict, mend = self._match(request.url.raw_path)
+        mdict, mend = self._match(request.url.path)
         if mdict is None:
             return None, set()
         subrequest = request.clone(
-            rel_url=request.url.with_path(request.url.raw_path[mend:]))
+            rel_url=request.url.with_path(request.url.path[mend:]))
         match_info = await self._app.router.resolve(subrequest)
         match_info.add_app(self._app)
         match_info.add_map(mdict)

--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -389,8 +389,8 @@ class PlainResource(Resource):
     def get_info(self):
         return {'path': self._path}
 
-    def url_for(self, **kwargs):
-        prefix = self._parent.url_for(**kwargs).raw_path if self._parent else ''
+    def url_for(self, **parts):
+        prefix = self._parent.url_for(**parts).raw_path if self._parent else ''
         return URL.build(path=prefix + self._path, encoded=True)
 
     def __repr__(self):
@@ -526,7 +526,7 @@ class StaticResource(PrefixResource):
                         'HEAD': ResourceRoute('HEAD', self._handle, self,
                                               expect_handler=expect_handler)}
 
-    def url_for(self, *, filename, append_version=None, **kwargs):
+    def url_for(self, *, filename, append_version=None, **parts):
         if append_version is None:
             append_version = self._append_version
         if isinstance(filename, Path):
@@ -536,7 +536,7 @@ class StaticResource(PrefixResource):
         filename = '/' + filename
 
         # filename is not encoded
-        prefix = self._parent.url_for(**kwargs).path if self._parent else ''
+        prefix = self._parent.url_for(**parts).path if self._parent else ''
         url = URL.build(path=prefix + self._prefix + filename)
 
         if append_version is True:

--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -682,6 +682,7 @@ class PrefixedSubAppResource(PrefixResource):
         if not request.url.raw_path.startswith(self._prefix):
             return None, set()
         match_info = await self._app.router.resolve(request)
+        match_info.maps.append({})
         match_info.add_app(self._app)
         if isinstance(match_info.http_exception, HTTPMethodNotAllowed):
             methods = match_info.http_exception.allowed_methods

--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -197,7 +197,7 @@ class AbstractRoute(abc.ABC):
         return await self._expect_handler(request)
 
 
-class UrlMappingMatchInfo(dict, AbstractMatchInfo):
+class UrlMappingMatchInfo(collections.ChainMap, AbstractMatchInfo):
 
     def __init__(self, match_dict, route):
         super().__init__(match_dict)
@@ -256,7 +256,7 @@ class UrlMappingMatchInfo(dict, AbstractMatchInfo):
         self._frozen = True
 
     def __repr__(self):
-        return "<MatchInfo {}: {}>".format(super().__repr__(), self._route)
+        return "<MatchInfo {}: {}>".format(dict(self).__repr__(), self._route)
 
 
 class MatchInfoError(UrlMappingMatchInfo):
@@ -732,9 +732,7 @@ class DynamicSubAppResource(DynamicResource):
         subrequest = request.clone(
             rel_url=request.url.with_path(request.url.raw_path[mend:]))
         match_info = await self._app.router.resolve(subrequest)
-        for k, v in mdict.items():
-            if k not in match_info:
-                match_info[k] = v
+        match_info.maps.append(mdict)
         match_info.add_app(self._app)
         if isinstance(match_info.http_exception, HTTPMethodNotAllowed):
             methods = match_info.http_exception.allowed_methods

--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -707,11 +707,6 @@ class DynamicSubAppResource(DynamicResource):
         self._app = app
         self._prefix = prefix
 
-    def add_prefix(self, prefix):
-        super().add_prefix(prefix)
-        for resource in self._app.router.resources():
-            resource.add_prefix(prefix)
-
     def url_for(self, *args, **kwargs):
         raise RuntimeError(".url_for() is not supported "
                            "by sub-application root")

--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -258,6 +258,8 @@ class UrlMappingMatchInfo(AbstractMatchInfo, Mapping):
         for k, v in match_dict.items():
             if name:
                 k = (name + '.' + k)
+            if k in self._variables:
+                continue
             self._variables[k] = v
 
     def freeze(self):

--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -329,6 +329,8 @@ class Resource(AbstractResource):
         return route_obj
 
     def add_prefix(self, resource):
+        assert self._parent is None, \
+            'This app instance already has a prefix resource.'
         assert isinstance(resource,
                           (PrefixedSubAppResource, DynamicSubAppResource))
         self._parent = resource
@@ -481,6 +483,8 @@ class PrefixResource(AbstractResource):
         self._prefix = URL.build(path=prefix).raw_path
 
     def add_prefix(self, resource):
+        assert self._parent is None, \
+            'This app instance already has a prefix resource.'
         assert isinstance(resource,
                           (PrefixedSubAppResource, DynamicSubAppResource))
         self._parent = resource

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -160,6 +160,7 @@ Nagle’s
 namedtuple
 nameservers
 namespace
+namespaces
 nginx
 Nginx
 Nikolay
@@ -237,6 +238,7 @@ ssl
 SSLContext
 startup
 subapplication
+subapplications
 subclasses
 submodules
 subpackage

--- a/docs/web_advanced.rst
+++ b/docs/web_advanced.rst
@@ -696,6 +696,23 @@ use the following explicit technique::
        admin = request.app['admin']
        url = admin.router['name'].url_for()
 
+You may use variables in the subapplication prefixes, with optional
+dot-separated variable namespaces::
+
+   admin = web.Application()
+   admin.add_routes([web.get('/revision/{version:\d+}', handler, name='name')])
+
+   app.add_subapp('/v{version:\d+}/admin', admin, name='admin')
+   app['admin'] = admin
+
+   async def handler(request):  # main application's handler
+       admin = request.app['admin']
+       api_ver = request.match_info['admin.version']
+       revision = request.match_info['version']
+       url = admin.router['name'].url_for(**{
+           'admin.version': '123',
+           'version': '456'})
+
 .. _aiohttp-web-expect-header:
 
 *Expect* Header

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -2354,18 +2354,6 @@ In general the result may be any object derived from
       A tuple of :class:`Application` instances matched through the resolving
       process.  The innermost application comes at last.
 
-   .. attribute:: maps
-
-      A tuple of :class:`dict` instances where each instance corresponds to the
-      variables matched for each dynamic prefix of in the nested application
-      hierarchy.  The match dict of the innermost match comes at last.
-      Static prefixes without any variable insert an empty dict here.
-
-      This provides a decomposed view of the match info, while the match info
-      provides a merged view where innermost variables override outer variables
-      with duplicate names defined from dynamic prefixes in different levels of
-      the hierarchy.
-
 
 View
 ^^^^

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -1357,7 +1357,7 @@ duplicated like one using :meth:`Application.copy`.
       You may use variables in *prefix*. If a matched resource in the
       sub-application defines another variable with the same name, the
       sub-application's match result will override the *prefix*'s match result.
-      In web handlers, all overriden results can be accessed via ``maps``
+      In web handlers, all overridden results can be accessed via ``maps``
       attribute of ``request.match_info`` object as it is a merged view
       (:class:`collections.ChainMap`) of all nested dynamically prefixed
       sub-applications in the reversed order.

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -1347,7 +1347,7 @@ duplicated like one using :meth:`Application.copy`.
 
       .. seealso:: :ref:`aiohttp-web-cleanup-ctx`.
 
-   .. method:: add_subapp(prefix, subapp)
+   .. method:: add_subapp(prefix, subapp, *, name=None)
 
       Register nested sub-application under given path *prefix*.
 
@@ -1358,16 +1358,25 @@ duplicated like one using :meth:`Application.copy`.
       matched variables defined by this *prefix* along with the variables
       defined by the matched resource.
 
-      If there are variables with duplicate names in prefixes and resources,
-      the innermost values are exposed on the match info, but you still have
-      access to the overridden values via its ``maps`` property.
+      When one or more variables in the subapplication chain have a same name,
+      the innermost matched value survives.
+      If you set explicit *name* here, variables in the subapplication prefixes
+      are prefixed with ``"name."``.
 
       :param str prefix: path's prefix for the resource.
 
       :param Application subapp: nested application attached under *prefix*.
 
+      :param str name: name for the subapplication resource which prefixes
+                       variables with *prefix*.
+
       :returns: a :class:`PrefixedSubAppResource` or
                 :class:`DynamicSubAppResource` instance.
+
+      .. versionchanged:: 3.1
+
+         *prefix* may have variables and they can be prefixed with *name*
+         when read from ``request.match_info`` and passed to ``route.url_for``.
 
    .. method:: add_routes(routes_table)
 
@@ -1848,6 +1857,11 @@ Resource classes hierarchy::
       *args* and **kwargs** depend on a parameters list accepted by
       inherited resource class.
 
+      When the resource has multiple dynamic subapplication prefixes, you
+      should also provide variables defined in them.
+      If subapplications are added with explicit names, then **kwargs** should
+      have keys prefixed with ``"name."`` for all occurring names.
+
       :return: :class:`~yarl.URL` -- resulting URL instance.
 
 
@@ -1943,20 +1957,12 @@ Resource classes hierarchy::
    A resource for serving nested applications. The class instance is
    returned by :class:`~aiohttp.web.Application.add_subapp` call.
 
-   .. method:: url_for(**kwargs)
-
-      The call is not allowed, it raises :exc:`RuntimeError`.
-
 
 .. class:: DynamicSubAppResource
 
    A resource for serving nested applications with dynamic variables in its prefix.
    The class instance is returned by
    :class:`~aiohttp.web.Application.add_subapp` call.
-
-   .. method:: url_for(**kwargs)
-
-      The call is not allowed, it raises :exc:`RuntimeError`.
 
 
 .. _aiohttp-web-route:

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -1357,6 +1357,10 @@ duplicated like one using :meth:`Application.copy`.
       You may use variables in *prefix*. If a matched resource in the
       sub-application defines another variable with the same name, the
       sub-application's match result will override the *prefix*'s match result.
+      In web handlers, all overriden results can be accessed via ``maps``
+      attribute of ``request.match_info`` object as it is a merged view
+      (:class:`collections.ChainMap`) of all nested dynamically prefixed
+      sub-applications in the reversed order.
 
       :param str prefix: path's prefix for the resource.
 
@@ -2306,8 +2310,8 @@ In general the result may be any object derived from
 
 .. class:: UrlMappingMatchInfo
 
-   Inherited from :class:`dict` and :class:`AbstractMatchInfo`. Dict
-   items are filled by matching info and is :term:`resource`\-specific.
+   Inherited from :class:`collections.ChainMap` and :class:`AbstractMatchInfo`.
+   Dict items are filled by matching info and is :term:`resource`\-specific.
 
    .. attribute:: expect_handler
 

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -1354,6 +1354,10 @@ duplicated like one using :meth:`Application.copy`.
       In resolving process if request's path starts with *prefix* then
       further resolving is passed to *subapp*.
 
+      You may use variables in *prefix*. If a matched resource in the
+      sub-application defines another variable with the same name, the
+      sub-application's match result will override the *prefix*'s match result.
+
       :param str prefix: path's prefix for the resource.
 
       :param Application subapp: nested application attached under *prefix*.

--- a/tests/test_client_request.py
+++ b/tests/test_client_request.py
@@ -352,7 +352,7 @@ def test_basic_auth_from_url(make_request):
     assert 'python.org' == req.host
 
 
-def test_basic_auth_from_url_overriden(make_request):
+def test_basic_auth_from_url_overridden(make_request):
     req = make_request('get', 'http://garbage@python.org',
                        auth=aiohttp.BasicAuth('nkim', '1234'))
     assert 'AUTHORIZATION' in req.headers

--- a/tests/test_urldispatch.py
+++ b/tests/test_urldispatch.py
@@ -1144,7 +1144,7 @@ async def test_dynamic_subapp_variable_collision(app, loop):
         make_mocked_request('GET', '/andrew/abc.py'))
     assert 'abc' == ret[0]['var']  # innermost survives.
     assert set() == ret[1]
-    url = route.url_for(var='xxx')
+    url = route.url_for(var='xxx')  # used by all!
     assert '/xxx/xxx.py' == str(url)
 
 
@@ -1204,6 +1204,11 @@ async def test_nested_dynamic_subapps(app, loop):
         'b.key': 'def',
         'filename': 'figure.png'})
     assert '/%ED%95%9C%EA%B8%80/def/figure.png' == str(url)
+    with pytest.raises(KeyError):
+        # Error when name-prefixed variables are missing
+        url = route.url_for(**{
+            'key': 'abc',
+            'filename': 'figure.png'})
 
 
 def test_cannot_add_subapp_with_empty_prefix(app, loop):

--- a/tests/test_urldispatch.py
+++ b/tests/test_urldispatch.py
@@ -1125,7 +1125,7 @@ async def test_dynamic_subapp_resolution(app, loop):
     assert set() == ret[1]
 
 
-async def test_dynamic_subapp_resolution_overriden(app, loop):
+async def test_dynamic_subapp_resolution_overridden(app, loop):
     handler = make_handler()
     subapp = web.Application()
     subresource = subapp.router.add_resource('/{name}.py')

--- a/tests/test_urldispatch.py
+++ b/tests/test_urldispatch.py
@@ -12,9 +12,9 @@ from aiohttp import hdrs, web
 from aiohttp.test_utils import make_mocked_request
 from aiohttp.web import HTTPMethodNotAllowed, HTTPNotFound, Response
 from aiohttp.web_urldispatcher import (PATH_SEP, AbstractResource,
-                                       ResourceRoute, SystemRoute, View,
                                        DynamicSubAppResource,
-                                       PrefixedSubAppResource,
+                                       PrefixedSubAppResource, ResourceRoute,
+                                       SystemRoute, View,
                                        _default_expect_handler)
 
 

--- a/tests/test_urldispatch.py
+++ b/tests/test_urldispatch.py
@@ -1012,8 +1012,7 @@ def test_subapp_get_info(app, loop):
 def test_subapp_url_for(app, loop):
     subapp = web.Application()
     resource = app.add_subapp('/pre', subapp)
-    with pytest.raises(RuntimeError):
-        resource.url_for()
+    assert '/pre' == resource.url_for().path
 
 
 def test_subapp_repr(app, loop):

--- a/tests/test_urldispatch.py
+++ b/tests/test_urldispatch.py
@@ -1134,6 +1134,8 @@ async def test_dynamic_subapp_resolution_overriden(app, loop):
     ret = await resource.resolve(
         make_mocked_request('GET', '/andrew/abc.py'))
     assert 'abc' == ret[0]['name']
+    assert 'abc' == ret[0].maps[0]['name']
+    assert 'andrew' == ret[0].maps[1]['name']
     assert set() == ret[1]
 
 

--- a/tests/test_urldispatch.py
+++ b/tests/test_urldispatch.py
@@ -625,7 +625,7 @@ async def test_regular_match_info(router):
     req = make_request('GET', '/get/john')
     match_info = await router.resolve(req)
     assert {'name': 'john'} == match_info
-    assert re.match("<MatchInfo {'name': 'john'}: .+<Dynamic.+>>",
+    assert re.match(r"<MatchInfo ChainMap\({'name': 'john'}\): .+<Dynamic.+>>",
                     repr(match_info))
 
 
@@ -1134,9 +1134,9 @@ async def test_dynamic_subapp_resolution_overridden(app, loop):
     ret = await resource.resolve(
         make_mocked_request('GET', '/andrew/abc.py'))
     assert 'abc' == ret[0]['name']
-    assert 'andrew' == ret[0].variable_maps[0]['name']
-    assert 'abc' == ret[0].variable_maps[1]['name']
-    assert 2 == len(ret[0].variable_maps)
+    assert 'andrew' == ret[0].maps[0]['name']
+    assert 'abc' == ret[0].maps[1]['name']
+    assert 2 == len(ret[0].maps)
     assert set() == ret[1]
 
 

--- a/tests/test_urldispatch.py
+++ b/tests/test_urldispatch.py
@@ -1134,8 +1134,9 @@ async def test_dynamic_subapp_resolution_overridden(app, loop):
     ret = await resource.resolve(
         make_mocked_request('GET', '/andrew/abc.py'))
     assert 'abc' == ret[0]['name']
-    assert 'abc' == ret[0].maps[0]['name']
-    assert 'andrew' == ret[0].maps[1]['name']
+    assert 'andrew' == ret[0].variable_maps[0]['name']
+    assert 'abc' == ret[0].variable_maps[1]['name']
+    assert 2 == len(ret[0].variable_maps)
     assert set() == ret[1]
 
 


### PR DESCRIPTION
## What do these changes do?

This allows use of variables (regular expressions) in the subapp prefixes.

## Are there changes in behavior for the user?

Existing codes are not affected.

## Related issue number

I am making this PR after discussion with @asvetlov in gitter.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] I'm already in `CONTRIBUTORS.txt`
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
