### PR TITLE
Do not use translated path

### DIFF
--- a/CHANGES/3051.bugfix
+++ b/CHANGES/3051.bugfix
@@ -1,0 +1,1 @@
+Make redirect with `normalize_path_middleware` work when using url encoded paths.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -206,6 +206,7 @@ Vladyslav Bondar
 W. Trevor King
 Will McGugan
 Willem de Groot
+William Grzybowski
 Wilson Ong
 Wei Lin
 Weiwei Wang

--- a/aiohttp/web_middlewares.py
+++ b/aiohttp/web_middlewares.py
@@ -73,7 +73,7 @@ def normalize_path_middleware(
                 resolves, request = await _check_request_resolves(
                     request, path)
                 if resolves:
-                    raise redirect_class(request.path + query)
+                    raise redirect_class(path + query)
 
         return await handler(request)
 

--- a/aiohttp/web_middlewares.py
+++ b/aiohttp/web_middlewares.py
@@ -73,7 +73,7 @@ def normalize_path_middleware(
                 resolves, request = await _check_request_resolves(
                     request, path)
                 if resolves:
-                    raise redirect_class(path + query)
+                    raise redirect_class(request.raw_path)
 
         return await handler(request)
 

--- a/tests/test_web_middleware.py
+++ b/tests/test_web_middleware.py
@@ -86,6 +86,8 @@ def cli(loop, aiohttp_client):
             'GET', '/resource1/a/b', handler)
         app.router.add_route(
             'GET', '/resource2/a/b/', handler)
+        app.router.add_route(
+            'GET', '/resource2/a/b%2Fc/', handler)
         app.middlewares.extend(extra_middlewares)
         return aiohttp_client(app, server_kwargs={'skip_url_asserts': True})
     return wrapper
@@ -101,7 +103,9 @@ class TestNormalizePathMiddleware:
         ('/resource1?p1=1&p2=2', 200),
         ('/resource1/?p1=1&p2=2', 404),
         ('/resource2?p1=1&p2=2', 200),
-        ('/resource2/?p1=1&p2=2', 200)
+        ('/resource2/?p1=1&p2=2', 200),
+        ('/resource2/a/b%2Fc', 200),
+        ('/resource2/a/b%2Fc/', 200)
     ])
     async def test_add_trailing_when_necessary(
             self, path, status, cli):
@@ -120,7 +124,9 @@ class TestNormalizePathMiddleware:
         ('/resource1?p1=1&p2=2', 200),
         ('/resource1/?p1=1&p2=2', 404),
         ('/resource2?p1=1&p2=2', 404),
-        ('/resource2/?p1=1&p2=2', 200)
+        ('/resource2/?p1=1&p2=2', 200),
+        ('/resource2/a/b%2Fc', 404),
+        ('/resource2/a/b%2Fc/', 200)
     ])
     async def test_no_trailing_slash_when_disabled(
             self, path, status, cli):


### PR DESCRIPTION
## What do these changes do?

Allow redirect to work when using url encoded paths and normalize path middleware, e.g.

/foo/bar%2Fbar will redirect to /foo/bar%2Fbar/ instead of /foo/bar/bar/

## Are there changes in behavior for the user?

Not as far as I am aware, since its a bug fix.