### PR TITLE
Fix RuntimeError in _sendfile_cb

### DIFF
--- a/CHANGES/1893.bugfix
+++ b/CHANGES/1893.bugfix
@@ -1,0 +1,1 @@
+Fix RuntimeError in _sendfile_cb.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -107,6 +107,7 @@ Jaesung Lee
 Jake Davis
 Jakub Wilk
 Jashandeep Sohi
+Jason Hu
 Jeongkyu Shin
 Jeroen van der Heijden
 Jesus Cea

--- a/aiohttp/web_fileresponse.py
+++ b/aiohttp/web_fileresponse.py
@@ -51,10 +51,11 @@ class SendfileStreamWriter(StreamWriter):
                      offset: int, count: int,
                      loop: asyncio.AbstractEventLoop,
                      registered: bool) -> None:
-        if registered:
-            loop.remove_writer(out_fd)
         if fut.cancelled():
             return
+
+        if registered:
+            loop.remove_writer(out_fd)
 
         try:
             n = os.sendfile(out_fd, in_fd, offset, count)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Under some circumstances, a Runtime Error `RuntimeError: File descriptor 36 is used by transport <ReadUnixTransport closed=False reading=True 0x7f9c51da9d48>` will be raise.

This change try to fix it by check if task has been canceled before remove stream writer.

I have never met this issue personally, so I won't be able to write a case to reproduce issue. However this patch has been published in https://github.com/home-assistant/home-assistant/issues/12832#issuecomment-428919964 and got positive responses from users who had this issue.

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->

## Related issue number

fixes #1893 

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
