### PR TITLE
Use new link to warehouse PYPI in README badge

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@ Async http client/server framework
    :alt: codecov.io status for master branch
 
 .. image:: https://badge.fury.io/py/aiohttp.svg
-   :target: https://badge.fury.io/py/aiohttp
+   :target: https://pypi.org/project/aiohttp
    :alt: Latest PyPI package version
 
 .. image:: https://readthedocs.org/projects/aiohttp/badge/?version=latest

--- a/README.rst
+++ b/README.rst
@@ -7,6 +7,8 @@ Async http client/server framework
    :width: 64px
    :alt: aiohttp logo
 
+|
+
 .. image:: https://travis-ci.org/aio-libs/aiohttp.svg?branch=master
    :target:  https://travis-ci.org/aio-libs/aiohttp
    :align: right


### PR DESCRIPTION
## What do these changes do?

Link readme badge to warehouse version of PYPI, which is the new best practice.
Also fix logo being misrendered on the same line as badges.

## Are there changes in behavior for the user?

‒

## Related issue number

‒

## Checklist

- [X] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
