### PR TITLE
Deprecate stream.unread_data()

### DIFF
--- a/CHANGES/3260.removal
+++ b/CHANGES/3260.removal
@@ -1,0 +1,1 @@
+Deprecate ``stream.unread_data()``

--- a/aiohttp/multipart.py
+++ b/aiohttp/multipart.py
@@ -312,7 +312,10 @@ class BodyPartReader:
             idx = window.find(sub, max(0, len(self._prev_chunk) - len(sub)))
         if idx >= 0:
             # pushing boundary back to content
-            self._content.unread_data(window[idx:])
+            with warnings.catch_warnings():
+                warnings.filterwarnings("ignore",
+                                        category=DeprecationWarning)
+                self._content.unread_data(window[idx:])
             if size > idx:
                 self._prev_chunk = self._prev_chunk[:idx]
             chunk = window[len(self._prev_chunk):idx]

--- a/aiohttp/streams.py
+++ b/aiohttp/streams.py
@@ -1,5 +1,6 @@
 import asyncio
 import collections
+import warnings
 from typing import List  # noqa
 from typing import Awaitable, Callable, Generic, Optional, Tuple, TypeVar
 
@@ -211,6 +212,10 @@ class StreamReader(AsyncStreamReaderMixin):
     def unread_data(self, data: bytes) -> None:
         """ rollback reading some data from stream, inserting it to buffer head.
         """
+        warnings.warn("unread_data() is deprecated "
+                      "and will be removed in future releases (#3260)",
+                      DeprecationWarning,
+                      stacklevel=2)
         if not data:
             return
 

--- a/tests/test_streams.py
+++ b/tests/test_streams.py
@@ -211,7 +211,8 @@ class TestStreamReader:
             await stream.read()
             await stream.read()
             await stream.read()
-        stream.unread_data(b'data')
+        with pytest.warns(DeprecationWarning):
+            stream.unread_data(b'data')
         await stream.read()
         await stream.read()
         assert not internal_logger.warning.called
@@ -434,7 +435,8 @@ class TestStreamReader:
         data = await stream.read(5)
         assert b'line1' == data
 
-        stream.unread_data(data)
+        with pytest.warns(DeprecationWarning):
+            stream.unread_data(data)
 
         data = await stream.read(5)
         assert b'line1' == data
@@ -442,7 +444,8 @@ class TestStreamReader:
         data = await stream.read(4)
         assert b'line' == data
 
-        stream.unread_data(b'line1line')
+        with pytest.warns(DeprecationWarning):
+            stream.unread_data(b'line1line')
 
         data = b''
         while len(data) < 10:
@@ -452,19 +455,22 @@ class TestStreamReader:
         data = await stream.read(7)
         assert b'onemore' == data
 
-        stream.unread_data(data)
+        with pytest.warns(DeprecationWarning):
+            stream.unread_data(data)
 
         data = b''
         while len(data) < 11:
             data += await stream.read(11)
         assert b'onemoreline' == data
 
-        stream.unread_data(b'line')
+        with pytest.warns(DeprecationWarning):
+            stream.unread_data(b'line')
         data = await stream.read(4)
         assert b'line' == data
 
         stream.feed_eof()
-        stream.unread_data(b'at_eof')
+        with pytest.warns(DeprecationWarning):
+            stream.unread_data(b'at_eof')
         data = await stream.read(6)
         assert b'at_eof' == data
 
@@ -666,7 +672,8 @@ class TestStreamReader:
         data, end_of_chunk = await stream.readchunk()
 
         # Try to unread a part of the first chunk
-        stream.unread_data(b'rt1')
+        with pytest.warns(DeprecationWarning):
+            stream.unread_data(b'rt1')
 
         # The end_of_chunk signal was already received for the first chunk,
         # so we receive up to the second one
@@ -675,7 +682,8 @@ class TestStreamReader:
         assert end_of_chunk
 
         # Unread a part of the second chunk
-        stream.unread_data(b'rt2')
+        with pytest.warns(DeprecationWarning):
+            stream.unread_data(b'rt2')
 
         data, end_of_chunk = await stream.readchunk()
         assert b'rt2' == data
@@ -814,7 +822,8 @@ class TestStreamReader:
         stream = self._make_one()
         stream.feed_data(b'line1')
         stream.feed_eof()
-        stream.unread_data(b'')
+        with pytest.warns(DeprecationWarning):
+            stream.unread_data(b'')
 
         data = await stream.read(5)
         assert b'line1' == data


### PR DESCRIPTION
A partial fix for #3260 

@kxepal reported that removal of `stream.unread_data()` in a multipart reader is not a trivial task.

As a workaround the PR deprecates the method but adds a *warnings filter* to suppress an error report if the call is made from the multipart reader.

I believe it is a good compromise that eliminates a show stopper but adds a sign of our clean intention to drop the API eventually.