### PR TITLE
This line is misindented relative to everything around it

### DIFF
--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -268,7 +268,7 @@ and :ref:`aiohttp-web-signals` handlers.
 
          Use :meth:`can_read_body` instead.
 
- .. attribute:: content_type
+   .. attribute:: content_type
 
       Read-only property with *content* part of *Content-Type* header.
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

This line in the server reference documentation appears to be misindented in the ReST. This causes the actual rendered markup to get weirdly wrapped in blockquotes, and some `<dd>`s to have child `<dd>`s that make no sense, etc.

This corrects that rather minor error.

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

No; this only affects the formatting of the documentation.

## Related issue number

N/A
<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [X] I think the code is well written
- [ ] Unit tests for the changes exist
- [X] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
