### PR TITLE
Ensure that transport is closed before releasing it.

### DIFF
--- a/aiohttp/base_protocol.py
+++ b/aiohttp/base_protocol.py
@@ -60,6 +60,8 @@ class BaseProtocol(asyncio.Protocol):
     def connection_lost(self, exc: Optional[Exception]) -> None:
         self._connection_lost = True
         # Wake up the writer if currently paused.
+        if self.transport is not None:
+            self.transport.close()
         self.transport = None
         if not self._paused:
             return


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

While a development of my web server where I've used both server and client part from this library, I noticed a lot of `ResourceWarning` on `_SSLTransport` from asyncio. I've tried many things to fix from various tickets and answers on SO or make constantly catch this problem. Nevertheless, it wasn't gone and go back from time to time. 
I've ended up with printing a full wanrning traceback (with custom `show_warnings`) and it was during transport finalization after setting it to `None`in the `aiohttp.base_transport.BaseTransport` class. 

The change is to call `close()` to transport just before releasing it. This done a trick and I had never such warnings afterwards with any way to write asyncio code. Probably, it will fix many related issues (there was many and most of them closed as "invalid" or "won't fix")

I'll add tests and other stuff a bit later. 

Python environment:

Python 3.7.0 from MacPorts
aiohttp 3.4.4 
macOS  10.12 

## Are there changes in behavior for the user?
No changes to the user
<!-- Outline any notable behaviour for the end users. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."