### PR TITLE
Add FAQ entry about re-using response objects

### DIFF
--- a/CHANGES/3020.doc
+++ b/CHANGES/3020.doc
@@ -1,0 +1,2 @@
+Add a new FAQ entry that clarifies that you should not reuse response
+objects in middleware functions.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -126,6 +126,7 @@ Lu Gong
 Lubomir Gelo
 Ludovic Gasc
 Lukasz Marcin Dobrzanski
+Luis Pedrosa
 Makc Belousow
 Manuel Miranda
 Marat Sharafutdinov

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -334,6 +334,36 @@ required by aiohttp web contracts, even though the response
 already been sent.
 
 
+How do I make sure my custom middleware response will behave correctly?
+------------------------------------------------------------------------
+
+Sometimes your middleware handlers might need to send a custom response.
+This is just fine as long as you always create a new
+:class:`aiohttp.web.Response` object when required.
+
+The response object is a Finite State Machine. Once it has been dispatched
+by the server, it will reach its final state and cannot be used again.
+
+The following middleware will make the server hang, once it serves the second
+response::
+
+    from aiohttp import web
+
+    def misbehaved_middleware():
+        # don't do this!
+        cached = web.Response(status=200, text='Hi, I am cached!')
+
+        @web.middleware
+        async def middleware(request, handler):
+            # ignoring response for the sake of this example
+            _res = handler(request)
+            return cached
+
+        return middleware
+
+The rule of thumb is *one request, one response*.
+
+
 Why is creating a ClientSession outside of an event loop dangerous?
 -------------------------------------------------------------------
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
This clarifies the behaviour encountered in #3020.  After a short discussion, it was decided that the best way to clarify the intended behaviour was through a new FAQ entry

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->
N/A

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
#3020 

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
