### PR TITLE
Fixes some bugs in the limit connection feature

### DIFF
--- a/CHANGES/2964.bugfix
+++ b/CHANGES/2964.bugfix
@@ -1,0 +1,1 @@
+Fixes some bugs in the limit connection feature

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -415,10 +415,10 @@ class BaseConnector:
                 except ValueError:  # fut may no longer be in list
                     pass
 
+                raise e
+            finally:
                 if not waiters:
                     del self._waiters[key]
-
-                raise e
 
             if traces:
                 for trace in traces:
@@ -508,19 +508,11 @@ class BaseConnector:
                 continue
 
             waiters = self._waiters[key]
-
             while waiters:
                 waiter = waiters.popleft()
                 if not waiter.done():
                     waiter.set_result(None)
-
-                    if not waiters:
-                        del self._waiters[key]
-
                     return
-
-            if not waiters:
-                del self._waiters[key]
 
     def _release_acquired(self, key, proto):
         if self._closed:

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -1,5 +1,6 @@
 import asyncio
 import functools
+import random
 import sys
 import traceback
 import warnings
@@ -494,8 +495,15 @@ class BaseConnector:
         Iterates over all waiters till found one that is not finsihed and
         belongs to a host that has available connections.
         """
+        if not self._waiters:
+            return
 
-        for key in list(self._waiters.keys()):
+        # Having the dict keys ordered this avoids to iterate
+        # at the same order at each call.
+        queues = list(self._waiters.keys())
+        random.shuffle(queues)
+
+        for key in queues:
             if self._available_connections(key) < 1:
                 continue
 

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -414,11 +414,8 @@ class BaseConnector:
                 except ValueError:  # fut may no longer be in list
                     pass
 
-                try:
-                    if not self._waiters[key]:
-                        del self._waiters[key]
-                except KeyError:
-                    pass
+                if key in self._waiters and not self._waiters[key]:
+                    del self._waiters[key]
 
                 raise e
 

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -418,7 +418,11 @@ class BaseConnector:
                 raise e
             finally:
                 if not waiters:
-                    del self._waiters[key]
+                    try:
+                        del self._waiters[key]
+                    except KeyError:
+                        # the key was evicted before.
+                        pass
 
             if traces:
                 for trace in traces:

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -415,7 +415,7 @@ class BaseConnector:
                 except ValueError:  # fut may no longer be in list
                     pass
 
-                if key in self._waiters and not self._waiters[key]:
+                if not waiters:
                     del self._waiters[key]
 
                 raise e
@@ -507,20 +507,20 @@ class BaseConnector:
             if self._available_connections(key) < 1:
                 continue
 
-            found = False
             waiters = self._waiters[key]
 
-            while waiters and not found:
+            while waiters:
                 waiter = waiters.popleft()
                 if not waiter.done():
                     waiter.set_result(None)
-                    found = True
+
+                    if not waiters:
+                        del self._waiters[key]
+
+                    return
 
             if not waiters:
                 del self._waiters[key]
-
-            if found:
-                return
 
     def _release_acquired(self, key, proto):
         if self._closed:

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -359,9 +359,14 @@ class BaseConnector:
         """
         return self._closed
 
-    async def connect(self, req, traces=None):
-        """Get from pool or create new connection."""
-        key = req.connection_key
+    def _available_connections(self, key):
+        """
+        Return number of available connections taking into account
+        the limit, limit_per_host and the connection key.
+
+        If it returns less than 1 means that there is no connections
+        availables.
+        """
 
         if self._limit:
             # total calc available connections
@@ -380,6 +385,13 @@ class BaseConnector:
         else:
             available = 1
 
+        return available
+
+    async def connect(self, req, traces=None):
+        """Get from pool or create new connection."""
+        key = req.connection_key
+        available = self._available_connections(key)
+
         # Wait if there are no available connections.
         if available <= 0:
             fut = self._loop.create_future()
@@ -394,7 +406,7 @@ class BaseConnector:
 
             try:
                 await fut
-            except BaseException:
+            except BaseException as e:
                 # remove a waiter even if it was cancelled, normally it's
                 #  removed when it's notified
                 try:
@@ -402,10 +414,13 @@ class BaseConnector:
                 except ValueError:  # fut may no longer be in list
                     pass
 
-                if not waiters:
-                    del self._waiters[key]
+                try:
+                    if not self._waiters[key]:
+                        del self._waiters[key]
+                except KeyError:
+                    pass
 
-                raise
+                raise e
 
             if traces:
                 for trace in traces:
@@ -430,12 +445,12 @@ class BaseConnector:
                     proto.close()
                     raise ClientConnectionError("Connector is closed.")
             except BaseException:
-                # signal to waiter
-                if key in self._waiters:
-                    waiters = self._waiters[key]
-                    self._release_key_waiter(key, waiters)
+                if not self._closed:
+                    self._acquired.remove(placeholder)
+                    self._drop_acquired_per_host(key, placeholder)
+                    self._release_waiter()
                 raise
-            finally:
+            else:
                 if not self._closed:
                     self._acquired.remove(placeholder)
                     self._drop_acquired_per_host(key, placeholder)
@@ -477,35 +492,30 @@ class BaseConnector:
         del self._conns[key]
         return None
 
-    def _release_key_waiter(self, key, waiters):
-        if not waiters:
-            return False
-
-        waiter = waiters.popleft()
-        if not waiter.done():
-            waiter.set_result(None)
-
-        if not waiters:
-            del self._waiters[key]
-
-        return True
-
     def _release_waiter(self):
-        # always release only one waiter
+        """
+        Iterates over all waiters till found one that is not finsihed and
+        belongs to a host that has available connections.
+        """
 
-        if self._limit:
-            # if we have limit and we have available
-            if self._limit - len(self._acquired) > 0:
-                for key, waiters in self._waiters.items():
-                    if self._release_key_waiter(key, waiters):
-                        break
+        for key in list(self._waiters.keys()):
+            if self._available_connections(key) < 1:
+                continue
 
-        elif self._limit_per_host:
-            # if we have dont have limit but have limit per host
-            # then release first available
-            for key, waiters in self._waiters.items():
-                if self._release_key_waiter(key, waiters):
-                    break
+            found = False
+            waiters = self._waiters[key]
+
+            while waiters and not found:
+                waiter = waiters.popleft()
+                if not waiter.done():
+                    waiter.set_result(None)
+                    found = True
+
+            if not waiters:
+                del self._waiters[key]
+
+            if found:
+                return
 
     def _release_acquired(self, key, proto):
         if self._closed:

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -96,7 +96,7 @@ def test_connection_detach(loop):
     conn = Connection(connector, key, protocol, loop=loop)
     conn._notify_release = mock.Mock()
     conn.detach()
-    conn._notify_release.assert_called()
+    assert conn._notify_release.called
     connector._release_acquired.assert_called_with(protocol)
 
 

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -325,7 +325,7 @@ def test_release_waiter_no_limit(loop, key, key2):
     w.done.return_value = False
     conn._waiters[key].append(w)
     conn._release_waiter()
-    assert len(conn._waiters) == 0
+    assert len(conn._waiters[key]) == 0
     assert w.done.called
     conn.close()
 

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -299,8 +299,8 @@ def test_release_waiter(loop, key, key2):
     w.done.return_value = False
     conn._waiters[key].append(w)
     conn._release_waiter()
-    assert len(conn._waiters) == 1
-    assert not w.done.called
+    assert len(conn._waiters) == 0
+    assert w.done.called
     conn.close()
 
     # release first available
@@ -334,7 +334,7 @@ def test_release_waiter(loop, key, key2):
     conn._waiters[key] = deque([w1, w2])
     conn._release_waiter()
     assert not w1.set_result.called
-    assert not w2.set_result.called
+    assert w2.set_result.called
     conn.close()
 
 

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -67,6 +67,7 @@ def test_connection_del(loop):
     connector = mock.Mock()
     key = mock.Mock()
     protocol = mock.Mock()
+    loop.set_debug(0)
     conn = Connection(connector, key, protocol, loop=loop)
     exc_handler = mock.Mock()
     loop.set_exception_handler(exc_handler)

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -89,6 +89,17 @@ def test_connection_del(loop):
     exc_handler.assert_called_with(loop, msg)
 
 
+def test_connection_detach(loop):
+    connector = mock.Mock()
+    key = mock.Mock()
+    protocol = mock.Mock()
+    conn = Connection(connector, key, protocol, loop=loop)
+    conn._notify_release = mock.Mock()
+    conn.detach()
+    conn._notify_release.assert_called()
+    connector._release_acquired.assert_called_with(protocol)
+
+
 def test_del(loop):
     conn = aiohttp.BaseConnector(loop=loop)
     proto = mock.Mock(should_close=False)

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -67,7 +67,6 @@ def test_connection_del(loop):
     connector = mock.Mock()
     key = mock.Mock()
     protocol = mock.Mock()
-    loop.set_debug(1)
     conn = Connection(connector, key, protocol, loop=loop)
     exc_handler = mock.Mock()
     loop.set_exception_handler(exc_handler)
@@ -84,9 +83,47 @@ def test_connection_del(loop):
     msg = {
         'message': mock.ANY,
         'client_connection': mock.ANY,
+    }
+    exc_handler.assert_called_with(loop, msg)
+
+
+def test_connection_del_loop_debug(loop):
+    connector = mock.Mock()
+    key = mock.Mock()
+    protocol = mock.Mock()
+    loop.set_debug(1)
+    conn = Connection(connector, key, protocol, loop=loop)
+    exc_handler = mock.Mock()
+    loop.set_exception_handler(exc_handler)
+
+    with pytest.warns(ResourceWarning):
+        del conn
+        gc.collect()
+
+    msg = {
+        'message': mock.ANY,
+        'client_connection': mock.ANY,
         'source_traceback': mock.ANY
     }
     exc_handler.assert_called_with(loop, msg)
+
+
+def test_connection_del_loop_closed(loop):
+    connector = mock.Mock()
+    key = mock.Mock()
+    protocol = mock.Mock()
+    loop.set_debug(1)
+    conn = Connection(connector, key, protocol, loop=loop)
+    exc_handler = mock.Mock()
+    loop.set_exception_handler(exc_handler)
+    loop.close()
+
+    with pytest.warns(ResourceWarning):
+        del conn
+        gc.collect()
+
+    assert not connector._release.called
+    assert not exc_handler.called
 
 
 def test_connection_detach(loop):


### PR DESCRIPTION
There are two places which both try to release the next waiter. When the ongoing connection is being canceled calling explicitly to wake up a waiter and when the connection is being released, either because was called explicitly or implicitly due to the close of a response.

In both situations, we call the same method `_release_waiter` that will iterate per all of the
queues till found one that has a waiter that is not already canceled.

This iteration will also check that the limit and the limit per host is not overcome. The logic to check how many available connections/free slots there are has been placed behind the new `_available_connections` function.

So far this PR fixes:

- Take into account the limit and limit per host at any time that we try
to wake up a waiter. No connection available, no wake-up.
- Don't give up till reach a waiter that is not finished.
- Iterate always through all of the different hosts.