### PR TITLE
Regression in parsing empty headers

### DIFF
--- a/CHANGES/3218.bugfix
+++ b/CHANGES/3218.bugfix
@@ -1,0 +1,1 @@
+Fix empty header parsing regression.

--- a/CHANGES/3219.bugfix
+++ b/CHANGES/3219.bugfix
@@ -1,1 +1,0 @@
-Fix empty header parsing regression.

--- a/CHANGES/3219.bugfix
+++ b/CHANGES/3219.bugfix
@@ -1,0 +1,1 @@
+Fix empty header parsing regression.

--- a/aiohttp/_http_parser.pyx
+++ b/aiohttp/_http_parser.pyx
@@ -260,6 +260,7 @@ cdef class HttpParser:
 
         bytearray _raw_name
         bytearray _raw_value
+        bint      _has_value
 
         object _protocol
         object _loop
@@ -327,6 +328,7 @@ cdef class HttpParser:
 
         self._raw_name = bytearray()
         self._raw_value = bytearray()
+        self._has_value = False
 
         self._max_line_size = max_line_size
         self._max_headers = max_headers
@@ -364,12 +366,13 @@ cdef class HttpParser:
 
             PyByteArray_Resize(self._raw_name, 0)
             PyByteArray_Resize(self._raw_value, 0)
+            self._has_value = False
             self._raw_headers.append((raw_name, raw_value))
 
     cdef _on_header_field(self, char* at, size_t length):
         cdef Py_ssize_t size
         cdef char *buf
-        if self._raw_value:
+        if self._has_value:
             self._process_header()
 
         size = PyByteArray_Size(self._raw_name)
@@ -385,6 +388,7 @@ cdef class HttpParser:
         PyByteArray_Resize(self._raw_value, size + length)
         buf = PyByteArray_AsString(self._raw_value)
         memcpy(buf + size, at, length)
+        self._has_value = True
 
     cdef _on_headers_complete(self):
         self._process_header()

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -495,6 +495,26 @@ async def test_raw_headers(aiohttp_client):
     resp.close()
 
 
+async def test_empty_header_values(aiohttp_client):
+    async def handler(request):
+        resp = web.Response()
+        resp.headers['X-Empty'] = ''
+        return resp
+
+    app = web.Application()
+    app.router.add_route('GET', '/', handler)
+    client = await aiohttp_client(app)
+    resp = await client.get('/')
+    assert resp.status == 200
+    raw_headers = tuple((bytes(h), bytes(v)) for h, v in resp.raw_headers)
+    assert raw_headers == ((b'X-Empty', b''),
+                           (b'Content-Length', b'0'),
+                           (b'Content-Type', b'application/octet-stream'),
+                           (b'Date', mock.ANY),
+                           (b'Server', mock.ANY))
+    resp.close()
+
+
 async def test_204_with_gzipped_content_encoding(aiohttp_client):
     async def handler(request):
         resp = web.StreamResponse(status=204)


### PR DESCRIPTION
## What do these changes do?

The v3.4 release bring regression in headers parsing:
empty header values are ignored and such empty headers get concatenated to first non-empty.

This PR just adds a test to recreate the issue #3219.