### PR TITLE
Update client_quickstart.rst

### DIFF
--- a/docs/client_quickstart.rst
+++ b/docs/client_quickstart.rst
@@ -422,10 +422,11 @@ Supported :class:`ClientTimeout` fields are:
 
       The whole operation time including connection
       establishment, request sending and response reading.
+      Defaults to 5 minutes.
 
    ``connect``
 
-      Total timeout for acquiring a connection from pool.  The time
+       The time
       consists connection establishment for a new connection or
       waiting for a free connection from a pool if pool connection
       limits are exceeded.


### PR DESCRIPTION
Total timeout is shown as disabled in the docs, but in reality it seems like it is set to 5 minutes. http://docs.aiohttp.org/en/stable/client_reference.html#clienttimeout