### PR TITLE
Enhanced basic auth decode

### DIFF
--- a/CHANGES/3239.bugfix
+++ b/CHANGES/3239.bugfix
@@ -1,0 +1,1 @@
+Enhanced parsing and validation of helpers.BasicAuth.decode.

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,6 +34,8 @@ branch = True
 source = aiohttp, tests
 omit = site-packages
 
+[mypy]
+incremental = false
 
 [mypy-pytest]
 ignore_missing_imports = true

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -85,7 +85,9 @@ def test_basic_auth4():
 
 
 @pytest.mark.parametrize('header', (
-    'Basic bmtpbTpwd2Q=', 'basic bmtpbTpwd2Q='))
+    'Basic bmtpbTpwd2Q=',
+    'basic bmtpbTpwd2Q=',
+))
 def test_basic_auth_decode(header):
     auth = helpers.BasicAuth.decode(header)
     assert auth.login == 'nkim'
@@ -120,11 +122,14 @@ def test_basic_auth_decode_invalid_credentials():
 
 
 @pytest.mark.parametrize('credentials, expected_auth', (
-    (':', helpers.BasicAuth(login='', password='')),
-    ('username:', helpers.BasicAuth(login='username', password='')),
-    (':password', helpers.BasicAuth(login='', password='password')),
+    (':', helpers.BasicAuth(
+        login='', password='', encoding='latin1')),
+    ('username:', helpers.BasicAuth(
+        login='username', password='', encoding='latin1')),
+    (':password', helpers.BasicAuth(
+        login='', password='password', encoding='latin1')),
     ('username:password', helpers.BasicAuth(
-        login='username', password='password')),
+        login='username', password='password', encoding='latin1')),
 ))
 def test_basic_auth_decode_blank_username(credentials, expected_auth):
     header = 'Basic {}'.format(base64.b64encode(credentials.encode()).decode())


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

These changes prevent passing illegal chars in the base64 payload.
It was possible to use `Authorization: Basic ???` to get `BasicAuth(login='', password='')` without exceptions.
Also, the related RFC https://www.ietf.org/rfc/rfc2617.txt allows the username and password to be blank, but the colon must be present.
```
      credentials = "Basic" basic-credentials
      basic-credentials = base64-user-pass
      base64-user-pass  = <base64 [4] encoding of user-pass, except not limited to 76 char/line>
      user-pass   = userid ":" password
      userid      = *<TEXT excluding ":">
      password    = *TEXT
```
and
```
curl -vv -u '' example.com
Authorization: Basic Og==  # which is just ":"
```

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."