### PR TITLE
Add a check for python version in parallel to environment marker

### DIFF
--- a/CHANGES/2813.bugfix
+++ b/CHANGES/2813.bugfix
@@ -1,0 +1,4 @@
+Restore a imperative check in ``setup.py`` for python version. The
+check works in parallel to environment marker. As effect a error about
+unsupported Python versions is raised even on outdated systems with
+very old ``setuptools`` version installed.

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,10 @@ from setuptools import Extension, setup
 from setuptools.command.test import test as TestCommand
 
 
+if sys.version_info < (3, 5, 3):
+    raise RuntimeError("aiohttp 3.x requires Python 3.5.3+")
+
+
 try:
     from Cython.Build import cythonize
     USE_CYTHON = True


### PR DESCRIPTION
If people install aiohttp on old non-supported Python the interpreter is very likely also has outdated setuptools without environment markers support.

The change will raise an exception on installation stage for such outdated systems.