### PR TITLE
[3.5] Allow run_app(access_log=None) (#3504)

### DIFF
--- a/CHANGES/3504.bugfix
+++ b/CHANGES/3504.bugfix
@@ -1,0 +1,1 @@
+Fix type stubs for ``aiohttp.web.run_app(access_log=True)`` and fix edge case of ``access_log=True`` and the event loop being in debug mode.

--- a/aiohttp/web.py
+++ b/aiohttp/web.py
@@ -269,7 +269,7 @@ async def _run_app(app: Union[Application, Awaitable[Application]], *,
                    backlog: int=128,
                    access_log_class: Type[AbstractAccessLogger]=AccessLogger,
                    access_log_format: str=AccessLogger.LOG_FORMAT,
-                   access_log: logging.Logger=access_logger,
+                   access_log: Optional[logging.Logger]=access_logger,
                    handle_signals: bool=True,
                    reuse_address: Optional[bool]=None,
                    reuse_port: Optional[bool]=None) -> None:
@@ -383,7 +383,7 @@ def run_app(app: Union[Application, Awaitable[Application]], *,
             backlog: int=128,
             access_log_class: Type[AbstractAccessLogger]=AccessLogger,
             access_log_format: str=AccessLogger.LOG_FORMAT,
-            access_log: logging.Logger=access_logger,
+            access_log: Optional[logging.Logger]=access_logger,
             handle_signals: bool=True,
             reuse_address: Optional[bool]=None,
             reuse_port: Optional[bool]=None) -> None:
@@ -391,7 +391,7 @@ def run_app(app: Union[Application, Awaitable[Application]], *,
     loop = asyncio.get_event_loop()
 
     # Configure if and only if in debugging mode and using the default logger
-    if loop.get_debug() and access_log.name == 'aiohttp.access':
+    if loop.get_debug() and access_log and access_log.name == 'aiohttp.access':
         if access_log.level == logging.NOTSET:
             access_log.setLevel(logging.DEBUG)
         if not access_log.hasHandlers():


### PR DESCRIPTION
* Mark access_log as optional

* Make access_log=None work in debug mode
(cherry picked from commit c562ffe3)

Co-authored-by: Hynek Schlawack <hs@ox.cx>
