### PR TITLE
Forbid reading response BODY after release

### DIFF
--- a/CHANGES/2983.feature
+++ b/CHANGES/2983.feature
@@ -1,1 +1,1 @@
-Disable reading response BODY after release
+Forbid reading response BODY after release

--- a/CHANGES/2983.feature
+++ b/CHANGES/2983.feature
@@ -1,0 +1,1 @@
+Disable reading response BODY after release

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -362,8 +362,6 @@ class ClientSession:
                             resp.close()
                             raise TooManyRedirects(
                                 history[0].request_info, tuple(history))
-                        else:
-                            resp.release()
 
                         # For 301 and 302, mimic IE, now changed in RFC
                         # https://github.com/kennethreitz/requests/pull/269
@@ -381,6 +379,10 @@ class ClientSession:
                         if r_url is None:
                             # see github.com/aio-libs/aiohttp/issues/2022
                             break
+                        else:
+                            # reading from correct redirection
+                            # response is forbidden
+                            resp.release()
 
                         try:
                             r_url = URL(

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -2549,3 +2549,35 @@ async def test_async_payload_generator(aiohttp_client):
 
     resp = await client.post('/', data=gen())
     assert resp.status == 200
+
+
+async def test_read_from_closed_response(aiohttp_client):
+    async def handler(request):
+        return web.Response(body=b'data')
+
+    app = web.Application()
+    app.add_routes([web.get('/', handler)])
+
+    client = await aiohttp_client(app)
+
+    async with client.get('/') as resp:
+        assert resp.status == 200
+
+    with pytest.raises(aiohttp.ClientConnectionError):
+        await resp.read()
+
+
+async def test_read_from_closed_content(aiohttp_client):
+    async def handler(request):
+        return web.Response(body=b'data')
+
+    app = web.Application()
+    app.add_routes([web.get('/', handler)])
+
+    client = await aiohttp_client(app)
+
+    async with client.get('/') as resp:
+        assert resp.status == 200
+
+    with pytest.raises(aiohttp.ClientConnectionError):
+        await resp.content.readline()

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -2567,6 +2567,23 @@ async def test_read_from_closed_response(aiohttp_client):
         await resp.read()
 
 
+async def test_read_from_closed_response2(aiohttp_client):
+    async def handler(request):
+        return web.Response(body=b'data')
+
+    app = web.Application()
+    app.add_routes([web.get('/', handler)])
+
+    client = await aiohttp_client(app)
+
+    async with client.get('/') as resp:
+        assert resp.status == 200
+        await resp.read()
+
+    with pytest.raises(aiohttp.ClientConnectionError):
+        await resp.read()
+
+
 async def test_read_from_closed_content(aiohttp_client):
     async def handler(request):
         return web.Response(body=b'data')


### PR DESCRIPTION
Now the following code produces unspecified behavior:
```
async with session.get(url) as resp:
      pass
await resp.read()
```
The same for reading from `resp.content`.

If the response has a data into the internal buffer -- the data is returned. Otherwise, an exception is raised.
Reading from the released response is a logical error, the PR raises an exception unconditionally in the case.