### PR TITLE
Docs: re-style command line options

### DIFF
--- a/docs/deployment.rst
+++ b/docs/deployment.rst
@@ -272,15 +272,15 @@ as command line flags or in your config file.
 
 In this case, we will use:
 
-* the *'--bind'* flag to set the server's socket address;
-* the *'--worker-class'* flag to tell Gunicorn that we want to use a
+* the ``--bind`` flag to set the server's socket address;
+* the ``--worker-class`` flag to tell Gunicorn that we want to use a
   custom worker subclass instead of one of the Gunicorn default worker
   types;
-* you may also want to use the *'--workers'* flag to tell Gunicorn how
+* you may also want to use the ``--workers`` flag to tell Gunicorn how
   many worker processes to use for handling requests. (See the
   documentation for recommendations on `How Many Workers?
   <http://docs.gunicorn.org/en/latest/design.html#how-many-workers>`_)
-* you may also want to use the *'--accesslog'* flag to enable the access
+* you may also want to use the ``--accesslog`` flag to enable the access
   log to be populated. (See :ref:`logging <gunicorn-accesslog>` for more information.)
 
 The custom worker subclass is defined in ``aiohttp.GunicornWebWorker``::


### PR DESCRIPTION
Command line options look weird now on the official docs site:

![image](https://user-images.githubusercontent.com/12324/50527944-5b0af280-0aa0-11e9-9de0-20b56f1a5cf6.png)

Should look better after the fix:

![image](https://user-images.githubusercontent.com/12324/50527899-2c8d1780-0aa0-11e9-9773-fbc2aa97503d.png)

https://docs.aiohttp.org/en/stable/deployment.html

