### PR TITLE
Refactor ClientResponse constructor

### DIFF
--- a/CHANGES/2820.feature
+++ b/CHANGES/2820.feature
@@ -1,0 +1,2 @@
+Refactor ``ClientResponse`` constructor: make logically required
+constructor arguments mandatory, drop ``_post_init()`` method.

--- a/tests/test_client_proto.py
+++ b/tests/test_client_proto.py
@@ -6,6 +6,7 @@ from aiohttp import http
 from aiohttp.client_exceptions import ClientOSError, ServerDisconnectedError
 from aiohttp.client_proto import ResponseHandler
 from aiohttp.client_reqrep import ClientResponse
+from aiohttp.helpers import TimerNoop
 
 
 async def test_oserror(loop):
@@ -65,8 +66,15 @@ async def test_client_protocol_readuntil_eof(loop):
 
     proto.data_received(b'HTTP/1.1 200 Ok\r\n\r\n')
 
-    response = ClientResponse('get', URL('http://def-cl-resp.org'))
-    response._post_init(loop, mock.Mock())
+    response = ClientResponse('get', URL('http://def-cl-resp.org'),
+                              writer=mock.Mock(),
+                              continue100=None,
+                              timer=TimerNoop(),
+                              request_info=mock.Mock(),
+                              auto_decompress=True,
+                              traces=[],
+                              loop=loop,
+                              session=mock.Mock())
     await response.start(conn, read_until_eof=True)
 
     assert not response.content.is_eof()

--- a/tests/test_client_request.py
+++ b/tests/test_client_request.py
@@ -1077,8 +1077,13 @@ async def test_custom_req_rep(loop):
             resp = self.response_class(self.method,
                                        self.url,
                                        writer=self._writer,
-                                       continue100=self._continue)
-            resp._post_init(self.loop, mock.Mock())
+                                       continue100=self._continue,
+                                       timer=self._timer,
+                                       request_info=self.request_info,
+                                       auto_decompress=self._auto_decompress,
+                                       traces=self._traces,
+                                       loop=self.loop,
+                                       session=self._session)
             self.response = resp
             nonlocal called
             called = True

--- a/tests/test_client_response.py
+++ b/tests/test_client_response.py
@@ -11,6 +11,7 @@ from yarl import URL
 import aiohttp
 from aiohttp import http
 from aiohttp.client_reqrep import ClientResponse, RequestInfo
+from aiohttp.helpers import TimerNoop
 from aiohttp.test_utils import make_mocked_coro
 
 
@@ -23,8 +24,14 @@ async def test_http_processing_error(session):
     loop = mock.Mock()
     request_info = mock.Mock()
     response = ClientResponse(
-        'get', URL('http://del-cl-resp.org'), request_info=request_info)
-    response._post_init(loop, session)
+        'get', URL('http://del-cl-resp.org'), request_info=request_info,
+        writer=mock.Mock(),
+        continue100=None,
+        timer=TimerNoop(),
+        auto_decompress=True,
+        traces=[],
+        loop=loop,
+        session=session)
     loop.get_debug = mock.Mock()
     loop.get_debug.return_value = True
 
@@ -41,8 +48,15 @@ async def test_http_processing_error(session):
 
 def test_del(session):
     loop = mock.Mock()
-    response = ClientResponse('get', URL('http://del-cl-resp.org'))
-    response._post_init(loop, session)
+    response = ClientResponse('get', URL('http://del-cl-resp.org'),
+                              request_info=mock.Mock(),
+                              writer=mock.Mock(),
+                              continue100=None,
+                              timer=TimerNoop(),
+                              auto_decompress=True,
+                              traces=[],
+                              loop=loop,
+                              session=session)
     loop.get_debug = mock.Mock()
     loop.get_debug.return_value = True
 
@@ -59,8 +73,15 @@ def test_del(session):
 
 
 def test_close(loop, session):
-    response = ClientResponse('get', URL('http://def-cl-resp.org'))
-    response._post_init(loop, session)
+    response = ClientResponse('get', URL('http://def-cl-resp.org'),
+                              request_info=mock.Mock(),
+                              writer=mock.Mock(),
+                              continue100=None,
+                              timer=TimerNoop(),
+                              auto_decompress=True,
+                              traces=[],
+                              loop=loop,
+                              session=session)
     response._closed = False
     response._connection = mock.Mock()
     response.close()
@@ -71,23 +92,43 @@ def test_close(loop, session):
 
 def test_wait_for_100_1(loop, session):
     response = ClientResponse(
-        'get', URL('http://python.org'), continue100=object())
-    response._post_init(loop, session)
+        'get', URL('http://python.org'), continue100=object(),
+        request_info=mock.Mock(),
+        writer=mock.Mock(),
+        timer=TimerNoop(),
+        auto_decompress=True,
+        traces=[],
+        loop=loop,
+        session=session)
     assert response._continue is not None
     response.close()
 
 
 def test_wait_for_100_2(loop, session):
     response = ClientResponse(
-        'get', URL('http://python.org'))
-    response._post_init(loop, session)
+        'get', URL('http://python.org'),
+        request_info=mock.Mock(),
+        continue100=None,
+        writer=mock.Mock(),
+        timer=TimerNoop(),
+        auto_decompress=True,
+        traces=[],
+        loop=loop,
+        session=session)
     assert response._continue is None
     response.close()
 
 
 def test_repr(loop, session):
-    response = ClientResponse('get', URL('http://def-cl-resp.org'))
-    response._post_init(loop, session)
+    response = ClientResponse('get', URL('http://def-cl-resp.org'),
+                              request_info=mock.Mock(),
+                              writer=mock.Mock(),
+                              continue100=None,
+                              timer=TimerNoop(),
+                              auto_decompress=True,
+                              traces=[],
+                              loop=loop,
+                              session=session)
     response.status = 200
     response.reason = 'Ok'
     assert '<ClientResponse(http://def-cl-resp.org) [200 Ok]>'\
@@ -95,27 +136,58 @@ def test_repr(loop, session):
 
 
 def test_repr_non_ascii_url():
-    response = ClientResponse('get', URL('http://fake-host.org/\u03bb'))
+    response = ClientResponse('get', URL('http://fake-host.org/\u03bb'),
+                              request_info=mock.Mock(),
+                              writer=mock.Mock(),
+                              continue100=None,
+                              timer=TimerNoop(),
+                              auto_decompress=True,
+                              traces=[],
+                              loop=mock.Mock(),
+                              session=mock.Mock())
     assert "<ClientResponse(http://fake-host.org/%CE%BB) [None None]>"\
         in repr(response)
 
 
 def test_repr_non_ascii_reason():
-    response = ClientResponse('get', URL('http://fake-host.org/path'))
+    response = ClientResponse('get', URL('http://fake-host.org/path'),
+                              request_info=mock.Mock(),
+                              writer=mock.Mock(),
+                              continue100=None,
+                              timer=TimerNoop(),
+                              auto_decompress=True,
+                              traces=[],
+                              loop=mock.Mock(),
+                              session=mock.Mock())
     response.reason = '\u03bb'
     assert "<ClientResponse(http://fake-host.org/path) [None \\u03bb]>"\
         in repr(response)
 
 
 def test_url_obj_deprecated():
-    response = ClientResponse('get', URL('http://fake-host.org/'))
+    response = ClientResponse('get', URL('http://fake-host.org/'),
+                              request_info=mock.Mock(),
+                              writer=mock.Mock(),
+                              continue100=None,
+                              timer=TimerNoop(),
+                              auto_decompress=True,
+                              traces=[],
+                              loop=mock.Mock(),
+                              session=mock.Mock())
     with pytest.warns(DeprecationWarning):
         response.url_obj
 
 
 async def test_read_and_release_connection(loop, session):
-    response = ClientResponse('get', URL('http://def-cl-resp.org'))
-    response._post_init(loop, session)
+    response = ClientResponse('get', URL('http://def-cl-resp.org'),
+                              request_info=mock.Mock(),
+                              writer=mock.Mock(),
+                              continue100=None,
+                              timer=TimerNoop(),
+                              auto_decompress=True,
+                              traces=[],
+                              loop=loop,
+                              session=session)
 
     def side_effect(*args, **kwargs):
         fut = loop.create_future()
@@ -130,8 +202,15 @@ async def test_read_and_release_connection(loop, session):
 
 
 async def test_read_and_release_connection_with_error(loop, session):
-    response = ClientResponse('get', URL('http://def-cl-resp.org'))
-    response._post_init(loop, session)
+    response = ClientResponse('get', URL('http://def-cl-resp.org'),
+                              request_info=mock.Mock(),
+                              writer=mock.Mock(),
+                              continue100=None,
+                              timer=TimerNoop(),
+                              auto_decompress=True,
+                              traces=[],
+                              loop=loop,
+                              session=session)
     content = response.content = mock.Mock()
     content.read.return_value = loop.create_future()
     content.read.return_value.set_exception(ValueError)
@@ -142,8 +221,15 @@ async def test_read_and_release_connection_with_error(loop, session):
 
 
 async def test_release(loop, session):
-    response = ClientResponse('get', URL('http://def-cl-resp.org'))
-    response._post_init(loop, session)
+    response = ClientResponse('get', URL('http://def-cl-resp.org'),
+                              request_info=mock.Mock(),
+                              writer=mock.Mock(),
+                              continue100=None,
+                              timer=TimerNoop(),
+                              auto_decompress=True,
+                              traces=[],
+                              loop=loop,
+                              session=session)
     fut = loop.create_future()
     fut.set_result(b'')
     content = response.content = mock.Mock()
@@ -160,8 +246,15 @@ async def test_release_on_del(loop, session):
     connection.protocol.upgraded = False
 
     def run(conn):
-        response = ClientResponse('get', URL('http://def-cl-resp.org'))
-        response._post_init(loop, session)
+        response = ClientResponse('get', URL('http://def-cl-resp.org'),
+                                  request_info=mock.Mock(),
+                                  writer=mock.Mock(),
+                                  continue100=None,
+                                  timer=TimerNoop(),
+                                  auto_decompress=True,
+                                  traces=[],
+                                  loop=loop,
+                                  session=session)
         response._closed = False
         response._connection = conn
 
@@ -171,8 +264,15 @@ async def test_release_on_del(loop, session):
 
 
 async def test_response_eof(loop, session):
-    response = ClientResponse('get', URL('http://def-cl-resp.org'))
-    response._post_init(loop, session)
+    response = ClientResponse('get', URL('http://def-cl-resp.org'),
+                              request_info=mock.Mock(),
+                              writer=mock.Mock(),
+                              continue100=None,
+                              timer=TimerNoop(),
+                              auto_decompress=True,
+                              traces=[],
+                              loop=loop,
+                              session=session)
     response._closed = False
     conn = response._connection = mock.Mock()
     conn.protocol.upgraded = False
@@ -183,8 +283,15 @@ async def test_response_eof(loop, session):
 
 
 async def test_response_eof_upgraded(loop, session):
-    response = ClientResponse('get', URL('http://def-cl-resp.org'))
-    response._post_init(loop, session)
+    response = ClientResponse('get', URL('http://def-cl-resp.org'),
+                              request_info=mock.Mock(),
+                              writer=mock.Mock(),
+                              continue100=None,
+                              timer=TimerNoop(),
+                              auto_decompress=True,
+                              traces=[],
+                              loop=loop,
+                              session=session)
 
     conn = response._connection = mock.Mock()
     conn.protocol.upgraded = True
@@ -195,8 +302,15 @@ async def test_response_eof_upgraded(loop, session):
 
 
 async def test_response_eof_after_connection_detach(loop, session):
-    response = ClientResponse('get', URL('http://def-cl-resp.org'))
-    response._post_init(loop, session)
+    response = ClientResponse('get', URL('http://def-cl-resp.org'),
+                              request_info=mock.Mock(),
+                              writer=mock.Mock(),
+                              continue100=None,
+                              timer=TimerNoop(),
+                              auto_decompress=True,
+                              traces=[],
+                              loop=loop,
+                              session=session)
     response._closed = False
     conn = response._connection = mock.Mock()
     conn.protocol = None
@@ -207,8 +321,15 @@ async def test_response_eof_after_connection_detach(loop, session):
 
 
 async def test_text(loop, session):
-    response = ClientResponse('get', URL('http://def-cl-resp.org'))
-    response._post_init(loop, session)
+    response = ClientResponse('get', URL('http://def-cl-resp.org'),
+                              request_info=mock.Mock(),
+                              writer=mock.Mock(),
+                              continue100=None,
+                              timer=TimerNoop(),
+                              auto_decompress=True,
+                              traces=[],
+                              loop=loop,
+                              session=session)
 
     def side_effect(*args, **kwargs):
         fut = loop.create_future()
@@ -226,8 +347,15 @@ async def test_text(loop, session):
 
 
 async def test_text_bad_encoding(loop, session):
-    response = ClientResponse('get', URL('http://def-cl-resp.org'))
-    response._post_init(loop, session)
+    response = ClientResponse('get', URL('http://def-cl-resp.org'),
+                              request_info=mock.Mock(),
+                              writer=mock.Mock(),
+                              continue100=None,
+                              timer=TimerNoop(),
+                              auto_decompress=True,
+                              traces=[],
+                              loop=loop,
+                              session=session)
 
     def side_effect(*args, **kwargs):
         fut = loop.create_future()
@@ -248,8 +376,15 @@ async def test_text_bad_encoding(loop, session):
 
 
 async def test_text_custom_encoding(loop, session):
-    response = ClientResponse('get', URL('http://def-cl-resp.org'))
-    response._post_init(loop, session)
+    response = ClientResponse('get', URL('http://def-cl-resp.org'),
+                              request_info=mock.Mock(),
+                              writer=mock.Mock(),
+                              continue100=None,
+                              timer=TimerNoop(),
+                              auto_decompress=True,
+                              traces=[],
+                              loop=loop,
+                              session=session)
 
     def side_effect(*args, **kwargs):
         fut = loop.create_future()
@@ -269,8 +404,15 @@ async def test_text_custom_encoding(loop, session):
 
 
 async def test_text_detect_encoding(loop, session):
-    response = ClientResponse('get', URL('http://def-cl-resp.org'))
-    response._post_init(loop, session)
+    response = ClientResponse('get', URL('http://def-cl-resp.org'),
+                              request_info=mock.Mock(),
+                              writer=mock.Mock(),
+                              continue100=None,
+                              timer=TimerNoop(),
+                              auto_decompress=True,
+                              traces=[],
+                              loop=loop,
+                              session=session)
 
     def side_effect(*args, **kwargs):
         fut = loop.create_future()
@@ -288,8 +430,15 @@ async def test_text_detect_encoding(loop, session):
 
 
 async def test_text_detect_encoding_if_invalid_charset(loop, session):
-    response = ClientResponse('get', URL('http://def-cl-resp.org'))
-    response._post_init(loop, session)
+    response = ClientResponse('get', URL('http://def-cl-resp.org'),
+                              request_info=mock.Mock(),
+                              writer=mock.Mock(),
+                              continue100=None,
+                              timer=TimerNoop(),
+                              auto_decompress=True,
+                              traces=[],
+                              loop=loop,
+                              session=session)
 
     def side_effect(*args, **kwargs):
         fut = loop.create_future()
@@ -308,8 +457,15 @@ async def test_text_detect_encoding_if_invalid_charset(loop, session):
 
 
 async def test_text_after_read(loop, session):
-    response = ClientResponse('get', URL('http://def-cl-resp.org'))
-    response._post_init(loop, session)
+    response = ClientResponse('get', URL('http://def-cl-resp.org'),
+                              request_info=mock.Mock(),
+                              writer=mock.Mock(),
+                              continue100=None,
+                              timer=TimerNoop(),
+                              auto_decompress=True,
+                              traces=[],
+                              loop=loop,
+                              session=session)
 
     def side_effect(*args, **kwargs):
         fut = loop.create_future()
@@ -327,8 +483,15 @@ async def test_text_after_read(loop, session):
 
 
 async def test_json(loop, session):
-    response = ClientResponse('get', URL('http://def-cl-resp.org'))
-    response._post_init(loop, session)
+    response = ClientResponse('get', URL('http://def-cl-resp.org'),
+                              request_info=mock.Mock(),
+                              writer=mock.Mock(),
+                              continue100=None,
+                              timer=TimerNoop(),
+                              auto_decompress=True,
+                              traces=[],
+                              loop=loop,
+                              session=session)
 
     def side_effect(*args, **kwargs):
         fut = loop.create_future()
@@ -346,8 +509,15 @@ async def test_json(loop, session):
 
 
 async def test_json_extended_content_type(loop, session):
-    response = ClientResponse('get', URL('http://def-cl-resp.org'))
-    response._post_init(loop, session)
+    response = ClientResponse('get', URL('http://def-cl-resp.org'),
+                              request_info=mock.Mock(),
+                              writer=mock.Mock(),
+                              continue100=None,
+                              timer=TimerNoop(),
+                              auto_decompress=True,
+                              traces=[],
+                              loop=loop,
+                              session=session)
 
     def side_effect(*args, **kwargs):
         fut = loop.create_future()
@@ -366,8 +536,15 @@ async def test_json_extended_content_type(loop, session):
 
 
 async def test_json_custom_content_type(loop, session):
-    response = ClientResponse('get', URL('http://def-cl-resp.org'))
-    response._post_init(loop, session)
+    response = ClientResponse('get', URL('http://def-cl-resp.org'),
+                              request_info=mock.Mock(),
+                              writer=mock.Mock(),
+                              continue100=None,
+                              timer=TimerNoop(),
+                              auto_decompress=True,
+                              traces=[],
+                              loop=loop,
+                              session=session)
 
     def side_effect(*args, **kwargs):
         fut = loop.create_future()
@@ -385,8 +562,15 @@ async def test_json_custom_content_type(loop, session):
 
 
 async def test_json_custom_loader(loop, session):
-    response = ClientResponse('get', URL('http://def-cl-resp.org'))
-    response._post_init(loop, session)
+    response = ClientResponse('get', URL('http://def-cl-resp.org'),
+                              request_info=mock.Mock(),
+                              writer=mock.Mock(),
+                              continue100=None,
+                              timer=TimerNoop(),
+                              auto_decompress=True,
+                              traces=[],
+                              loop=loop,
+                              session=session)
     response.headers = {
         'Content-Type': 'application/json;charset=cp1251'}
     response._content = b'data'
@@ -399,8 +583,15 @@ async def test_json_custom_loader(loop, session):
 
 
 async def test_json_invalid_content_type(loop, session):
-    response = ClientResponse('get', URL('http://def-cl-resp.org'))
-    response._post_init(loop, session)
+    response = ClientResponse('get', URL('http://def-cl-resp.org'),
+                              request_info=mock.Mock(),
+                              writer=mock.Mock(),
+                              continue100=None,
+                              timer=TimerNoop(),
+                              auto_decompress=True,
+                              traces=[],
+                              loop=loop,
+                              session=session)
     response.headers = {
         'Content-Type': 'data/octet-stream'}
     response._content = b''
@@ -412,8 +603,15 @@ async def test_json_invalid_content_type(loop, session):
 
 
 async def test_json_no_content(loop, session):
-    response = ClientResponse('get', URL('http://def-cl-resp.org'))
-    response._post_init(loop, session)
+    response = ClientResponse('get', URL('http://def-cl-resp.org'),
+                              request_info=mock.Mock(),
+                              writer=mock.Mock(),
+                              continue100=None,
+                              timer=TimerNoop(),
+                              auto_decompress=True,
+                              traces=[],
+                              loop=loop,
+                              session=session)
     response.headers = {
         'Content-Type': 'data/octet-stream'}
     response._content = b''
@@ -423,8 +621,15 @@ async def test_json_no_content(loop, session):
 
 
 async def test_json_override_encoding(loop, session):
-    response = ClientResponse('get', URL('http://def-cl-resp.org'))
-    response._post_init(loop, session)
+    response = ClientResponse('get', URL('http://def-cl-resp.org'),
+                              request_info=mock.Mock(),
+                              writer=mock.Mock(),
+                              continue100=None,
+                              timer=TimerNoop(),
+                              auto_decompress=True,
+                              traces=[],
+                              loop=loop,
+                              session=session)
 
     def side_effect(*args, **kwargs):
         fut = loop.create_future()
@@ -443,20 +648,16 @@ async def test_json_override_encoding(loop, session):
     assert not response.get_encoding.called
 
 
-@pytest.mark.xfail
-def test_override_flow_control(loop, session):
-    class MyResponse(ClientResponse):
-        flow_control_class = aiohttp.StreamReader
-    response = MyResponse('get', URL('http://my-cl-resp.org'))
-    response._post_init(loop, session)
-    response._connection = mock.Mock()
-    assert isinstance(response.content, aiohttp.StreamReader)
-    response.close()
-
-
 def test_get_encoding_unknown(loop, session):
-    response = ClientResponse('get', URL('http://def-cl-resp.org'))
-    response._post_init(loop, session)
+    response = ClientResponse('get', URL('http://def-cl-resp.org'),
+                              request_info=mock.Mock(),
+                              writer=mock.Mock(),
+                              continue100=None,
+                              timer=TimerNoop(),
+                              auto_decompress=True,
+                              traces=[],
+                              loop=loop,
+                              session=session)
 
     response.headers = {'Content-Type': 'application/json'}
     with mock.patch('aiohttp.client_reqrep.chardet') as m_chardet:
@@ -465,14 +666,30 @@ def test_get_encoding_unknown(loop, session):
 
 
 def test_raise_for_status_2xx():
-    response = ClientResponse('get', URL('http://def-cl-resp.org'))
+    response = ClientResponse('get', URL('http://def-cl-resp.org'),
+                              request_info=mock.Mock(),
+                              writer=mock.Mock(),
+                              continue100=None,
+                              timer=TimerNoop(),
+                              auto_decompress=True,
+                              traces=[],
+                              loop=mock.Mock(),
+                              session=mock.Mock())
     response.status = 200
     response.reason = 'OK'
     response.raise_for_status()  # should not raise
 
 
 def test_raise_for_status_4xx():
-    response = ClientResponse('get', URL('http://def-cl-resp.org'))
+    response = ClientResponse('get', URL('http://def-cl-resp.org'),
+                              request_info=mock.Mock(),
+                              writer=mock.Mock(),
+                              continue100=None,
+                              timer=TimerNoop(),
+                              auto_decompress=True,
+                              traces=[],
+                              loop=mock.Mock(),
+                              session=mock.Mock())
     response.status = 409
     response.reason = 'CONFLICT'
     with pytest.raises(aiohttp.ClientResponseError) as cm:
@@ -482,47 +699,103 @@ def test_raise_for_status_4xx():
 
 
 def test_resp_host():
-    response = ClientResponse('get', URL('http://del-cl-resp.org'))
+    response = ClientResponse('get', URL('http://del-cl-resp.org'),
+                              request_info=mock.Mock(),
+                              writer=mock.Mock(),
+                              continue100=None,
+                              timer=TimerNoop(),
+                              auto_decompress=True,
+                              traces=[],
+                              loop=mock.Mock(),
+                              session=mock.Mock())
     assert 'del-cl-resp.org' == response.host
 
 
 def test_content_type():
-    response = ClientResponse('get', URL('http://def-cl-resp.org'))
+    response = ClientResponse('get', URL('http://def-cl-resp.org'),
+                              request_info=mock.Mock(),
+                              writer=mock.Mock(),
+                              continue100=None,
+                              timer=TimerNoop(),
+                              auto_decompress=True,
+                              traces=[],
+                              loop=mock.Mock(),
+                              session=mock.Mock())
     response.headers = {'Content-Type': 'application/json;charset=cp1251'}
 
     assert 'application/json' == response.content_type
 
 
 def test_content_type_no_header():
-    response = ClientResponse('get', URL('http://def-cl-resp.org'))
+    response = ClientResponse('get', URL('http://def-cl-resp.org'),
+                              request_info=mock.Mock(),
+                              writer=mock.Mock(),
+                              continue100=None,
+                              timer=TimerNoop(),
+                              auto_decompress=True,
+                              traces=[],
+                              loop=mock.Mock(),
+                              session=mock.Mock())
     response.headers = {}
 
     assert 'application/octet-stream' == response.content_type
 
 
 def test_charset():
-    response = ClientResponse('get', URL('http://def-cl-resp.org'))
+    response = ClientResponse('get', URL('http://def-cl-resp.org'),
+                              request_info=mock.Mock(),
+                              writer=mock.Mock(),
+                              continue100=None,
+                              timer=TimerNoop(),
+                              auto_decompress=True,
+                              traces=[],
+                              loop=mock.Mock(),
+                              session=mock.Mock())
     response.headers = {'Content-Type': 'application/json;charset=cp1251'}
 
     assert 'cp1251' == response.charset
 
 
 def test_charset_no_header():
-    response = ClientResponse('get', URL('http://def-cl-resp.org'))
+    response = ClientResponse('get', URL('http://def-cl-resp.org'),
+                              request_info=mock.Mock(),
+                              writer=mock.Mock(),
+                              continue100=None,
+                              timer=TimerNoop(),
+                              auto_decompress=True,
+                              traces=[],
+                              loop=mock.Mock(),
+                              session=mock.Mock())
     response.headers = {}
 
     assert response.charset is None
 
 
 def test_charset_no_charset():
-    response = ClientResponse('get', URL('http://def-cl-resp.org'))
+    response = ClientResponse('get', URL('http://def-cl-resp.org'),
+                              request_info=mock.Mock(),
+                              writer=mock.Mock(),
+                              continue100=None,
+                              timer=TimerNoop(),
+                              auto_decompress=True,
+                              traces=[],
+                              loop=mock.Mock(),
+                              session=mock.Mock())
     response.headers = {'Content-Type': 'application/json'}
 
     assert response.charset is None
 
 
 def test_content_disposition_full():
-    response = ClientResponse('get', URL('http://def-cl-resp.org'))
+    response = ClientResponse('get', URL('http://def-cl-resp.org'),
+                              request_info=mock.Mock(),
+                              writer=mock.Mock(),
+                              continue100=None,
+                              timer=TimerNoop(),
+                              auto_decompress=True,
+                              traces=[],
+                              loop=mock.Mock(),
+                              session=mock.Mock())
     response.headers = {'Content-Disposition':
                         'attachment; filename="archive.tar.gz"; foo=bar'}
 
@@ -534,7 +807,15 @@ def test_content_disposition_full():
 
 
 def test_content_disposition_no_parameters():
-    response = ClientResponse('get', URL('http://def-cl-resp.org'))
+    response = ClientResponse('get', URL('http://def-cl-resp.org'),
+                              request_info=mock.Mock(),
+                              writer=mock.Mock(),
+                              continue100=None,
+                              timer=TimerNoop(),
+                              auto_decompress=True,
+                              traces=[],
+                              loop=mock.Mock(),
+                              session=mock.Mock())
     response.headers = {'Content-Disposition': 'attachment'}
 
     assert 'attachment' == response.content_disposition.type
@@ -543,14 +824,30 @@ def test_content_disposition_no_parameters():
 
 
 def test_content_disposition_no_header():
-    response = ClientResponse('get', URL('http://def-cl-resp.org'))
+    response = ClientResponse('get', URL('http://def-cl-resp.org'),
+                              request_info=mock.Mock(),
+                              writer=mock.Mock(),
+                              continue100=None,
+                              timer=TimerNoop(),
+                              auto_decompress=True,
+                              traces=[],
+                              loop=mock.Mock(),
+                              session=mock.Mock())
     response.headers = {}
 
     assert response.content_disposition is None
 
 
 def test_content_disposition_cache():
-    response = ClientResponse('get', URL('http://def-cl-resp.org'))
+    response = ClientResponse('get', URL('http://def-cl-resp.org'),
+                              request_info=mock.Mock(),
+                              writer=mock.Mock(),
+                              continue100=None,
+                              timer=TimerNoop(),
+                              auto_decompress=True,
+                              traces=[],
+                              loop=mock.Mock(),
+                              session=mock.Mock())
     response.headers = {'Content-Disposition': 'attachment'}
     cd = response.content_disposition
     ClientResponse.headers = {'Content-Disposition': 'spam'}
@@ -566,19 +863,18 @@ def test_response_request_info():
             url,
             'get',
             headers
-        )
+        ),
+        writer=mock.Mock(),
+        continue100=None,
+        timer=TimerNoop(),
+        auto_decompress=True,
+        traces=[],
+        loop=mock.Mock(),
+        session=mock.Mock()
     )
     assert url == response.request_info.url
     assert 'get' == response.request_info.method
     assert headers == response.request_info.headers
-
-
-def test_response_request_info_empty():
-    url = 'http://def-cl-resp.org'
-    response = ClientResponse(
-        'get', URL(url),
-    )
-    assert response.request_info is None
 
 
 def test_request_info_in_exception():
@@ -591,7 +887,14 @@ def test_request_info_in_exception():
             url,
             'get',
             headers
-        )
+        ),
+        writer=mock.Mock(),
+        continue100=None,
+        timer=TimerNoop(),
+        auto_decompress=True,
+        traces=[],
+        loop=mock.Mock(),
+        session=mock.Mock()
     )
     response.status = 409
     response.reason = 'CONFLICT'
@@ -610,7 +913,14 @@ def test_no_redirect_history_in_exception():
             url,
             'get',
             headers
-        )
+        ),
+        writer=mock.Mock(),
+        continue100=None,
+        timer=TimerNoop(),
+        auto_decompress=True,
+        traces=[],
+        loop=mock.Mock(),
+        session=mock.Mock()
     )
     response.status = 409
     response.reason = 'CONFLICT'
@@ -633,7 +943,14 @@ def test_redirect_history_in_exception():
             url,
             'get',
             headers
-        )
+        ),
+        writer=mock.Mock(),
+        continue100=None,
+        timer=TimerNoop(),
+        auto_decompress=True,
+        traces=[],
+        loop=mock.Mock(),
+        session=mock.Mock()
     )
     response.status = 409
     response.reason = 'CONFLICT'
@@ -645,7 +962,14 @@ def test_redirect_history_in_exception():
             url,
             'get',
             headers
-        )
+        ),
+        writer=mock.Mock(),
+        continue100=None,
+        timer=TimerNoop(),
+        auto_decompress=True,
+        traces=[],
+        loop=mock.Mock(),
+        session=mock.Mock()
     )
 
     hist_response.headers = hist_headers
@@ -665,9 +989,15 @@ async def test_response_read_triggers_callback(loop, session):
 
     response = ClientResponse(
         'get', URL('http://def-cl-resp.org'),
+        request_info=mock.Mock,
+        writer=mock.Mock(),
+        continue100=None,
+        timer=TimerNoop(),
+        auto_decompress=True,
+        loop=loop,
+        session=session,
         traces=[trace]
     )
-    response._post_init(loop, session)
 
     def side_effect(*args, **kwargs):
         fut = loop.create_future()

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -9,6 +9,7 @@ from yarl import URL
 
 import aiohttp
 from aiohttp.client_reqrep import ClientRequest, ClientResponse
+from aiohttp.helpers import TimerNoop
 from aiohttp.test_utils import make_mocked_coro
 
 
@@ -145,8 +146,15 @@ class TestProxy(unittest.TestCase):
                                   loop=self.loop)
         ClientRequestMock.return_value = proxy_req
 
-        proxy_resp = ClientResponse('get', URL('http://proxy.example.com'))
-        proxy_resp._loop = self.loop
+        proxy_resp = ClientResponse('get', URL('http://proxy.example.com'),
+                                    request_info=mock.Mock(),
+                                    writer=mock.Mock(),
+                                    continue100=None,
+                                    timer=TimerNoop(),
+                                    auto_decompress=True,
+                                    traces=[],
+                                    loop=self.loop,
+                                    session=mock.Mock())
         proxy_req.send = make_mocked_coro(proxy_resp)
         proxy_resp.start = make_mocked_coro(mock.Mock(status=200))
 
@@ -181,8 +189,15 @@ class TestProxy(unittest.TestCase):
                                   loop=self.loop)
         ClientRequestMock.return_value = proxy_req
 
-        proxy_resp = ClientResponse('get', URL('http://proxy.example.com'))
-        proxy_resp._loop = self.loop
+        proxy_resp = ClientResponse('get', URL('http://proxy.example.com'),
+                                    request_info=mock.Mock(),
+                                    writer=mock.Mock(),
+                                    continue100=None,
+                                    timer=TimerNoop(),
+                                    auto_decompress=True,
+                                    traces=[],
+                                    loop=self.loop,
+                                    session=mock.Mock())
         proxy_req.send = make_mocked_coro(proxy_resp)
         proxy_resp.start = make_mocked_coro(mock.Mock(status=200))
 
@@ -223,8 +238,15 @@ class TestProxy(unittest.TestCase):
                                   loop=self.loop)
         ClientRequestMock.return_value = proxy_req
 
-        proxy_resp = ClientResponse('get', URL('http://proxy.example.com'))
-        proxy_resp._loop = self.loop
+        proxy_resp = ClientResponse('get', URL('http://proxy.example.com'),
+                                    request_info=mock.Mock(),
+                                    writer=mock.Mock(),
+                                    continue100=None,
+                                    timer=TimerNoop(),
+                                    auto_decompress=True,
+                                    traces=[],
+                                    loop=self.loop,
+                                    session=mock.Mock())
         proxy_req.send = make_mocked_coro(proxy_resp)
         proxy_resp.start = make_mocked_coro(mock.Mock(status=200))
 
@@ -265,8 +287,15 @@ class TestProxy(unittest.TestCase):
                                   loop=self.loop)
         ClientRequestMock.return_value = proxy_req
 
-        proxy_resp = ClientResponse('get', URL('http://proxy.example.com'))
-        proxy_resp._loop = self.loop
+        proxy_resp = ClientResponse('get', URL('http://proxy.example.com'),
+                                    request_info=mock.Mock(),
+                                    writer=mock.Mock(),
+                                    continue100=None,
+                                    timer=TimerNoop(),
+                                    auto_decompress=True,
+                                    traces=[],
+                                    loop=self.loop,
+                                    session=mock.Mock())
         proxy_req.send = make_mocked_coro(proxy_resp)
         proxy_resp.start = make_mocked_coro(mock.Mock(status=200))
 
@@ -298,8 +327,15 @@ class TestProxy(unittest.TestCase):
                                   loop=self.loop)
         ClientRequestMock.return_value = proxy_req
 
-        proxy_resp = ClientResponse('get', URL('http://proxy.example.com'))
-        proxy_resp._loop = self.loop
+        proxy_resp = ClientResponse('get', URL('http://proxy.example.com'),
+                                    request_info=mock.Mock(),
+                                    writer=mock.Mock(),
+                                    continue100=None,
+                                    timer=TimerNoop(),
+                                    auto_decompress=True,
+                                    traces=[],
+                                    loop=self.loop,
+                                    session=mock.Mock())
         proxy_req.send = make_mocked_coro(proxy_resp)
         proxy_resp.start = make_mocked_coro(
             mock.Mock(status=400, reason='bad request'))
@@ -332,8 +368,15 @@ class TestProxy(unittest.TestCase):
                                   loop=self.loop)
         ClientRequestMock.return_value = proxy_req
 
-        proxy_resp = ClientResponse('get', URL('http://proxy.example.com'))
-        proxy_resp._loop = self.loop
+        proxy_resp = ClientResponse('get', URL('http://proxy.example.com'),
+                                    request_info=mock.Mock(),
+                                    writer=mock.Mock(),
+                                    continue100=None,
+                                    timer=TimerNoop(),
+                                    auto_decompress=True,
+                                    traces=[],
+                                    loop=self.loop,
+                                    session=mock.Mock())
         proxy_req.send = make_mocked_coro(proxy_resp)
         proxy_resp.start = make_mocked_coro(
             raise_exception=OSError("error message"))
@@ -399,8 +442,15 @@ class TestProxy(unittest.TestCase):
                                   loop=self.loop)
         ClientRequestMock.return_value = proxy_req
 
-        proxy_resp = ClientResponse('get', URL('http://proxy.example.com'))
-        proxy_resp._loop = self.loop
+        proxy_resp = ClientResponse('get', URL('http://proxy.example.com'),
+                                    request_info=mock.Mock(),
+                                    writer=mock.Mock(),
+                                    continue100=None,
+                                    timer=TimerNoop(),
+                                    auto_decompress=True,
+                                    traces=[],
+                                    loop=self.loop,
+                                    session=mock.Mock())
         proxy_req.send = make_mocked_coro(proxy_resp)
         proxy_resp.start = make_mocked_coro(mock.Mock(status=200))
 
@@ -443,8 +493,15 @@ class TestProxy(unittest.TestCase):
                                   loop=self.loop)
         ClientRequestMock.return_value = proxy_req
 
-        proxy_resp = ClientResponse('get', URL('http://proxy.example.com'))
-        proxy_resp._loop = self.loop
+        proxy_resp = ClientResponse('get', URL('http://proxy.example.com'),
+                                    request_info=mock.Mock(),
+                                    writer=mock.Mock(),
+                                    continue100=None,
+                                    timer=TimerNoop(),
+                                    auto_decompress=True,
+                                    traces=[],
+                                    loop=self.loop,
+                                    session=mock.Mock())
         proxy_req.send = make_mocked_coro(proxy_resp)
         proxy_resp.start = make_mocked_coro(mock.Mock(status=200))
 


### PR DESCRIPTION
1. Make logically required constructor arguments mandatory.
2. Drop `_post_init()` method