### PR TITLE
Fix MultipartWriter.append* no longer returning part/payload.

### DIFF
--- a/CHANGES/2759.bugfix
+++ b/CHANGES/2759.bugfix
@@ -1,0 +1,1 @@
+Fix MultipartWriter.append* no longer returning part/payload.

--- a/aiohttp/multipart.py
+++ b/aiohttp/multipart.py
@@ -14,7 +14,7 @@ from .hdrs import (CONTENT_DISPOSITION, CONTENT_ENCODING, CONTENT_LENGTH,
                    CONTENT_TRANSFER_ENCODING, CONTENT_TYPE)
 from .helpers import CHAR, TOKEN, parse_mimetype, reify
 from .http import HttpParser
-from .payload import (BytesPayload, LookupError, Payload, StringPayload,
+from .payload import (JsonPayload, LookupError, Payload, StringPayload,
                       get_payload, payload_type)
 
 
@@ -712,10 +712,10 @@ class MultipartWriter(Payload):
                 obj.headers.update(headers)
             else:
                 obj._headers = headers
-            self.append_payload(obj)
+            return self.append_payload(obj)
         else:
             try:
-                self.append_payload(get_payload(obj, headers=headers))
+                return self.append_payload(get_payload(obj, headers=headers))
             except LookupError:
                 raise TypeError
 
@@ -752,16 +752,14 @@ class MultipartWriter(Payload):
         ).encode('utf-8') + b'\r\n'
 
         self._parts.append((payload, headers, encoding, te_encoding))
+        return payload
 
     def append_json(self, obj, headers=None):
         """Helper to append JSON part."""
         if headers is None:
             headers = CIMultiDict()
 
-        data = json.dumps(obj).encode('utf-8')
-        self.append_payload(
-            BytesPayload(
-                data, headers=headers, content_type='application/json'))
+        return self.append_payload(JsonPayload(obj, headers=headers))
 
     def append_form(self, obj, headers=None):
         """Helper to append form urlencoded part."""

--- a/docs/multipart.rst
+++ b/docs/multipart.rst
@@ -152,9 +152,9 @@ will include the file's basename::
     part = root.append(open(__file__, 'rb'))
 
 If you want to send a file with a different name, just handle the
-:class:`BodyPartWriter` instance which :meth:`MultipartWriter.append` will
+:class:`Payload` instance which :meth:`MultipartWriter.append` will
 always return and set `Content-Disposition` explicitly by using
-the :meth:`BodyPartWriter.set_content_disposition` helper::
+the :meth:`Payload.set_content_disposition` helper::
 
     part.set_content_disposition('attachment', filename='secret.txt')
 


### PR DESCRIPTION
## What do these changes do?

- Fixes commit: caa6bdb2484bf821b52a65322efa98a889b593de

  MultipartWriter.append methods used to return the part appended to the writer so one could set the content_disposition, etc. This patch restores that functionality so the code matches the documentation in multipart.rst

- This patch also makes append_json use the JsonPayload object instead of duplicating functionality.

## Are there changes in behavior for the user?

Fix regression

## Related issue number

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
