### PR TITLE
Added Link header (RFC8288) parsing

### DIFF
--- a/CHANGES/2948.feature
+++ b/CHANGES/2948.feature
@@ -1,1 +1,1 @@
-Added raw_links and links properties for ClientResponse object
+Added and links property for ClientResponse object

--- a/CHANGES/2948.feature
+++ b/CHANGES/2948.feature
@@ -1,0 +1,1 @@
+Added raw_links and links properties for ClientResponse object

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -20,7 +20,8 @@ from .client_exceptions import (ClientConnectionError, ClientOSError,
                                 ClientResponseError, ContentTypeError,
                                 InvalidURL, ServerFingerprintMismatch)
 from .formdata import FormData
-from .helpers import PY_36, HeadersMixin, TimerNoop, noop, reify, set_result
+from .helpers import (PY_36, HeadersMixin, TimerNoop, noop, reify, set_result,
+                      parse_header_links)
 from .http import SERVER_SOFTWARE, HttpVersion10, HttpVersion11, StreamWriter
 from .log import client_logger
 
@@ -686,6 +687,22 @@ class ClientResponse(HeadersMixin):
     def history(self):
         """A sequence of of responses, if redirects occurred."""
         return self._history
+
+    @property
+    def raw_links(self):
+        links = ", ".join(self.headers.getall("link", []))
+        return parse_header_links(links)
+
+    @property
+    def links(self):
+        links = {}
+        for link in self.raw_links:
+            key = link.get("rel") or link.get("url")
+            link["url"] = URL(link["url"])
+            links[key] = link
+        return links
+
+
 
     async def start(self, connection, read_until_eof=False):
         """Start response processing."""

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -20,8 +20,8 @@ from .client_exceptions import (ClientConnectionError, ClientOSError,
                                 ClientResponseError, ContentTypeError,
                                 InvalidURL, ServerFingerprintMismatch)
 from .formdata import FormData
-from .helpers import (PY_36, HeadersMixin, TimerNoop, noop, reify, set_result,
-                      parse_header_links)
+from .helpers import (PY_36, HeadersMixin, TimerNoop, noop, parse_header_links,
+                      reify, set_result)
 from .http import SERVER_SOFTWARE, HttpVersion10, HttpVersion11, StreamWriter
 from .log import client_logger
 

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -702,8 +702,6 @@ class ClientResponse(HeadersMixin):
             links[key] = link
         return links
 
-
-
     async def start(self, connection, read_until_eof=False):
         """Start response processing."""
         self._closed = False

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -257,60 +257,6 @@ def parse_mimetype(mimetype):
                     parameters=params)
 
 
-def parse_header_links(value):
-    """Parses Link header.
-
-    value is a Link HTTP Header value.
-
-    Returns a list of links as dicts.
-
-    Example:
-
-    >>> parse_header_links(
-    ...     '''<http://example.com/front.jpeg>; rel=front; type="image/jpeg",
-    ...     <http://example.com/back.jpeg>; rel=back; type="image/jpeg"''')
-    ({'rel': 'front',
-      'type': 'image/jpeg',
-      'url': 'http://example.com/front.jpeg'},
-     {'rel': 'back',
-      'type': 'image/jpeg',
-      'url': 'http://example.com/back.jpeg'})
-
-    """
-
-    if not value:
-        return ()
-
-    replace_chars = ' \'"'
-
-    value = value.strip(replace_chars)
-
-    if not value:
-        return ()
-
-    links = []
-
-    for val in re.split(', *<', value):
-        try:
-            url, params = val.split(';', 1)
-        except ValueError:
-            url, params = val, ''
-
-        link = {'url': url.strip('<> \'"')}
-
-        for param in params.split(';'):
-            try:
-                key, value = param.split('=')
-            except ValueError:
-                break
-
-            link[key.strip(replace_chars)] = value.strip(replace_chars)
-
-        links.append(link)
-
-    return tuple(links)
-
-
 def guess_filename(obj, default=None):
     name = getattr(obj, 'name', None)
     if name and isinstance(name, str) and name[0] != '<' and name[-1] != '>':

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -257,6 +257,60 @@ def parse_mimetype(mimetype):
                     parameters=params)
 
 
+def parse_header_links(value):
+    """Parses Link header.
+
+    value is a Link HTTP Header value.
+
+    Returns a list of links as dicts.
+
+    Example:
+
+    >>> parse_header_links(
+    ...     '''<http://example.com/front.jpeg>; rel=front; type="image/jpeg",
+    ...     <http://example.com/back.jpeg>; rel=back; type="image/jpeg"''')
+    ({'rel': 'front',
+      'type': 'image/jpeg',
+      'url': 'http://example.com/front.jpeg'},
+     {'rel': 'back',
+      'type': 'image/jpeg',
+      'url': 'http://example.com/back.jpeg'})
+
+    """
+
+    if not value:
+        return ()
+
+    replace_chars = ' \'"'
+
+    value = value.strip(replace_chars)
+
+    if not value:
+        return ()
+
+    links = []
+
+    for val in re.split(', *<', value):
+        try:
+            url, params = val.split(';', 1)
+        except ValueError:
+            url, params = val, ''
+
+        link = {'url': url.strip('<> \'"')}
+
+        for param in params.split(';'):
+            try:
+                key, value = param.split('=')
+            except ValueError:
+                break
+
+            link[key.strip(replace_chars)] = value.strip(replace_chars)
+
+        links.append(link)
+
+    return tuple(links)
+
+
 def guess_filename(obj, default=None):
     name = getattr(obj, 'name', None)
     if name and isinstance(name, str) and name[0] != '<' and name[-1] != '>':

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -1097,6 +1097,16 @@ Response object
       Unmodified HTTP headers of response as unconverted bytes, a sequence of
       ``(key, value)`` pairs.
 
+   .. attribute:: raw_links
+
+      Link HTTP headers of response parsed into a sequence of dictionaries
+      with `url` key for link uri itself.
+
+   .. attribute:: links
+
+      :attr:`raw_links` additionally parsed into a dict with `rel` or `url`
+      keys and `url` parsed into :class:`yarl.URL` object.
+
    .. attribute:: content_type
 
       Read-only property with *content* part of *Content-Type* header.

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -1097,17 +1097,13 @@ Response object
       Unmodified HTTP headers of response as unconverted bytes, a sequence of
       ``(key, value)`` pairs.
 
-   .. attribute:: raw_links
-
-      Link HTTP headers of response parsed into a sequence of dictionaries
-      with `url` key for link url itself.
-
-      .. versionadded:: 3.2
-
    .. attribute:: links
 
-      :attr:`raw_links` additionally parsed into a dict with `rel` or `url`
-      keys and `url` parsed into :class:`yarl.URL` object.
+      Link HTTP header parsed into a :class:`~multidict.MultiDictProxy`.
+
+      For each link, key is link param `rel` when it exists, or link url as
+      :class:`str` otherwise, and value is :class:`~multidict.MultiDictProxy`
+      of link params and url at key `url` as :class:`~yarl.URL` instance.
 
       .. versionadded:: 3.2
 

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -1100,12 +1100,16 @@ Response object
    .. attribute:: raw_links
 
       Link HTTP headers of response parsed into a sequence of dictionaries
-      with `url` key for link uri itself.
+      with `url` key for link url itself.
+
+      .. versionadded:: 3.2
 
    .. attribute:: links
 
       :attr:`raw_links` additionally parsed into a dict with `rel` or `url`
       keys and `url` parsed into :class:`yarl.URL` object.
+
+      .. versionadded:: 3.2
 
    .. attribute:: content_type
 

--- a/tests/test_client_response.py
+++ b/tests/test_client_response.py
@@ -1055,13 +1055,6 @@ def test_response_links_comma_separated(loop, session):
         )
     ])
     assert (
-        response.raw_links ==
-        ({'url': 'http://example.com/page/1.html',
-          'rel': 'next'},
-         {'url': 'http://example.com/',
-          'rel': 'home'})
-    )
-    assert (
         response.links ==
         {'next':
          {'url': URL('http://example.com/page/1.html'),
@@ -1095,13 +1088,6 @@ def test_response_links_multiple_headers(loop, session):
         )
     ])
     assert (
-        response.raw_links ==
-        ({'url': 'http://example.com/page/1.html',
-          'rel': 'next'},
-         {'url': 'http://example.com/',
-          'rel': 'home'})
-    )
-    assert (
         response.links ==
         {'next':
          {'url': URL('http://example.com/page/1.html'),
@@ -1131,13 +1117,61 @@ def test_response_links_no_rel(loop, session):
         )
     ])
     assert (
-        response.raw_links ==
-        ({'url': 'http://example.com/'}, )
-    )
-    assert (
         response.links ==
         {
             'http://example.com/':
             {'url': URL('http://example.com/')}
         }
+    )
+
+
+def test_response_links_quoted(loop, session):
+    url = URL('http://def-cl-resp.org/')
+    response = ClientResponse('get', url,
+                              request_info=mock.Mock(),
+                              writer=mock.Mock(),
+                              continue100=None,
+                              timer=TimerNoop(),
+                              auto_decompress=True,
+                              traces=[],
+                              loop=loop,
+                              session=session)
+    response.headers = CIMultiDict([
+        (
+            "Link",
+            '<http://example.com/>; rel="home-page"'
+        ),
+    ])
+    assert (
+        response.links ==
+        {'home-page':
+         {'url': URL('http://example.com/'),
+          'rel': 'home-page'}
+         }
+    )
+
+
+def test_response_links_relative(loop, session):
+    url = URL('http://def-cl-resp.org/')
+    response = ClientResponse('get', url,
+                              request_info=mock.Mock(),
+                              writer=mock.Mock(),
+                              continue100=None,
+                              timer=TimerNoop(),
+                              auto_decompress=True,
+                              traces=[],
+                              loop=loop,
+                              session=session)
+    response.headers = CIMultiDict([
+        (
+            "Link",
+            '</relative/path>; rel=rel'
+        ),
+    ])
+    assert (
+        response.links ==
+        {'rel':
+         {'url': URL('http://def-cl-resp.org/relative/path'),
+          'rel': 'rel'}
+         }
     )

--- a/tests/test_client_response.py
+++ b/tests/test_client_response.py
@@ -1175,3 +1175,18 @@ def test_response_links_relative(loop, session):
           'rel': 'rel'}
          }
     )
+
+
+def test_response_links_empty(loop, session):
+    url = URL('http://def-cl-resp.org/')
+    response = ClientResponse('get', url,
+                              request_info=mock.Mock(),
+                              writer=mock.Mock(),
+                              continue100=None,
+                              timer=TimerNoop(),
+                              auto_decompress=True,
+                              traces=[],
+                              loop=loop,
+                              session=session)
+    response.headers = CIMultiDict()
+    assert response.links == {}

--- a/tests/test_client_response.py
+++ b/tests/test_client_response.py
@@ -6,8 +6,8 @@ import sys
 from unittest import mock
 
 import pytest
-from yarl import URL
 from multidict import CIMultiDict
+from yarl import URL
 
 import aiohttp
 from aiohttp import http


### PR DESCRIPTION
## What do these changes do?

Added and `links` property for ClientResponse object. 

`links` parses `Link` header into a dict.
Dict keys are `rel` link params or url itself as string.
Values are dicts of link params and url as yarl URL object

Look also [RFC 8288](https://tools.ietf.org/html/rfc8288)

## Are there changes in behavior for the user?

New properties added, no backward incompatible changes

## Related issue number

#2948 

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
- [x] Add a new news fragment into the `CHANGES` folder

