### PR TITLE
[3.5] Ignore done tasks (#3500)

### DIFF
--- a/CHANGES/3497.bugfix
+++ b/CHANGES/3497.bugfix
@@ -1,0 +1,1 @@
+Ignore done tasks when cancels pending activities on ``web.run_app`` finalization.

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -63,10 +63,15 @@ except ImportError:
     from typing_extensions import ContextManager
 
 
-all_tasks = asyncio.Task.all_tasks
+def all_tasks(
+        loop: Optional[asyncio.AbstractEventLoop] = None
+) -> Set['asyncio.Task[Any]']:
+    tasks = list(asyncio.Task.all_tasks(loop))  # type: ignore
+    return {t for t in tasks if not t.done()}
+
 
 if PY_37:
-    all_tasks = getattr(asyncio, 'all_tasks')  # use the trick to cheat mypy
+    all_tasks = getattr(asyncio, 'all_tasks')  # noqa
 
 
 _T = TypeVar('_T')


### PR DESCRIPTION
* Fix #3497: Ignore done tasks when cancels pending activities on web.run_app finalization.
(cherry picked from commit 4e99e817)

Co-authored-by: Andrew Svetlov <andrew.svetlov@gmail.com>
