### PR TITLE
Add 'speedups' extra dependencies group

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -151,6 +151,13 @@ args = dict(
     packages=['aiohttp'],
     python_requires='>=3.5.3',
     install_requires=install_requires,
+    extras_require={
+        'speedups': [
+            'aiodns',
+            'brotlipy',
+            'cchardet',
+        ],
+    },
     tests_require=tests_require,
     setup_requires=pytest_runner,
     include_package_data=True,


### PR DESCRIPTION
Resolves #2397

## What do these changes do?

Add extra deps so that it'd possible to install them along with the main project as `pip install aiohttp[speedups]`

## Are there changes in behavior for the user?

Enable users to use `pip install aiohttp[speedups]`

## Related issue number

#2397

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
