### PR TITLE
Fix websocket client should stopped without returning stop marker to user when get an EofStream.

### DIFF
--- a/CHANGES/2784.bugfix
+++ b/CHANGES/2784.bugfix
@@ -1,0 +1,1 @@
+Fix websocket client return EofStream.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -203,6 +203,7 @@ Willem de Groot
 Wilson Ong
 Wei Lin
 Weiwei Wang
+Yang Zhou
 Yannick Koechlin
 Yannick Péroux
 Yegor Roganov

--- a/aiohttp/client_ws.py
+++ b/aiohttp/client_ws.py
@@ -202,10 +202,9 @@ class ClientWebSocketResponse:
                 self._close_code = 1006
                 raise
             except EofStream:
-                self._closing = True
                 self._close_code = 1000
                 await self.close()
-                return WSMessage(WSMsgType.CLOSING, None, None)
+                return WSMessage(WSMsgType.CLOSED, None, None)
             except ClientError:
                 self._closed = True
                 self._close_code = 1006

--- a/aiohttp/client_ws.py
+++ b/aiohttp/client_ws.py
@@ -9,6 +9,7 @@ from .client_exceptions import ClientError
 from .helpers import call_later, set_result
 from .http import (WS_CLOSED_MESSAGE, WS_CLOSING_MESSAGE, WebSocketError,
                    WSMessage, WSMsgType)
+from .streams import EofStream
 
 
 class ClientWebSocketResponse:
@@ -200,6 +201,11 @@ class ClientWebSocketResponse:
             except (asyncio.CancelledError, asyncio.TimeoutError):
                 self._close_code = 1006
                 raise
+            except EofStream:
+                self._closing = True
+                self._close_code = 1000
+                await self.close()
+                return WSMessage(WSMsgType.CLOSING, None, None)
             except ClientError:
                 self._closed = True
                 self._close_code = 1006

--- a/aiohttp/web_ws.py
+++ b/aiohttp/web_ws.py
@@ -354,7 +354,7 @@ class WebSocketResponse(StreamResponse):
             except EofStream:
                 self._close_code = 1000
                 await self.close()
-                return WSMessage(WSMsgType.CLOSING, None, None)
+                return WSMessage(WSMsgType.CLOSED, None, None)
             except WebSocketError as exc:
                 self._close_code = exc.code
                 await self.close(code=exc.code)

--- a/tests/test_web_websocket.py
+++ b/tests/test_web_websocket.py
@@ -356,7 +356,7 @@ async def test_receive_eofstream_in_reader(make_request, loop):
     ws._payload_writer.drain.return_value.set_result(True)
 
     msg = await ws.receive()
-    assert msg.type == WSMsgType.CLOSING
+    assert msg.type == WSMsgType.CLOSED
     assert ws.closed
 
 

--- a/tests/test_web_websocket.py
+++ b/tests/test_web_websocket.py
@@ -6,6 +6,7 @@ from multidict import CIMultiDict
 
 from aiohttp import WSMessage, WSMsgType, signals
 from aiohttp.log import ws_logger
+from aiohttp.streams import EofStream
 from aiohttp.test_utils import make_mocked_coro, make_mocked_request
 from aiohttp.web import HTTPBadRequest, HTTPMethodNotAllowed, WebSocketResponse
 from aiohttp.web_ws import WS_CLOSED_MESSAGE, WebSocketReady
@@ -338,6 +339,25 @@ async def test_write_eof_idempotent(make_request):
     await ws.write_eof()
     await ws.write_eof()
     await ws.write_eof()
+
+
+async def test_receive_eofstream_in_reader(make_request, loop):
+    req = make_request('GET', '/')
+    ws = WebSocketResponse()
+    await ws.prepare(req)
+
+    ws._reader = mock.Mock()
+    exc = EofStream()
+    res = loop.create_future()
+    res.set_exception(exc)
+    ws._reader.read = make_mocked_coro(res)
+    ws._payload_writer.drain = mock.Mock()
+    ws._payload_writer.drain.return_value = loop.create_future()
+    ws._payload_writer.drain.return_value.set_result(True)
+
+    msg = await ws.receive()
+    assert msg.type == WSMsgType.CLOSING
+    assert ws.closed
 
 
 async def test_receive_exc_in_reader(make_request, loop):


### PR DESCRIPTION
…user when get an EofStream.

## What do these changes do?

If `ClientWebSocketResponse.receive()` raise a `EofStream`, should not return it to user, just stop iteration.

## Are there changes in behavior for the user?

use `asyn for` in ClientWebSocketResponse will not get a EofStream.

## Related issue number

#2784 

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."