### PR TITLE
Release HTTP response before raising status exception

### DIFF
--- a/CHANGES/3364.bugfix
+++ b/CHANGES/3364.bugfix
@@ -1,0 +1,1 @@
+Release HTTP response before raising status exception

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -93,6 +93,7 @@ Gregory Haynes
 Gus Goulart
 Gustavo Carneiro
 Günther Jena
+Hans Adema
 Harmon Y.
 Hu Bo
 Hugo Herter

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -907,6 +907,7 @@ class ClientResponse(HeadersMixin):
     def raise_for_status(self) -> None:
         if 400 <= self.status:
             assert self.reason  # always not None for started response
+            self.release()
             raise ClientResponseError(
                 self.request_info,
                 self.history,

--- a/tests/test_client_response.py
+++ b/tests/test_client_response.py
@@ -665,6 +665,7 @@ def test_raise_for_status_4xx() -> None:
         response.raise_for_status()
     assert str(cm.value.status) == '409'
     assert str(cm.value.message) == "CONFLICT"
+    assert response.closed
 
 
 def test_resp_host() -> None:


### PR DESCRIPTION
## What do these changes do?

A bugfix for issue #3364 - it releases the HTTP response before the ClientResponse exception is thrown.

## Are there changes in behavior for the user?

If there is some way to get the HTTP response from a ClientResponseException (which, AFAIK, isn't possible), the response would be closed already.

Beyond that, no behavioral changes except for that connections are closed properly.

## Related issue number

#3364

## Checklist

- [X] I think the code is well written
- [ ] Unit tests for the changes exist: _I could not reproduce this issue with aiohttp's server_.
- [X] Documentation reflects the changes: _I could not find relevant docs._
- [X] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [X] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
