### PR TITLE
Raise TooManyRedirects error when client gets redirected too many times

### DIFF
--- a/CHANGES/2631.feature
+++ b/CHANGES/2631.feature
@@ -1,0 +1,2 @@
+Raise ``TooManyRedirects`` exception when client gets redirected too many times
+instead of returning last response.

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -18,7 +18,8 @@ from . import connector as connector_mod
 from . import hdrs, http, payload
 from .client_exceptions import *  # noqa
 from .client_exceptions import (ClientError, ClientOSError, InvalidURL,
-                                ServerTimeoutError, WSServerHandshakeError)
+                                ServerTimeoutError, TooManyRedirects,
+                                WSServerHandshakeError)
 from .client_reqrep import *  # noqa
 from .client_reqrep import ClientRequest, ClientResponse, _merge_ssl_params
 from .client_ws import ClientWebSocketResponse
@@ -360,7 +361,8 @@ class ClientSession:
                         history.append(resp)
                         if max_redirects and redirects >= max_redirects:
                             resp.close()
-                            break
+                            raise TooManyRedirects(
+                                history[0].request_info, tuple(history))
                         else:
                             resp.release()
 

--- a/aiohttp/client_exceptions.py
+++ b/aiohttp/client_exceptions.py
@@ -93,6 +93,10 @@ class ClientHttpProxyError(ClientResponseError):
     """
 
 
+class TooManyRedirects(ClientResponseError):
+    """Client was redirected too many times."""
+
+
 class ClientConnectionError(ClientError):
     """Base class for client socket errors."""
 

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -251,6 +251,9 @@ The client session supports the context manager protocol for self closing.
       :param bool allow_redirects: If set to ``False``, do not follow redirects.
                                    ``True`` by default (optional).
 
+      :param int max_redirects: Maximum number of redirects to follow.
+                                ``10`` by default.
+
       :param bool compress: Set to ``True`` if request has to be compressed
          with deflate encoding. If `compress` can not be combined
          with a *Content-Encoding* and *Content-Length* headers.
@@ -501,7 +504,7 @@ The client session supports the context manager protocol for self closing.
 
       :param bool autoclose: Automatically close websocket connection on close
                              message from server. If *autoclose* is False
-                             them close procedure has to be handled manually. 
+                             then close procedure has to be handled manually.
                              ``True`` by default
 
       :param bool autoping: automatically send *pong* on *ping*
@@ -514,7 +517,7 @@ The client session supports the context manager protocol for self closing.
                               reception.(optional)
 
       :param str origin: Origin header to send to server(optional)
-      
+
       :param dict headers: HTTP Headers to send with
                            the request (optional)
 
@@ -565,7 +568,7 @@ The client session supports the context manager protocol for self closing.
          authority channel, supported SSL options etc.
 
          .. versionadded:: 2.3
-         
+
          .. deprecated:: 3.0
 
             Use ``ssl=ssl_context``
@@ -1726,6 +1729,18 @@ Response errors
    Derived from :exc:`ClientResponseError`
 
    .. versionadded:: 2.3
+
+
+.. class:: TooManyRedirects
+
+   Client was redirected too many times.
+
+   Maximum number of redirects can be configured by using
+   parameter ``max_redirects`` in :meth:`request<aiohttp.ClientSession.request>`.
+
+   Derived from :exc:`ClientResponseError`
+
+   .. versionadded:: 3.2
 
 Connection errors
 ^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Closes #2631

## What do these changes do?
Client now raises TooManyRedirects when gets redirected too many times instead of returning last response.

## Are there changes in behavior for the user?
It is a breaking change.

## Related issue number
#2631 

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
