### PR TITLE
Backport 6a6ab7d and c5d399 to 3.1

### DIFF
--- a/CHANGES/2909.bugfix
+++ b/CHANGES/2909.bugfix
@@ -1,0 +1,1 @@
+Call on_chunk_sent when write_eof takes as a param the last chunk

--- a/aiohttp/http_writer.py
+++ b/aiohttp/http_writer.py
@@ -105,6 +105,9 @@ class StreamWriter(AbstractStreamWriter):
         if self._eof:
             return
 
+        if chunk and self._on_chunk_sent is not None:
+            await self._on_chunk_sent(chunk)
+
         if self._compress:
             if chunk:
                 chunk = self._compress.compress(chunk)
@@ -122,9 +125,6 @@ class StreamWriter(AbstractStreamWriter):
                     chunk = b'0\r\n\r\n'
 
         if chunk:
-            if self._on_chunk_sent is not None:
-                await self._on_chunk_sent(chunk)
-
             self._write(chunk)
 
         await self.drain()

--- a/aiohttp/http_writer.py
+++ b/aiohttp/http_writer.py
@@ -122,6 +122,9 @@ class StreamWriter(AbstractStreamWriter):
                     chunk = b'0\r\n\r\n'
 
         if chunk:
+            if self._on_chunk_sent is not None:
+                await self._on_chunk_sent(chunk)
+
             self._write(chunk)
 
         await self.drain()

--- a/tests/test_http_writer.py
+++ b/tests/test_http_writer.py
@@ -171,6 +171,18 @@ async def test_write_calls_callback(protocol, transport, loop):
     assert on_chunk_sent.call_args == mock.call(chunk)
 
 
+async def test_write_eof_calls_callback(protocol, transport, loop):
+    on_chunk_sent = make_mocked_coro()
+    msg = http.StreamWriter(
+        protocol, transport, loop,
+        on_chunk_sent=on_chunk_sent
+    )
+    chunk = b'1'
+    await msg.write_eof(chunk=chunk)
+    assert on_chunk_sent.called
+    assert on_chunk_sent.call_args == mock.call(chunk)
+
+
 async def test_write_to_closing_transport(protocol, transport, loop):
     msg = http.StreamWriter(protocol, transport, loop)
 


### PR DESCRIPTION
## What do these changes do?

Backports the fix related to the #2909 issue for the 3.1 branch.

Note that due that fix was finally made using two commits the backport has been by hand but trying to keep the nomenclature imposed by cherry_picker /cc @Mariatta 
