### PR TITLE
Disable keep-alive when working with proxy

### DIFF
--- a/CHANGES/3070.bugfix
+++ b/CHANGES/3070.bugfix
@@ -1,0 +1,2 @@
+Many HTTP proxies has buggy keepalive support.
+Let's not reuse connection but close it after processing every response.

--- a/aiohttp/client_proto.py
+++ b/aiohttp/client_proto.py
@@ -45,6 +45,9 @@ class ResponseHandler(BaseProtocol, DataQueue):
                 self._payload_parser is not None or
                 len(self) or self._tail)
 
+    def force_close(self):
+        self._should_close = True
+
     def close(self):
         transport = self.transport
         if transport is not None:

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -895,6 +895,11 @@ class TCPConnector(BaseConnector):
         transport, proto = await self._create_direct_connection(
             proxy_req, [], timeout, client_error=ClientProxyConnectionError)
 
+        # Many HTTP proxies has buggy keepalive support.  Let's not
+        # reuse connection but close it after processing every
+        # response.
+        proto.force_close()
+
         auth = proxy_req.headers.pop(hdrs.AUTHORIZATION, None)
         if auth is not None:
             if not req.is_ssl():


### PR DESCRIPTION
Many HTTP proxies has buggy keepalive support.  

Let's not reuse connection but close it after processing every response.
