### PR TITLE
Return empty bytes with end-of-chunk marker in empty stream reader

### DIFF
--- a/CHANGES/3186.bugfix
+++ b/CHANGES/3186.bugfix
@@ -1,0 +1,1 @@
+Return empty bytes with end-of-chunk marker in empty stream reader.

--- a/aiohttp/streams.py
+++ b/aiohttp/streams.py
@@ -482,7 +482,7 @@ class EmptyStreamReader(AsyncStreamReaderMixin):
         return b''
 
     async def readchunk(self) -> Tuple[bytes, bool]:
-        return (b'', False)
+        return (b'', True)
 
     async def readexactly(self, n: int) -> bytes:
         raise asyncio.streams.IncompleteReadError(b'', n)

--- a/tests/test_streams.py
+++ b/tests/test_streams.py
@@ -750,7 +750,7 @@ async def test_empty_stream_reader() -> None:
     assert await s.read() == b''
     assert await s.readline() == b''
     assert await s.readany() == b''
-    assert await s.readchunk() == (b'', False)
+    assert await s.readchunk() == (b'', True)
     with pytest.raises(asyncio.IncompleteReadError):
         await s.readexactly(10)
     assert s.read_nowait() == b''


### PR DESCRIPTION
Fixes #3186