### PR TITLE
Adding link to asynapplicationinsights

### DIFF
--- a/docs/third_party.rst
+++ b/docs/third_party.rst
@@ -225,6 +225,6 @@ period ask to raise the status.
   the `Eider RPC protocol <http://eider.readthedocs.io/>`_.
 
 - `asynapplicationinsights <https://github.com/RobertoPrevato/asynapplicationinsights>`_ A client 
-for `Azure Application Insights <https://azure.microsoft.com/en-us/services/application-insights/>`_
-implemented using ``aiohttp`` client, including a middleware for ``aiohttp`` servers to collect web apps
-telemetry.
+  for `Azure Application Insights <https://azure.microsoft.com/en-us/services/application-insights/>`_
+  implemented using ``aiohttp`` client, including a middleware for ``aiohttp`` servers to collect web apps
+  telemetry.

--- a/docs/third_party.rst
+++ b/docs/third_party.rst
@@ -223,3 +223,8 @@ period ask to raise the status.
 
 - `eider-py <https://github.com/eider-rpc/eider-py>`_ Python implementation of
   the `Eider RPC protocol <http://eider.readthedocs.io/>`_.
+
+- `asynapplicationinsights <https://github.com/RobertoPrevato/asynapplicationinsights>`_ A client 
+for `Azure Application Insights <https://azure.microsoft.com/en-us/services/application-insights/>`_
+implemented using ``aiohttp`` client, including a middleware for ``aiohttp`` servers to collect web apps
+telemetry.


### PR DESCRIPTION
Adding link to third party library, client for Azure Application Insights using aiohttp client and containing a middleware for aiohttp servers to collect telemetry.

The preparation of this library has been described here: [https://robertoprevato.github.io/Using-Azure-Application-Insights-with-aiohttp/](https://robertoprevato.github.io/Using-Azure-Application-Insights-with-aiohttp/).