### PR TITLE
Add aiozipkin to third party section

### DIFF
--- a/docs/third_party.rst
+++ b/docs/third_party.rst
@@ -57,6 +57,9 @@ aiohttp extensions
 - `aiohttp-jinja2 <https://github.com/aio-libs/aiohttp-jinja2>`_ Jinja2
   template renderer for aiohttp.web.
 
+- `aiozipkin <https://github.com/aio-libs/aiozipkin>`_ distributed
+  tracing instrumentation for `aiohttp` client and server.
+
 Database drivers
 ^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
## What do these changes do?
**aiozipkin** is library for distributed tracing instrumentation, it has build in aiohttp support. aiozipkin uses middleware on server and signals on client, as result it is possible to trace request across different services and reason about latencies. 

This PR adds aiozipkin to the third party section in the docs.

https://github.com/aio-libs/aiozipkin


## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."