### PR TITLE
Remove Application.make_handler lingering_timeout parameter from docs

### DIFF
--- a/CHANGES/3151.doc
+++ b/CHANGES/3151.doc
@@ -1,0 +1,1 @@
+Remove no longer existing lingering_timeout parameter of Application.make_handler from documentation.

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -1437,9 +1437,6 @@ duplicated like one using :meth:`Application.copy`.
        lingering close is on.  Use ``0`` for disabling lingering on
        server channel closing.
 
-    :param float lingering_timeout: maximum waiting time for more
-        client data to arrive when lingering close is in effect
-
     You should pass result of the method as *protocol_factory* to
     :meth:`~asyncio.AbstractEventLoop.create_server`, e.g.::
 


### PR DESCRIPTION
### What does this change do?

Removes the no longer existing `lingering_timeout` parameter of [`Application.make_handler`](http://docs.aiohttp.org/en/latest/web_reference.html#aiohttp.web.Application.make_handler) from documentation
`lingering_timeout` was functionally removed in https://github.com/aio-libs/aiohttp/commit/af887906020f22c3e1408b46bd3eaf162ac10ff6, and the kwarg itself was removed in https://github.com/aio-libs/aiohttp/commit/9cfa4fe39e2a3b8fe4e7052f8dda02a7adfe2123

### Are there changes in behavior for the user?

No

### Related issue number

N/A

## Checklist

- [x] I think the code is well written
- [ ] ~~Unit tests for the changes exist~~
- [x] Documentation reflects the changes
- [ ] ~~If you provide code modification, please add yourself to `CONTRIBUTORS.txt`~~
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
