### PR TITLE
`normalize_path_middleware` should keep the query string. 

### DIFF
--- a/CHANGES/3278.bugfix
+++ b/CHANGES/3278.bugfix
@@ -1,1 +1,1 @@
-`normalize_path_middleware` should keep the query string.
+Keep the query string by `normalize_path_middleware`.

--- a/CHANGES/3278.bugfix
+++ b/CHANGES/3278.bugfix
@@ -1,0 +1,1 @@
+`normalize_path_middleware` should keep the query string.

--- a/aiohttp/web_middlewares.py
+++ b/aiohttp/web_middlewares.py
@@ -91,7 +91,7 @@ def normalize_path_middleware(
                 resolves, request = await _check_request_resolves(
                     request, path)
                 if resolves:
-                    raise redirect_class(request.raw_path)
+                    raise redirect_class(request.raw_path + query)
 
         return await handler(request)
 

--- a/tests/test_web_middleware.py
+++ b/tests/test_web_middleware.py
@@ -1,9 +1,9 @@
 import re
 
 import pytest
+from yarl import URL
 
 from aiohttp import web
-from yarl import URL
 
 
 async def test_middleware_modifies_response(loop, aiohttp_client):

--- a/tests/test_web_middleware.py
+++ b/tests/test_web_middleware.py
@@ -3,6 +3,7 @@ import re
 import pytest
 
 from aiohttp import web
+from yarl import URL
 
 
 async def test_middleware_modifies_response(loop, aiohttp_client):
@@ -115,6 +116,7 @@ class TestNormalizePathMiddleware:
 
         resp = await client.get(path)
         assert resp.status == status
+        assert resp.url.query == URL(path).query
 
     @pytest.mark.parametrize("path, status", [
         ('/resource1', 200),
@@ -136,6 +138,7 @@ class TestNormalizePathMiddleware:
 
         resp = await client.get(path)
         assert resp.status == status
+        assert resp.url.query == URL(path).query
 
     @pytest.mark.parametrize("path, status", [
         ('/resource1', 200),
@@ -158,6 +161,7 @@ class TestNormalizePathMiddleware:
 
         resp = await client.get(path)
         assert resp.status == status
+        assert resp.url.query == URL(path).query
 
     @pytest.mark.parametrize("path, status", [
         ('/resource1/a/b', 200),
@@ -180,6 +184,7 @@ class TestNormalizePathMiddleware:
 
         resp = await client.get(path)
         assert resp.status == status
+        assert resp.url.query == URL(path).query
 
     @pytest.mark.parametrize("path, status", [
         ('/resource1/a/b', 200),
@@ -220,6 +225,7 @@ class TestNormalizePathMiddleware:
         client = await cli(extra_middlewares)
         resp = await client.get(path)
         assert resp.status == status
+        assert resp.url.query == URL(path).query
 
     @pytest.mark.parametrize("path, status", [
         ('/resource1/a/b', 200),
@@ -262,6 +268,7 @@ class TestNormalizePathMiddleware:
         client = await cli(extra_middlewares)
         resp = await client.get(path)
         assert resp.status == status
+        assert resp.url.query == URL(path).query
 
     async def test_cannot_remove_and_add_slash(self):
         with pytest.raises(AssertionError):


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

`normalize_path_middleware` should keep the query string. 

<!-- Please give a short brief about these changes. -->

1. first commit reveals the bug.
  the query string should the same, after transforming by the middleware.
  ![image](https://user-images.githubusercontent.com/13523027/45748953-cc830b80-bc3c-11e8-931e-af9548daad97.png)

2. second commit for bugfix

<!-- Outline any notable behaviour for the end users. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
