### PR TITLE
correct filename in content-disposition with multipart body

### DIFF
--- a/CHANGES/3064.bugfix
+++ b/CHANGES/3064.bugfix
@@ -1,0 +1,1 @@
+correct filename in content-disposition with multipart body

--- a/aiohttp/multipart.py
+++ b/aiohttp/multipart.py
@@ -444,7 +444,7 @@ class BodyPartReaderPayload(Payload):
         if value.name is not None:
             params['name'] = value.name
         if value.filename is not None:
-            params['filename'] = value.name
+            params['filename'] = value.filename
 
         if params:
             self.set_content_disposition('attachment', **params)


### PR DESCRIPTION
## What do these changes do?

Correct filename in content-disposition with multipart body, also improve coverage.

## Are there changes in behavior for the user?

Filename will be correct where previously it used the part's name.

## Related issue number

#3064

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] Add a new news fragment into the `CHANGES` folder
