### PR TITLE
Allow installing aiodns and cchardet as extras

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -158,7 +158,9 @@ Requirements
 - yarl_
 
 Optionally you may install the cChardet_ and aiodns_ libraries (highly
-recommended for sake of speed).
+recommended for sake of speed)::
+
+    $ pip install aiohttp[cchardet,aiodns]
 
 .. _chardet: https://pypi.python.org/pypi/chardet
 .. _aiodns: https://pypi.python.org/pypi/aiodns

--- a/setup.py
+++ b/setup.py
@@ -109,6 +109,11 @@ tests_require = [
     'pytest-xdist',
 ]
 
+extras_require = {
+    'cchardet': ['cchardet'],
+    'aiodns': ['aiodns'],
+}
+
 
 args = dict(
     name='aiohttp',
@@ -153,6 +158,7 @@ args = dict(
     install_requires=install_requires,
     tests_require=tests_require,
     setup_requires=pytest_runner,
+    extras_require=extras_require,
     include_package_data=True,
     ext_modules=extensions,
     cmdclass=dict(build_ext=ve_build_ext),


### PR DESCRIPTION
Users will be able to install `aiodns` and `cchardet` using `pip install aiohttp[aiodns,cchardet]`

Related to https://github.com/aio-libs/aiohttp/issues/2397