### PR TITLE
Don't uppercase HTTP verb in parser

### DIFF
--- a/CHANGES/3233.bugfix
+++ b/CHANGES/3233.bugfix
@@ -1,0 +1,1 @@
+Don't uppercase HTTP method in parser

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -371,7 +371,6 @@ class HttpRequestParser(HttpParser):
                 'Status line is too long', self.max_line_size, len(path))
 
         # method
-        method = method.upper()
         if not METHRE.match(method):
             raise BadStatusLine(method)
 


### PR DESCRIPTION
[RFC 7320 sec. 3.1.1](https://tools.ietf.org/html/rfc7230#section-3.1.1): 

> The request method is case sensitive