### PR TITLE
Support brotli compression of HTTP responses

### DIFF
--- a/CHANGES/2518.feature
+++ b/CHANGES/2518.feature
@@ -1,0 +1,1 @@
+Add support for ``br`` (brotli) Content-Encoding compression (enabled if ``brotlipy`` is installed).

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -15,7 +15,7 @@ import attr
 from multidict import CIMultiDict, CIMultiDictProxy, MultiDict, MultiDictProxy
 from yarl import URL
 
-from . import hdrs, helpers, http, multipart, payload
+from . import compression, hdrs, helpers, http, multipart, payload
 from .client_exceptions import (ClientConnectionError, ClientOSError,
                                 ClientResponseError, ContentTypeError,
                                 InvalidURL, ServerFingerprintMismatch)
@@ -152,7 +152,7 @@ class ClientRequest:
 
     DEFAULT_HEADERS = {
         hdrs.ACCEPT: '*/*',
-        hdrs.ACCEPT_ENCODING: 'gzip, deflate',
+        hdrs.ACCEPT_ENCODING: compression.DEFAULT_ACCEPT_ENCODING,
     }
 
     body = b''

--- a/aiohttp/compression.py
+++ b/aiohttp/compression.py
@@ -1,0 +1,116 @@
+import zlib
+
+from .http_exceptions import ContentEncodingError
+
+
+try:
+    import brotli
+except ImportError:  # pragma: nocover
+    brotli = None
+
+
+def get_compressor(encoding):
+    if encoding == 'gzip':
+        return zlib.compressobj(wbits=16 + zlib.MAX_WBITS)
+    elif encoding == 'deflate':
+        return zlib.compressobj(wbits=-zlib.MAX_WBITS)
+    else:
+        raise RuntimeError('Encoding is %s not supported' % encoding)
+
+
+def decompress(encoding, data):
+    decompressor = get_decompressor(encoding)
+    decompressed = decompressor.decompress(data) + decompressor.flush()
+    if not decompressor.eof:
+        raise ContentEncodingError(
+            'Can not decode content-encoding: %s' % encoding)
+    return decompressed
+
+
+def get_decompressor(encoding):
+    if encoding == 'br':
+        return BrotliDecompressor()
+    elif encoding == 'gzip':
+        return GzipDecompressor()
+    elif encoding == 'deflate':
+        return DeflateDecompressor()
+    else:
+        raise RuntimeError('Encoding %s is not supported' % encoding)
+
+
+class DeflateDecompressor:
+
+    __slots__ = ('_decompressor', '_started_decoding')
+
+    def __init__(self):
+        self._decompressor = zlib.decompressobj(wbits=-zlib.MAX_WBITS)
+        self._started_decoding = False
+
+    def decompress(self, chunk):
+        try:
+            decompressed = self._decompressor.decompress(chunk)
+            if decompressed:
+                self._started_decoding = True
+            return decompressed
+        except Exception:
+            # Try another wbits setting. See #1918 for details.
+            if not self._started_decoding:
+                self._decompressor = zlib.decompressobj()
+                return self.decompress(chunk)
+            raise
+
+    def flush(self):
+        return self._decompressor.flush()
+
+    @property
+    def eof(self):
+        return self._decompressor.eof
+
+
+class GzipDecompressor:
+
+    __slots__ = ('_decompressor',)
+
+    def __init__(self):
+        self._decompressor = zlib.decompressobj(wbits=16 + zlib.MAX_WBITS)
+
+    def decompress(self, chunk):
+        return self._decompressor.decompress(chunk)
+
+    def flush(self):
+        return self._decompressor.flush()
+
+    @property
+    def eof(self):
+        return self._decompressor.eof
+
+
+class BrotliDecompressor:
+
+    __slots__ = ('_decompressor', '_eof')
+
+    def __init__(self):
+        if brotli is None:  # pragma: no cover
+            raise ContentEncodingError(
+                'Can not decode content-encoding: brotli (br). '
+                'Please install `brotlipy`')
+        self._decompressor = brotli.Decompressor()
+        self._eof = None
+
+    def decompress(self, chunk):
+        return self._decompressor.decompress(chunk)
+
+    def flush(self):
+        # Brotli decompression is eager.
+        return b''
+
+    @property
+    def eof(self):
+        if self._eof is not None:
+            return self._eof
+        try:
+            self._decompressor.finish()
+            self._eof = True
+        except brotli.Error:
+            self._eof = False
+        return self._eof

--- a/aiohttp/http_writer.py
+++ b/aiohttp/http_writer.py
@@ -110,7 +110,7 @@ class StreamWriter(AbstractStreamWriter):
             if chunk:
                 chunk = self._compress.compress(chunk)
 
-            chunk = chunk + self._compress.flush()
+            chunk = chunk + self._compress.finish()
             if chunk and self.chunked:
                 chunk_len = ('%x\r\n' % len(chunk)).encode('ascii')
                 chunk = chunk_len + chunk + b'\r\n0\r\n\r\n'

--- a/aiohttp/http_writer.py
+++ b/aiohttp/http_writer.py
@@ -2,9 +2,9 @@
 
 import asyncio
 import collections
-import zlib
 
 from .abc import AbstractStreamWriter
+from .compression import get_compressor
 
 
 __all__ = ('StreamWriter', 'HttpVersion', 'HttpVersion10', 'HttpVersion11')
@@ -44,9 +44,7 @@ class StreamWriter(AbstractStreamWriter):
         self.chunked = True
 
     def enable_compression(self, encoding='deflate'):
-        zlib_mode = (16 + zlib.MAX_WBITS
-                     if encoding == 'gzip' else -zlib.MAX_WBITS)
-        self._compress = zlib.compressobj(wbits=zlib_mode)
+        self._compress = get_compressor(encoding)
 
     def _write(self, chunk):
         size = len(chunk)

--- a/docs/client_quickstart.rst
+++ b/docs/client_quickstart.rst
@@ -158,8 +158,8 @@ You can also access the response body as bytes, for non-text requests::
 The ``gzip`` and ``deflate`` transfer-encodings are automatically
 decoded for you.
 
-You can enable ``brotli`` transfer-encodings support,
-just install  `brotlipy <https://github.com/python-hyper/brotlipy>`_.
+``brotli`` transfer-encodings support is enabled if
+`brotlipy <https://github.com/python-hyper/brotlipy>`_ is installed.
 
 JSON Request
 ============

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -2676,6 +2676,13 @@ Constants
 
       *GZIP compression*
 
+   .. attribute:: br
+
+      *BROTLI compression*
+
+      Supported if  `brotlipy <https://github.com/python-hyper/brotlipy>`_
+      is installed.
+
    .. attribute:: identity
 
       *no compression*

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,8 @@ import tempfile
 import pytest
 from py import path
 
+import aiohttp.compression
+
 
 pytest_plugins = ['aiohttp.pytest_plugin', 'pytester']
 
@@ -15,3 +17,7 @@ def shorttmpdir():
     tmpdir = path.local(tempfile.mkdtemp())
     yield tmpdir
     tmpdir.remove(rec=1)
+
+
+skip_if_no_brotli = pytest.mark.skipif(aiohttp.compression.brotli is None,
+                                       reason='brotlipy not installed')

--- a/tests/test_client_request.py
+++ b/tests/test_client_request.py
@@ -21,6 +21,12 @@ from aiohttp.client_reqrep import (ClientRequest, ClientResponse, Fingerprint,
 from aiohttp.test_utils import make_mocked_coro
 
 
+try:
+    import brotli
+except ImportError:
+    brotli = None
+
+
 @pytest.fixture
 def make_request(loop):
     request = None
@@ -261,7 +267,7 @@ def test_default_headers_useragent_custom(make_request):
 
 def test_skip_default_useragent_header(make_request):
     req = make_request('get', 'http://python.org/',
-                       skip_auto_headers=set([istr('user-agent')]))
+                       skip_auto_headers={istr('user-agent')})
 
     assert 'User-Agent' not in req.headers
 
@@ -272,7 +278,10 @@ def test_headers(make_request):
 
     assert 'CONTENT-TYPE' in req.headers
     assert req.headers['CONTENT-TYPE'] == 'text/plain'
-    assert req.headers['ACCEPT-ENCODING'] == 'gzip, deflate'
+    if brotli:
+        assert req.headers['ACCEPT-ENCODING'] == 'gzip, deflate, br'
+    else:
+        assert req.headers['ACCEPT-ENCODING'] == 'gzip, deflate'
 
 
 def test_headers_list(make_request):

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -11,12 +11,7 @@ import aiohttp
 from aiohttp import http_exceptions, streams
 from aiohttp.http_parser import (DeflateBuffer, HttpPayloadParser,
                                  HttpRequestParserPy, HttpResponseParserPy)
-
-
-try:
-    import brotli
-except ImportError:
-    brotli = None
+from tests.conftest import skip_if_no_brotli
 
 
 REQUEST_PARSERS = [HttpRequestParserPy]
@@ -299,7 +294,7 @@ def test_compression_gzip(parser):
     assert msg.compression == 'gzip'
 
 
-@pytest.mark.skipif(brotli is None, reason="brotli is not installed")
+@skip_if_no_brotli
 def test_compression_brotli(parser):
     text = (b'GET /test HTTP/1.1\r\n'
             b'content-encoding: br\r\n\r\n')
@@ -808,8 +803,9 @@ class TestParsePayload:
         assert p.done
         assert out.is_eof()
 
-    @pytest.mark.skipif(brotli is None, reason="brotli is not installed")
+    @skip_if_no_brotli
     def test_http_payload_brotli(self, stream):
+        import brotli
         compressed = brotli.compress(b'brotli data')
         out = aiohttp.FlowControlDataQueue(stream)
         p = HttpPayloadParser(


### PR DESCRIPTION
## What do these changes do?
This PR adds support for `br` (brotli) content-type compression.

I have also refactored compressors and decompressors to a separate module (aiohttp.compression) because there are some differences between zlib's and brotli's intefraces.

Related tests have also been refactored a bit, now pytest's parametrization is used more aggressively.

For now brotli compression of websocket responses is not supported,

## Are there changes in behavior for the user?
aiohttp now can compress responses using brotli compression algorithm if `brotlipy` is installed.

## Related issue number
Closes #2518 