### PR TITLE
Optimize HTTP parser

### DIFF
--- a/CHANGES/3015.feature
+++ b/CHANGES/3015.feature
@@ -1,0 +1,1 @@
+Optimize HTTP parser

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -769,8 +769,8 @@ class ClientResponse(HeadersMixin):
         self.reason = message.reason
 
         # headers
-        self._headers = CIMultiDictProxy(message.headers)
-        self._raw_headers = tuple(message.raw_headers)
+        self._headers = message.headers  # type is CIMultiDictProxy
+        self._raw_headers = message.raw_headers  # type is Tuple[bytes, bytes]
 
         # payload
         self.content = payload

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -4,7 +4,7 @@ import string
 import zlib
 from enum import IntEnum
 
-from multidict import CIMultiDict
+from multidict import CIMultiDict, CIMultiDictProxy
 from yarl import URL
 
 from . import hdrs
@@ -324,6 +324,7 @@ class HttpParser:
         upgrade = False
         chunked = False
         raw_headers = tuple(raw_headers)
+        headers = CIMultiDictProxy(headers)
 
         # keep-alive
         conn = headers.get(hdrs.CONNECTION)
@@ -385,8 +386,8 @@ class HttpRequestParserPy(HttpParser):
             raise BadStatusLine(version)
 
         # read headers
-        headers, raw_headers, \
-            close, compression, upgrade, chunked = self.parse_headers(lines)
+        (headers, raw_headers,
+         close, compression, upgrade, chunked) = self.parse_headers(lines)
 
         if close is None:  # then the headers weren't set in the request
             if version <= HttpVersion10:  # HTTP 1.0 must asks to not close
@@ -438,8 +439,8 @@ class HttpResponseParserPy(HttpParser):
             raise BadStatusLine(line)
 
         # read headers
-        headers, raw_headers, \
-            close, compression, upgrade, chunked = self.parse_headers(lines)
+        (headers, raw_headers,
+         close, compression, upgrade, chunked) = self.parse_headers(lines)
 
         if close is None:
             close = version <= HttpVersion10

--- a/aiohttp/test_utils.py
+++ b/aiohttp/test_utils.py
@@ -10,7 +10,7 @@ import unittest
 from abc import ABC, abstractmethod
 from unittest import mock
 
-from multidict import CIMultiDict
+from multidict import CIMultiDict, CIMultiDictProxy
 from yarl import URL
 
 import aiohttp
@@ -489,11 +489,11 @@ def make_mocked_request(method, path, headers=None, *,
         closing = True
 
     if headers:
-        headers = CIMultiDict(headers)
+        headers = CIMultiDictProxy(CIMultiDict(headers))
         raw_hdrs = tuple(
             (k.encode('utf-8'), v.encode('utf-8')) for k, v in headers.items())
     else:
-        headers = CIMultiDict()
+        headers = CIMultiDictProxy(CIMultiDict())
         raw_hdrs = ()
 
     chunked = 'chunked' in headers.get(hdrs.TRANSFER_ENCODING, '').lower()

--- a/aiohttp/web_request.py
+++ b/aiohttp/web_request.py
@@ -131,7 +131,8 @@ class BaseRequest(collections.MutableMapping, HeadersMixin):
             dct['url'] = rel_url
             dct['path'] = str(rel_url)
         if headers is not sentinel:
-            dct['headers'] = CIMultiDict(headers)
+            # a copy semantic
+            dct['headers'] = CIMultiDictProxy(CIMultiDict(headers))
             dct['raw_headers'] = tuple((k.encode('utf-8'), v.encode('utf-8'))
                                        for k, v in headers.items())
 

--- a/tests/test_test_utils.py
+++ b/tests/test_test_utils.py
@@ -2,7 +2,7 @@ import gzip
 from unittest import mock
 
 import pytest
-from multidict import CIMultiDict
+from multidict import CIMultiDict, CIMultiDictProxy
 from yarl import URL
 
 import aiohttp
@@ -170,7 +170,7 @@ def test_make_mocked_request(headers):
     assert req.method == "GET"
     assert req.path == "/"
     assert isinstance(req, web.Request)
-    assert isinstance(req.headers, CIMultiDict)
+    assert isinstance(req.headers, CIMultiDictProxy)
 
 
 def test_make_mocked_request_sslcontext():

--- a/tests/test_web_functional.py
+++ b/tests/test_web_functional.py
@@ -8,7 +8,7 @@ from unittest import mock
 
 import pytest
 from async_generator import async_generator, yield_
-from multidict import MultiDict
+from multidict import CIMultiDictProxy, MultiDict
 from yarl import URL
 
 import aiohttp
@@ -1814,6 +1814,20 @@ async def test_request_path(aiohttp_client):
 async def test_app_add_routes(aiohttp_client):
 
     async def handler(request):
+        return web.Response()
+
+    app = web.Application()
+    app.add_routes([web.get('/get', handler)])
+
+    client = await aiohttp_client(app)
+    resp = await client.get('/get')
+    assert resp.status == 200
+
+
+async def test_request_headers_type(aiohttp_client):
+
+    async def handler(request):
+        assert isinstance(request.headers, CIMultiDictProxy)
         return web.Response()
 
     app = web.Application()


### PR DESCRIPTION
* Don't use temporal list of pairs for HTTP headers creation
* Don't recode headers twice
* Make sure that HTTP headers returned by a peer are always immutable