### PR TITLE
Add default logging handler to web.run_app (#3243)

### DIFF
--- a/CHANGES/3324.feature
+++ b/CHANGES/3324.feature
@@ -1,0 +1,3 @@
+Add default logging handler to web.run_app
+
+If the `Application.debug` flag is set and the default logger `aiohttp.access` is used, access logs will now be output using a `stderr` `StreamHandler` if no handlers are attached. Furthermore, if the default logger has no log level set, the log level will be set to `DEBUG`.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -30,6 +30,7 @@ Andrej Antonov
 Andrew Leech
 Andrew Lytvyn
 Andrew Svetlov
+Andrew Zhou
 Andrii Soldatenko
 Antoine Pietri
 Anton Kasyanov

--- a/aiohttp/web.py
+++ b/aiohttp/web.py
@@ -53,7 +53,7 @@ def run_app(app, *, host=None, port=None, path=None, sock=None,
         app = loop.run_until_complete(app)
 
     # Configure if and only if in debugging mode and using the default logger
-    if app.debug and access_log is access_logger:
+    if app.debug and access_log.name == 'aiohttp.access':
         if access_log.level == logging.NOTSET:
             access_log.setLevel(logging.DEBUG)
         if not access_log.hasHandlers():

--- a/aiohttp/web.py
+++ b/aiohttp/web.py
@@ -52,6 +52,13 @@ def run_app(app, *, host=None, port=None, path=None, sock=None,
     if asyncio.iscoroutine(app):
         app = loop.run_until_complete(app)
 
+    # Configure if and only if in debugging mode and using the default logger
+    if app.debug and access_log is access_logger:
+        if access_log.level == logging.NOTSET:
+            access_log.setLevel(logging.DEBUG)
+        if not access_log.hasHandlers():
+            access_log.addHandler(logging.StreamHandler())
+
     runner = AppRunner(app, handle_signals=handle_signals,
                        access_log_class=access_log_class,
                        access_log_format=access_log_format,

--- a/docs/logging.rst
+++ b/docs/logging.rst
@@ -34,21 +34,18 @@ logger ``'aiohttp.access'`` is used, access logs will be output to
 Furthermore, if the default logger has no log level set, the log level will be
 set to :obj:`logging.DEBUG`.
 
-The log may be controlled by :meth:`aiohttp.web.AppRunner` and
+This logging may be controlled by :meth:`aiohttp.web.AppRunner` and
 :func:`aiohttp.web.run_app`.
 
-
-Pass *access_log* parameter with value of :class:`logging.Logger`
-instance to override default logger.
+To override the default logger, pass an instance of :class:`logging.Logger` to
+override the default logger.
 
 .. note::
 
-   Use ``web.run_app(app, access_log=None)`` for disabling access logs.
+   Use ``web.run_app(app, access_log=None)`` to disable access logs.
 
 
-Other parameter called *access_log_format* may be used for specifying log
-format (see below).
-
+In addition, *access_log_format* may be used to specify the log format.
 
 .. _aiohttp-logging-access-log-format-spec:
 
@@ -88,7 +85,7 @@ request and response:
 | ``%{FOO}o``  | ``response.headers['FOO']``                             |
 +--------------+---------------------------------------------------------+
 
-Default access log format is::
+The default access log format is::
 
    '%a %t "%r" %s %b "%{Referer}i" "%{User-Agent}i"'
 
@@ -96,7 +93,7 @@ Default access log format is::
 
 *access_log_class* introduced.
 
-Example of drop-in replacement for :class:`aiohttp.helpers.AccessLogger`::
+Example of a drop-in replacement for :class:`aiohttp.helpers.AccessLogger`::
 
   from aiohttp.abc import AbstractAccessLogger
 
@@ -113,13 +110,13 @@ Example of drop-in replacement for :class:`aiohttp.helpers.AccessLogger`::
 Gunicorn access logs
 ^^^^^^^^^^^^^^^^^^^^
 When `Gunicorn <http://docs.gunicorn.org/en/latest/index.html>`_ is used for
-:ref:`deployment <aiohttp-deployment-gunicorn>` its default access log format
+:ref:`deployment <aiohttp-deployment-gunicorn>`, its default access log format
 will be automatically replaced with the default aiohttp's access log format.
 
 If Gunicorn's option access_logformat_ is
-specified explicitly it should use aiohttp's format specification.
+specified explicitly, it should use aiohttp's format specification.
 
-Gunicorn access log works only if accesslog_ is specified explicitly in your
+Gunicorn's access log works only if accesslog_ is specified explicitly in your
 config or as a command line option.
 This configuration can be either a path or ``'-'``. If the application uses
 a custom logging setup intercepting the ``'gunicorn.access'`` logger,
@@ -132,13 +129,13 @@ access log file upon every startup.
 Error logs
 ----------
 
-*aiohttp.web* uses logger named ``'aiohttp.server'`` to store errors
+:mod:`aiohttp.web` uses a logger named ``'aiohttp.server'`` to store errors
 given on web requests handling.
 
-The log is enabled by default.
+This log is enabled by default.
 
-To use different logger name please pass *logger* parameter
-(:class:`logging.Logger` instance) to :meth:`aiohttp.web.AppRunner` constructor.
+To use a different logger name, pass *logger* (:class:`logging.Logger`
+instance) to the :meth:`aiohttp.web.AppRunner` constructor.
 
 
 .. _access_logformat:

--- a/docs/logging.rst
+++ b/docs/logging.rst
@@ -28,8 +28,11 @@ configuring whole loggers in your application.
 Access logs
 -----------
 
-Access log by default is switched on and uses ``'aiohttp.access'``
-logger name.
+Access logs are enabled by default. If the `debug` flag is set, and the default
+logger ``'aiohttp.access'`` is used, access logs will be output to
+:obj:`~sys.stderr` if no handlers are attached.
+Furthermore, if the default logger has no log level set, the log level will be
+set to :obj:`logging.DEBUG`.
 
 The log may be controlled by :meth:`aiohttp.web.AppRunner` and
 :func:`aiohttp.web.run_app`.

--- a/tests/test_run_app.py
+++ b/tests/test_run_app.py
@@ -561,7 +561,8 @@ def test_run_app_default_logger(monkeypatch, patched_loop):
     assert isinstance(mock_logger.addHandler.call_args[0][0],
                       logging.StreamHandler)
 
-def test_run_app_default_logger_setup_requires_debug(monkeypatch, patched_loop):
+
+def test_run_app_default_logger_setup_requires_debug(patched_loop):
     logger = web.access_logger
     attrs = {
         'hasHandlers.return_value': False,
@@ -579,7 +580,8 @@ def test_run_app_default_logger_setup_requires_debug(monkeypatch, patched_loop):
     mock_logger.hasHandlers.assert_not_called()
     mock_logger.addHandler.assert_not_called()
 
-def test_run_app_default_logger_setup_requires_default_logger(monkeypatch, patched_loop):
+
+def test_run_app_default_logger_setup_requires_default_logger(patched_loop):
     logger = web.access_logger
     attrs = {
         'hasHandlers.return_value': False,
@@ -597,7 +599,8 @@ def test_run_app_default_logger_setup_requires_default_logger(monkeypatch, patch
     mock_logger.hasHandlers.assert_not_called()
     mock_logger.addHandler.assert_not_called()
 
-def test_run_app_default_logger_setup_only_if_unconfigured(monkeypatch, patched_loop):
+
+def test_run_app_default_logger_setup_only_if_unconfigured(patched_loop):
     logger = web.access_logger
     attrs = {
         'hasHandlers.return_value': True,

--- a/tests/test_run_app.py
+++ b/tests/test_run_app.py
@@ -551,11 +551,7 @@ def test_run_app_default_logger(monkeypatch, patched_loop):
     }
     mock_logger = mock.create_autospec(logger, name='mock_access_logger')
     mock_logger.configure_mock(**attrs)
-    # with monkeypatch.context() as m:
-    # m.setattr(web,
-    #           'run_app',
-    #           functools.partial(web.run_app,
-    #                             access_log=mock_logger))
+
     app = web.Application(debug=True)
     web.run_app(app,
                 print=stopper(patched_loop),
@@ -564,3 +560,57 @@ def test_run_app_default_logger(monkeypatch, patched_loop):
     mock_logger.hasHandlers.assert_called_with()
     assert isinstance(mock_logger.addHandler.call_args[0][0],
                       logging.StreamHandler)
+
+def test_run_app_default_logger_setup_requires_debug(monkeypatch, patched_loop):
+    logger = web.access_logger
+    attrs = {
+        'hasHandlers.return_value': False,
+        'level': logging.NOTSET,
+        'name': 'aiohttp.access',
+    }
+    mock_logger = mock.create_autospec(logger, name='mock_access_logger')
+    mock_logger.configure_mock(**attrs)
+
+    app = web.Application(debug=False)
+    web.run_app(app,
+                print=stopper(patched_loop),
+                access_log=mock_logger)
+    mock_logger.setLevel.assert_not_called()
+    mock_logger.hasHandlers.assert_not_called()
+    mock_logger.addHandler.assert_not_called()
+
+def test_run_app_default_logger_setup_requires_default_logger(monkeypatch, patched_loop):
+    logger = web.access_logger
+    attrs = {
+        'hasHandlers.return_value': False,
+        'level': logging.NOTSET,
+        'name': None,
+    }
+    mock_logger = mock.create_autospec(logger, name='mock_access_logger')
+    mock_logger.configure_mock(**attrs)
+
+    app = web.Application()
+    web.run_app(app,
+                print=stopper(patched_loop),
+                access_log=mock_logger)
+    mock_logger.setLevel.assert_not_called()
+    mock_logger.hasHandlers.assert_not_called()
+    mock_logger.addHandler.assert_not_called()
+
+def test_run_app_default_logger_setup_only_if_unconfigured(monkeypatch, patched_loop):
+    logger = web.access_logger
+    attrs = {
+        'hasHandlers.return_value': True,
+        'level': None,
+        'name': 'aiohttp.access',
+    }
+    mock_logger = mock.create_autospec(logger, name='mock_access_logger')
+    mock_logger.configure_mock(**attrs)
+
+    app = web.Application(debug=False)
+    web.run_app(app,
+                print=stopper(patched_loop),
+                access_log=mock_logger)
+    mock_logger.setLevel.assert_not_called()
+    mock_logger.hasHandlers.assert_not_called()
+    mock_logger.addHandler.assert_not_called()


### PR DESCRIPTION
Fixes #3243.

## What do these changes do?

Add a default logging handler to `web.run_app`.

## Are there changes in behavior for the user?

If the `Application.debug` flag is set and the default logger `aiohttp.access` is used, access logs will now be output using a `stderr` `StreamHandler` if no handlers are attached. Furthermore, if the default logger has no log level set, the log level will be set to `DEBUG`.

## Related issue number

This issue fixes #3243.

## Checklist

- [X] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [X] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [X] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
