### PR TITLE
Call on_chunk_sent when write_eof is called with a valid chunk

### DIFF
--- a/CHANGES/2909.bugfix
+++ b/CHANGES/2909.bugfix
@@ -1,0 +1,1 @@
+Call on_chunk_sent when write_eof takes as a param the last chunk

--- a/aiohttp/http_writer.py
+++ b/aiohttp/http_writer.py
@@ -122,6 +122,9 @@ class StreamWriter(AbstractStreamWriter):
                     chunk = b'0\r\n\r\n'
 
         if chunk:
+            if self._on_chunk_sent is not None:
+                await self._on_chunk_sent(chunk)
+
             self._write(chunk)
 
         await self.drain()

--- a/tests/test_http_writer.py
+++ b/tests/test_http_writer.py
@@ -171,6 +171,18 @@ async def test_write_calls_callback(protocol, transport, loop):
     assert on_chunk_sent.call_args == mock.call(chunk)
 
 
+async def test_write_eof_calls_callback(protocol, transport, loop):
+    on_chunk_sent = make_mocked_coro()
+    msg = http.StreamWriter(
+        protocol, transport, loop,
+        on_chunk_sent=on_chunk_sent
+    )
+    chunk = b'1'
+    await msg.write_eof(chunk=chunk)
+    assert on_chunk_sent.called
+    assert on_chunk_sent.call_args == mock.call(chunk)
+
+
 async def test_write_to_closing_transport(protocol, transport, loop):
     msg = http.StreamWriter(protocol, transport, loop)
 


### PR DESCRIPTION
## What do these changes do?

Fixes a bug with `on_chunk_sent` signal that must be triggered when `write_eof` is called using a valid chunk.


## Related issue number

#2909 

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
