### PR TITLE
Deprecate obsolete timeout sessions in ClientSession

### DIFF
--- a/CHANGES/3438.removal
+++ b/CHANGES/3438.removal
@@ -1,0 +1,1 @@
+Deprecate obsolete ``read_timeout`` and ``conn_timeout`` in ``ClientSession`` constructor.

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -154,10 +154,18 @@ class ClientSession:
         if timeout is sentinel:
             self._timeout = DEFAULT_TIMEOUT
             if read_timeout is not sentinel:
+                warnings.warn("read_timeout is deprecated, "
+                              "use timeout argument instead",
+                              DeprecationWarning,
+                              stacklevel=2)
                 self._timeout = attr.evolve(self._timeout, total=read_timeout)
             if conn_timeout is not None:
                 self._timeout = attr.evolve(self._timeout,
                                             connect=conn_timeout)
+                warnings.warn("conn_timeout is deprecated, "
+                              "use timeout argument instead",
+                              DeprecationWarning,
+                              stacklevel=2)
         else:
             self._timeout = timeout  # type: ignore
             if read_timeout is not sentinel:

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -599,7 +599,10 @@ async def test_timeout_on_session_read_timeout(aiohttp_client, mocker) -> None:
     app.router.add_route('GET', '/', handler)
 
     conn = aiohttp.TCPConnector()
-    client = await aiohttp_client(app, connector=conn, read_timeout=0.01)
+    client = await aiohttp_client(
+        app,
+        connector=conn,
+        timeout=aiohttp.ClientTimeout(sock_read=0.01))
 
     with pytest.raises(asyncio.TimeoutError):
         await client.get('/')

--- a/tests/test_client_session.py
+++ b/tests/test_client_session.py
@@ -674,7 +674,10 @@ async def test_client_session_timeout_args(loop) -> None:
     session1 = ClientSession(loop=loop)
     assert session1._timeout == client.DEFAULT_TIMEOUT
 
-    session2 = ClientSession(loop=loop, read_timeout=20*60, conn_timeout=30*60)
+    with pytest.warns(DeprecationWarning):
+        session2 = ClientSession(loop=loop,
+                                 read_timeout=20*60,
+                                 conn_timeout=30*60)
     assert session2._timeout == client.ClientTimeout(total=20*60,
                                                      connect=30*60)
 


### PR DESCRIPTION
Deprecate obsolete `read_timeout` and `conn_timeout` in `ClientSession` constructor.
