### PR TITLE
partially fixed #2805 (multiple http byte ranges are not yet supported)

### DIFF
--- a/CHANGES/2805.bugfix
+++ b/CHANGES/2805.bugfix
@@ -1,1 +1,2 @@
-Property http_range of BaseRequest now returns a python-like slice when requesting the tail of the range. It's now indicated by a negative value in rng.start rather then in rng.stop
+Property `BaseRequest.http_range` now returns a python-like slice when requesting the tail of the range. 
+It's now indicated by a negative value in `range.start` rather then in `range.stop`

--- a/CHANGES/2805.bugfix
+++ b/CHANGES/2805.bugfix
@@ -1,0 +1,1 @@
+Property http_range of BaseRequest now returns a python-like slice when requesting the tail of the range. It's now indicated by a negative value in rng.start rather then in rng.stop

--- a/aiohttp/web_fileresponse.py
+++ b/aiohttp/web_fileresponse.py
@@ -193,9 +193,9 @@ class FileResponse(StreamResponse):
         # If a range request has been made, convert start, end slice notation
         # into file pointer offset and count
         if start is not None or end is not None:
-            if start is None and end < 0:  # return tail of file
-                start = file_size + end
-                count = -end
+            if start < 0 and end is None:  # return tail of file
+                start = file_size + start
+                count = file_size - start
             else:
                 count = (end or file_size) - start
 

--- a/aiohttp/web_request.py
+++ b/aiohttp/web_request.py
@@ -439,7 +439,7 @@ class BaseRequest(collections.MutableMapping, HeadersMixin):
 
             if start is None and end is not None:
                 # end with no start is to return tail of content
-                end = -end
+                start = -end
 
             if start is not None and end is not None:
                 # end is inclusive in range header, exclusive for slice

--- a/aiohttp/web_request.py
+++ b/aiohttp/web_request.py
@@ -440,6 +440,7 @@ class BaseRequest(collections.MutableMapping, HeadersMixin):
             if start is None and end is not None:
                 # end with no start is to return tail of content
                 start = -end
+                end = None
 
             if start is not None and end is not None:
                 # end is inclusive in range header, exclusive for slice
@@ -450,6 +451,7 @@ class BaseRequest(collections.MutableMapping, HeadersMixin):
 
             if start is end is None:  # No valid range supplied
                 raise ValueError('No start or end of range specified')
+
         return slice(start, end, 1)
 
     @property


### PR DESCRIPTION
<!-- Thank you for your contribution!

## What do these changes do?

<!-- Please give a short brief about these changes. -->
Now the slice returned by Request.http_range() is also correct when there is no "start" value specified i.e. when the requester only wants the tail of the range.
## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->
If they rely on rng.start and rng.stop this change will break their app.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Partial fix for #2805, if we want to create a set or list of ranges from those exotic headers, we probably need another method name (http_multi_ranges) or something


## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
