### PR TITLE
Refactor the way how Payload headers are handled

### DIFF
--- a/CHANGES/3035.bugfix
+++ b/CHANGES/3035.bugfix
@@ -1,1 +1,6 @@
 Preserve MultipartWriter parts headers on write.
+
+Refactor the way how Payload.headers are handled. Payload instances now always
+have headers and Content-Type defined.
+
+Fix Payload Content-Disposition header reset after initial creation.

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -495,16 +495,14 @@ class ClientRequest:
                     if hdrs.CONTENT_LENGTH not in self.headers:
                         self.headers[hdrs.CONTENT_LENGTH] = str(size)
 
-        # set content-type
-        if (hdrs.CONTENT_TYPE not in self.headers and
-                hdrs.CONTENT_TYPE not in self.skip_auto_headers):
-            self.headers[hdrs.CONTENT_TYPE] = body.content_type
-
         # copy payload headers
-        if body.headers:
-            for (key, value) in body.headers.items():
-                if key not in self.headers:
-                    self.headers[key] = value
+        assert body.headers
+        for (key, value) in body.headers.items():
+            if key in self.headers:
+                continue
+            if key in self.skip_auto_headers:
+                continue
+            self.headers[key] = value
 
     def update_expect_continue(self, expect: bool=False) -> None:
         if expect:

--- a/aiohttp/payload.py
+++ b/aiohttp/payload.py
@@ -7,15 +7,13 @@ import os
 import warnings
 from abc import ABC, abstractmethod
 from itertools import chain
-from typing import (  # noqa
+from typing import (
     IO,
     TYPE_CHECKING,
     Any,
     ByteString,
-    Callable,
     Dict,
     Iterable,
-    List,
     Optional,
     Text,
     TextIO,
@@ -45,6 +43,10 @@ __all__ = ('PAYLOAD_REGISTRY', 'get_payload', 'payload_type', 'Payload',
            'AsyncIterablePayload')
 
 TOO_LARGE_BYTES_BODY = 2 ** 20  # 1 MB
+
+
+if TYPE_CHECKING:  # pragma: no cover
+    from typing import List  # noqa
 
 
 class LookupError(Exception):
@@ -120,9 +122,8 @@ class PayloadRegistry:
 
 class Payload(ABC):
 
+    _default_content_type = 'application/octet-stream'  # type: str
     _size = None  # type: Optional[int]
-    _headers = None  # type: Optional[_CIMultiDict]
-    _content_type = 'application/octet-stream'  # type: Optional[str]
 
     def __init__(self,
                  value: Any,
@@ -137,18 +138,20 @@ class Payload(ABC):
                  filename: Optional[str]=None,
                  encoding: Optional[str]=None,
                  **kwargs: Any) -> None:
-        self._value = value
         self._encoding = encoding
         self._filename = filename
-        if headers is not None:
-            self._headers = CIMultiDict(headers)
-            if content_type is sentinel and hdrs.CONTENT_TYPE in self._headers:
-                content_type = self._headers[hdrs.CONTENT_TYPE]
-
-        if content_type is sentinel:
-            content_type = None
-
-        self._content_type = content_type
+        self._headers = CIMultiDict()  # type: _CIMultiDict
+        self._value = value
+        if content_type is not sentinel and content_type is not None:
+            self._headers[hdrs.CONTENT_TYPE] = content_type
+        elif self._filename is not None:
+            content_type = mimetypes.guess_type(self._filename)[0]
+            if content_type is None:
+                content_type = self._default_content_type
+            self._headers[hdrs.CONTENT_TYPE] = content_type
+        else:
+            self._headers[hdrs.CONTENT_TYPE] = self._default_content_type
+        self._headers.update(headers or {})
 
     @property
     def size(self) -> Optional[int]:
@@ -161,15 +164,12 @@ class Payload(ABC):
         return self._filename
 
     @property
-    def headers(self) -> Optional[_CIMultiDict]:
+    def headers(self) -> _CIMultiDict:
         """Custom item headers"""
         return self._headers
 
     @property
     def _binary_headers(self) -> bytes:
-        if self.headers is None:
-            # FIXME: This case actually is unreachable.
-            return b''  # pragma: no cover
         return ''.join(
             [k + ': ' + v + '\r\n' for k, v in self.headers.items()]
         ).encode('utf-8') + b'\r\n'
@@ -180,24 +180,15 @@ class Payload(ABC):
         return self._encoding
 
     @property
-    def content_type(self) -> Optional[str]:
+    def content_type(self) -> str:
         """Content type"""
-        if self._content_type is not None:
-            return self._content_type
-        elif self._filename is not None:
-            mime = mimetypes.guess_type(self._filename)[0]
-            return 'application/octet-stream' if mime is None else mime
-        else:
-            return Payload._content_type
+        return self._headers[hdrs.CONTENT_TYPE]
 
     def set_content_disposition(self,
                                 disptype: str,
                                 quote_fields: bool=True,
                                 **params: Any) -> None:
         """Sets ``Content-Disposition`` header."""
-        if self._headers is None:
-            self._headers = CIMultiDict()
-
         self._headers[hdrs.CONTENT_DISPOSITION] = content_disposition_header(
             disptype, quote_fields=quote_fields, **params)
 
@@ -292,7 +283,10 @@ class IOBasePayload(Payload):
         super().__init__(value, *args, **kwargs)
 
         if self._filename is not None and disposition is not None:
-            self.set_content_disposition(disposition, filename=self._filename)
+            if hdrs.CONTENT_DISPOSITION not in self.headers:
+                self.set_content_disposition(
+                    disposition, filename=self._filename
+                )
 
     async def write(self, writer: AbstractStreamWriter) -> None:
         loop = asyncio.get_event_loop()

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -1117,7 +1117,10 @@ class TestMultipartWriter:
         """
         with open(__file__, 'rb') as fobj:
             with aiohttp.MultipartWriter('form-data', boundary=':') as writer:
-                part = writer.append(fobj)
+                part = writer.append(
+                    fobj,
+                    headers={CONTENT_TYPE: 'text/plain'},
+                )
 
             content_length = part.size
 
@@ -1131,7 +1134,7 @@ class TestMultipartWriter:
 
         assert headers == (
             b'--:\r\n'
-            b'Content-Type: text/x-python\r\n'
+            b'Content-Type: text/plain\r\n'
             b'Content-Disposition:'
             b' attachments; filename="bug.py"; filename*=utf-8\'\'bug.py\r\n'
             b'Content-Length: %s'


### PR DESCRIPTION
This change actually solves three separated, but heavy coupled
issues:

1. `Payload.content_type` may conflict with `Payload.headers[CONTENT_TYPE]`.

While in the end priority goes to the former one, it seems quite strange that
Payload object may have dual state about what content type it contains.

2. IOPayload respects Content-Disposition which comes with headers.

This is part of #3035 issue.

3. ClientRequest.skip_autoheaders now filters Payload.headers as well.

This issue was eventually found due to refactoring: Payload object
may setup some autoheaders, but those will bypass skip logic.