### PR TITLE
[WIP] first draft of more generic timeouts throughout the request lifecycle

### DIFF
--- a/aiohttp/lifecycle.py
+++ b/aiohttp/lifecycle.py
@@ -1,0 +1,109 @@
+import asyncio
+import time
+import warnings
+from collections import defaultdict
+from math import ceil
+
+import attr
+
+from aiohttp.helpers import TimerContext, TimerNoop
+from aiohttp.tracing import SIGNALS
+
+
+def _tm(start, end):
+    if start not in SIGNALS.keys():
+        raise ValueError("Invalid timeout start signal %s" % start)
+    if end not in SIGNALS.keys():
+        raise ValueError("Invalid timeout end signal %s" % end)
+    return {"start": start, "end": end}
+
+
+@attr.s(frozen=True, slots=True)
+class RequestTimeouts:
+    # XXX what happens between "connection_create_start" and "connection_create_end" and whether we'll get callbacks is implementation dependent
+    read_timeout = attr.ib(type=float, default=None)  # TODO
+    connection_create_timeout = attr.ib(type=float, default=None, metadata=_tm("connection_create_start", "connection_create_end"))
+
+    uber_timeout = attr.ib(type=float, default=None, metadata=_tm("request_start", "request_end"))
+    pool_queue_timeout = attr.ib(type=float, default=None, metadata=_tm("connection_queued_start", "connection_queued_end"))
+    dns_resolution_timeout = attr.ib(type=float, default=None, metadata=_tm("dns_resolvehost_start", "dns_resolvehost_end"))
+    socket_connect_timeout = attr.ib(type=float, default=None)  # TODO
+    connection_acquiring_timeout = attr.ib(type=float, default=None)  # TODO
+    new_connection_timeout = attr.ib(type=float, default=None)  # TODO
+    http_header_timeout = attr.ib(type=float, default=None)  # TODO metadata=_tm("request_sent", "response_headers_received"))
+    response_body_timeout = attr.ib(type=float, default=None)  # TODO metadata=_tm("response_headers_received", "request_end"))
+
+    # to create a timeout specific for a single request, either
+    # - create a completely new one to overwrite the default
+    # - or use http://www.attrs.org/en/stable/api.html#attr.evolve to overwrite the defaults
+    # (maybe this should be done through either session.extend_timeout or session.replace_timeout without directly calling RequestTimeouts)
+
+
+class RequestLifecycle:
+    """ Internal class used to keep together the main dependencies used
+    at the moment of send a signal."""
+
+    def __init__(self, session, loop, trace_configs, trace_request_ctx, timeout_config):
+        self._session = session
+        self._loop = loop
+        self._trace_configs = [
+            (config, config.trace_config_ctx(trace_request_ctx=trace_request_ctx)) for config in trace_configs
+        ]
+        self._timeout_config = timeout_config
+
+        self._signal_timestamps = {}
+        self._set_timeouts = defaultdict(list)
+        self._active_timeouts = defaultdict(list)
+
+        # filter timeouts that were actually set by the user
+        if timeout_config:
+            for timeout_field in attr.fields(RequestTimeouts):
+                if timeout_field.metadata and getattr(timeout_config, timeout_field.name):
+                    self._active_timeouts[timeout_field.metadata["start"]].append(
+                        (timeout_field.metadata["end"], getattr(timeout_config, timeout_field.name))
+                    )
+
+        # create a timeout context depending on wether any timeouts were actually set
+        if self._set_timeouts:
+            self.request_timer_context = TimerContext(self._loop)
+        else:
+            self.request_timer_context = TimerNoop()
+
+        # generate send_signal methods, sending on_signal to all trace listeners and keeping track of timeouts, for all Signals
+        for signal, params_class in SIGNALS:
+            setattr(self, "send_" + signal, self._send(signal, params_class))
+
+    def _send(self, signal, params_class):
+        async def sender(*args, **kwargs):
+            # record timestamp
+            self._signal_timestamps[signal] = time.time()
+
+            # cancel all running timeouts that end with this signal
+            while self._set_timeouts[signal]:
+                timeout_handle = self._set_timeouts[signal].pop()
+                timeout_handle.cancel()
+
+            # send on_signal to all trace listeners
+            params = params_class(*args, **kwargs)
+            await asyncio.gather(
+                getattr(trace_config, "on_" + signal).send(self._session, trace_context, params)
+                for trace_config, trace_context in self._trace_configs
+            )
+
+            # start all timeouts that begin with this signal and register their handles for the end signal
+            for end, timeout in self._set_timeouts[signal]:
+                assert isinstance(self.request_timer_context, TimerContext)
+                at = ceil(self._loop.time() + timeout)
+                handle = self._loop.call_at(at, self.request_timer_context.timeout)
+                self._set_timeouts[end].append(handle)
+
+        return sender
+
+    def clear_timeouts(self):
+        for signal, timeout_handles in self._set_timeouts.items():
+            while timeout_handles[signal]:
+                timeout_handle = timeout_handles[signal].pop()
+                warnings.warn("Timeout handle %s wasn't cancelled by it's end signal %s. "
+                              "There was something wrong with the lifecycle transitions."
+                              % (timeout_handle, signal))
+                timeout_handle.cancel()

--- a/aiohttp/tracing.py
+++ b/aiohttp/tracing.py
@@ -335,3 +335,22 @@ class Trace:
             self._trace_config_ctx,
             TraceDnsCacheMissParams(host)
         )
+
+
+SIGNALS = {
+    "request_start": TraceRequestStartParams,  # (method, url, headers)
+    "request_chunk_sent": TraceRequestChunkSentParams,  # (chunk)
+    "response_chunk_received": TraceResponseChunkReceivedParams,  # (chunk)
+    "request_end": TraceRequestEndParams,  # (method, url, headers, response)
+    "request_exception": TraceRequestExceptionParams,  # (method, url, headers, exception)
+    "request_redirect": TraceRequestRedirectParams,  # (method, url, headers, response)
+    "connection_queued_start": TraceConnectionQueuedStartParams,  # ()
+    "connection_queued_end": TraceConnectionQueuedEndParams,  # ()
+    "connection_create_start": TraceConnectionCreateStartParams,  # ()
+    "connection_create_end": TraceConnectionCreateEndParams,  # ()
+    "connection_reuseconn": TraceConnectionReuseconnParams,  # ()
+    "dns_resolvehost_start": TraceDnsResolveHostStartParams,  # (host)
+    "dns_resolvehost_end": TraceDnsResolveHostEndParams,  # (host)
+    "dns_cache_hit": TraceDnsCacheHitParams,  # (host)
+    "dns_cache_miss": TraceDnsCacheMissParams,  # (host)
+}


### PR DESCRIPTION
## What do these changes do?

I combined the `TimeoutHandle` class used for the current uber (read) timeout and it's `timer()` context with the list of registered `Trace`s into the `RequestLifecycle` class. This class now provides a context to execute the request in and methods to notify the `Trace`s of changes of the request change, while also keeping track of various timeouts between the various states throughout the whole request lifecycle.

The main changes lie within the new lifecycle.py file:
The attr.s class `RequestTimeouts` is used for configuring the various timeouts. Additionally, attr.ib metadata is used to define the signals where a timeout should be started or ended, where applicable. This makes the attribute definitions analogous to the [timeout table in my comment to the issue](https://github.com/aio-libs/aiohttp/issues/2768#issuecomment-373142177).
Unfortunately, some of the proposed timeouts can't be defined using the currently available signals. In those cases, we could either add further signals, or add code for tracking the specific timeout explicitly.

The `RequestLifecycle` class now uses this meta-information together with a list of all signals and their parameters class to build the various `send_*` dynamically (if you don't like this dynamic generation, the methods could also be "precompiled" statically, but I didn't want to make all that writing effort right now). The new `send_*` methods now do the following:

1. they cancel any active timeout that should be ended by the respective currently emmited signal
2. they notify all registered `Trace` in parallel using asyncio.gather
3. they start and register all timeouts that begin with the respective currently emmited signal

This leads to the time for the tracing of signals between timeout start and end signals to count for encompassing timeout, while the tracing for start and end signal themselves won't be counted. As timeouts are executed in parallel by `asyncio.gather`, the impact should be minimal when using sensible tracing function.

On the topic of merging the timeout config with the session or default config:
The attr.s class `RequestTimeouts` is frozen, preventing any direct modification to and thus requiring the user to create and assign a new instance to make changes. This can either be done by directly calling the class constructor and thus ignoring all set session and default configs, or by using [`attr.evolve`](http://www.attrs.org/en/stable/api.html#attr.evolve)`(session.timeouts, overwritten_timeout=12.3)` to reuse the existing config and only overwrite some specific values.
If you deem the chance of users now accidentally overwriting the default config by always creating a new instance, we could also try to hide the constructor and let the users either use `session.defaulted_timeout_config(**kwargs)` for the `attr.evolve` version or `session.new_timeout_config(**kwargs)` for the one without defaults.

## Are there changes in behavior for the user?

These changes should be 100% backward-compatible for users only using the interface defined by ClientSession. The old `read_timeout` and `conn_timeout` parameters to the `__init__` function will be translated to the new RequestTimeouts config object and the `timeout` parameter can either be a new config object or as previously a number that will be merged into the config object.

To respect the merge of `timer` and `traces` I changed the parameters of `__init__` method and some other request-lifecycle-related methods in `ClientRequest`, `ClientResponse` or `Connector` objects.
To circumvent these breaking-changes, `lifecycle.request_timer_context` can be used as drop-in replacement of the old `timer` (compare [client_reqrep:680](#diff-2fa8ab44317df4fbb7864536a6794d7aR680), where I already did this to circumvent any changes to native code) and `[lifecycle]` can be used as drop-in replacement of the old `traces` array.
If you use these drop-ins starting from [client:254](#diff-7dd84b5ef8d5eea2de1dfc5329411dfcR254), you can drop all the changes to client_reqrep.py and connector.py, as just renamed parameters and replaced for-loops with direct calls there.

## Related issue number

See #2768 for discussion.

## Checklist

Nothing done here yet, as this is just a draft intended as material for discussion. I had to make a PR to allow inline comments within the code. As soon as everything is settled, I'll make a proper PR.

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
