### PR TITLE
Fix #2206: Allow content-types "application/xxx+json" in ClientResponse.json()

### DIFF
--- a/CHANGES/2206.doc
+++ b/CHANGES/2206.doc
@@ -1,0 +1,1 @@
+Change ```ClientResponse.json()``` documentation to reflect that it now allows "application/xxx+json" content-types

--- a/CHANGES/2206.feature
+++ b/CHANGES/2206.feature
@@ -1,0 +1,2 @@
+Relax JSON content-type checking in the ``ClientResponse.json()`` to allow
+ "application/xxx+json" instead of strict "application/json".

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -2,6 +2,7 @@ import asyncio
 import codecs
 import io
 import json
+import re
 import sys
 import traceback
 import warnings
@@ -37,6 +38,9 @@ except ImportError:  # pragma: no cover
 
 
 __all__ = ('ClientRequest', 'ClientResponse', 'RequestInfo', 'Fingerprint')
+
+
+json_re = re.compile('^application/(?:[\w.+-]+?\+)?json')
 
 
 @attr.s(frozen=True, slots=True)
@@ -129,6 +133,12 @@ def _merge_ssl_params(ssl, verify_ssl, ssl_context, fingerprint):
 
 
 ConnectionKey = namedtuple('ConnectionKey', ['host', 'port', 'ssl'])
+
+
+def _is_expected_content_type(response_content_type, expected_content_type):
+    if expected_content_type == 'application/json':
+        return json_re.match(response_content_type)
+    return response_content_type in expected_content_type
 
 
 class ClientRequest:
@@ -859,7 +869,7 @@ class ClientResponse(HeadersMixin):
 
         if content_type:
             ctype = self.headers.get(hdrs.CONTENT_TYPE, '').lower()
-            if content_type not in ctype:
+            if not _is_expected_content_type(ctype, content_type):
                 raise ContentTypeError(
                     self.request_info,
                     self.history,

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -138,7 +138,7 @@ ConnectionKey = namedtuple('ConnectionKey', ['host', 'port', 'ssl'])
 def _is_expected_content_type(response_content_type, expected_content_type):
     if expected_content_type == 'application/json':
         return json_re.match(response_content_type)
-    return response_content_type in expected_content_type
+    return expected_content_type in response_content_type
 
 
 class ClientRequest:

--- a/docs/client_advanced.rst
+++ b/docs/client_advanced.rst
@@ -215,13 +215,18 @@ Disabling content type validation for JSON responses
 ----------------------------------------------------
 
 The standard explicitly restricts JSON ``Content-Type`` HTTP header to
-``apllication/json``. Unfortunately some servers send wrong type like
-``text/html`` or custom one, e.g. ``application/vnd.custom-type+json``.
+``application/json`` or any extended form, e.g. ``application/vnd.custom-type+json``.
+Unfortunately, some servers send a wrong type, like ``text/html``.
 
-In this case there are two options:
+This can be worked around in two ways:
 
-1. Pass expected type explicitly: ``await resp.json(content_type='custom')``.
-2. Disable the check entirely: ``await resp.json(content_type=None)``.
+1. Pass the expected type explicitly (in this case checking will be strict, without the extended form support,
+   so ``custom/xxx+type`` won't be accepted):
+
+   ``await resp.json(content_type='custom/type')``.
+2. Disable the check entirely:
+
+   ``await resp.json(content_type=None)``.
 
 .. _aiohttp-client-tracing:
 

--- a/tests/test_client_response.py
+++ b/tests/test_client_response.py
@@ -345,6 +345,26 @@ async def test_json(loop, session):
     assert response._connection is None
 
 
+async def test_json_extended_content_type(loop, session):
+    response = ClientResponse('get', URL('http://def-cl-resp.org'))
+    response._post_init(loop, session)
+
+    def side_effect(*args, **kwargs):
+        fut = loop.create_future()
+        fut.set_result('{"тест": "пройден"}'.encode('cp1251'))
+        return fut
+
+    response.headers = {
+        'Content-Type':
+            'application/this.is-1_content+subtype+json;charset=cp1251'}
+    content = response.content = mock.Mock()
+    content.read.side_effect = side_effect
+
+    res = await response.json()
+    assert res == {'тест': 'пройден'}
+    assert response._connection is None
+
+
 async def test_json_custom_loader(loop, session):
     response = ClientResponse('get', URL('http://def-cl-resp.org'))
     response._post_init(loop, session)

--- a/tests/test_client_response.py
+++ b/tests/test_client_response.py
@@ -365,6 +365,25 @@ async def test_json_extended_content_type(loop, session):
     assert response._connection is None
 
 
+async def test_json_custom_content_type(loop, session):
+    response = ClientResponse('get', URL('http://def-cl-resp.org'))
+    response._post_init(loop, session)
+
+    def side_effect(*args, **kwargs):
+        fut = loop.create_future()
+        fut.set_result('{"тест": "пройден"}'.encode('cp1251'))
+        return fut
+
+    response.headers = {
+        'Content-Type': 'custom/type;charset=cp1251'}
+    content = response.content = mock.Mock()
+    content.read.side_effect = side_effect
+
+    res = await response.json(content_type='custom/type')
+    assert res == {'тест': 'пройден'}
+    assert response._connection is None
+
+
 async def test_json_custom_loader(loop, session):
     response = ClientResponse('get', URL('http://def-cl-resp.org'))
     response._post_init(loop, session)


### PR DESCRIPTION
## What do these changes do?

Allow content-types "application/xxx+json" in ClientResponse.json()

## Are there changes in behavior for the user?

Yes, extended forms of "application/json" (see [examples](https://www.iana.org/assignments/media-types/media-types.xhtml)) will be accepted as valid json.

## Related issue number

#2206

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
