### PR TITLE
Fix 3102: add check for to py37 in test_timer_context_cancelled

### DIFF
--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -34,8 +34,8 @@ from .log import client_logger
 
 __all__ = ('BasicAuth', 'ChainMapProxy')
 
-PY_36 = sys.version_info >= (3, 6)
-PY_37 = sys.version_info >= (3, 7)
+PY_36 = (3, 6) <= sys.version_info < (3, 7)
+PY_37 = (3, 7) <= sys.version_info < (3, 8)
 
 if not PY_37:
     import idna_ssl

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -16,6 +16,7 @@ from yarl import URL
 
 import aiohttp
 from aiohttp import client, web
+from aiohttp import helpers
 from aiohttp.client import ClientRequest, ClientTimeout
 from aiohttp.client_reqrep import ConnectionKey
 from aiohttp.connector import Connection, _DNSCacheTable
@@ -493,8 +494,14 @@ async def test_tcp_connector_certificate_error(loop):
     assert isinstance(ctx.value, ssl.CertificateError)
     assert isinstance(ctx.value.certificate_error, ssl.CertificateError)
     assert isinstance(ctx.value, aiohttp.ClientSSLError)
-    assert str(ctx.value) == ('Cannot connect to host 127.0.0.1:443 ssl:True '
-                              '[CertificateError: ()]')
+
+    if helpers.PY_37:
+        msg = ('Cannot connect to host 127.0.0.1:443 ssl:True '
+               '[SSLCertVerificationError: ()]')
+    else:
+        msg = ('Cannot connect to host 127.0.0.1:443 ssl:True '
+               '[CertificateError: ()]')
+    assert str(ctx.value) == msg
 
 
 async def test_tcp_connector_multiple_hosts_errors(loop):

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -427,7 +427,10 @@ def test_timer_context_cancelled():
             with ctx:
                 pass
 
-        assert m_asyncio.Task.current_task.return_value.cancel.called
+        if helpers.PY_37:
+            assert m_asyncio.current_task.return_value.cancel.called
+        else:
+            assert m_asyncio.Task.current_task.return_value.cancel.called
 
 
 def test_timer_context_no_task(loop):


### PR DESCRIPTION
bugfix for #3102

Has implications for all tests marked with `@pytest.mark.skipif(not PY_36, reason="Python 3.6+ required")`

But current PY_36 check is rather wrong because for python 3.7
`PY_36 = sys.version_info >= (3, 6)` gives us `PY_36` as `True`

**upd:**
added fix for `test_tcp_connector_certificate_error`, [msg updated in py37](https://docs.python.org/3/library/ssl.html#ssl.CertificateError)