### PR TITLE
Add exception docs

### DIFF
--- a/CHANGES/3490.doc
+++ b/CHANGES/3490.doc
@@ -1,0 +1,1 @@
+Add documentation for ``aiohttp.web.HTTPException``.

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -115,6 +115,7 @@ impl
 incapsulates
 Indices
 infos
+initializer
 inline
 intaking
 io

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -1218,6 +1218,40 @@ Return :class:`Response` with predefined ``'application/json'``
 content type and *data* encoded by ``dumps`` parameter
 (:func:`json.dumps` by default).
 
+HTTP Exceptions
+^^^^^^^^^^^^^^^
+Errors can also be returned by raising a HTTP exception instance from within
+the handler.
+
+.. class:: HTTPException(*, headers=None, reason=None, text=None, content_type=None)
+
+   Low-level HTTP failure.
+
+   :param headers: headers for the response
+   :type headers: dict or multidict.CIMultiDict
+
+   :param str reason: reason included in the response
+
+   :param str text: response's body
+
+   :param str content_type: response's content type.  This is passed through
+      to the :class:`Response` initializer.
+
+   Sub-classes of ``HTTPException`` exist for the standard HTTP response codes
+   as described in :ref:`aiohttp-web-exceptions` and the expected usage is to
+   simply raise the appropriate exception type to respond with a specific HTTP
+   response code.
+
+   Since ``HTTPException`` is a sub-class of :class:`Response`, it contains the
+   methods and properties that allow you to directly manipulate details of the
+   response.
+
+   .. attribute:: status_code
+
+      HTTP status code for this exception class.  This attribute is usually
+      defined at the class level.  ``self.status_code`` is passed to the
+      :class:`Response` initializer.
+
 
 .. _aiohttp-web-app-and-router:
 

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -805,8 +805,8 @@ Response
 ^^^^^^^^
 
 .. class:: Response(*, body=None, status=200, reason=None, text=None, \
-   headers=None, content_type=None, charset=None, zlib_executor_size=sentinel,
-   zlib_executor=None)
+                    headers=None, content_type=None, charset=None, \
+                    zlib_executor_size=sentinel, zlib_executor=None)
 
    The most usable response class, inherited from :class:`StreamResponse`.
 

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -1207,7 +1207,7 @@ WebSocketReady
 
 
 json_response
--------------
+^^^^^^^^^^^^^
 
 .. function:: json_response([data], *, text=None, body=None, \
                             status=200, reason=None, headers=None, \


### PR DESCRIPTION
## What do these changes do?

A few simple documentation changes to enable linking to `aiohttp.web.Response` and `aiohttp.web.HTTPException` using `sphinx.ext.intersphinx`.  Previously the class documentation for `Response` was not indented properly so a link was not generated in _objects.inv_.  I added class documentation for `aiohttp.web.HTTPException` that refers to the existing exception documentation.

## Are there changes in behavior for the user?

Nope.  No changes in behavior whatsoever.

## Related issue number

Not that I am aware of.

## Checklist

- [ ] I think the code is well written **(N/A)**
- [ ] Unit tests for the changes exist **(N/A)**
- [X] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [X] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."