### PR TITLE
added _reuse_address and _reuse_port to web_runner.TCPSite.__slots__

### DIFF
--- a/aiohttp/web_runner.py
+++ b/aiohttp/web_runner.py
@@ -57,7 +57,7 @@ class BaseSite(ABC):
 
 
 class TCPSite(BaseSite):
-    __slots__ = ('_host', '_port')
+    __slots__ = ('_host', '_port', '_reuse_address', '_reuse_port')
 
     def __init__(self, runner, host=None, port=None, *,
                  shutdown_timeout=60.0, ssl_context=None,


### PR DESCRIPTION
Hi,
`_reuse_address` and `_reuse_port` are not included in `TCPSite.__slots__`

```python
import aiohttp.web
app = aiohttp.web.Application()
aiohttp.web.run_app(app)
```
Invokes:
`AttributeError: 'TCPSite' object has no attribute '_reuse_address'`

Best regards