### PR TITLE
Fix bug in FileResponse when compression wouldn't work

### DIFF
--- a/CHANGES/2942.bugfix
+++ b/CHANGES/2942.bugfix
@@ -1,0 +1,1 @@
+Fix compression of FileResponse

--- a/aiohttp/web_fileresponse.py
+++ b/aiohttp/web_fileresponse.py
@@ -107,7 +107,8 @@ class FileResponse(StreamResponse):
 
         transport = request.transport
         if (transport.get_extra_info("sslcontext") or
-                transport.get_extra_info("socket") is None):
+                transport.get_extra_info("socket") is None or
+                self.compression):
             writer = await self._sendfile_fallback(request, fobj, count)
         else:
             writer = SendfileStreamWriter(
@@ -131,7 +132,7 @@ class FileResponse(StreamResponse):
         # fobj is transferred in chunks controlled by the
         # constructor's chunk_size argument.
 
-        writer = (await super().prepare(request))
+        writer = await super().prepare(request)
 
         chunk_size = self._chunk_size
 

--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -43,7 +43,7 @@ class StreamResponse(collections.MutableMapping, HeadersMixin):
         self._keep_alive = None
         self._chunked = False
         self._compression = False
-        self._compression_force = False
+        self._compression_force = None
         self._cookies = SimpleCookie()
 
         self._req = None


### PR DESCRIPTION
Closes #2942

## What do these changes do?
Compression of FileResponse's now works

## Are there changes in behavior for the user?
Compression works

## Related issue number
#2942 
<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
