### PR TITLE
Windows documentation build fix

### DIFF
--- a/CHANGES/2898.bugfix
+++ b/CHANGES/2898.bugfix
@@ -1,0 +1,1 @@
+Documentation does not build on Windows platform

--- a/CHANGES/2898.bugfix
+++ b/CHANGES/2898.bugfix
@@ -1,1 +1,1 @@
-Documentation does not build on Windows platform
+Fix documentation build on Windows platform

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -106,6 +106,7 @@ Joel Watts
 Jon Nabozny
 Joongi Kim
 Josep Cugat
+Josip Haboić
 Julia Tsemusheva
 Julien Duponchelle
 Jungkook Park

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -28,7 +28,8 @@ with codecs.open(_version_path, 'r', 'latin1') as fp:
                                   r"\.(?P<minor>\d+)"
                                   r"\.(?P<patch>\d+)"
                                   r"(?P<tag>.*)?'$",
-                                  fp.read(), re.M).groupdict()
+                                  fp.readline().strip(), re.M).groupdict()
+
     except IndexError:
         raise RuntimeError('Unable to determine version.')
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Enable Windows platform developers to build aiohttp documentation.

## Are there changes in behavior for the user?

Only for Windows platform users.

## Related issue number
#2898
<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
