### PR TITLE
Add path_pattern property to routes and resources

### DIFF
--- a/CHANGES/2968.feature
+++ b/CHANGES/2968.feature
@@ -1,0 +1,1 @@
+Add canonical property to resources

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -153,6 +153,7 @@ Paul Colomiets
 Paulus Schoutsen
 Pavel Kamaev
 Pawel Miech
+Pepe Osca
 Philipp A.
 Pieter van Beek
 Rafael Viotti

--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -45,6 +45,15 @@ class AbstractResource(Sized, Iterable):
     def name(self):
         return self._name
 
+    @property
+    @abc.abstractmethod
+    def canonical(self):
+        """Exposes the resource's canonical path.
+
+        For example '/foo/bar/{name}'
+
+        """
+
     @abc.abstractmethod  # pragma: no branch
     def url_for(self, **kwargs):
         """Construct url for resource with additional params."""
@@ -300,6 +309,10 @@ class PlainResource(Resource):
         assert not path or path.startswith('/')
         self._path = path
 
+    @property
+    def canonical(self):
+        return self._path
+
     def freeze(self):
         if not self._path:
             self._path = '/'
@@ -373,6 +386,10 @@ class DynamicResource(Resource):
         self._pattern = compiled
         self._formatter = formatter
 
+    @property
+    def canonical(self):
+        return self._formatter
+
     def add_prefix(self, prefix):
         assert prefix.startswith('/')
         assert not prefix.endswith('/')
@@ -413,6 +430,10 @@ class PrefixResource(AbstractResource):
         assert prefix in ('', '/') or not prefix.endswith('/'), prefix
         super().__init__(name=name)
         self._prefix = URL.build(path=prefix).raw_path
+
+    @property
+    def canonical(self):
+        return self._prefix
 
     def add_prefix(self, prefix):
         assert prefix.startswith('/')

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -1823,6 +1823,13 @@ Resource classes hierarchy::
 
       Read-only *name* of resource or ``None``.
 
+   .. attribute:: canonical
+
+      Read-only *canonical path* associate with the resource. For example
+      ``/path/to`` or ``/path/{to}``
+
+      .. versionadded:: 3.3
+
    .. comethod:: resolve(request)
 
       Resolve resource by finding appropriate :term:`web-handler` for
@@ -1886,6 +1893,12 @@ Resource classes hierarchy::
    The class corresponds to resources with plain-text matching,
    ``'/path/to'`` for example.
 
+   .. attribute:: canonical
+
+      Read-only *canonical path* associate with the resource. Returns the path
+      used to create the PlainResource. For example ``/path/to``
+
+      .. versionadded:: 3.3
 
    .. method:: url_for()
 
@@ -1900,6 +1913,13 @@ Resource classes hierarchy::
    :ref:`variable <aiohttp-web-variable-handler>` matching,
    e.g. ``'/path/{to}/{param}'`` etc.
 
+   .. attribute:: canonical
+
+      Read-only *canonical path* associate with the resource. Returns the
+      formatter obtained from the path used to create the DynamicResource.
+      For example, from a path ``/get/{num:^\d+}``, it returns ``/get/{num}``
+
+      .. versionadded:: 3.3
 
    .. method:: url_for(**params)
 
@@ -1917,6 +1937,13 @@ Resource classes hierarchy::
 
    The class corresponds to resources for :ref:`static file serving
    <aiohttp-web-static-file-handling>`.
+
+   .. attribute:: canonical
+
+      Read-only *canonical path* associate with the resource. Returns the prefix
+      used to create the StaticResource. For example ``/prefix``
+
+      .. versionadded:: 3.3
 
    .. method:: url_for(filename, append_version=None)
 
@@ -1944,6 +1971,14 @@ Resource classes hierarchy::
 
    A resource for serving nested applications. The class instance is
    returned by :class:`~aiohttp.web.Application.add_subapp` call.
+
+   .. attribute:: canonical
+
+      Read-only *canonical path* associate with the resource. Returns the
+      prefix used to create the PrefixedSubAppResource.
+      For example ``/prefix``
+
+      .. versionadded:: 3.3
 
    .. method:: url_for(**kwargs)
 

--- a/tests/test_urldispatch.py
+++ b/tests/test_urldispatch.py
@@ -12,7 +12,9 @@ from aiohttp import hdrs, web
 from aiohttp.test_utils import make_mocked_request
 from aiohttp.web import HTTPMethodNotAllowed, HTTPNotFound, Response
 from aiohttp.web_urldispatcher import (PATH_SEP, AbstractResource,
-                                       ResourceRoute, SystemRoute, View,
+                                       DynamicResource, PlainResource,
+                                       ResourceRoute, StaticResource,
+                                       SystemRoute, View,
                                        _default_expect_handler)
 
 
@@ -1112,3 +1114,36 @@ def test_deprecate_non_coroutine(router):
 
     with pytest.warns(DeprecationWarning):
         router.add_route('GET', '/handler', handler)
+
+
+def test_plain_resource_canonical():
+    canonical = '/plain/path'
+    res = PlainResource(path=canonical)
+    assert res.canonical == canonical
+
+
+def test_dynamic_resource_canonical():
+    canonicals = {
+        '/get/{name}': '/get/{name}',
+        '/get/{num:^\d+}': '/get/{num}',
+        r'/handler/{to:\d+}': r'/handler/{to}',
+        r'/{one}/{two:.+}': r'/{one}/{two}',
+    }
+    for pattern, canonical in canonicals.items():
+        res = DynamicResource(path=pattern)
+        assert res.canonical == canonical
+
+
+def test_static_resource_canonical():
+    prefix = '/prefix'
+    directory = str(os.path.dirname(aiohttp.__file__))
+    canonical = prefix
+    res = StaticResource(prefix=prefix, directory=directory)
+    assert res.canonical == canonical
+
+
+def test_prefixed_subapp_resource_canonical(app, loop):
+    canonical = '/prefix'
+    subapp = web.Application()
+    res = subapp.add_subapp(canonical, subapp)
+    assert res.canonical == canonical


### PR DESCRIPTION
The path_pattern is the raw path used to add a new route. For example,
/foo/bar/{name:\d+}.

 - Add path_pattern property to AbstractRoute and AbstractResource
 - Add path pattern implementation to PlainResource, DynamicResource,
 PrefixResource, StaticResource, ResourceRoute and SystemRoute.
 - Add tests

Closes #2968

<!-- Thank you for your contribution! -->

## What do these changes do?

Add path_pattern property to routes and resources.
The path_pattern is the raw path used to add a new route. For example, /bar/{name:\d+}.

## Are there changes in behavior for the user?

The public API of Route and Resource has now a new property path_name to expose directly the raw path used to add a new route. Significant values have been selected for each implementation of the abstract classes.

## Related issue number

2968

## Checklist

- [X] I think the code is well written
- [X] Unit tests for the changes exist
- [X] Documentation reflects the changes
- [X] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [X] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
