### PR TITLE
Log suppressed exceptions in GunicornWebWorker (fixes #3464)

### DIFF
--- a/CHANGES/3464.bugfix
+++ b/CHANGES/3464.bugfix
@@ -1,0 +1,1 @@
+Log suppressed exceptions in ``GunicornWebWorker``.

--- a/aiohttp/worker.py
+++ b/aiohttp/worker.py
@@ -5,7 +5,6 @@ import os
 import re
 import signal
 import sys
-from contextlib import suppress
 from types import FrameType
 from typing import Any, Optional  # noqa
 
@@ -68,8 +67,10 @@ class GunicornWebWorker(base.Worker):
         self.loop.run_until_complete(self._runner.setup())
         self._task = self.loop.create_task(self._run())
 
-        with suppress(Exception):  # ignore all finalization problems
+        try:  # ignore all finalization problems
             self.loop.run_until_complete(self._task)
+        except Exception as error:
+            self.log.exception(error)
         if sys.version_info >= (3, 6):
             if hasattr(self.loop, 'shutdown_asyncgens'):
                 self.loop.run_until_complete(self.loop.shutdown_asyncgens())


### PR DESCRIPTION
Log traceback for exceptions instead of just ignoring them.
