### PR TITLE
Add support for setting cookies for individual request

### DIFF
--- a/CHANGES/2387.feature
+++ b/CHANGES/2387.feature
@@ -1,0 +1,1 @@
+Add support for setting cookies for individual request

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -234,6 +234,7 @@ Yannick Koechlin
 Yannick Péroux
 Ye Cao
 Yegor Roganov
+Yifei Kong
 Young-Ho Cha
 Yuriy Shatrov
 Yury Selivanov

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -237,6 +237,7 @@ class ClientSession:
             params: Optional[Mapping[str, str]]=None,
             data: Any=None,
             json: Any=None,
+            cookies: Optional[LooseCookies]=None,
             headers: LooseHeaders=None,
             skip_auto_headers: Optional[Iterable[str]]=None,
             auth: Optional[BasicAuth]=None,
@@ -352,7 +353,16 @@ class ClientSession:
                                          "with AUTH argument or credentials "
                                          "encoded in URL")
 
-                    cookies = self._cookie_jar.filter_cookies(url)
+                    session_cookies = self._cookie_jar.filter_cookies(url)
+
+                    if cookies is not None:
+                        tmp_cookie_jar = CookieJar()
+                        tmp_cookie_jar.update_cookies(cookies)
+                        req_cookies = tmp_cookie_jar.filter_cookies(url)
+                        if session_cookies and req_cookies:
+                            session_cookies.load(req_cookies)
+
+                    cookies = session_cookies
 
                     if proxy is not None:
                         proxy = URL(proxy)

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -258,6 +258,11 @@ The client session supports the context manager protocol for self closing.
       :param dict cookies: HTTP Cookies to send with
                            the request (optional)
 
+         Global session cookies and the explicitly set cookies will be merged
+         when sending the request.
+
+         .. versionadded:: 3.5
+
       :param dict headers: HTTP Headers to send with
                            the request (optional)
 

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -216,7 +216,7 @@ The client session supports the context manager protocol for self closing.
       .. deprecated:: 3.5
 
    .. comethod:: request(method, url, *, params=None, data=None, json=None,\
-                         headers=None, skip_auto_headers=None, \
+                         cookies=None, headers=None, skip_auto_headers=None, \
                          auth=None, allow_redirects=True,\
                          max_redirects=10,\
                          compress=None, chunked=None, expect100=False, raise_for_status=None,\
@@ -254,6 +254,9 @@ The client session supports the context manager protocol for self closing.
       :param json: Any json compatible python object
                    (optional). *json* and *data* parameters could not
                    be used at the same time.
+
+      :param dict cookies: HTTP Cookies to send with
+                           the request (optional)
 
       :param dict headers: HTTP Headers to send with
                            the request (optional)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

support to add additional cookies per request when using `aiohttp.ClientSession.request`

## Are there changes in behavior for the user?

User could now use cookies per request

## Related issue number

#2387

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
