### PR TITLE
Use weakref.WeakSet for tracking websocket objects in the doc sample

### DIFF
--- a/docs/web_advanced.rst
+++ b/docs/web_advanced.rst
@@ -783,23 +783,28 @@ Developer should keep a list of opened connections
 The following :term:`websocket` snippet shows an example for websocket
 handler::
 
+    from aiohttp import web
+    import weakref
+
     app = web.Application()
-    app['websockets'] = []
+    app['websockets'] = weakref.WeakSet()
 
     async def websocket_handler(request):
         ws = web.WebSocketResponse()
         await ws.prepare(request)
 
-        request.app['websockets'].append(ws)
+        request.app['websockets'].add(ws)
         try:
             async for msg in ws:
                 ...
         finally:
-            request.app['websockets'].remove(ws)
+            request.app['websockets'].discard(ws)
 
         return ws
 
 Signal handler may look like::
+
+    from aiohttp import WSCloseCode
 
     async def on_shutdown(app):
         for ws in app['websockets']:


### PR DESCRIPTION
Update the example code for "Graceful Shutdown" documentation to use `weakref.WeakSet` instead of plain list. Strong references here may leak the memory in certain situations.