### PR TITLE
Add test accessing request.url when transport is closed

### DIFF
--- a/aiohttp/web_request.py
+++ b/aiohttp/web_request.py
@@ -78,7 +78,8 @@ class BaseRequest(collections.MutableMapping, HeadersMixin):
     ATTRS = HeadersMixin.ATTRS | frozenset([
         '_message', '_protocol', '_payload_writer', '_payload', '_headers',
         '_method', '_version', '_rel_url', '_post', '_read_bytes',
-        '_state', '_cache', '_task', '_client_max_size', '_loop'])
+        '_state', '_cache', '_task', '_client_max_size', '_loop',
+        '_transport_sslcontext', '_transport_peername'])
 
     def __init__(self, message, payload, protocol, payload_writer, task,
                  loop,

--- a/aiohttp/web_request.py
+++ b/aiohttp/web_request.py
@@ -105,8 +105,9 @@ class BaseRequest(collections.MutableMapping, HeadersMixin):
         self._client_max_size = client_max_size
         self._loop = loop
 
-        self._transport_sslcontext = self._protocol.transport.get_extra_info('sslcontext')
-        self._transport_peername = self._protocol.transport.get_extra_info('peername')
+        transport = self._protocol.transport
+        self._transport_sslcontext = transport.get_extra_info('sslcontext')
+        self._transport_peername = transport.get_extra_info('peername')
 
         if scheme is not None:
             self._cache['scheme'] = scheme

--- a/aiohttp/web_request.py
+++ b/aiohttp/web_request.py
@@ -105,6 +105,9 @@ class BaseRequest(collections.MutableMapping, HeadersMixin):
         self._client_max_size = client_max_size
         self._loop = loop
 
+        self._transport_sslcontext = self._protocol.transport.get_extra_info('sslcontext')
+        self._transport_peername = self._protocol.transport.get_extra_info('peername')
+
         if scheme is not None:
             self._cache['scheme'] = scheme
         if host is not None:
@@ -292,7 +295,7 @@ class BaseRequest(collections.MutableMapping, HeadersMixin):
 
         'http' or 'https'.
         """
-        if self.transport.get_extra_info('sslcontext'):
+        if self._transport_sslcontext:
             return 'https'
         else:
             return 'http'
@@ -338,13 +341,10 @@ class BaseRequest(collections.MutableMapping, HeadersMixin):
         - overridden value by .clone(remote=new_remote) call.
         - peername of opened socket
         """
-        if self.transport is None:
-            return None
-        peername = self.transport.get_extra_info('peername')
-        if isinstance(peername, (list, tuple)):
-            return peername[0]
+        if isinstance(self._transport_peername, (list, tuple)):
+            return self._transport_peername[0]
         else:
-            return peername
+            return self._transport_peername
 
     @reify
     def url(self) -> URL:

--- a/tests/test_web_request.py
+++ b/tests/test_web_request.py
@@ -631,15 +631,23 @@ def test_request_custom_attr():
 
 
 def test_remote_with_closed_transport():
-    req = make_mocked_request('GET', '/')
+    transp = mock.Mock()
+    transp.get_extra_info.return_value = ('10.10.10.10', 1234)
+    req = make_mocked_request('GET', '/', transport=transp)
     req._protocol = None
-    assert req.remote is None
+    assert req.remote == '10.10.10.10'
 
 
-def test_url_with_closed_transport():
+def test_url_http_with_closed_transport():
     req = make_mocked_request('GET', '/')
     req._protocol = None
-    assert str(req.url).endswith('/')
+    assert str(req.url).startswith('http://')
+
+
+def test_url_https_with_closed_transport():
+    req = make_mocked_request('GET', '/', sslcontext=True)
+    req._protocol = None
+    assert str(req.url).startswith('https://')
 
 
 def test_eq():

--- a/tests/test_web_request.py
+++ b/tests/test_web_request.py
@@ -636,6 +636,12 @@ def test_remote_with_closed_transport():
     assert req.remote is None
 
 
+def test_url_with_closed_transport():
+    req = make_mocked_request('GET', '/')
+    req._protocol = None
+    assert str(req.url).endswith('/')
+
+
 def test_eq():
     req1 = make_mocked_request('GET', '/path/to?a=1&b=2')
     req2 = make_mocked_request('GET', '/path/to?a=1&b=2')


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

I am finding an issue on production when trying to retrieve the `request.url` property on a closed transport fails. The stacktrace is the following:

```
    segment.put_http_meta(http.URL, str(request.url))
  File "/usr/local/lib/python3.6/site-packages/aiohttp/helpers.py", line 504, in __get__
    val = self.wrapped(inst)
  File "/usr/local/lib/python3.6/site-packages/aiohttp/web_request.py", line 340, in url
    url = URL.build(scheme=self.scheme, host=self.host)
  File "/usr/local/lib/python3.6/site-packages/aiohttp/helpers.py", line 504, in __get__
    val = self.wrapped(inst)
  File "/usr/local/lib/python3.6/site-packages/aiohttp/web_request.py", line 284, in scheme
    if self.transport.get_extra_info('sslcontext'):
AttributeError: 'NoneType' object has no attribute 'get_extra_info'
```

I found a similar issue already fixed, but it was for the `request.remote` property instead: https://github.com/aio-libs/aiohttp/issues/2474

I'm not really sure what's the best way to fix it, that's why I'm just adding a simple test case to show the problem. Any hint on how to solve it?

This is the test failure:

```
$ pytest tests/test_web_request.py::test_url_with_closed_transport -vv
Test session starts (platform: darwin, Python 3.6.1, pytest 3.6.4, pytest-sugar 0.9.1)
cachedir: .pytest_cache
rootdir: /Users/josepcugat/workspace/aiohttp, inifile: setup.cfg
plugins: xdist-1.22.5, sugar-0.9.1, mock-1.10.0, forked-0.2, cov-2.5.1


――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― test_url_with_closed_transport ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――

>   return inst._cache[self.name]
E   KeyError: 'url'

aiohttp/_helpers.pyx:24: KeyError

During handling of the above exception, another exception occurred:

>   return inst._cache[self.name]
E   KeyError: 'scheme'

aiohttp/_helpers.pyx:24: KeyError

During handling of the above exception, another exception occurred:

    def test_url_with_closed_transport():
        req = make_mocked_request('GET', '/')
        req._protocol = None
>       assert str(req.url).endswith('/')

tests/test_web_request.py:642:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
aiohttp/_helpers.pyx:32: in aiohttp._helpers.reify.__get__
    raise
aiohttp/_helpers.pyx:26: in aiohttp._helpers.reify.__get__
    val = self.wrapped(inst)
aiohttp/web_request.py:351: in url
    url = URL.build(scheme=self.scheme, host=self.host)
aiohttp/_helpers.pyx:32: in aiohttp._helpers.reify.__get__
    raise
aiohttp/_helpers.pyx:26: in aiohttp._helpers.reify.__get__
    val = self.wrapped(inst)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <Request GET / >

    @reify
    def scheme(self) -> str:
        """A string representing the scheme of the request.

            Hostname is resolved in this order:

            - overridden value by .clone(scheme=new_scheme) call.
            - type of connection to peer: HTTPS if socket is SSL, HTTP otherwise.

            'http' or 'https'.
            """
>       if self.transport.get_extra_info('sslcontext'):
E       AttributeError: 'NoneType' object has no attribute 'get_extra_info'

aiohttp/web_request.py:295: AttributeError

 tests/test_web_request.py::test_url_with_closed_transport ⨯                                                                                                                                                                                                                                                                                               100% ██████████

Results (0.18s):
       1 failed
         - tests/test_web_request.py:639 test_url_with_closed_transport
```

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->

No.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [X] I think the code is well written
- [X] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
