### PR TITLE
ABCs should import from collections.abc in Py3.7+

### DIFF
--- a/CHANGES/3273.bugfix
+++ b/CHANGES/3273.bugfix
@@ -1,1 +1,1 @@
-In Python 3.8, importing ABCs directly from the collections module will not be supported anymore.
+Fix forward compatibility with Python 3.8: importing ABCs directly from the collections module will not be supported anymore.

--- a/CHANGES/3273.bugfix
+++ b/CHANGES/3273.bugfix
@@ -1,0 +1,1 @@
+In Python 3.8, importing ABCs directly from the collections module will not be supported anymore.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -87,6 +87,7 @@ Georges Dubus
 Greg Holt
 Gregory Haynes
 Günther Jena
+Gus Goulart
 Gustavo Carneiro
 Hu Bo
 Hugo Herter

--- a/aiohttp/web.py
+++ b/aiohttp/web.py
@@ -3,7 +3,7 @@ import logging
 import socket
 import sys
 from argparse import ArgumentParser
-from collections import Iterable
+from collections.abc import Iterable
 from importlib import import_module
 
 from . import (helpers, web_app, web_exceptions, web_fileresponse,

--- a/aiohttp/web_app.py
+++ b/aiohttp/web_app.py
@@ -1,7 +1,7 @@
 import asyncio
 import logging
 import warnings
-from collections import MutableMapping
+from collections.abc import MutableMapping
 from functools import partial
 from typing import (TYPE_CHECKING, Any, Awaitable, Callable, List, Mapping,
                     Optional, Sequence, Tuple, Union)

--- a/tests/test_web_request.py
+++ b/tests/test_web_request.py
@@ -1,5 +1,5 @@
 import socket
-from collections import MutableMapping
+from collections.abc import MutableMapping
 from unittest import mock
 
 import pytest


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

In Python 3.8, importing ABCs directly from the `collections` module will not be supported anymore.
The proposed changes will stop the current warnings for the users working with Python 3.7 and prevent backward incompatibility.

https://github.com/python/cpython/pull/5460
## Are there changes in behavior for the user?
No.
<!-- Outline any notable behaviour for the end users. -->

## Related issue number

https://github.com/aio-libs/aiohttp/issues/3273

PR https://github.com/aio-libs/aiohttp/pull/3258 also fixed some imports.
<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
