### PR TITLE
Don't raise InvalidStateError on two consequenced  data_received() calls

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,12 @@ Changelog
 
 .. towncrier release notes start
 
+3.0.5 (2018-02-27)
+==================
+
+- Fix ``InvalidStateError`` on processing a seria of two consequenced
+  ``RequestHandler.data_received`` calls on web server. (#2773)
+
 3.0.4 (2018-02-26)
 ==================
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,7 +17,7 @@ Changelog
 3.0.5 (2018-02-27)
 ==================
 
-- Fix ``InvalidStateError`` on processing a seria of two consequenced
+- Fix ``InvalidStateError`` on processing a sequence of two
   ``RequestHandler.data_received`` calls on web server. (#2773)
 
 3.0.4 (2018-02-26)

--- a/aiohttp/web_protocol.py
+++ b/aiohttp/web_protocol.py
@@ -250,8 +250,11 @@ class RequestHandler(asyncio.streams.FlowControlMixin, asyncio.Protocol):
                         self._request_count += 1
                         self._messages.append((msg, payload))
 
-                    if self._waiter is not None:
-                        self._waiter.set_result(None)
+                    waiter = self._waiter
+                    if waiter is not None:
+                        if not waiter.done():
+                            # don't set result twice
+                            waiter.set_result(None)
 
                 self._upgraded = upgraded
                 if upgraded and tail:


### PR DESCRIPTION
Fix for #2773 