### PR TITLE
false-negative indicator end_of_HTTP_chunk in readchunk

### DIFF
--- a/CHANGES/3361.bugfix
+++ b/CHANGES/3361.bugfix
@@ -1,0 +1,1 @@
+fix false-negative indicator end_of_HTTP_chunk in StreamReader.readchunk function

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -149,6 +149,7 @@ Matthieu Rigal
 Michael Ihnatenko
 Mikhail Kashkin
 Mikhail Lukyanchenko
+Mikhail Nacharov
 Misha Behersky
 Mitchell Ferree
 Morgan Delahaye-Prat


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?
<!-- Please give a short brief about these changes. -->

fix a race-condition bug #3361 by:
* waking up an `await self._wait('readchunk')` when `on_chunk_complete` called
*  `return ("", True)` in `readchunk` when buffer is empty, but `_http_chunk_splits` isn't and the end user already has a full chunk of data `pos==cursor` (`on_chunk_complete` called recently)

## Are there changes in behavior for the user?
<!-- Outline any notable behaviour for the end users. -->

## Related issue number
<!-- Are there any issues opened that will be resolved by merging this change? -->
#3361

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
