### PR TITLE
`Line too long` error when proxying a request

### DIFF
--- a/CHANGES/3054.bugfix
+++ b/CHANGES/3054.bugfix
@@ -1,0 +1,1 @@
+When using a server-request body as the `data=` argument of a client request, iterate over the content with `readany` instead of `readline` to avoid `Line too long` errors.

--- a/aiohttp/payload.py
+++ b/aiohttp/payload.py
@@ -13,7 +13,7 @@ from multidict import CIMultiDict
 from . import hdrs
 from .helpers import (PY_36, content_disposition_header, guess_filename,
                       parse_mimetype, sentinel)
-from .streams import DEFAULT_LIMIT
+from .streams import DEFAULT_LIMIT, StreamReader
 
 
 __all__ = ('PAYLOAD_REGISTRY', 'get_payload', 'payload_type', 'Payload',
@@ -325,6 +325,12 @@ class AsyncIterablePayload(Payload):
             self._iter = None
 
 
+class StreamReaderPayload(AsyncIterablePayload):
+
+    def __init__(self, value, *args, **kwargs):
+        super().__init__(value.iter_any(), *args, **kwargs)
+
+
 PAYLOAD_REGISTRY = PayloadRegistry()
 PAYLOAD_REGISTRY.register(BytesPayload, (bytes, bytearray, memoryview))
 PAYLOAD_REGISTRY.register(StringPayload, str)
@@ -334,6 +340,7 @@ PAYLOAD_REGISTRY.register(BytesIOPayload, io.BytesIO)
 PAYLOAD_REGISTRY.register(
     BufferedReaderPayload, (io.BufferedReader, io.BufferedRandom))
 PAYLOAD_REGISTRY.register(IOBasePayload, io.IOBase)
+PAYLOAD_REGISTRY.register(StreamReaderPayload, StreamReader)
 # try_last for giving a chance to more specialized async interables like
 # multidict.BodyPartReaderPayload override the default
 PAYLOAD_REGISTRY.register(AsyncIterablePayload, AsyncIterable,

--- a/tests/test_payload.py
+++ b/tests/test_payload.py
@@ -1,9 +1,10 @@
 from io import StringIO
+from unittest import mock
 
 import pytest
 from async_generator import async_generator
 
-from aiohttp import payload
+from aiohttp import payload, streams
 
 
 @pytest.fixture
@@ -111,3 +112,20 @@ def test_async_iterable_payload_not_async_iterable():
 
     with pytest.raises(TypeError):
         payload.AsyncIterablePayload(object())
+
+
+async def test_stream_reader_long_lines(loop):
+    DATA = b'0' * 1024 ** 3
+
+    stream = streams.StreamReader(mock.Mock(), loop=loop)
+    stream.feed_data(DATA)
+    stream.feed_eof()
+    body = payload.get_payload(stream)
+
+    writer = mock.Mock()
+    writer.write.return_value = loop.create_future()
+    writer.write.return_value.set_result(None)
+    await body.write(writer)
+    writer.write.assert_called_once_with(mock.ANY)
+    (chunk,), _ = writer.write.call_args
+    assert len(chunk) == len(DATA)


### PR DESCRIPTION
When sending a request with a body set to a `StreamReader` (ie when your aiohttp server proxy a request to another server), the body could contain very long lines.

Such line go over the high water mark, and trigger an exception.
The `payload` module should not write the `StreamReader` by (async)-iterating over the lines, but should instead iterate over whatever is available. This patch implements that.

Here is a small script reproducing the error:
```python
import aiohttp
import asyncio


async def handle(request):
	return aiohttp.web.Response(body=b'0' * 2 ** 18)

async def main(loop):
	app = aiohttp.web.Application()
	app.add_routes([aiohttp.web.get('/', handle)])
	handler = app.make_handler()
	await loop.create_server(handler, '0.0.0.0', 1111)

	async with aiohttp.ClientSession() as session:
		async with session.get('http://0.0.0.0:1111') as resp:
			# this is just a stream of 2**18 0-bytes
			stream = resp.content

			async with session.post('http://httpbin.org/anything', data=stream):
				pass


loop = asyncio.get_event_loop()
loop.run_until_complete(main(loop))
```

