### PR TITLE
Import the web package when aiohttp is imported

### DIFF
--- a/aiohttp/__init__.py
+++ b/aiohttp/__init__.py
@@ -16,6 +16,7 @@ from .resolver import *  # noqa
 from .signals import *  # noqa
 from .streams import *  # noqa
 from .tracing import *  # noqa
+from .web import *  # noqa
 
 try:
     from .worker import GunicornWebWorker, GunicornUVLoopWebWorker  # noqa


### PR DESCRIPTION
## What do these changes do?

Import `aiohttp.web` package and its explicit dependencies when the user makes the typical `import aiohttp`.

I'm wondering if this was on purpose ...