### PR TITLE
Compatibility with pytest 3.7

### DIFF
--- a/CHANGES/3170.bugfix
+++ b/CHANGES/3170.bugfix
@@ -1,0 +1,1 @@
+Fix compatibility with pytest 3.7.0

--- a/aiohttp/pytest_plugin.py
+++ b/aiohttp/pytest_plugin.py
@@ -40,7 +40,7 @@ def pytest_fixture_setup(fixturedef):
     """
     Allow fixtures to be coroutines. Run coroutine fixtures in an event loop.
     """
-    func = fixturedef.func
+    func = getattr(fixturedef.func, '__wrapped__', fixturedef.func)
 
     if isasyncgenfunction(func):
         # async generator fixture

--- a/requirements/ci-wheel.txt
+++ b/requirements/ci-wheel.txt
@@ -11,7 +11,7 @@ gunicorn==19.8.1
 isort==4.3.4
 pyflakes==2.0.0
 multidict==4.3.1
-pytest==3.6.0
+pytest==3.7.0
 pytest-cov==2.5.1
 pytest-mock==1.10.0
 pytest-xdist==1.22.2


### PR DESCRIPTION
## What do these changes do?

Add compatibility to pytest plugin with pytest 3.7.0. This was also tested with pytest 3.6.4.

## Are there changes in behavior for the user?

This fixes async fixtures when using pytest 3.7.0.

## Related issue number

N/A

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
