### PR TITLE
Specify timeout in aiohttp.request

### DIFF
--- a/CHANGES/3213.feature
+++ b/CHANGES/3213.feature
@@ -1,0 +1,1 @@
+Enable users to set `ClientTimeout` in `aiohttp.request`

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -103,6 +103,7 @@ Jashandeep Sohi
 Jeongkyu Shin
 Jeroen van der Heijden
 Jesus Cea
+Jian Zeng
 Jinkyu Yi
 Joel Watts
 Jon Nabozny

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -906,6 +906,7 @@ def request(method, url, *,
             connector=None,
             loop=None,
             read_until_eof=True,
+            timeout=sentinel,
             proxy=None,
             proxy_auth=None) -> _SessionRequestContextManager:
     """Constructs and sends a request. Returns response object.
@@ -933,6 +934,8 @@ def request(method, url, *,
     read_until_eof - Read response until eof if response
        does not have Content-Length header.
     loop - Optional event loop.
+    timeout - Optional ClientTimeout settings structure, 5min
+       total timeout by default.
     Usage::
       >>> import aiohttp
       >>> resp = await aiohttp.request('GET', 'http://python.org/')
@@ -946,7 +949,7 @@ def request(method, url, *,
         connector = TCPConnector(loop=loop, force_close=True)
 
     session = ClientSession(
-        loop=loop, cookies=cookies, version=version,
+        loop=loop, cookies=cookies, version=version, timeout=timeout,
         connector=connector, connector_owner=connector_owner)
 
     return _SessionRequestContextManager(

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -660,7 +660,7 @@ certification chaining.
                         version=HttpVersion(major=1, minor=1), \
                         compress=None, chunked=None, expect100=False, raise_for_status=None, \
                         connector=None, loop=None,\
-                        read_until_eof=True)
+                        read_until_eof=True, timeout=sentinel)
 
    :async-with:
 
@@ -718,6 +718,9 @@ certification chaining.
    :param bool read_until_eof: Read response until EOF if response
                                does not have Content-Length header.
                                ``True`` by default (optional).
+
+   :param timeout: a :class:`ClientTimeout` settings structure, 5min
+        total timeout by default.
 
    :param loop: :ref:`event loop<asyncio-event-loop>`
                 used for processing HTTP requests.


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?
Enable users to set `ClientTimeout` in `aiohttp.request`

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
