### PR TITLE
Wrap parse_mimetype in an lru_cache

### DIFF
--- a/CHANGES/3341.misc
+++ b/CHANGES/3341.misc
@@ -1,0 +1,1 @@
+Added a `lru_cache` to the `parse_mimetype` method

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -25,7 +25,7 @@ from urllib.request import getproxies
 
 import async_timeout
 import attr
-from multidict import MultiDict
+from multidict import MultiDict, MultiDictProxy
 from yarl import URL
 
 from . import hdrs
@@ -234,7 +234,7 @@ class MimeType:
     type = attr.ib(type=str)
     subtype = attr.ib(type=str)
     suffix = attr.ib(type=str)
-    parameters = attr.ib(type=MultiDict)  # type: MultiDict[str]
+    parameters = attr.ib(type=MultiDictProxy)  # type: MultiDictProxy[str]
 
 
 @functools.lru_cache(maxsize=56)
@@ -253,7 +253,7 @@ def parse_mimetype(mimetype: str) -> MimeType:
 
     """
     if not mimetype:
-        return MimeType(type='', subtype='', suffix='', parameters=MultiDict())
+        return MimeType(type='', subtype='', suffix='', parameters=MultiDictProxy(MultiDict()))
 
     parts = mimetype.split(';')
     params_lst = []
@@ -275,7 +275,7 @@ def parse_mimetype(mimetype: str) -> MimeType:
                      if '+' in stype else (stype, ''))
 
     return MimeType(type=mtype, subtype=stype, suffix=suffix,
-                    parameters=params)
+                    parameters=MultiDictProxy(params))
 
 
 def guess_filename(obj: Any, default: Optional[str]=None) -> Optional[str]:

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -237,6 +237,7 @@ class MimeType:
     parameters = attr.ib(type=MultiDict)  # type: MultiDict[str]
 
 
+@functools.lru_cache(maxsize=56)
 def parse_mimetype(mimetype: str) -> MimeType:
     """Parses a MIME type into its components.
 

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -253,7 +253,8 @@ def parse_mimetype(mimetype: str) -> MimeType:
 
     """
     if not mimetype:
-        return MimeType(type='', subtype='', suffix='', parameters=MultiDictProxy(MultiDict()))
+        return MimeType(type='', subtype='', suffix='',
+                        parameters=MultiDictProxy(MultiDict()))
 
     parts = mimetype.split(';')
     params_lst = []


### PR DESCRIPTION
## What do these changes do?

`parse_mimetype` seems like an ideal candidate for an `lru_cache`. The return result is immutable, it's non-trivial, called fairly often and has a single, immutable input.

## Are there changes in behavior for the user?

Nope.

## Related issue number

None.

## Checklist

- [X] I think the code is well written
- [X] Unit tests for the changes exist
- [X] Documentation reflects the changes
- [X] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [X] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
