### PR TITLE
Make log format %b doc reflect behavior and docstring

### DIFF
--- a/CHANGES/3307.doc
+++ b/CHANGES/3307.doc
@@ -1,0 +1,2 @@
+Make server access log format placeholder %b documentation reflect
+behavior and docstring.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -45,6 +45,7 @@ Brian Muller
 Bryce Drennan
 Carl George
 Cecile Tonglet
+Colin Dunklau
 Chien-Wei Huang
 Chih-Yuan Chen
 Chris AtLee

--- a/docs/logging.rst
+++ b/docs/logging.rst
@@ -71,7 +71,7 @@ request and response:
 +--------------+---------------------------------------------------------+
 | ``%s``       | Response status code                                    |
 +--------------+---------------------------------------------------------+
-| ``%b``       | Size of response in bytes, excluding HTTP headers       |
+| ``%b``       | Size of response in bytes, including HTTP headers       |
 +--------------+---------------------------------------------------------+
 | ``%T``       | The time taken to serve the request, in seconds         |
 +--------------+---------------------------------------------------------+


### PR DESCRIPTION
## What do these changes do?

Update logging doc to reflect behavior and `aiohttp.helpers.AccessLogger` docs, fixing #3307.

I dug into the tests to make sure the full-response-size behavior is tested, but I'm confused about what this test is doing with `response.body_length`, or rather, what that attribute actually means:

https://github.com/aio-libs/aiohttp/blob/4c4401ad06c931929031d919180ee1f1e0c06835/tests/test_helpers.py#L185-L216

ISTM that `body_length` would be the length of the response content, excluding status line, headers, and terminating blank line, but that doesn't reflect how it's used... it looks like that's the length of the entire response, not just the content. @asvetlov could you suggest how to make sure this test exercises that behavior, or should I work on a separate one?

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
