### PR TITLE
Fix documentation build configuration file for Windows

### DIFF
--- a/CHANGES/3147.doc
+++ b/CHANGES/3147.doc
@@ -1,0 +1,1 @@
+Fix documentation build configuration file for Windows.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,7 +13,7 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import codecs
+import io
 import os
 import re
 import sys
@@ -21,7 +21,7 @@ import sys
 _docs_path = os.path.dirname(__file__)
 _version_path = os.path.abspath(os.path.join(_docs_path,
                                              '..', 'aiohttp', '__init__.py'))
-with codecs.open(_version_path, 'r', 'latin1') as fp:
+with io.open(_version_path, 'r', encoding='latin1') as fp:
     try:
         _version_info = re.search(r"^__version__ = '"
                                   r"(?P<major>\d+)"


### PR DESCRIPTION
### What does this change do?

Fixes documentation builds for Windows

### Are there changes in behavior for the user?

No
Python <2.6 support is dropped for building the documentation
Not sure why `codecs.open` was used, but Python 2.6+ support is maintained with `io.open`

### Related issue number

Fixes #3147

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
