### PR TITLE
make_mocked_request: subscriptable default app

### DIFF
--- a/CHANGES/3174.feature
+++ b/CHANGES/3174.feature
@@ -1,0 +1,2 @@
+The default ``app`` in the request returned by ``test_utils.make_mocked_request``
+can now have objects assigned to it and retrieved using the ``[]`` operator.

--- a/aiohttp/test_utils.py
+++ b/aiohttp/test_utils.py
@@ -448,7 +448,17 @@ def teardown_test_loop(loop, fast=False):
 
 
 def _create_app_mock():
-    app = mock.Mock()
+    def get_dict(app, key):
+        return app.__app_dict[key]
+
+    def set_dict(app, key, value):
+        app.__app_dict[key] = value
+
+    app = mock.MagicMock()
+    app.__app_dict = {}
+    app.__getitem__ = get_dict
+    app.__setitem__ = set_dict
+
     app._debug = False
     app.on_response_prepare = Signal(app)
     app.on_response_prepare.freeze()

--- a/tests/test_test_utils.py
+++ b/tests/test_test_utils.py
@@ -189,6 +189,12 @@ def test_make_mocked_request_app():
     assert req.app is app
 
 
+def test_make_mocked_request_app_can_store_values():
+    req = make_mocked_request('GET', '/')
+    req.app['a_field'] = 'a_value'
+    assert req.app['a_field'] == 'a_value'
+
+
 def test_make_mocked_request_match_info():
     req = make_mocked_request('GET', '/', match_info={'a': '1', 'b': '2'})
     assert req.match_info == {'a': '1', 'b': '2'}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

App in the default request created with make_mocked_request won't crash when accessed with `[]`.

## Are there changes in behavior for the user?

Nope.

## Related issue number

#3134 
