### PR TITLE
Pingpong default message

### DIFF
--- a/CHANGES/xxxxx.bugfix
+++ b/CHANGES/xxxxx.bugfix
@@ -1,0 +1,1 @@
+Fix default message for server ping and pong frames.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -64,6 +64,7 @@ Denis Matiychuk
 Dima Veselov
 Dimitar Dimitrov
 Dmitry Doroshev
+Dmitry Lukashin
 Dmitry Shamov
 Dmitry Trofimov
 Dmytro Kuznetsov

--- a/aiohttp/web_ws.py
+++ b/aiohttp/web_ws.py
@@ -237,12 +237,12 @@ class WebSocketResponse(StreamResponse):
     def exception(self):
         return self._exception
 
-    async def ping(self, message='b'):
+    async def ping(self, message=b''):
         if self._writer is None:
             raise RuntimeError('Call .prepare() first')
         await self._writer.ping(message)
 
-    async def pong(self, message='b'):
+    async def pong(self, message=b''):
         # unsolicited pong
         if self._writer is None:
             raise RuntimeError('Call .prepare() first')


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Fix typo in default message for ping and pong methods

## Are there changes in behavior for the user?

Ping and pong frames sent by server will not set default message as 'b' anymore
<!-- Outline any notable behaviour for the end users. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [ + ] I think the code is well written
- [ - ] Unit tests for the changes exist
- [ + ] Documentation reflects the changes
- [ + ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [ + ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
