### PR TITLE
Extract route definitions into a separate file

### DIFF
--- a/CHANGES/2876.feature
+++ b/CHANGES/2876.feature
@@ -1,0 +1,1 @@
+Extract route definitions into separate ``web_routedef.py`` file

--- a/aiohttp/web.py
+++ b/aiohttp/web.py
@@ -7,7 +7,7 @@ from importlib import import_module
 
 from . import (helpers, web_app, web_exceptions, web_fileresponse,
                web_middlewares, web_protocol, web_request, web_response,
-               web_runner, web_server, web_urldispatcher, web_ws)
+               web_routedef, web_runner, web_server, web_urldispatcher, web_ws)
 from .log import access_logger
 from .web_app import *  # noqa
 from .web_exceptions import *  # noqa
@@ -16,6 +16,7 @@ from .web_middlewares import *  # noqa
 from .web_protocol import *  # noqa
 from .web_request import *  # noqa
 from .web_response import *  # noqa
+from .web_routedef import *  # noqa
 from .web_runner import *  # noqa
 from .web_runner import AppRunner, GracefulExit, SockSite, TCPSite, UnixSite
 from .web_server import *  # noqa
@@ -28,6 +29,7 @@ __all__ = (web_protocol.__all__ +
            web_fileresponse.__all__ +
            web_request.__all__ +
            web_response.__all__ +
+           web_routedef.__all__ +
            web_exceptions.__all__ +
            web_urldispatcher.__all__ +
            web_ws.__all__ +

--- a/aiohttp/web_routedef.py
+++ b/aiohttp/web_routedef.py
@@ -1,0 +1,147 @@
+import abc
+from collections.abc import Sequence
+
+import attr
+
+from . import hdrs
+
+
+__all__ = ('RouteDef', 'StaticDef', 'RouteTableDef', 'head', 'get',
+           'post', 'patch', 'put', 'delete', 'route', 'view',
+           'static')
+
+
+class AbstractRouteDef(abc.ABC):
+    @abc.abstractmethod
+    def register(self, router):
+        pass  # pragma: no cover
+
+
+@attr.s(frozen=True, repr=False, slots=True)
+class RouteDef(AbstractRouteDef):
+    method = attr.ib(type=str)
+    path = attr.ib(type=str)
+    handler = attr.ib()
+    kwargs = attr.ib()
+
+    def __repr__(self):
+        info = []
+        for name, value in sorted(self.kwargs.items()):
+            info.append(", {}={!r}".format(name, value))
+        return ("<RouteDef {method} {path} -> {handler.__name__!r}"
+                "{info}>".format(method=self.method, path=self.path,
+                                 handler=self.handler, info=''.join(info)))
+
+    def register(self, router):
+        if self.method in hdrs.METH_ALL:
+            reg = getattr(router, 'add_'+self.method.lower())
+            reg(self.path, self.handler, **self.kwargs)
+        else:
+            router.add_route(self.method, self.path, self.handler,
+                             **self.kwargs)
+
+
+@attr.s(frozen=True, repr=False, slots=True)
+class StaticDef(AbstractRouteDef):
+    prefix = attr.ib(type=str)
+    path = attr.ib(type=str)
+    kwargs = attr.ib()
+
+    def __repr__(self):
+        info = []
+        for name, value in sorted(self.kwargs.items()):
+            info.append(", {}={!r}".format(name, value))
+        return ("<StaticDef {prefix} -> {path}"
+                "{info}>".format(prefix=self.prefix, path=self.path,
+                                 info=''.join(info)))
+
+    def register(self, router):
+        router.add_static(self.prefix, self.path, **self.kwargs)
+
+
+def route(method, path, handler, **kwargs):
+    return RouteDef(method, path, handler, kwargs)
+
+
+def head(path, handler, **kwargs):
+    return route(hdrs.METH_HEAD, path, handler, **kwargs)
+
+
+def get(path, handler, *, name=None, allow_head=True, **kwargs):
+    return route(hdrs.METH_GET, path, handler, name=name,
+                 allow_head=allow_head, **kwargs)
+
+
+def post(path, handler, **kwargs):
+    return route(hdrs.METH_POST, path, handler, **kwargs)
+
+
+def put(path, handler, **kwargs):
+    return route(hdrs.METH_PUT, path, handler, **kwargs)
+
+
+def patch(path, handler, **kwargs):
+    return route(hdrs.METH_PATCH, path, handler, **kwargs)
+
+
+def delete(path, handler, **kwargs):
+    return route(hdrs.METH_DELETE, path, handler, **kwargs)
+
+
+def view(path, handler, **kwargs):
+    return route(hdrs.METH_ANY, path, handler, **kwargs)
+
+
+def static(prefix, path, **kwargs):
+    return StaticDef(prefix, path, kwargs)
+
+
+class RouteTableDef(Sequence):
+    """Route definition table"""
+    def __init__(self):
+        self._items = []
+
+    def __repr__(self):
+        return "<RouteTableDef count={}>".format(len(self._items))
+
+    def __getitem__(self, index):
+        return self._items[index]
+
+    def __iter__(self):
+        return iter(self._items)
+
+    def __len__(self):
+        return len(self._items)
+
+    def __contains__(self, item):
+        return item in self._items
+
+    def route(self, method, path, **kwargs):
+        def inner(handler):
+            self._items.append(RouteDef(method, path, handler, kwargs))
+            return handler
+        return inner
+
+    def head(self, path, **kwargs):
+        return self.route(hdrs.METH_HEAD, path, **kwargs)
+
+    def get(self, path, **kwargs):
+        return self.route(hdrs.METH_GET, path, **kwargs)
+
+    def post(self, path, **kwargs):
+        return self.route(hdrs.METH_POST, path, **kwargs)
+
+    def put(self, path, **kwargs):
+        return self.route(hdrs.METH_PUT, path, **kwargs)
+
+    def patch(self, path, **kwargs):
+        return self.route(hdrs.METH_PATCH, path, **kwargs)
+
+    def delete(self, path, **kwargs):
+        return self.route(hdrs.METH_DELETE, path, **kwargs)
+
+    def view(self, path, **kwargs):
+        return self.route(hdrs.METH_ANY, path, **kwargs)
+
+    def static(self, prefix, path, **kwargs):
+        self._items.append(StaticDef(prefix, path, kwargs))

--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -8,13 +8,12 @@ import keyword
 import os
 import re
 import warnings
-from collections.abc import Container, Iterable, Sequence, Sized
+from collections.abc import Container, Iterable, Sized
 from contextlib import contextmanager
 from functools import wraps
 from pathlib import Path
 from types import MappingProxyType
 
-import attr
 from yarl import URL
 
 from . import hdrs
@@ -29,61 +28,11 @@ from .web_response import Response
 __all__ = ('UrlDispatcher', 'UrlMappingMatchInfo',
            'AbstractResource', 'Resource', 'PlainResource', 'DynamicResource',
            'AbstractRoute', 'ResourceRoute',
-           'StaticResource', 'View', 'RouteDef', 'StaticDef', 'RouteTableDef',
-           'head', 'get', 'post', 'patch', 'put', 'delete', 'route', 'view',
-           'static')
+           'StaticResource', 'View')
 
 HTTP_METHOD_RE = re.compile(r"^[0-9A-Za-z!#\$%&'\*\+\-\.\^_`\|~]+$")
 ROUTE_RE = re.compile(r'(\{[_a-zA-Z][^{}]*(?:\{[^{}]*\}[^{}]*)*\})')
 PATH_SEP = re.escape('/')
-
-
-class AbstractRouteDef(abc.ABC):
-    @abc.abstractmethod
-    def register(self, router):
-        pass  # pragma: no cover
-
-
-@attr.s(frozen=True, repr=False, slots=True)
-class RouteDef(AbstractRouteDef):
-    method = attr.ib(type=str)
-    path = attr.ib(type=str)
-    handler = attr.ib()
-    kwargs = attr.ib()
-
-    def __repr__(self):
-        info = []
-        for name, value in sorted(self.kwargs.items()):
-            info.append(", {}={!r}".format(name, value))
-        return ("<RouteDef {method} {path} -> {handler.__name__!r}"
-                "{info}>".format(method=self.method, path=self.path,
-                                 handler=self.handler, info=''.join(info)))
-
-    def register(self, router):
-        if self.method in hdrs.METH_ALL:
-            reg = getattr(router, 'add_'+self.method.lower())
-            reg(self.path, self.handler, **self.kwargs)
-        else:
-            router.add_route(self.method, self.path, self.handler,
-                             **self.kwargs)
-
-
-@attr.s(frozen=True, repr=False, slots=True)
-class StaticDef(AbstractRouteDef):
-    prefix = attr.ib(type=str)
-    path = attr.ib(type=str)
-    kwargs = attr.ib()
-
-    def __repr__(self):
-        info = []
-        for name, value in sorted(self.kwargs.items()):
-            info.append(", {}={!r}".format(name, value))
-        return ("<StaticDef {prefix} -> {path}"
-                "{info}>".format(prefix=self.prefix, path=self.path,
-                                 info=''.join(info)))
-
-    def register(self, router):
-        router.add_static(self.prefix, self.path, **self.kwargs)
 
 
 class AbstractResource(Sized, Iterable):
@@ -985,91 +934,3 @@ class UrlDispatcher(AbstractRouter, collections.abc.Mapping):
         """
         for route_obj in routes:
             route_obj.register(self)
-
-
-def route(method, path, handler, **kwargs):
-    return RouteDef(method, path, handler, kwargs)
-
-
-def head(path, handler, **kwargs):
-    return route(hdrs.METH_HEAD, path, handler, **kwargs)
-
-
-def get(path, handler, *, name=None, allow_head=True, **kwargs):
-    return route(hdrs.METH_GET, path, handler, name=name,
-                 allow_head=allow_head, **kwargs)
-
-
-def post(path, handler, **kwargs):
-    return route(hdrs.METH_POST, path, handler, **kwargs)
-
-
-def put(path, handler, **kwargs):
-    return route(hdrs.METH_PUT, path, handler, **kwargs)
-
-
-def patch(path, handler, **kwargs):
-    return route(hdrs.METH_PATCH, path, handler, **kwargs)
-
-
-def delete(path, handler, **kwargs):
-    return route(hdrs.METH_DELETE, path, handler, **kwargs)
-
-
-def view(path, handler, **kwargs):
-    return route(hdrs.METH_ANY, path, handler, **kwargs)
-
-
-def static(prefix, path, **kwargs):
-    return StaticDef(prefix, path, kwargs)
-
-
-class RouteTableDef(Sequence):
-    """Route definition table"""
-    def __init__(self):
-        self._items = []
-
-    def __repr__(self):
-        return "<RouteTableDef count={}>".format(len(self._items))
-
-    def __getitem__(self, index):
-        return self._items[index]
-
-    def __iter__(self):
-        return iter(self._items)
-
-    def __len__(self):
-        return len(self._items)
-
-    def __contains__(self, item):
-        return item in self._items
-
-    def route(self, method, path, **kwargs):
-        def inner(handler):
-            self._items.append(RouteDef(method, path, handler, kwargs))
-            return handler
-        return inner
-
-    def head(self, path, **kwargs):
-        return self.route(hdrs.METH_HEAD, path, **kwargs)
-
-    def get(self, path, **kwargs):
-        return self.route(hdrs.METH_GET, path, **kwargs)
-
-    def post(self, path, **kwargs):
-        return self.route(hdrs.METH_POST, path, **kwargs)
-
-    def put(self, path, **kwargs):
-        return self.route(hdrs.METH_PUT, path, **kwargs)
-
-    def patch(self, path, **kwargs):
-        return self.route(hdrs.METH_PATCH, path, **kwargs)
-
-    def delete(self, path, **kwargs):
-        return self.route(hdrs.METH_DELETE, path, **kwargs)
-
-    def view(self, path, **kwargs):
-        return self.route(hdrs.METH_ANY, path, **kwargs)
-
-    def static(self, prefix, path, **kwargs):
-        self._items.append(StaticDef(prefix, path, kwargs))


### PR DESCRIPTION
A part of #2766 reorganization
`web_urldispatcher.py` is very huge.

Route definitions could be extracted into a separate `web_routedef.py` easy.
No tests are broken.
Anyway these names are part of `aiohttp.web` namespace, importing them directly from `aiohttp.web_urldispatcher` is an error.
