### PR TITLE
Prevent double closing when client connection is released before the last data_received() callback.

### DIFF
--- a/CHANGES/3031.bugfix
+++ b/CHANGES/3031.bugfix
@@ -1,0 +1,2 @@
+Prevent double closing when client connection is released before the
+last ``data_received()`` callback.

--- a/aiohttp/client_proto.py
+++ b/aiohttp/client_proto.py
@@ -194,7 +194,11 @@ class ResponseHandler(BaseProtocol, DataQueue):
                 try:
                     messages, upgraded, tail = self._parser.feed_data(data)
                 except BaseException as exc:
-                    self.transport.close()
+                    if self.transport is not None:
+                        # connection.release() could be called BEFORE
+                        # data_received(), the transport is already
+                        # closed in this case
+                        self.transport.close()
                     # should_close is True after the call
                     self.set_exception(exc)
                     return


### PR DESCRIPTION
Fix #3031
