### PR TITLE
Tone down the logging level of the home dir not found warning

### DIFF
--- a/CHANGES/3351.misc
+++ b/CHANGES/3351.misc
@@ -1,0 +1,1 @@
+Toned down the logging level of the "home directory not found" warning when looking for .netrc

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -170,8 +170,8 @@ def netrc_from_env() -> Optional[netrc.netrc]:
             home_dir = Path.home()
         except RuntimeError as e:  # pragma: no cover
             # if pathlib can't resolve home, it may raise a RuntimeError
-            client_logger.warning('Could not resolve home directory when '
-                                  'trying to look for .netrc file: %s', e)
+            client_logger.debug('Could not resolve home directory when '
+                                'trying to look for .netrc file: %s', e)
             return None
 
         netrc_path = home_dir / (


### PR DESCRIPTION
It is common for the home directory to be unresolvable in Docker containers.

<!-- Thank you for your contribution! -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
It reduces noise when the home directory cannot be resolved when looking for the .netrc file.

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->
None whatsoever.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
This change was discussed in #3267.

## Checklist

- [X] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
