### PR TITLE
Issue#3119: example on how to use session wo context manager

### DIFF
--- a/docs/client_quickstart.rst
+++ b/docs/client_quickstart.rst
@@ -61,7 +61,9 @@ Other HTTP methods are available as well::
    A session contains a connection pool inside. Connection reusage and
    keep-alives (both are on by default) may speed up total performance.
 
-It is also possible to use session without context manager, like so::
+A session context manager usage is not mandatory 
+but ``await session.close()`` method 
+should be called in this case, e.g.::
 
     session = aiohttp.ClientSession()
     async with session.get('...'):

--- a/docs/client_quickstart.rst
+++ b/docs/client_quickstart.rst
@@ -61,6 +61,13 @@ Other HTTP methods are available as well::
    A session contains a connection pool inside. Connection reusage and
    keep-alives (both are on by default) may speed up total performance.
 
+It is also possible to use session without context manager, like so::
+
+    session = aiohttp.ClientSession()
+    async with session.get('...'):
+        # ...
+    await session.close()
+
 
 Passing Parameters In URLs
 ==========================

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -9,6 +9,7 @@ alives
 api
 api’s
 app
+apps
 app’s
 arg
 Arsenic


### PR DESCRIPTION
Fixes #3119 
Also add the word "apps" to `spelling_wordlist.txt` to fix sphinx spelling warnings.