### PR TITLE
Print stacktrace when catching TimeoutError

### DIFF
--- a/CHANGES/3414.bugfix
+++ b/CHANGES/3414.bugfix
@@ -1,0 +1,2 @@
+Fix `asyncio.TimeoutError` stack trace not logged, when it is caught
+in the handler.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -171,6 +171,7 @@ Paulius Šileikis
 Paulus Schoutsen
 Pavel Kamaev
 Pavel Polyakov
+Pawel Kowalski
 Pawel Miech
 Pepe Osca
 Philipp A.

--- a/aiohttp/web_protocol.py
+++ b/aiohttp/web_protocol.py
@@ -409,8 +409,8 @@ class RequestHandler(BaseProtocol):
                     self.log_debug('Ignored premature client disconnection')
                     break
                 except asyncio.TimeoutError as exc:
-                    self.log_debug('Request handler timed out.')
-                    resp = self.handle_error(request, 504, exc)
+                    self.log_debug('Request handler timed out.', exc_info=exc)
+                    resp = self.handle_error(request, 504)
                 except Exception as exc:
                     resp = self.handle_error(request, 500, exc)
                 else:

--- a/aiohttp/web_protocol.py
+++ b/aiohttp/web_protocol.py
@@ -408,9 +408,9 @@ class RequestHandler(BaseProtocol):
                 except asyncio.CancelledError:
                     self.log_debug('Ignored premature client disconnection')
                     break
-                except asyncio.TimeoutError:
+                except asyncio.TimeoutError as exc:
                     self.log_debug('Request handler timed out.')
-                    resp = self.handle_error(request, 504)
+                    resp = self.handle_error(request, 504, exc)
                 except Exception as exc:
                     resp = self.handle_error(request, 500, exc)
                 else:

--- a/tests/test_web_protocol.py
+++ b/tests/test_web_protocol.py
@@ -581,6 +581,17 @@ async def test_handle_500(srv, buf, transport, request_handler) -> None:
     assert b'500 Internal Server Error' in buf
 
 
+async def test_handle_504(srv, buf, request_handler) -> None:
+    request_handler.side_effect = asyncio.TimeoutError
+
+    srv.data_received(
+        b'GET / HTTP/1.0\r\n'
+        b'Host: example.com\r\n\r\n')
+    await srv._task_handler
+
+    assert b'504 Gateway Timeout' in buf
+
+
 async def test_keep_alive(make_srv, transport, ceil) -> None:
     loop = asyncio.get_event_loop()
     srv = make_srv(keepalive_timeout=0.05)

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -53,7 +53,7 @@ async def test_raw_server_handler_timeout(aiohttp_raw_server,
     assert resp.status == 504
 
     await resp.text()
-    logger.debug.assert_called_with("Request handler timed out.")
+    logger.debug.assert_called_with("Request handler timed out.", exc_info=exc)
 
 
 async def test_raw_server_do_not_swallow_exceptions(aiohttp_raw_server,


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

When `TimeoutError` is caught in the handler, the exception stack trace is logged.

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->

## Related issue number

No related issue.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
