### PR TITLE
AbstractRouteDef is importable from the web module (#3183)

### DIFF
--- a/CHANGES/3183.feature
+++ b/CHANGES/3183.feature
@@ -1,0 +1,1 @@
+The class `AbstractRouteDef` is importable from `aiohttp.web`.

--- a/aiohttp/web_routedef.py
+++ b/aiohttp/web_routedef.py
@@ -6,9 +6,9 @@ import attr
 from . import hdrs
 
 
-__all__ = ('RouteDef', 'StaticDef', 'RouteTableDef', 'head', 'options', 'get',
-           'post', 'patch', 'put', 'delete', 'route', 'view',
-           'static')
+__all__ = ('AbstractRouteDef', 'RouteDef', 'StaticDef', 'RouteTableDef',
+           'head', 'options', 'get', 'post', 'patch', 'put', 'delete',
+           'route', 'view', 'static')
 
 
 class AbstractRouteDef(abc.ABC):


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
Add AbstractRouteDef to the `__all__` tuple in order to allow importation from web module

<!-- Please give a short brief about these changes. -->
According to the documentation, the user can use `from aiohttp.web import  AbstractRouteDef` instead of `from aiohttp.web_routedef import AbstractRouteDef`

## Related issue number

#3183 

## Checklist

- [X]  I think the code is well written
- [ ] Unit tests for the changes exist
- [X]  Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [X] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."