### PR TITLE
use Host header to check certificate, closes #3455

### DIFF
--- a/CHANGES/3455.bugfix
+++ b/CHANGES/3455.bugfix
@@ -1,0 +1,2 @@
+Fix the SSL hostname verification when using a `Host` header, and the IP in the URL.
+

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -37,6 +37,7 @@ Antoine Pietri
 Anton Kasyanov
 Anton Zhdan-Pushkin
 Arthur Darcet
+Arthur Vuillard
 Ben Bader
 Benedikt Reinartz
 Boris Feld

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -942,12 +942,13 @@ class TCPConnector(BaseConnector):
             host = hinfo['host']
             port = hinfo['port']
 
+            server_hostname = req.headers.get('Host') or hinfo['hostname']
             try:
                 transp, proto = await self._wrap_create_connection(
                     self._factory, host, port, timeout=timeout,
                     ssl=sslcontext, family=hinfo['family'],
                     proto=hinfo['proto'], flags=hinfo['flags'],
-                    server_hostname=hinfo['hostname'] if sslcontext else None,
+                    server_hostname=server_hostname if sslcontext else None,
                     local_addr=self._local_addr,
                     req=req, client_error=client_error)
             except ClientConnectorError as exc:


### PR DESCRIPTION
## What do these changes do?

This Pull Request aims at fixing issue 

When an host header is set, aiohttp will use it to check the certificate hostnames

## Are there changes in behavior for the user?

In that particular case, (ip in url + host header + sslcontext), the ssl handshake will be made and the request done

## Related issue number

#3455

## Checklist

- [X] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [X] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
- [X] Add a new news fragment into the `CHANGES` folder