### PR TITLE
Do not use async_timeout 3.0.0 on the 2.3 branch

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ with codecs.open(os.path.join(os.path.abspath(os.path.dirname(
 
 
 install_requires = ['chardet', 'multidict>=4.0.0',
-                    'async_timeout>=1.2.0', 'yarl>=1.0.0']
+                    'async_timeout>=1.2.0,<3.0.0', 'yarl>=1.0.0']
 
 
 if sys.version_info < (3, 7):


### PR DESCRIPTION
## What do these changes do?

This change "pins" the async_timeout dependency to 2.x

Because async_timeout >= 3.0 dropped python3.4, not pinning this will break on python 3.4


I do not know about aiohttp policies for the 2.3 branch, so this may not be the correct way to do this 

Also this will since this will pin to 2.x even on python 3.5+, I may add a version check if you wish