### PR TITLE
Rename request fixture for compatibility with a new pytest

### DIFF
--- a/tests/test_client_connection.py
+++ b/tests/test_client_connection.py
@@ -12,11 +12,6 @@ def key():
 
 
 @pytest.fixture
-def request():
-    return mock.Mock()
-
-
-@pytest.fixture
 def loop():
     return mock.Mock()
 


### PR DESCRIPTION
Fixes #3392 