### PR TITLE
plain text http responses to errors

### DIFF
--- a/CHANGES/3483.feature
+++ b/CHANGES/3483.feature
@@ -1,0 +1,1 @@
+Internal Server Errors in plain text if the browser does not support HTML.

--- a/aiohttp/test_utils.py
+++ b/aiohttp/test_utils.py
@@ -219,7 +219,7 @@ class RawTestServer(BaseTestServer):
                            debug: bool=True,
                            **kwargs: Any) -> ServerRunner:
         srv = Server(
-            self._handler, loop=self._loop, debug=True, **kwargs)
+            self._handler, loop=self._loop, debug=debug, **kwargs)
         return ServerRunner(srv, debug=debug, **kwargs)
 
 

--- a/aiohttp/web_protocol.py
+++ b/aiohttp/web_protocol.py
@@ -526,9 +526,8 @@ class RequestHandler(BaseProtocol):
 
         ct = 'text/plain'
         if status == HTTPStatus.INTERNAL_SERVER_ERROR:
-            title = '{http_status_code:d} {http_response_reason}'.format(
-                http_status_code=str(HTTPStatus.INTERNAL_SERVER_ERROR.value),
-                http_response_reason=HTTPStatus.INTERNAL_SERVER_ERROR.phrase,
+            title = '{0.value} {0.phrase}'.format(
+                HTTPStatus.INTERNAL_SERVER_ERROR
             )
             msg = HTTPStatus.INTERNAL_SERVER_ERROR.description
             tb = None
@@ -539,7 +538,7 @@ class RequestHandler(BaseProtocol):
             if 'text/html' in request.headers.get('Accept', ''):
                 if tb:
                     tb = html_escape(tb)
-                    msg += '\n<h2>Traceback:</h2>\n<pre>{}</pre>'.format(tb)
+                    msg = '<h2>Traceback:</h2>\n<pre>{}</pre>'.format(tb)
                 message = (
                     "<html><head>"
                     "<title>{title}</title>"
@@ -549,7 +548,7 @@ class RequestHandler(BaseProtocol):
                 ct = 'text/html'
             else:
                 if tb:
-                    msg += '\n' + tb
+                    msg = tb
                 message = title + '\n\n' + msg
 
         resp = Response(status=status, text=message, content_type=ct)

--- a/aiohttp/web_protocol.py
+++ b/aiohttp/web_protocol.py
@@ -536,16 +536,18 @@ class RequestHandler(BaseProtocol):
             if 'text/html' in request.headers.get('Accept', ''):
                 if tb:
                     tb = html_escape(tb)
-                    msg = '<h2>Traceback:</h2>\n<pre>{}</pre>'.format(tb)
+                    msg += '\n<h2>Traceback:</h2>\n<pre>{}</pre>'.format(tb)
                 message = (
                     "<html><head>"
                     "<title>{title}</title>"
                     "</head><body>\n<h1>{title}</h1>"
-                    "<br>\n{msg}\n</body></html>\n"
+                    "\n{msg}\n</body></html>\n"
                 ).format(title=title, msg=msg)
                 ct = 'text/html'
             else:
-                message = title + '\n\n' + (tb or msg)
+                if tb:
+                    msg += '\n' + tb
+                message = title + '\n\n' + msg
 
         resp = Response(status=status, text=message, content_type=ct)
         resp.force_close()

--- a/aiohttp/web_protocol.py
+++ b/aiohttp/web_protocol.py
@@ -526,9 +526,9 @@ class RequestHandler(BaseProtocol):
 
         ct = 'text/plain'
         if status == HTTPStatus.INTERNAL_SERVER_ERROR:
-            title = (
-                str(HTTPStatus.INTERNAL_SERVER_ERROR.value) +
-                ' ' + HTTPStatus.INTERNAL_SERVER_ERROR.phrase
+            title = '{http_status_code:d} {http_response_reason}'.format(
+                http_status_code=str(HTTPStatus.INTERNAL_SERVER_ERROR.value),
+                http_response_reason=HTTPStatus.INTERNAL_SERVER_ERROR.phrase,
             )
             msg = HTTPStatus.INTERNAL_SERVER_ERROR.description
             tb = None

--- a/aiohttp/web_protocol.py
+++ b/aiohttp/web_protocol.py
@@ -551,7 +551,7 @@ class RequestHandler(BaseProtocol):
                                 content_type='text/plain')
         else:
             resp = Response(status=status, text=message,
-                            content_type='text/html')
+                            content_type='text/plain')
 
         resp.force_close()
 

--- a/aiohttp/web_protocol.py
+++ b/aiohttp/web_protocol.py
@@ -526,7 +526,10 @@ class RequestHandler(BaseProtocol):
 
         ct = 'text/plain'
         if status == HTTPStatus.INTERNAL_SERVER_ERROR:
-            title = '500 Internal Server Error'
+            title = (
+                str(HTTPStatus.INTERNAL_SERVER_ERROR.value) + ' '
+                + HTTPStatus.INTERNAL_SERVER_ERROR.phrase
+            )
             msg = HTTPStatus.INTERNAL_SERVER_ERROR.description
             tb = None
             if self.debug:

--- a/aiohttp/web_protocol.py
+++ b/aiohttp/web_protocol.py
@@ -1,6 +1,5 @@
 import asyncio
 import asyncio.streams
-import textwrap
 import traceback
 import warnings
 from collections import deque
@@ -526,32 +525,28 @@ class RequestHandler(BaseProtocol):
 
         if status == 500:
             if 'text/html' in request.headers.get('Accept', ''):
-                msg = "<h1>500 Internal Server Error</h1>"
                 if self.debug:
                     with suppress(Exception):
                         tb = traceback.format_exc()
                         tb = html_escape(tb)
-                        msg += '<br><h2>Traceback:</h2>\n<pre>'
-                        msg += tb
-                        msg += '</pre>'
+                        msg = '<h2>Traceback:</h2>\n<pre>{}</pre>'.format(tb)
                 else:
-                    msg += "Server got itself in trouble"
-                    msg = (
-                        "<html><head>"
-                        "<title>500 Internal Server Error</title>"
-                        "</head><body>{msg}</body></html>"
-                    ).format(msg)
+                    msg = 'Server got itself in trouble'
+                msg = (
+                    "<html><head>"
+                    "<title>500 Internal Server Error</title>"
+                    "</head><body>\n<h1>500 Internal Server Error</h1>"
+                    "<br>\n{msg}\n</body></html>\n"
+                ).format(msg=msg)
                 resp = Response(status=status, text=msg,
                                 content_type='text/html')
             else:
-                msg = '500 Internal Server Error'
                 if self.debug:
                     with suppress(Exception):
-                        msg += '\n\nTraceback:\n'
-                        tb = traceback.format_exc()
-                        msg += textwrap.indent(tb, '    ')
+                        msg = traceback.format_exc()
                 else:
-                    msg += '\n\nServer got itself in trouble'
+                    msg = 'Server got itself in trouble'
+                msg = '500 Internal Server Error\n\n' + msg
                 resp = Response(status=status, text=msg,
                                 content_type='text/plain')
         else:

--- a/aiohttp/web_protocol.py
+++ b/aiohttp/web_protocol.py
@@ -527,8 +527,8 @@ class RequestHandler(BaseProtocol):
         ct = 'text/plain'
         if status == HTTPStatus.INTERNAL_SERVER_ERROR:
             title = (
-                str(HTTPStatus.INTERNAL_SERVER_ERROR.value) + ' '
-                + HTTPStatus.INTERNAL_SERVER_ERROR.phrase
+                str(HTTPStatus.INTERNAL_SERVER_ERROR.value) +
+                ' ' + HTTPStatus.INTERNAL_SERVER_ERROR.phrase
             )
             msg = HTTPStatus.INTERNAL_SERVER_ERROR.description
             tb = None

--- a/tests/test_web_protocol.py
+++ b/tests/test_web_protocol.py
@@ -299,7 +299,7 @@ async def test_handle_error__utf(
     await asyncio.sleep(0)
 
     assert b'HTTP/1.0 500 Internal Server Error' in buf
-    assert b'Content-Type: text/html; charset=utf-8' in buf
+    assert b'Content-Type: text/plain; charset=utf-8' in buf
     pattern = escape("RuntimeError: что-то пошло не так")
     assert pattern.encode('utf-8') in buf
     assert not srv._keepalive

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -34,7 +34,7 @@ async def test_raw_server_not_http_exception(aiohttp_raw_server,
 
     txt = await resp.text()
     assert txt.startswith("500 Internal Server Error")
-    assert "Traceback:" not in txt
+    assert 'Traceback' not in txt
 
     logger.exception.assert_called_with(
         "Error handling request",
@@ -134,7 +134,6 @@ async def test_raw_server_html_exception(aiohttp_raw_server, aiohttp_client):
         'Server got itself in trouble\n'
         '</body></html>\n'
     )
-    assert "Traceback" not in txt
 
     logger.exception.assert_called_with(
         "Error handling request", exc_info=exc)

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -128,9 +128,10 @@ async def test_raw_server_html_exception(aiohttp_raw_server, aiohttp_client):
     assert resp.headers['Content-Type'].startswith('text/html')
 
     txt = await resp.text()
+    debug(txt)
     assert txt == (
         '<html><head><title>500 Internal Server Error</title></head><body>\n'
-        '<h1>500 Internal Server Error</h1><br>\n'
+        '<h1>500 Internal Server Error</h1>\n'
         'Server got itself in trouble\n'
         '</body></html>\n'
     )
@@ -156,7 +157,8 @@ async def test_raw_server_html_exception_debug(aiohttp_raw_server,
     txt = await resp.text()
     assert txt.startswith(
         '<html><head><title>500 Internal Server Error</title></head><body>\n'
-        '<h1>500 Internal Server Error</h1><br>\n'
+        '<h1>500 Internal Server Error</h1>\n'
+        'Server got itself in trouble\n'
         '<h2>Traceback:</h2>\n'
         '<pre>Traceback (most recent call last):\n'
     )

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -128,7 +128,6 @@ async def test_raw_server_html_exception(aiohttp_raw_server, aiohttp_client):
     assert resp.headers['Content-Type'].startswith('text/html')
 
     txt = await resp.text()
-    debug(txt)
     assert txt == (
         '<html><head><title>500 Internal Server Error</title></head><body>\n'
         '<h1>500 Internal Server Error</h1>\n'

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -33,7 +33,7 @@ async def test_raw_server_not_http_exception(aiohttp_raw_server,
     assert resp.headers['Content-Type'].startswith('text/plain')
 
     txt = await resp.text()
-    assert txt.startswith("500 Internal Server Error")
+    assert txt.startswith('500 Internal Server Error')
     assert 'Traceback' not in txt
 
     logger.exception.assert_called_with(

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -157,7 +157,6 @@ async def test_raw_server_html_exception_debug(aiohttp_raw_server,
     assert txt.startswith(
         '<html><head><title>500 Internal Server Error</title></head><body>\n'
         '<h1>500 Internal Server Error</h1>\n'
-        'Server got itself in trouble\n'
         '<h2>Traceback:</h2>\n'
         '<pre>Traceback (most recent call last):\n'
     )

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -107,7 +107,7 @@ async def test_raw_server_not_http_exception_debug(aiohttp_raw_server,
     assert resp.headers['Content-Type'].startswith('text/plain')
 
     txt = await resp.text()
-    assert "Traceback:" in txt
+    assert 'Traceback (most recent call last):\n' in txt
 
     logger.exception.assert_called_with(
         "Error handling request",
@@ -128,7 +128,12 @@ async def test_raw_server_html_exception(aiohttp_raw_server, aiohttp_client):
     assert resp.headers['Content-Type'].startswith('text/html')
 
     txt = await resp.text()
-    assert txt.startswith("<h1>500 Internal Server Error</h1>")
+    assert txt == (
+        '<html><head><title>500 Internal Server Error</title></head><body>\n'
+        '<h1>500 Internal Server Error</h1><br>\n'
+        'Server got itself in trouble\n'
+        '</body></html>\n'
+    )
     assert "Traceback" not in txt
 
     logger.exception.assert_called_with(
@@ -150,8 +155,12 @@ async def test_raw_server_html_exception_debug(aiohttp_raw_server,
     assert resp.headers['Content-Type'].startswith('text/html')
 
     txt = await resp.text()
-    assert txt.startswith("<h1>500 Internal Server Error</h1>")
-    assert "<h2>Traceback:</h2>" in txt
+    assert txt.startswith(
+        '<html><head><title>500 Internal Server Error</title></head><body>\n'
+        '<h1>500 Internal Server Error</h1><br>\n'
+        '<h2>Traceback:</h2>\n'
+        '<pre>Traceback (most recent call last):\n'
+    )
 
     logger.exception.assert_called_with(
         "Error handling request", exc_info=exc)

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -26,13 +26,15 @@ async def test_raw_server_not_http_exception(aiohttp_raw_server,
         raise exc
 
     logger = mock.Mock()
-    server = await aiohttp_raw_server(handler, logger=logger)
+    server = await aiohttp_raw_server(handler, logger=logger, debug=False)
     cli = await aiohttp_client(server)
     resp = await cli.get('/path/to')
     assert resp.status == 500
+    assert resp.headers['Content-Type'].startswith('text/plain')
 
     txt = await resp.text()
-    assert "<h1>500 Internal Server Error</h1>" in txt
+    assert txt.startswith("500 Internal Server Error")
+    assert "Traceback:" not in txt
 
     logger.exception.assert_called_with(
         "Error handling request",
@@ -102,10 +104,54 @@ async def test_raw_server_not_http_exception_debug(aiohttp_raw_server,
     cli = await aiohttp_client(server)
     resp = await cli.get('/path/to')
     assert resp.status == 500
+    assert resp.headers['Content-Type'].startswith('text/plain')
 
     txt = await resp.text()
-    assert "<h2>Traceback:</h2>" in txt
+    assert "Traceback:" in txt
 
     logger.exception.assert_called_with(
         "Error handling request",
         exc_info=exc)
+
+
+async def test_raw_server_html_exception(aiohttp_raw_server, aiohttp_client):
+    exc = RuntimeError("custom runtime error")
+
+    async def handler(request):
+        raise exc
+
+    logger = mock.Mock()
+    server = await aiohttp_raw_server(handler, logger=logger, debug=False)
+    cli = await aiohttp_client(server)
+    resp = await cli.get('/path/to', headers={'Accept': 'text/html'})
+    assert resp.status == 500
+    assert resp.headers['Content-Type'].startswith('text/html')
+
+    txt = await resp.text()
+    assert txt.startswith("<h1>500 Internal Server Error</h1>")
+    assert "Traceback" not in txt
+
+    logger.exception.assert_called_with(
+        "Error handling request", exc_info=exc)
+
+
+async def test_raw_server_html_exception_debug(aiohttp_raw_server,
+                                               aiohttp_client):
+    exc = RuntimeError("custom runtime error")
+
+    async def handler(request):
+        raise exc
+
+    logger = mock.Mock()
+    server = await aiohttp_raw_server(handler, logger=logger, debug=True)
+    cli = await aiohttp_client(server)
+    resp = await cli.get('/path/to', headers={'Accept': 'text/html'})
+    assert resp.status == 500
+    assert resp.headers['Content-Type'].startswith('text/html')
+
+    txt = await resp.text()
+    assert txt.startswith("<h1>500 Internal Server Error</h1>")
+    assert "<h2>Traceback:</h2>" in txt
+
+    logger.exception.assert_called_with(
+        "Error handling request", exc_info=exc)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

When using curl or httpie, error responses should not be html.

## Are there changes in behavior for the user?

Yes, errors should be plain text not html when `text/html` is not in the "browsers" `Accept` header.

Currently this is failing due to an existing error which I inadvertently uncovered. I'll comment on the code below. I'll add `CHANGES` etc. once this is fixed.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
