### PR TITLE
Fix StreamResponse equality

### DIFF
--- a/CHANGES/3100.bugfix
+++ b/CHANGES/3100.bugfix
@@ -1,0 +1,1 @@
+Fix `StreamResponse` equality, now that they are `MutableMapping` objects.

--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -432,6 +432,9 @@ class StreamResponse(collections.MutableMapping, HeadersMixin):
     def __hash__(self):
         return hash(id(self))
 
+    def __eq__(self, other):
+        return self is other
+
 
 class Response(StreamResponse):
 

--- a/tests/test_web_response.py
+++ b/tests/test_web_response.py
@@ -82,6 +82,14 @@ def test_stream_response_hashable():
     hash(StreamResponse())
 
 
+def test_stream_response_eq():
+    resp1 = StreamResponse()
+    resp2 = StreamResponse()
+
+    assert resp1 == resp1
+    assert not resp1 == resp2
+
+
 def test_stream_response_is_mutable_mapping():
     resp = StreamResponse()
     assert isinstance(resp, collections.MutableMapping)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

StreamResponse as subclass of MutableMapping introduced equality defined as `return dict(self.items()) == dict(other.items())`.
Now, it is back to identity of addresses.

## Are there changes in behavior for the user?

Back to the behaviour of pre-3.0 aiohttp version.

## Related issue number

Fixes #3100 

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes (no specific mention of  `__eq__` in the docs)
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
