### PR TITLE
Make Request.post() also work with content-type application/json

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -135,6 +135,7 @@ Makc Belousow
 Manuel Miranda
 Marat Sharafutdinov
 Marco Paolini
+Marconi Feo
 Mariano Anaya
 Martin Melka
 Martin Richard

--- a/tests/test_web_functional.py
+++ b/tests/test_web_functional.py
@@ -163,6 +163,8 @@ async def test_post_json(aiohttp_client):
         assert dct == data
         data2 = await request.json(loads=json.loads)
         assert data == data2
+        data3 = await request.post()
+        assert data == data3
         resp = web.Response()
         resp.content_type = 'application/json'
         resp.body = json.dumps(data).encode('utf8')


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
Make Request.post() also work with content-type application/json. So the user doesn't have to check content-type to use either Request.post() or Request.json(). Added test that fails without the change, and that passes with the change.

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->
When a user calls Request.post() for a request with json data in the body and content-type application/json, he/she will get the data as expected (instead of empty Multidict and having to investigate and discover that in this case Request.json() should be used instead of Request.post())

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [X] I think the code is well written
- [X] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [X] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
