### PR TITLE
add web.options

### DIFF
--- a/CHANGES/3062.bugfix
+++ b/CHANGES/3062.bugfix
@@ -1,0 +1,1 @@
+fix `UrlDispatcher` has no attribute `add_options`, add `web.options`

--- a/aiohttp/web_routedef.py
+++ b/aiohttp/web_routedef.py
@@ -6,7 +6,7 @@ import attr
 from . import hdrs
 
 
-__all__ = ('RouteDef', 'StaticDef', 'RouteTableDef', 'head', 'get',
+__all__ = ('RouteDef', 'StaticDef', 'RouteTableDef', 'head', 'options', 'get',
            'post', 'patch', 'put', 'delete', 'route', 'view',
            'static')
 
@@ -65,6 +65,10 @@ def route(method, path, handler, **kwargs):
 
 def head(path, handler, **kwargs):
     return route(hdrs.METH_HEAD, path, handler, **kwargs)
+
+
+def options(path, handler, **kwargs):
+    return route(hdrs.METH_OPTIONS, path, handler, **kwargs)
 
 
 def get(path, handler, *, name=None, allow_head=True, **kwargs):

--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -906,6 +906,12 @@ class UrlDispatcher(AbstractRouter, collections.abc.Mapping):
         """
         return self.add_route(hdrs.METH_HEAD, path, handler, **kwargs)
 
+    def add_options(self, path, handler, **kwargs):
+        """
+        Shortcut for add_route with method OPTIONS
+        """
+        return self.add_route(hdrs.METH_OPTIONS, path, handler, **kwargs)
+
     def add_get(self, path, handler, *, name=None, allow_head=True, **kwargs):
         """
         Shortcut for add_route with method GET, if allow_head is true another

--- a/tests/test_route_def.py
+++ b/tests/test_route_def.py
@@ -42,6 +42,19 @@ def test_head(router):
     assert str(route.url_for()) == '/'
 
 
+def test_options(router):
+    async def handler(request):
+        pass
+
+    router.add_routes([web.options('/', handler)])
+    assert len(router.routes()) == 1
+
+    route = list(router.routes())[0]
+    assert route.handler is handler
+    assert route.method == 'OPTIONS'
+    assert str(route.url_for()) == '/'
+
+
 def test_post(router):
     async def handler(request):
         pass


### PR DESCRIPTION
## What do these changes do?

See #3062 

## Are there changes in behavior for the user?

`web.options` is added and `web.route(METH_OPTIONS, '/foo/', foo, name='foo')` now works

## Related issue number

#3062

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] ~~Documentation reflects the changes~~ (there's no explicit docs for `web.head` etc. either)
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
