### PR TITLE
Change type of Payload.size from Optional[float] to Optional[int]

### DIFF
--- a/CHANGES/3484.bugfix
+++ b/CHANGES/3484.bugfix
@@ -1,0 +1,1 @@
+``Payload.size`` type annotation changesd from `Optional[float]` to `Optional[int]`.

--- a/aiohttp/payload.py
+++ b/aiohttp/payload.py
@@ -120,7 +120,7 @@ class PayloadRegistry:
 
 class Payload(ABC):
 
-    _size = None  # type: Optional[float]
+    _size = None  # type: Optional[int]
     _headers = None  # type: Optional[_CIMultiDict]
     _content_type = 'application/octet-stream'  # type: Optional[str]
 
@@ -151,7 +151,7 @@ class Payload(ABC):
         self._content_type = content_type
 
     @property
-    def size(self) -> Optional[float]:
+    def size(self) -> Optional[int]:
         """Size of the payload."""
         return self._size
 
@@ -338,7 +338,7 @@ class TextIOPayload(IOBasePayload):
         )
 
     @property
-    def size(self) -> Optional[float]:
+    def size(self) -> Optional[int]:
         try:
             return os.fstat(self._value.fileno()).st_size - self._value.tell()
         except OSError:
@@ -362,7 +362,7 @@ class TextIOPayload(IOBasePayload):
 class BytesIOPayload(IOBasePayload):
 
     @property
-    def size(self) -> float:
+    def size(self) -> int:
         position = self._value.tell()
         end = self._value.seek(0, os.SEEK_END)
         self._value.seek(position)
@@ -372,7 +372,7 @@ class BytesIOPayload(IOBasePayload):
 class BufferedReaderPayload(IOBasePayload):
 
     @property
-    def size(self) -> Optional[float]:
+    def size(self) -> Optional[int]:
         try:
             return os.fstat(self._value.fileno()).st_size - self._value.tell()
         except OSError:


### PR DESCRIPTION
## What do these changes do?

This changes type of `Payload.size` property from `float` to `int`. Since this property defines amount of bytes which payload contains, it's impossible to have there floating point value.

This behavior was introduced in #3294.

## Are there changes in behavior for the user?

It's possible to break some annotations for users custom Payload instances, but no runtime issues should be caused.
