### PR TITLE
web_fileresponse calls file io in executor

### DIFF
--- a/CHANGES/3461.misc
+++ b/CHANGES/3461.misc
@@ -1,0 +1,1 @@
+web_fileresponse.py calls file io in executor

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -68,6 +68,7 @@ Dima Veselov
 Dimitar Dimitrov
 Dmitriy Safonov
 Dmitry Doroshev
+Dmitry Erlikh
 Dmitry Lukashin
 Dmitry Shamov
 Dmitry Trofimov


### PR DESCRIPTION
## What do these changes do?
SendfileStreamWriter._do_sendfile now executes in executor.

## Are there changes in behavior for the user?
No

## Related issue number
#3313

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
