### PR TITLE
Remove heartbeat on closing connection on keepalive timeout

### DIFF
--- a/CHANGES/3041.feature
+++ b/CHANGES/3041.feature
@@ -1,0 +1,2 @@
+Remove heartbeat on closing connection on keepalive timeout.
+The used hack violates HTTP protocol.

--- a/aiohttp/web_protocol.py
+++ b/aiohttp/web_protocol.py
@@ -286,14 +286,12 @@ class RequestHandler(BaseProtocol):
         if self._waiter:
             self._waiter.cancel()
 
-    def force_close(self, send_last_heartbeat=False):
+    def force_close(self):
         """Force close connection"""
         self._force_close = True
         if self._waiter:
             self._waiter.cancel()
         if self.transport is not None:
-            if send_last_heartbeat:
-                self.transport.write(b"\r\n")
             self.transport.close()
             self.transport = None
 
@@ -317,7 +315,7 @@ class RequestHandler(BaseProtocol):
         # handler in idle state
         if self._waiter:
             if self._loop.time() > next:
-                self.force_close(send_last_heartbeat=True)
+                self.force_close()
                 return
 
         # not all request handlers are done,


### PR DESCRIPTION
Revert  bf49f8e75fb263113d6a448a532293107d2e03bc
The used hack violates HTTP protocol.

Fixes #2782