### PR TITLE
Remove explicit defining of pyflake package in requirements

### DIFF
--- a/requirements/ci-wheel.txt
+++ b/requirements/ci-wheel.txt
@@ -8,8 +8,6 @@ chardet==3.0.4
 coverage==4.5.1
 cython==0.29
 gunicorn==19.9.0
-cython==0.28.5
-gunicorn==19.8.1
 multidict==4.4.2
 pytest==3.8.2
 pytest-cov==2.6.0

--- a/requirements/ci-wheel.txt
+++ b/requirements/ci-wheel.txt
@@ -8,7 +8,8 @@ chardet==3.0.4
 coverage==4.5.1
 cython==0.29
 gunicorn==19.9.0
-pyflakes==2.0.0
+cython==0.28.5
+gunicorn==19.8.1
 multidict==4.4.2
 pytest==3.8.2
 pytest-cov==2.6.0


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?
Deleted `pyflakes` package from `requirements/ci-wheel.txt` as a redundant cause during installing `flake8` `pyflakes` will be installed as a dependency with the correct version. It allows to have consistency and correctness in the flake8-check for Travis CI and local development process. 
## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->

## Related issue number

[#3345](https://github.com/aio-libs/aiohttp/issues/3345)

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
