### PR TITLE
Add close_boundary option to write closing boundary on multipart writer

### DIFF
--- a/CHANGES/3104.feature
+++ b/CHANGES/3104.feature
@@ -1,0 +1,1 @@
+Add `close_boundary` option in `MultipartWriter.write` method. Support streaming

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -188,6 +188,7 @@ Thanos Lefteris
 Thijs Vermeir
 Thomas Grainger
 Tolga Tezel
+Trinh Hoang Nhu
 Vadim Suharnikov
 Vaibhav Sagar
 Vamsi Krishna Avula

--- a/aiohttp/multipart.py
+++ b/aiohttp/multipart.py
@@ -796,7 +796,7 @@ class MultipartWriter(Payload):
         total += 2 + len(self._boundary) + 4  # b'--'+self._boundary+b'--\r\n'
         return total
 
-    async def write(self, writer):
+    async def write(self, writer, close_boundary=True):
         """Write body."""
         if not self._parts:
             return
@@ -818,7 +818,8 @@ class MultipartWriter(Payload):
 
             await writer.write(b'\r\n')
 
-        await writer.write(b'--' + self._boundary + b'--\r\n')
+        if close_boundary:
+            await writer.write(b'--' + self._boundary + b'--\r\n')
 
 
 class MultipartPayloadWriter:

--- a/docs/multipart.rst
+++ b/docs/multipart.rst
@@ -187,7 +187,7 @@ Please note, that on :meth:`MultipartWriter.write` all the file objects
 will be read until the end and there is no way to repeat a request without
 rewinding their pointers to the start.
 
-Example MJpeg Streaming `multipart/x-mixed-replace`. By default
+Example MJPEG Streaming `multipart/x-mixed-replace`. By default
 :meth:`MultipartWriter.write` will append closing --boundary-- and break your
 content. Providing `close_boundary = False` will prevent this.::
 

--- a/docs/multipart.rst
+++ b/docs/multipart.rst
@@ -187,6 +187,27 @@ Please note, that on :meth:`MultipartWriter.write` all the file objects
 will be read until the end and there is no way to repeat a request without
 rewinding their pointers to the start.
 
+Example MJpeg Streaming `multipart/x-mixed-replace`. By default
+:meth:`MultipartWriter.write` will append closing --boundary-- and break your
+content. Providing `close_boundary = False` will prevent this.::
+
+    my_boundary = 'some-boundary'
+    response = web.StreamResponse(
+        status=200,
+        reason='OK',
+        headers={
+            'Content-Type': 'multipart/x-mixed-replace;boundary=--%s' % my_boundary
+        }
+    )
+    while True:
+        frame = get_jpeg_frame()
+        with MultipartWriter('image/jpeg', boundary=my_boundary) as mpwriter:
+            mpwriter.append(frame, {
+                'Content-Type': 'image/jpeg'
+            })
+            await mpwriter.write(response, close_boundary=False)
+        await response.drain()
+
 Hacking Multipart
 -----------------
 

--- a/docs/multipart.rst
+++ b/docs/multipart.rst
@@ -187,9 +187,9 @@ Please note, that on :meth:`MultipartWriter.write` all the file objects
 will be read until the end and there is no way to repeat a request without
 rewinding their pointers to the start.
 
-Example MJPEG Streaming `multipart/x-mixed-replace`. By default
-:meth:`MultipartWriter.write` will append closing --boundary-- and break your
-content. Providing `close_boundary = False` will prevent this.::
+Example MJPEG Streaming ``multipart/x-mixed-replace``. By default
+:meth:`MultipartWriter.write` appends closing ``--boundary--`` and breaks your
+content. Providing `close_boundary = False` prevents this.::
 
     my_boundary = 'some-boundary'
     response = web.StreamResponse(

--- a/docs/multipart_reference.rst
+++ b/docs/multipart_reference.rst
@@ -157,7 +157,7 @@ Multipart reference
       Returns the next body part reader.
 
 
-.. class:: MultipartWriter(subtype='mixed', boundary=None)
+.. class:: MultipartWriter(subtype='mixed', boundary=None, close_boundary=True)
 
    Multipart body writer.
 
@@ -191,6 +191,10 @@ Multipart reference
 
       Size of the payload.
 
-   .. comethod:: write(writer)
+   .. comethod:: write(writer, close_boundary=True)
 
       Write body.
+
+      :param bool close_boundary: The boolean (:class:`bool`) that will emit
+                                  boundary closing. You may want to disable
+                                  when streaming (multipart/x-mixed-replace)

--- a/docs/multipart_reference.rst
+++ b/docs/multipart_reference.rst
@@ -197,4 +197,8 @@ Multipart reference
 
       :param bool close_boundary: The (:class:`bool`) that will emit
                                   boundary closing. You may want to disable
-                                  when streaming (multipart/x-mixed-replace)
+                                  when streaming (``multipart/x-mixed-replace``)
+
+      .. versionadded:: 3.4
+         
+         Support ``close_boundary`` argument.

--- a/docs/multipart_reference.rst
+++ b/docs/multipart_reference.rst
@@ -195,6 +195,6 @@ Multipart reference
 
       Write body.
 
-      :param bool close_boundary: The boolean (:class:`bool`) that will emit
+      :param bool close_boundary: The (:class:`bool`) that will emit
                                   boundary closing. You may want to disable
                                   when streaming (multipart/x-mixed-replace)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Add close_boundary option in write method of MultipartWriter to support Streaming content

## Are there changes in behavior for the user?

Allow MJpeg (and other streaming that use `multipart/x-mixed-replace`)

## Related issue number

https://github.com/aio-libs/aiohttp/issues/3104

## Checklist

- [ ✔] I think the code is well written
- [ ✔] Unit tests for the changes exist
- [ ✔] Documentation reflects the changes
- [ ✔] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [ ✔] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
