### PR TITLE
Optimize tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -143,8 +143,8 @@ jobs:
   - python: nightly
 
   include:
-  - name: Run without extensions
-  - python: 3.7
+  - name: 3.7 without extensions
+    python: 3.7
     env:
       AIOHTTP_NO_EXTENSIONS: 1
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ install:
 
 script:
 - make cov-ci-no-ext
-- make cov-ci-aio-debug
 - make cov-ci-run
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ python:
 - 3.5
 - 3.6
 - &mainstream_python 3.7
-- 3.7-dev
 - nightly
 - &pypy3 pypy3.5
 
@@ -139,7 +138,6 @@ os: linux
 jobs:
   fast_finish: true
   allow_failures:
-  - python: 3.7-dev
   - python: nightly
 
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ sudo: required
 language: python
 
 python:
+- 3.5
 - 3.6
 - &mainstream_python 3.7
 - 3.7-dev
@@ -21,7 +22,6 @@ install:
 - pip install -r requirements/ci.txt
 
 script:
-- make cov-ci-no-ext
 - make cov-ci-run
 
 after_success:
@@ -143,9 +143,10 @@ jobs:
   - python: nightly
 
   include:
-  - python: 3.5
+  - name: Run without extensions
+  - python: 3.7
     env:
-      PYTEST_ADDOPTS: -n0
+      AIOHTTP_NO_EXTENSIONS: 1
 
   - <<: *_doc_base
     name: Checking docs spelling

--- a/Makefile
+++ b/Makefile
@@ -59,14 +59,11 @@ cov-dev: .develop
 cov-ci-no-ext: .develop
 	@echo "Run without extensions"
 	@AIOHTTP_NO_EXTENSIONS=1 pytest
-cov-ci-aio-debug: .develop
-	@echo "Run in debug mode"
-	@PYTHONASYNCIODEBUG=1 pytest -c pytest.ci.ini --cov-append
 cov-ci-run: .develop
 	@echo "Regular run"
 	@pytest -c pytest.ci.ini --cov-report=html --cov-append
 
-cov-dev-full: cov-ci-no-ext cov-ci-aio-debug cov-ci-run
+cov-dev-full: cov-ci-no-ext cov-ci-run
 	@echo "open file://`pwd`/htmlcov/index.html"
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -51,19 +51,14 @@ cov cover coverage:
 	tox
 
 cov-dev: .develop
-	@echo "Run without extensions"
-	@AIOHTTP_NO_EXTENSIONS=1 pytest
-	@pytest -c pytest.ci.ini --cov-report=html --cov-append
+	@pytest -c pytest.ci.ini --cov-report=html
 	@echo "open file://`pwd`/htmlcov/index.html"
 
-cov-ci-no-ext: .develop
-	@echo "Run without extensions"
-	@AIOHTTP_NO_EXTENSIONS=1 pytest
 cov-ci-run: .develop
 	@echo "Regular run"
-	@pytest -c pytest.ci.ini --cov-report=html --cov-append
+	@pytest -c pytest.ci.ini --cov-report=html
 
-cov-dev-full: cov-ci-no-ext cov-ci-run
+cov-dev-full: cov-ci-run
 	@echo "open file://`pwd`/htmlcov/index.html"
 
 clean:

--- a/aiohttp/base_protocol.py
+++ b/aiohttp/base_protocol.py
@@ -1,8 +1,6 @@
 import asyncio
 from typing import Optional, cast
 
-from .log import internal_logger
-
 
 class BaseProtocol(asyncio.Protocol):
     __slots__ = ('_loop', '_paused', '_drain_waiter',
@@ -20,14 +18,10 @@ class BaseProtocol(asyncio.Protocol):
     def pause_writing(self) -> None:
         assert not self._paused
         self._paused = True
-        if self._loop.get_debug():
-            internal_logger.debug("%r pauses writing", self)
 
     def resume_writing(self) -> None:
         assert self._paused
         self._paused = False
-        if self._loop.get_debug():
-            internal_logger.debug("%r resumes writing", self)
 
         waiter = self._drain_waiter
         if waiter is not None:

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -747,7 +747,7 @@ RawRequestMessagePy = RawRequestMessage
 RawResponseMessagePy = RawResponseMessage
 
 try:
-    if not NO_EXTENSIONS:  # pragma: no cover
+    if not NO_EXTENSIONS:
         from ._http_parser import (HttpRequestParser,  # type: ignore  # noqa
                                    HttpResponseParser,
                                    RawRequestMessage,

--- a/aiohttp/http_websocket.py
+++ b/aiohttp/http_websocket.py
@@ -139,7 +139,7 @@ def _websocket_mask_python(mask: bytes, data: bytearray) -> None:
         data[3::4] = data[3::4].translate(d)
 
 
-if NO_EXTENSIONS:
+if NO_EXTENSIONS:  # pragma: no cover
     _websocket_mask = _websocket_mask_python
 else:
     try:

--- a/aiohttp/http_writer.py
+++ b/aiohttp/http_writer.py
@@ -167,7 +167,7 @@ _serialize_headers = _py_serialize_headers
 try:
     import aiohttp._http_writer as _http_writer  # type: ignore
     _c_serialize_headers = _http_writer._serialize_headers
-    if not NO_EXTENSIONS:  # pragma: no cover
+    if not NO_EXTENSIONS:
         _serialize_headers = _c_serialize_headers
 except ImportError:
     pass

--- a/aiohttp/web_app.py
+++ b/aiohttp/web_app.py
@@ -31,7 +31,7 @@ from .web_urldispatcher import (AbstractResource, Domain, MaskDomain,
 __all__ = ('Application', 'CleanupError')
 
 
-if TYPE_CHECKING:  # pragma: no branch
+if TYPE_CHECKING:  # pragma: no cover
     _AppSignal = Signal[Callable[['Application'], Awaitable[None]]]
     _RespPrepareSignal = Signal[Callable[[Request, StreamResponse],
                                          Awaitable[None]]]
@@ -119,7 +119,7 @@ class Application(MutableMapping[str, Any]):
                       DeprecationWarning,
                       stacklevel=2)
 
-    if DEBUG:
+    if DEBUG:  # pragma: no cover
         def __setattr__(self, name: str, val: Any) -> None:
             if name not in self.ATTRS:
                 warnings.warn("Setting custom web.Application.{} attribute "
@@ -403,8 +403,10 @@ class Application(MutableMapping[str, Any]):
         yield _fix_request_current_app(self), True
 
     async def _handle(self, request: Request) -> StreamResponse:
+        loop = asyncio.get_event_loop()
+        debug = loop.get_debug()
         match_info = await self._router.resolve(request)
-        if DEBUG:  # pragma: no cover
+        if debug:  # pragma: no cover
             if not isinstance(match_info, AbstractMatchInfo):
                 raise TypeError("match_info should be AbstractMatchInfo "
                                 "instance, not {!r}".format(match_info))
@@ -432,7 +434,7 @@ class Application(MutableMapping[str, Any]):
 
             resp = await handler(request)
 
-        if DEBUG:
+        if debug:
             if not isinstance(resp, StreamResponse):
                 msg = ("Handler {!r} should return response instance, "
                        "got {!r} [middlewares {!r}]").format(

--- a/aiohttp/web_app.py
+++ b/aiohttp/web_app.py
@@ -434,15 +434,6 @@ class Application(MutableMapping[str, Any]):
 
             resp = await handler(request)
 
-        if debug:
-            if not isinstance(resp, StreamResponse):
-                msg = ("Handler {!r} should return response instance, "
-                       "got {!r} [middlewares {!r}]").format(
-                           match_info.handler, type(resp),
-                           [middleware
-                            for app in match_info.apps
-                            for middleware in app.middlewares])
-                raise TypeError(msg)
         return resp
 
     def __call__(self) -> 'Application':

--- a/aiohttp/web_protocol.py
+++ b/aiohttp/web_protocol.py
@@ -424,9 +424,13 @@ class RequestHandler(BaseProtocol):
 
                 if self.debug:
                     if not isinstance(resp, StreamResponse):
-                        raise RuntimeError("Web-handler should return "
-                                           "a response instance, "
-                                           "got {!r}".format(resp))
+                        if resp is None:
+                            raise RuntimeError("Missing return "
+                                               "statement on request handler")
+                        else:
+                            raise RuntimeError("Web-handler should return "
+                                               "a response instance, "
+                                               "got {!r}".format(resp))
                 await resp.prepare(request)
                 await resp.write_eof()
 

--- a/aiohttp/web_protocol.py
+++ b/aiohttp/web_protocol.py
@@ -424,8 +424,6 @@ class RequestHandler(BaseProtocol):
 
                 if self.debug:
                     if not isinstance(resp, StreamResponse):
-                        self.log_debug("Possibly missing return "
-                                       "statement on request handler")
                         raise RuntimeError("Web-handler should return "
                                            "a response instance, "
                                            "got {!r}".format(resp))

--- a/pytest.ci.ini
+++ b/pytest.ci.ini
@@ -1,5 +1,5 @@
 [pytest]
-addopts = -n auto --aiohttp-loop=all --cov=aiohttp --cov-report term-missing:skip-covered -v -rxXs
+addopts = --cov=aiohttp --cov-report term-missing:skip-covered -v -rxXs
 filterwarnings = error
 junit_suite_name = aiohttp_test_suite
 norecursedirs = dist docs build .tox .eggs

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-addopts = --aiohttp-loop=all --cov=aiohttp -v -rxXs
+addopts = --cov=aiohttp -v -rxXs
 filterwarnings = error
 junit_suite_name = aiohttp_test_suite
 norecursedirs = dist docs build .tox .eggs

--- a/requirements/ci-wheel.txt
+++ b/requirements/ci-wheel.txt
@@ -12,7 +12,6 @@ multidict==4.4.2
 pytest==3.8.2
 pytest-cov==2.6.0
 pytest-mock==1.10.0
-pytest-xdist==1.23.2
 tox==3.5.2
 twine==1.12.1
 yarl==1.2.6

--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -559,4 +559,4 @@ def test_app_iter():
     app = web.Application()
     app['a'] = '1'
     app['b'] = '2'
-    assert list(app) == ['a', 'b']
+    assert sorted(list(app)) == ['a', 'b']

--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -553,3 +553,10 @@ async def test_subapp_on_startup(aiohttp_client) -> None:
     assert ctx_post_called
     assert shutdown_called
     assert cleanup_called
+
+
+def test_app_iter():
+    app = web.Application()
+    app['a'] = '1'
+    app['b'] = '2'
+    assert list(app) == ['a', 'b']

--- a/tests/test_web_functional.py
+++ b/tests/test_web_functional.py
@@ -14,8 +14,6 @@ from yarl import URL
 import aiohttp
 from aiohttp import (FormData, HttpVersion10, HttpVersion11, TraceConfig,
                      multipart, web)
-from aiohttp.helpers import DEBUG
-
 
 try:
     import ssl
@@ -67,10 +65,9 @@ async def test_simple_get_with_text(aiohttp_client) -> None:
     assert 'OK' == txt
 
 
-@pytest.mark.skipif(not DEBUG,
-                    reason="The check is enabled in debug mode only")
 async def test_handler_returns_not_response(aiohttp_server,
                                             aiohttp_client) -> None:
+    asyncio.get_event_loop().set_debug(True)
     logger = mock.Mock()
 
     async def handler(request):
@@ -81,10 +78,11 @@ async def test_handler_returns_not_response(aiohttp_server,
     server = await aiohttp_server(app, logger=logger)
     client = await aiohttp_client(server)
 
-    resp = await client.get('/')
-    assert 500 == resp.status
+    with pytest.raises(aiohttp.ServerDisconnectedError):
+        await client.get('/')
 
-    assert logger.exception.called
+    logger.exception.assert_called_with('Unhandled runtime exception',
+                                        exc_info=mock.ANY)
 
 
 async def test_head_returns_empty_body(aiohttp_client) -> None:

--- a/tests/test_web_functional.py
+++ b/tests/test_web_functional.py
@@ -15,6 +15,7 @@ import aiohttp
 from aiohttp import (FormData, HttpVersion10, HttpVersion11, TraceConfig,
                      multipart, web)
 
+
 try:
     import ssl
 except ImportError:
@@ -81,6 +82,27 @@ async def test_handler_returns_not_response(aiohttp_server,
     with pytest.raises(aiohttp.ServerDisconnectedError):
         await client.get('/')
 
+    logger.exception.assert_called_with('Unhandled runtime exception',
+                                        exc_info=mock.ANY)
+
+
+async def test_handler_returns_none(aiohttp_server,
+                                    aiohttp_client) -> None:
+    asyncio.get_event_loop().set_debug(True)
+    logger = mock.Mock()
+
+    async def handler(request):
+        return None
+
+    app = web.Application()
+    app.router.add_get('/', handler)
+    server = await aiohttp_server(app, logger=logger)
+    client = await aiohttp_client(server)
+
+    with pytest.raises(aiohttp.ServerDisconnectedError):
+        await client.get('/')
+
+    # Actual error text is placed in exc_info
     logger.exception.assert_called_with('Unhandled runtime exception',
                                         exc_info=mock.ANY)
 

--- a/tests/test_web_protocol.py
+++ b/tests/test_web_protocol.py
@@ -519,32 +519,6 @@ async def test_handle_cancel(make_srv, transport) -> None:
     assert log.debug.called
 
 
-async def test_handle_none_response(make_srv, transport, request_handler):
-    loop = asyncio.get_event_loop()
-    log = mock.Mock()
-
-    srv = make_srv(logger=log, debug=True)
-    srv.connection_made(transport)
-
-    handle = mock.Mock()
-    handle.return_value = loop.create_future()
-    handle.return_value.set_result(None)
-    request_handler.side_effect = handle
-
-    srv.data_received(
-        b'GET / HTTP/1.0\r\n'
-        b'Content-Length: 10\r\n'
-        b'Host: example.com\r\n\r\n')
-
-    assert srv._task_handler
-
-    await asyncio.sleep(0, loop=loop)
-    await srv._task_handler
-    assert request_handler.called
-    log.debug.assert_called_with("Possibly missing return "
-                                 "statement on request handler")
-
-
 async def test_handle_cancelled(make_srv, transport) -> None:
     log = mock.Mock()
 


### PR DESCRIPTION
Currently, travis fails on about 10-15% runs.
This is because `pytest-xdist` plugin executes tests in several threads to speed up the time.
The intention is good, the benefit is obvious but some aiohttp tests require the main thread context to setup Unix signal handlers.

The PR refactors tests running strategy.
1. `pytest-xdist` is removed
2. Tests with `uvloop` are dropped. Before the change, every async tests was executed twice: with asyncio loop and uvloop, doubling the execution time. The last and only problem with uvloop was sendfile usage, found and fixed about 3 or 4 years ago.
3. `PYTHONASYNCIODEBUG` run was removed, several tests for explicit debug loop was added instead.
4. `AIOHTTP_NO_EXTENSIONS` run was removed from every job run but added an explicit job for making sure that aiohttp works without C extensions.

As the result:
1. A regular job execution was reduced about 2.5 times. 
2. The total run time was shrinked from 33 to 18 secs.
3. Tests are stable.
4. Coverage is not changed (increased a little after adding new tests actually)
5. Output log always fit into Travis requirements, it is browsable again.