### PR TITLE
add facebook´s doh-proxy to built_with list

### DIFF
--- a/docs/built_with.rst
+++ b/docs/built_with.rst
@@ -22,3 +22,4 @@ project, pointing to `<https://github.com/aio-libs/aiohttp>`_.
 * `Arsenic <https://github.com/hde/arsenic>`_ Async WebDriver.
 * `Home Assistant <https://home-assistant.io>`_ Home Automation Platform.
 * `Backend.AI <https://backend.ai>`_ Code execution API service.
+* `doh-proxy <https://github.com/facebookexperimental/doh-proxy>`_ DNS Over HTTPS Proxy.


### PR DESCRIPTION
## What do these changes do?

it adds the doh-proxy from Facebook to the of 'built_with' aiohttp list
doh-proxy is a proof of concept for an DNS-over-HTTP proxy.