### PR TITLE
Setup default loop in test utilities

### DIFF
--- a/CHANGES/2804.feature
+++ b/CHANGES/2804.feature
@@ -1,0 +1,3 @@
+Install a test event loop as default by
+``asyncio.set_event_loop()``. The change affects aiohttp test utils
+but backward compatibility is not broken for 99.99% of use cases.

--- a/aiohttp/pytest_plugin.py
+++ b/aiohttp/pytest_plugin.py
@@ -200,11 +200,17 @@ def pytest_generate_tests(metafunc):
 @pytest.fixture
 def loop(loop_factory, fast, loop_debug):
     """Return an instance of the event loop."""
+    try:
+        old_loop = asyncio.get_event_loop()
+    except RuntimeError:
+        old_loop = None
     with loop_context(loop_factory, fast=fast) as _loop:
         if loop_debug:
             _loop.set_debug(True)  # pragma: no cover
+        asyncio.set_event_loop(_loop)
         yield _loop
-    asyncio.set_event_loop(None)
+    if old_loop is not None and not old_loop.is_closed():
+        asyncio.set_event_loop(old_loop)
 
 
 @pytest.fixture

--- a/aiohttp/pytest_plugin.py
+++ b/aiohttp/pytest_plugin.py
@@ -200,17 +200,11 @@ def pytest_generate_tests(metafunc):
 @pytest.fixture
 def loop(loop_factory, fast, loop_debug):
     """Return an instance of the event loop."""
-    try:
-        old_loop = asyncio.get_event_loop()
-    except RuntimeError:
-        old_loop = None
     with loop_context(loop_factory, fast=fast) as _loop:
         if loop_debug:
             _loop.set_debug(True)  # pragma: no cover
         asyncio.set_event_loop(_loop)
         yield _loop
-    if old_loop is not None and not old_loop.is_closed():
-        asyncio.set_event_loop(old_loop)
 
 
 @pytest.fixture

--- a/aiohttp/test_utils.py
+++ b/aiohttp/test_utils.py
@@ -410,7 +410,7 @@ def setup_test_loop(loop_factory=asyncio.new_event_loop):
     once they are done with the loop.
     """
     loop = loop_factory()
-    asyncio.set_event_loop(None)
+    asyncio.set_event_loop(loop)
     if sys.platform != "win32":
         policy = asyncio.get_event_loop_policy()
         watcher = asyncio.SafeChildWatcher()

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -788,6 +788,16 @@ Utilities
    The caller should also call teardown_test_loop, once they are done
    with the loop.
 
+   .. note::
+
+      As side effect the function changes asyncio *default loop* by
+      :func:`asyncio.set_event_loop` call.
+
+      Previous default loop is not restored.
+
+      It should not be a problem for test suite: every test expects a
+      new test loop instance anyway.
+
 .. function:: teardown_test_loop(loop)
 
    Teardown and cleanup an event_loop created by setup_test_loop.

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -798,6 +798,10 @@ Utilities
       It should not be a problem for test suite: every test expects a
       new test loop instance anyway.
 
+   .. versionchanged:: 3.1
+
+      The function installs a created event loop as *default*.
+
 .. function:: teardown_test_loop(loop)
 
    Teardown and cleanup an event_loop created by setup_test_loop.

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -30,3 +30,7 @@ class TestCase(AioHTTPTestCase):
     @unittest_run_loop
     async def test_on_startup_hook(self):
         assert self.startup_loop is not None
+
+
+def test_default_loop(loop):
+    assert asyncio.get_event_loop() is loop

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -29,7 +29,10 @@ class TestCase(AioHTTPTestCase):
 
     @unittest_run_loop
     async def test_on_startup_hook(self):
-        assert self.startup_loop is not None
+        self.assertIsNotNone(self.startup_loop)
+
+    def test_default_loop(self):
+        self.assertIs(self.loop, asyncio.get_event_loop())
 
 
 def test_default_loop(loop):


### PR DESCRIPTION
The change is safe: minimal supported Python 3.5.3 always returns a *running* event loop if `asyncio.get_event_loop()` is called from a coroutine.

Also it is a step for seamless integration with `pytest-asyncio`: the library installs the loop internally.