### PR TITLE
doc fix: Response does not take positional parameters.

### DIFF
--- a/docs/web_advanced.rst
+++ b/docs/web_advanced.rst
@@ -43,7 +43,7 @@ For example the following snippet is not safe::
    async def handler(request):
        await asyncio.shield(write_to_redis(request))
        await asyncio.shield(write_to_postgres(request))
-       return web.Response('OK')
+       return web.Response(text='OK')
 
 Cancellation might be occurred just after saving data in REDIS,
 ``write_to_postgres`` will be not called.
@@ -53,7 +53,7 @@ spawned tasks::
 
    async def handler(request):
        request.loop.create_task(write_to_redis(request))
-       return web.Response('OK')
+       return web.Response(text='OK')
 
 In this case errors from ``write_to_redis`` are not awaited, it leads
 to many asyncio log messages *Future exception was never retrieved*

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -503,7 +503,7 @@ The common case for sending an answer from
 :class:`Response` instance::
 
    def handler(request):
-       return Response("All right!")
+       return Response(text="All right!")
 
 Response classes are :obj:`dict` like objects,
 allowing them to be used for :ref:`sharing


### PR DESCRIPTION
Fixed doc about Response not taking positional parameters but used as `Response("some text")`.
