### PR TITLE
Fix resources __repr__  formatting

### DIFF
--- a/CHANGES/2935.bugfix
+++ b/CHANGES/2935.bugfix
@@ -1,0 +1,1 @@
+A closing bracket was added to __repr__ of resources

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -185,6 +185,7 @@ Thanos Lefteris
 Thijs Vermeir
 Thomas Grainger
 Tolga Tezel
+Vadim Suharnikov
 Vaibhav Sagar
 Vamsi Krishna Avula
 Vasiliy Faronov

--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -325,8 +325,8 @@ class PlainResource(Resource):
 
     def __repr__(self):
         name = "'" + self.name + "' " if self.name is not None else ""
-        return "<PlainResource {name} {path}".format(name=name,
-                                                     path=self._path)
+        return "<PlainResource {name} {path}>".format(name=name,
+                                                      path=self._path)
 
 
 class DynamicResource(Resource):
@@ -399,7 +399,7 @@ class DynamicResource(Resource):
 
     def __repr__(self):
         name = "'" + self.name + "' " if self.name is not None else ""
-        return ("<DynamicResource {name} {formatter}"
+        return ("<DynamicResource {name} {formatter}>"
                 .format(name=name, formatter=self._formatter))
 
 
@@ -602,7 +602,7 @@ class StaticResource(PrefixResource):
 
     def __repr__(self):
         name = "'" + self.name + "'" if self.name is not None else ""
-        return "<StaticResource {name} {path} -> {directory!r}".format(
+        return "<StaticResource {name} {path} -> {directory!r}>".format(
             name=name, path=self._prefix, directory=self._directory)
 
 


### PR DESCRIPTION
## What do these changes do?
Cosmetic change.
Now, when printing resources, they will have a closing bracket.


I broke my head reading this: 
```
[<StaticResource 'debugtoolbar.static' /_debugtoolbar/static -> PosixPath('/usr/local/lib/python3.6/site-packages/aiohttp_debugtoolbar/static'), <PlainResource 'debugtoolbar.source'  /_debugtoolbar/source, <PlainResource 'debugtoolbar.execute'  /_debugtoolbar/execute, <PlainResource 'debugtoolbar.exception'  /_debugtoolbar/exception, <PlainResource 'debugtoolbar.sse'  /_debugtoolbar/sse, <DynamicResource 'debugtoolbar.request'  /_debugtoolbar/{request_id}, <PlainResource 'debugtoolbar.main'  /_debugtoolbar, <PlainResource  /users/, <DynamicResource  /users/{user_id}, <PlainResource  /login, <PlainResource  /whoami, <PlainResource  /cars/, <DynamicResource  /cars/{car_id}, <DynamicResource  /cars/{car_id}/upload_image, <PlainResource  /cars/search, <PlainResource  /cars/brands/, <PlainResource  /cars/types/]
```