### PR TITLE
raise 413 from request.post() not ValueError

### DIFF
--- a/CHANGES/3087.bugfix
+++ b/CHANGES/3087.bugfix
@@ -1,1 +1,2 @@
 raise 413 "Payload Too Large" rather than raising ValueError in request.post()
+Add helpful debug message to 413 responses

--- a/CHANGES/3087.bugfix
+++ b/CHANGES/3087.bugfix
@@ -1,0 +1,1 @@
+raise 413 "Payload Too Large" rather than raising ValueError in request.post()

--- a/aiohttp/web_exceptions.py
+++ b/aiohttp/web_exceptions.py
@@ -253,6 +253,14 @@ class HTTPPreconditionFailed(HTTPClientError):
 class HTTPRequestEntityTooLarge(HTTPClientError):
     status_code = 413
 
+    def __init__(self, max_size, actual_size, **kwargs):
+        kwargs.setdefault(
+            'text',
+            'Maximum request body size {} exceeded, '
+            'actual body size {}'.format(max_size, actual_size)
+        )
+        super().__init__(**kwargs)
+
 
 class HTTPRequestURITooLong(HTTPClientError):
     status_code = 414

--- a/aiohttp/web_request.py
+++ b/aiohttp/web_request.py
@@ -587,8 +587,7 @@ class BaseRequest(collections.MutableMapping, HeadersMixin):
                         tmp.write(chunk)
                         size += len(chunk)
                         if 0 < max_size < size:
-                            raise ValueError(
-                                'Maximum request body size exceeded')
+                            raise HTTPRequestEntityTooLarge
                         chunk = await field.read_chunk(size=2**16)
                     tmp.seek(0)
 
@@ -605,8 +604,7 @@ class BaseRequest(collections.MutableMapping, HeadersMixin):
                     out.add(field.name, value)
                     size += len(value)
                     if 0 < max_size < size:
-                        raise ValueError(
-                            'Maximum request body size exceeded')
+                        raise HTTPRequestEntityTooLarge
 
                 field = await multipart.next()
         else:

--- a/aiohttp/web_request.py
+++ b/aiohttp/web_request.py
@@ -592,7 +592,9 @@ class BaseRequest(collections.MutableMapping, HeadersMixin):
                         size += len(chunk)
                         if 0 < max_size < size:
                             raise HTTPRequestEntityTooLarge(
-                                max_size=max_size, actual_size=size)
+                                max_size=max_size,
+                                actual_size=size
+                            )
                         chunk = await field.read_chunk(size=2**16)
                     tmp.seek(0)
 
@@ -610,7 +612,9 @@ class BaseRequest(collections.MutableMapping, HeadersMixin):
                     size += len(value)
                     if 0 < max_size < size:
                         raise HTTPRequestEntityTooLarge(
-                            max_size=max_size, actual_size=size)
+                            max_size=max_size,
+                            actual_size=size
+                        )
 
                 field = await multipart.next()
         else:

--- a/tests/test_web_functional.py
+++ b/tests/test_web_functional.py
@@ -1451,7 +1451,8 @@ async def test_app_max_client_size(aiohttp_client):
         resp = await client.post('/', data=data)
     assert 413 == resp.status
     resp_text = await resp.text()
-    assert 'Request Entity Too Large' in resp_text
+    assert 'Maximum request body size 1048576 exceeded, ' \
+           'actual body size 1048591' in resp_text
 
 
 async def test_app_max_client_size_adjusted(aiohttp_client):
@@ -1476,7 +1477,8 @@ async def test_app_max_client_size_adjusted(aiohttp_client):
         resp = await client.post('/', data=too_large_data)
     assert 413 == resp.status
     resp_text = await resp.text()
-    assert 'Request Entity Too Large' in resp_text
+    assert 'Maximum request body size 2097152 exceeded, ' \
+           'actual body size 2097166' in resp_text
 
 
 async def test_app_max_client_size_none(aiohttp_client):
@@ -1518,6 +1520,9 @@ async def test_post_max_client_size(aiohttp_client):
     resp = await client.post('/', data=data)
 
     assert 413 == resp.status
+    resp_text = await resp.text()
+    assert 'Maximum request body size 10 exceeded, ' \
+           'actual body size 1024' in resp_text
 
 
 async def test_post_max_client_size_for_file(aiohttp_client):

--- a/tests/test_web_functional.py
+++ b/tests/test_web_functional.py
@@ -1507,30 +1507,24 @@ async def test_app_max_client_size_none(aiohttp_client):
 async def test_post_max_client_size(aiohttp_client):
 
     async def handler(request):
-        try:
-            await request.post()
-        except ValueError:
-            return web.Response()
-        raise web.HTTPBadRequest()
+        await request.post()
+        return web.Response()
 
     app = web.Application(client_max_size=10)
     app.router.add_post('/', handler)
     client = await aiohttp_client(app)
 
-    data = {"long_string": 1024 * 'x', 'file': io.BytesIO(b'test')}
+    data = {'long_string': 1024 * 'x', 'file': io.BytesIO(b'test')}
     resp = await client.post('/', data=data)
 
-    assert 200 == resp.status
+    assert 413 == resp.status
 
 
 async def test_post_max_client_size_for_file(aiohttp_client):
 
     async def handler(request):
-        try:
-            await request.post()
-        except ValueError:
-            return web.Response()
-        raise web.HTTPBadRequest()
+        await request.post()
+        return web.Response()
 
     app = web.Application(client_max_size=2)
     app.router.add_post('/', handler)
@@ -1539,7 +1533,7 @@ async def test_post_max_client_size_for_file(aiohttp_client):
     data = {'file': io.BytesIO(b'test')}
     resp = await client.post('/', data=data)
 
-    assert 200 == resp.status
+    assert 413 == resp.status
 
 
 async def test_response_with_bodypart(aiohttp_client):


### PR DESCRIPTION
## What do these changes do?

Raise 413 "Payload Too Large" rather than raising ValueError in request.post()

## Are there changes in behavior for the user?

post will raise `HTTPRequestEntityTooLarge` rather than ValueError

## Related issue number

fix #3087

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
