### PR TITLE
Fix #2781: deprecate ClientResponseError.code in favor of .status

### DIFF
--- a/CHANGES/2781.feature
+++ b/CHANGES/2781.feature
@@ -1,0 +1,2 @@
+Deprecate ClientResponseError.code in favor of .status
+to keep similarity with response classes.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -65,6 +65,7 @@ Dmitry Doroshev
 Dmitry Shamov
 Dmitry Trofimov
 Dmytro Kuznetsov
+Dmitriy Safonov
 Dustin J. Mitchell
 Eduard Iskandarov
 Eli Ribble

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -541,7 +541,7 @@ class ClientSession:
                     resp.request_info,
                     resp.history,
                     message='Invalid response status',
-                    code=resp.status,
+                    status=resp.status,
                     headers=resp.headers)
 
             if resp.headers.get(hdrs.UPGRADE, '').lower() != 'websocket':
@@ -549,7 +549,7 @@ class ClientSession:
                     resp.request_info,
                     resp.history,
                     message='Invalid upgrade header',
-                    code=resp.status,
+                    status=resp.status,
                     headers=resp.headers)
 
             if resp.headers.get(hdrs.CONNECTION, '').lower() != 'upgrade':
@@ -557,7 +557,7 @@ class ClientSession:
                     resp.request_info,
                     resp.history,
                     message='Invalid connection header',
-                    code=resp.status,
+                    status=resp.status,
                     headers=resp.headers)
 
             # key calculation
@@ -569,7 +569,7 @@ class ClientSession:
                     resp.request_info,
                     resp.history,
                     message='Invalid challenge response',
-                    code=resp.status,
+                    status=resp.status,
                     headers=resp.headers)
 
             # websocket protocol
@@ -596,7 +596,7 @@ class ClientSession:
                             resp.request_info,
                             resp.history,
                             message=exc.args[0],
-                            code=resp.status,
+                            status=resp.status,
                             headers=resp.headers)
                 else:
                     compress = 0

--- a/aiohttp/client_exceptions.py
+++ b/aiohttp/client_exceptions.py
@@ -1,6 +1,7 @@
 """HTTP related errors."""
 
 import asyncio
+import warnings
 
 
 try:
@@ -38,14 +39,34 @@ class ClientResponseError(ClientError):
     """
 
     def __init__(self, request_info, history, *,
-                 code=0, message='', headers=None):
+                 code=None, status=0, message='', headers=None):
         self.request_info = request_info
-        self.code = code
+        self.status = status
+        if code is not None:
+            warnings.warn("code argument is deprecated, use status instead",
+                          DeprecationWarning,
+                          stacklevel=2)
+            if status == 0:
+                self.status = code
         self.message = message
         self.headers = headers
         self.history = history
 
-        super().__init__("%s, message='%s'" % (code, message))
+        super().__init__("%s, message='%s'" % (self.status, message))
+
+    @property
+    def code(self):
+        warnings.warn("code property is deprecated, use status instead",
+                      DeprecationWarning,
+                      stacklevel=2)
+        return self.status
+
+    @code.setter
+    def code(self, value):
+        warnings.warn("code property is deprecated, use status instead",
+                      DeprecationWarning,
+                      stacklevel=2)
+        self.status = value
 
 
 class ContentTypeError(ClientResponseError):

--- a/aiohttp/client_exceptions.py
+++ b/aiohttp/client_exceptions.py
@@ -39,15 +39,22 @@ class ClientResponseError(ClientError):
     """
 
     def __init__(self, request_info, history, *,
-                 code=None, status=0, message='', headers=None):
+                 code=None, status=None, message='', headers=None):
         self.request_info = request_info
-        self.status = status
         if code is not None:
+            if status is not None:
+                raise ValueError(
+                    "Both code and status arguments are provided; "
+                    "code is deprecated, use status instead")
             warnings.warn("code argument is deprecated, use status instead",
                           DeprecationWarning,
                           stacklevel=2)
-            if status == 0:
-                self.status = code
+        if status is not None:
+            self.status = status
+        elif code is not None:
+            self.status = code
+        else:
+            self.status = 0
         self.message = message
         self.headers = headers
         self.history = history

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -695,7 +695,7 @@ class ClientResponse(HeadersMixin):
                 except http.HttpProcessingError as exc:
                     raise ClientResponseError(
                         self.request_info, self.history,
-                        code=exc.code,
+                        status=exc.code,
                         message=exc.message, headers=exc.headers) from exc
 
                 if (message.code < 100 or
@@ -783,7 +783,7 @@ class ClientResponse(HeadersMixin):
             raise ClientResponseError(
                 self.request_info,
                 self.history,
-                code=self.status,
+                status=self.status,
                 message=self.reason,
                 headers=self.headers)
 

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -908,7 +908,7 @@ class TCPConnector(BaseConnector):
                         raise ClientHttpProxyError(
                             proxy_resp.request_info,
                             resp.history,
-                            code=resp.status,
+                            status=resp.status,
                             message=resp.reason,
                             headers=resp.headers)
                     rawsock = transport.get_extra_info('socket', default=None)

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -1673,9 +1673,9 @@ Response errors
       Instance of :class:`RequestInfo` object, contains information
       about request.
 
-   .. attribute:: code
+   .. attribute:: status
 
-      HTTP status code of response (:class:`int`), e.g. ``200``.
+      HTTP status code of response (:class:`int`), e.g. ``400``.
 
    .. attribute:: message
 
@@ -1691,6 +1691,12 @@ Response errors
 
       A :class:`tuple` of :class:`ClientResponse` objects used for
       handle redirection responses.
+
+   .. attribute:: code
+
+      HTTP status code of response (:class:`int`), e.g. ``400``.
+
+      .. deprecated:: 3.1
 
 
 .. class:: WSServerHandshakeError

--- a/tests/test_client_exceptions.py
+++ b/tests/test_client_exceptions.py
@@ -21,7 +21,20 @@ def test_invalid_url():
     assert repr(err) == "<InvalidURL http://example.com>"
 
 
-def test_deprecated_code_property():
+def test_response_default_status():
+    err = client.ClientResponseError(history=None,
+                                     request_info=None)
+    assert err.status == 0
+
+
+def test_response_status():
+    err = client.ClientResponseError(status=400,
+                                     history=None,
+                                     request_info=None)
+    assert err.status == 400
+
+
+def test_response_deprecated_code_property():
     with pytest.warns(DeprecationWarning):
         err = client.ClientResponseError(code=400,
                                          history=None,
@@ -32,3 +45,11 @@ def test_deprecated_code_property():
         err.code = '404'
     with pytest.warns(DeprecationWarning):
         assert err.code == err.status
+
+
+def test_response_both_code_and_status():
+    with pytest.raises(ValueError):
+        client.ClientResponseError(code=400,
+                                   status=400,
+                                   history=None,
+                                   request_info=None)

--- a/tests/test_client_exceptions.py
+++ b/tests/test_client_exceptions.py
@@ -1,5 +1,6 @@
-"""Tests for http_exceptions.py"""
+"""Tests for client_exceptions.py"""
 
+import pytest
 from yarl import URL
 
 from aiohttp import client
@@ -18,3 +19,16 @@ def test_invalid_url():
     assert err.args[0] is url
     assert err.url is url
     assert repr(err) == "<InvalidURL http://example.com>"
+
+
+def test_deprecated_code_property():
+    with pytest.warns(DeprecationWarning):
+        err = client.ClientResponseError(code=400,
+                                         history=None,
+                                         request_info=None)
+    with pytest.warns(DeprecationWarning):
+        assert err.code == err.status
+    with pytest.warns(DeprecationWarning):
+        err.code = '404'
+    with pytest.warns(DeprecationWarning):
+        assert err.code == err.status

--- a/tests/test_client_response.py
+++ b/tests/test_client_response.py
@@ -438,7 +438,7 @@ def test_raise_for_status_4xx():
     response.reason = 'CONFLICT'
     with pytest.raises(aiohttp.ClientResponseError) as cm:
         response.raise_for_status()
-    assert str(cm.value.code) == '409'
+    assert str(cm.value.status) == '409'
     assert str(cm.value.message) == "CONFLICT"
 
 


### PR DESCRIPTION
## What do these changes do?

Deprecate ClientResponseError.code in favor of .status

## Are there changes in behavior for the user?

ClientResponseError.code is deprecated, but continues to work

## Related issue number

#2781

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
