### PR TITLE
Don't throw away port number when parsing the Forwarded header #3009

### DIFF
--- a/CHANGES/3009.bugfix
+++ b/CHANGES/3009.bugfix
@@ -1,0 +1,1 @@
+When parsing the Forwarded header, the optional port number is now preserved.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -86,6 +86,7 @@ Georges Dubus
 Greg Holt
 Gregory Haynes
 Günther Jena
+Gustavo Carneiro
 Hu Bo
 Hugo Herter
 Hynek Schlawack

--- a/aiohttp/web_request.py
+++ b/aiohttp/web_request.py
@@ -52,7 +52,7 @@ _QUOTED_STRING = r'"(?:{quoted_pair}|{qdtext})*"'.format(
     qdtext=_QDTEXT, quoted_pair=_QUOTED_PAIR)
 
 _FORWARDED_PAIR = (
-    r'({token})=({token}|{quoted_string})'.format(
+    r'({token})=({token}|{quoted_string})(:\d{{1,4}})?'.format(
         token=_TOKEN,
         quoted_string=_QUOTED_STRING))
 
@@ -247,11 +247,13 @@ class BaseRequest(collections.MutableMapping, HeadersMixin):
                         # bad syntax here, skip to next comma
                         pos = field_value.find(',', pos)
                     else:
-                        (name, value) = match.groups()
+                        name, value, port = match.groups()
                         if value[0] == '"':
                             # quoted string: remove quotes and unescape
                             value = _QUOTED_PAIR_REPLACE_RE.sub(r'\1',
                                                                 value[1:-1])
+                        if port:
+                            value += port
                         elem[name.lower()] = value
                         pos += len(match.group(0))
                         need_separator = True

--- a/tests/test_web_request.py
+++ b/tests/test_web_request.py
@@ -296,6 +296,21 @@ def test_single_forwarded_header():
     assert req.forwarded[0]['proto'] == 'identifier'
 
 
+@pytest.mark.parametrize(
+    "forward_for_in, forward_for_out",
+    [
+        ("1.2.3.4:1234", "1.2.3.4:1234"),
+        ("1.2.3.4", "1.2.3.4"),
+        ('"[2001:db8:cafe::17]:1234"', '[2001:db8:cafe::17]:1234'),
+        ('"[2001:db8:cafe::17]"', '[2001:db8:cafe::17]'),
+    ])
+def test_forwarded_node_identifier(forward_for_in, forward_for_out):
+    header = 'for={}'.format(forward_for_in)
+    req = make_mocked_request('GET', '/',
+                              headers=CIMultiDict({'Forwarded': header}))
+    assert req.forwarded == ({'for': forward_for_out},)
+
+
 def test_single_forwarded_header_camelcase():
     header = 'bY=identifier;fOr=identifier;HOst=identifier;pRoTO=identifier'
     req = make_mocked_request('GET', '/',


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?
When parsing the Forwarded header, include the port number, if any, as part of the node identifier.

<!-- Please give a short brief about these changes. -->


## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->

Previously, request.forwarded would throw away the port number, while with the change the port number is included.  This could potentially break code.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

#3009 

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
