### PR TITLE
Raise ConnectionReserError instead of CancelledError

### DIFF
--- a/CHANGES/2499.feature
+++ b/CHANGES/2499.feature
@@ -1,0 +1,2 @@
+Raise ``ConnectionReserError`` instead of ``CancelledError`` on trying
+to write to a closed stream.

--- a/CHANGES/2499.feature
+++ b/CHANGES/2499.feature
@@ -1,2 +1,2 @@
-Raise ``ConnectionReserError`` instead of ``CancelledError`` on trying
+Raise ``ConnectionResetError`` instead of ``CancelledError`` on trying
 to write to a closed stream.

--- a/aiohttp/http_writer.py
+++ b/aiohttp/http_writer.py
@@ -1,6 +1,5 @@
 """Http related parsers and protocol."""
 
-import asyncio
 import collections
 import zlib
 
@@ -55,7 +54,7 @@ class StreamWriter(AbstractStreamWriter):
         self.output_size += size
 
         if self._transport is None or self._transport.is_closing():
-            raise asyncio.CancelledError('Cannot write to closing transport')
+            raise ConnectionResetError('Cannot write to closing transport')
         self._transport.write(chunk)
 
     async def write(self, chunk, *, drain=True, LIMIT=0x10000):

--- a/tests/test_http_writer.py
+++ b/tests/test_http_writer.py
@@ -1,5 +1,4 @@
 """Tests for aiohttp/http_writer.py"""
-import asyncio
 import zlib
 from unittest import mock
 
@@ -189,7 +188,7 @@ async def test_write_to_closing_transport(protocol, transport, loop):
     await msg.write(b'Before closing')
     transport.is_closing.return_value = True
 
-    with pytest.raises(asyncio.CancelledError):
+    with pytest.raises(ConnectionResetError):
         await msg.write(b'After closing')
 
 


### PR DESCRIPTION
on trying to write to a closed stream.
