### PR TITLE
Drop dead Connection.detach() and Connection.writer

### DIFF
--- a/CHANGES/3358.removal
+++ b/CHANGES/3358.removal
@@ -1,0 +1,2 @@
+Drop dead ``Connection.detach()`` and ``Connection.writer``. Both methods were broken
+for more than 2 years.

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -87,10 +87,6 @@ class Connection:
     def protocol(self):
         return self._protocol
 
-    @property
-    def writer(self):
-        return self._protocol.writer
-
     def add_callback(self, callback):
         if callback is not None:
             self._callbacks.append(callback)
@@ -118,13 +114,6 @@ class Connection:
                 self._key, self._protocol,
                 should_close=self._protocol.should_close)
             self._protocol = None
-
-    def detach(self):
-        self._notify_release()
-
-        if self._protocol is not None:
-            self._connector._release_acquired(self._protocol)
-        self._protocol = None
 
     @property
     def closed(self):

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -1062,13 +1062,6 @@ Connection
       later if timeout (30 seconds by default) for connection was not
       expired.
 
-   .. method:: detach()
-
-      Detach underlying socket from connection.
-
-      Underlying socket is not closed, next :meth:`close` or
-      :meth:`release` calls don't return socket to free pool.
-
 
 Response object
 ---------------

--- a/tests/test_client_connection.py
+++ b/tests/test_client_connection.py
@@ -65,19 +65,6 @@ def test_callbacks_on_release(connector, key, protocol, loop) -> None:
     assert notified
 
 
-def test_callbacks_on_detach(connector, key, protocol, loop) -> None:
-    conn = Connection(connector, key, protocol, loop)
-    notified = False
-
-    def cb():
-        nonlocal notified
-        notified = True
-
-    conn.add_callback(cb)
-    conn.detach()
-    assert notified
-
-
 def test_callbacks_exception(connector, key, protocol, loop) -> None:
     conn = Connection(connector, key, protocol, loop)
     notified = False
@@ -151,22 +138,3 @@ def test_release_released(connector, key, protocol, loop) -> None:
     assert not protocol.transport.close.called
     assert conn._protocol is None
     assert not connector._release.called
-
-
-def test_detach(connector, key, protocol, loop) -> None:
-    conn = Connection(connector, key, protocol, loop)
-    assert not conn.closed
-    conn.detach()
-    assert conn._protocol is None
-    assert connector._release_acquired.called
-    assert not connector._release.called
-    assert conn.closed
-
-
-def test_detach_closed(connector, key, protocol, loop) -> None:
-    conn = Connection(connector, key, protocol, loop)
-    conn.release()
-    conn.detach()
-
-    assert not connector._release_acquired.called
-    assert conn._protocol is None

--- a/tests/test_client_connection.py
+++ b/tests/test_client_connection.py
@@ -35,7 +35,6 @@ def test_ctor(connector, key, protocol, loop) -> None:
     conn = Connection(connector, key, protocol, loop)
     assert conn.loop is loop
     assert conn.protocol is protocol
-    assert conn.writer is protocol.writer
     conn.close()
 
 

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -129,17 +129,6 @@ def test_connection_del_loop_closed(loop) -> None:
     assert not exc_handler.called
 
 
-def test_connection_detach(loop) -> None:
-    connector = mock.Mock()
-    key = mock.Mock()
-    protocol = mock.Mock()
-    conn = Connection(connector, key, protocol, loop=loop)
-    conn._notify_release = mock.Mock()
-    conn.detach()
-    assert conn._notify_release.called
-    connector._release_acquired.assert_called_with(protocol)
-
-
 def test_del(loop) -> None:
     conn = aiohttp.BaseConnector(loop=loop)
     proto = mock.Mock(should_close=False)


### PR DESCRIPTION
Both methods were broken for more than 2 years.
