### PR TITLE
Make TCPSite accept a loop argument

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,37 @@ Changelog
 
 .. towncrier release notes start
 
+3.3.0a0 (2018-05-19)
+====================
+
+Features
+--------
+
+- Raise ``ConnectionResetError`` instead of ``CancelledError`` on trying to
+  write to a closed stream. (#2499)
+- Implement ``ClientTimeout`` class and support socket read timeout. (#2768)
+- Forbid reading response BODY after release (#2983)
+- Implement base protocol class to avoid a dependency from internal
+  ``asyncio.streams.FlowControlMixin`` (#2986)
+- Cythonize ``@helpers.reify``, 5% boost on macro benchmark (#2995)
+- Optimize HTTP parser (#3015)
+
+
+Bugfixes
+--------
+
+- Don't reuse a connection with the same URL but different proxy/TLS settings
+  (#2981)
+- When parsing the Forwarded header, the optional port number is now preserved.
+  (#3009)
+
+
+Misc
+----
+
+- #3008, #3011
+
+
 3.2.1 (2018-05-10)
 ==================
 

--- a/CHANGES/3016.feature
+++ b/CHANGES/3016.feature
@@ -1,0 +1,1 @@
+Allow passing an already existing loop to TCPSite, so as to include aiohttp in a larger app

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -157,6 +157,7 @@ Pawel Miech
 Philipp A.
 Pieter van Beek
 Rafael Viotti
+Raphaël Jacquot
 Raúl Cumplido
 Required Field
 Robert Lu

--- a/aiohttp/web_runner.py
+++ b/aiohttp/web_runner.py
@@ -62,9 +62,12 @@ class TCPSite(BaseSite):
     def __init__(self, runner, host=None, port=None, *,
                  shutdown_timeout=60.0, ssl_context=None,
                  backlog=128, reuse_address=None,
-                 reuse_port=None):
+                 reuse_port=None, loop=None):
         super().__init__(runner, shutdown_timeout=shutdown_timeout,
                          ssl_context=ssl_context, backlog=backlog)
+        if loop is None:
+            loop = asyncio.get_event_loop()
+        self.loop = loop
         if host is None:
             host = "0.0.0.0"
         self._host = host
@@ -81,8 +84,7 @@ class TCPSite(BaseSite):
 
     async def start(self):
         await super().start()
-        loop = asyncio.get_event_loop()
-        self._server = await loop.create_server(
+        self._server = await self.loop.create_server(
             self._runner.server, self._host, self._port,
             ssl=self._ssl_context, backlog=self._backlog,
             reuse_address=self._reuse_address,

--- a/docs/web_advanced.rst
+++ b/docs/web_advanced.rst
@@ -783,6 +783,16 @@ The simple startup code for serving HTTP site on ``'localhost'``, port
     site = web.TCPSite(runner, 'localhost', 8080)
     await site.start()
 
+TCPSite now also allows passing an already existing loop as follows::
+
+    loop = asyncio.get_event_loop()
+    app = web.Application(loop=loop, debug=True)
+    app.router.add_get('/', index)
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.TCPSite(runner, 'localhost', 8080, loop=loop)
+    await site.start()
+
 To stop serving call :meth:`AppRunner.cleanup`::
 
     await runner.cleanup()

--- a/examples/web_srv_external_loop.py
+++ b/examples/web_srv_external_loop.py
@@ -46,6 +46,7 @@ class LoopTester(object):
             self.counter += 1
             await asyncio.sleep(1)
 
+
 if __name__ == '__main__':
     import logging
 
@@ -58,9 +59,8 @@ if __name__ == '__main__':
         loop.run_forever()
     except KeyboardInterrupt:
         tasks = asyncio.gather(
-                    *asyncio.Task.all_tasks(loop=loop),
-                    loop=loop,
-                    return_exceptions=True)
+            *asyncio.Task.all_tasks(loop=loop),
+            loop=loop,
+            return_exceptions=True)
         tasks.add_done_callback(lambda t: loop.stop())
         tasks.cancel()
-

--- a/examples/web_srv_external_loop.py
+++ b/examples/web_srv_external_loop.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3.6
+# -*- coding: utf-8 -*-
+import asyncio
+from aiohttp import web, web_runner
+
+
+class WebServer(object):
+    def __init__(self, address='127.0.0.1', port=8080, loop=None):
+        self.address = address
+        self.port = port
+        if loop is None:
+            loop = asyncio.get_event_loop()
+        self.loop = loop
+        asyncio.ensure_future(self.start(), loop=self.loop)
+
+    async def start(self):
+        self.app = web.Application(loop=self.loop, debug=True)
+        self.setup_routes()
+        self.runner = web.AppRunner(self.app)
+        await self.runner.setup()
+        self.site = web_runner.TCPSite(self.runner,
+                                       self.address, self.port,
+                                       loop=self.loop)
+        await self.site.start()
+        print('------ serving on %s:%d ------'
+              % (self.address, self.port))
+
+    def setup_routes(self):
+        self.app.router.add_get('/', self.index)
+
+    async def index(self, request):
+        return web.Response(text='Hello Aiohttp!!')
+
+
+class LoopTester(object):
+    def __init__(self, loop=None):
+        if loop is None:
+            loop = asyncio.get_event_loop()
+        self.loop = loop
+        self.counter = 0
+        asyncio.ensure_future(self.run(), loop=self.loop)
+
+    async def run(self):
+        while self.loop.is_running():
+            print('basic test %d' % (self.counter))
+            self.counter += 1
+            await asyncio.sleep(1)
+
+if __name__ == '__main__':
+    import logging
+
+    loop = asyncio.get_event_loop()
+    logging.basicConfig(level=logging.DEBUG)
+    loop.set_debug(False)
+    lt = LoopTester(loop=loop)
+    ws = WebServer(loop=loop)
+    try:
+        loop.run_forever()
+    except KeyboardInterrupt:
+        tasks = asyncio.gather(
+                    *asyncio.Task.all_tasks(loop=loop),
+                    loop=loop,
+                    return_exceptions=True)
+        tasks.add_done_callback(lambda t: loop.stop())
+        tasks.cancel()
+


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

The changes make TCPsite accept a loop argument, and use it where appropriate

## Are there changes in behavior for the user?

the advanced user may refer to `/examples/web_srv_external_loop.py` for a working sample of the change

## Related issue number

#3016

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
  (no but I have an example, I have no idea how to write a unit test)
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
