### PR TITLE
Add example for SSL client auth.

### DIFF
--- a/CHANGES/3320.doc
+++ b/CHANGES/3320.doc
@@ -1,0 +1,1 @@
+Add SSL client auth example to docs

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -56,6 +56,7 @@ Damien Nadé
 Dan Xu
 Daniel García
 Daniel Nelson
+Daniel Taylor
 Danny Song
 David Bibb
 David Michael Brown

--- a/docs/client_advanced.rst
+++ b/docs/client_advanced.rst
@@ -424,7 +424,15 @@ same thing as the previous example, but add another call to
                              '/path/to/client/private/device.key')
   r = await session.get('https://example.com', ssl=sslcontext)
 
-There is explicit errors when ssl verification fails
+If you need to use client-side SSL certificates for authentication
+you can create the :class:`ssl.SSLContext` with that purpose::
+
+  sslcontext = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
+  sslcontext.load_cert_chain('/path/to/client/public/device.pem',
+                             '/path/to/client/private/device.key')
+  r = await session.get('https://example.com', ssl=sslcontext)
+
+There are explicit errors when ssl verification fails
 
 :class:`aiohttp.ClientConnectorSSLError`::
 


### PR DESCRIPTION
## What do these changes do?

For my use-case I needed to set up the SSL context to do client auth. It will not work unless I pass in the right purpose when creating the context. I searched around a long time and couldn't find anything about it, so I'm adding it to the docs to help others (and my own forgetful future self).

## Are there changes in behavior for the user?

No

## Related issue number

None

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
