### PR TITLE
update `BaseRunner` and `AppRunner` to honor an event loop other than the current loop

### DIFF
--- a/CHANGES/3373.feature
+++ b/CHANGES/3373.feature
@@ -1,0 +1,1 @@
+Enable users to an explict event loop in `AppRunner`

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -144,6 +144,7 @@ Mariano Anaya
 Martin Melka
 Martin Richard
 Mathias Fröjdman
+Matt Bone
 Matthieu Hauglustaine
 Matthieu Rigal
 Michael Ihnatenko

--- a/aiohttp/web_runner.py
+++ b/aiohttp/web_runner.py
@@ -162,7 +162,8 @@ class SockSite(BaseSite):
 class BaseRunner(ABC):
     __slots__ = ('_handle_signals', '_kwargs', '_server', '_sites', '_loop')
 
-    def __init__(self, *, handle_signals: bool=False, loop: asyncio.AbstractEventLoop=None, **kwargs: Any) -> None:
+    def __init__(self, *, handle_signals: bool=False,
+                 loop: asyncio.AbstractEventLoop=None, **kwargs: Any) -> None:
         self._handle_signals = handle_signals
         self._kwargs = kwargs
         self._server = None  # type: Optional[Server]
@@ -194,8 +195,10 @@ class BaseRunner(ABC):
     async def setup(self) -> None:
         if self._handle_signals:
             try:
-                self._loop.add_signal_handler(signal.SIGINT, _raise_graceful_exit)
-                self._loop.add_signal_handler(signal.SIGTERM, _raise_graceful_exit)
+                self._loop.add_signal_handler(signal.SIGINT,
+                                              _raise_graceful_exit)
+                self._loop.add_signal_handler(signal.SIGTERM,
+                                              _raise_graceful_exit)
             except NotImplementedError:  # pragma: no cover
                 # add_signal_handler is not implemented on Windows
                 pass

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -2506,6 +2506,8 @@ application on specific TCP or Unix socket, e.g.::
 
    :param Application app: web application instance to serve.
 
+   :param asyncio.AbstractEventLoop loop: event loop for this server
+
    :param bool handle_signals: add signal handlers for
                                :data:`signal.SIGINT` and
                                :data:`signal.SIGTERM` (``False`` by

--- a/tests/test_web_runner.py
+++ b/tests/test_web_runner.py
@@ -96,6 +96,8 @@ async def test_app_property(make_runner, app) -> None:
 
 
 def test_non_app() -> None:
+    asyncio.set_event_loop(asyncio.new_event_loop())
+
     with pytest.raises(TypeError):
         web.AppRunner(object())
 
@@ -114,3 +116,16 @@ async def test_addresses(make_runner, shorttmpdir) -> None:
     actual_addrs = runner.addresses
     expected_host, expected_post = _sock.getsockname()[:2]
     assert actual_addrs == [(expected_host, expected_post), path]
+
+
+async def test_runner_with_explict_loop(app):
+    old_loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(old_loop)
+
+    new_loop = asyncio.new_event_loop()
+
+    assert new_loop is not old_loop
+
+    runner = web.AppRunner(app, loop=new_loop)
+    await runner.setup()
+    assert runner._app.loop == new_loop


### PR DESCRIPTION
## What do these changes do?

These changes make it possible to explicitly pass an event loop into an `AppRunner`. Previously the current event loop returned by `asyncio.get_event_loop()` was always used.

## Are there changes in behavior for the user?

By default there are no changes for the user. A user must opt-in to this new behavior.

## Related issue number

I couldn't find any. Happy to create a new issue if that is useful.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
