### PR TITLE
Fixes #3158 - Support overriding access_log_class with handler_args

### DIFF
--- a/CHANGES/3158.bugfix
+++ b/CHANGES/3158.bugfix
@@ -1,0 +1,1 @@
+Enable passing `access_log_class` via `handler_args`

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -192,6 +192,7 @@ Taras Voinarovskyi
 Terence Honles
 Thanos Lefteris
 Thijs Vermeir
+Thomas Forbes
 Thomas Grainger
 Tolga Tezel
 Trinh Hoang Nhu

--- a/aiohttp/web_app.py
+++ b/aiohttp/web_app.py
@@ -293,12 +293,12 @@ class Application(MutableMapping):
         self.freeze()
 
         kwargs['debug'] = self.debug
+        kwargs['access_log_class'] = access_log_class
         if self._handler_args:
             for k, v in self._handler_args.items():
                 kwargs[k] = v
 
         return Server(self._handle, request_factory=self._make_request,
-                      access_log_class=access_log_class,
                       loop=self.loop, **kwargs)
 
     def make_handler(self, *,

--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -95,6 +95,13 @@ def test_app_make_handler_access_log_class(loop, mocker):
                            request_factory=app._make_request,
                            loop=loop, debug=mock.ANY)
 
+    app = web.Application(handler_args={'access_log_class': Logger})
+    app._make_handler(access_log_class=Logger, loop=loop)
+    srv.assert_called_with(app._handle,
+                           access_log_class=Logger,
+                           request_factory=app._make_request,
+                           loop=loop, debug=mock.ANY)
+
 
 def test_app_make_handler_raises_deprecation_warning(loop):
     app = web.Application()


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Support overriding `access_log_class` with `handler_args`

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

Nope, currently it throws an error when this is the case, as described in the ticket

<!-- Outline any notable behaviour for the end users. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

#3158

## Checklist

- [X] I think the code is well written
- [X] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [X] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [X] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
