### PR TITLE
Add app.pre_frozen state

### DIFF
--- a/CHANGES/3237.bugfix
+++ b/CHANGES/3237.bugfix
@@ -1,0 +1,1 @@
+Add ``app.pre_frozen`` state to properly handle startup signals in sub-applications.


### PR DESCRIPTION
Before the PR sub-applications was *frozen* after adding to main app.
As the result sub-application state modification (`subapp['key'] = 'val'`) in `on_startup` signal raised a warning.

To solve this the PR introduces a new `pre_frozen` state: a router and signals are frozen but an application state is still open for modification.
The state becomes frozen after handling startup signals and before running a server.