### PR TITLE
[3.5] Fix aiohttp.ClientTimeout type annotations to accept None for fields (#3511)

### DIFF
--- a/CHANGES/3511.bugfix
+++ b/CHANGES/3511.bugfix
@@ -1,0 +1,1 @@
+Fix ``aiohttp.ClientTimeout`` type annotations to accept ``None`` for fields

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -130,10 +130,10 @@ except ImportError:  # pragma: no cover
 
 @attr.s(frozen=True, slots=True)
 class ClientTimeout:
-    total = attr.ib(type=float, default=None)
-    connect = attr.ib(type=float, default=None)
-    sock_read = attr.ib(type=float, default=None)
-    sock_connect = attr.ib(type=float, default=None)
+    total = attr.ib(type=Optional[float], default=None)
+    connect = attr.ib(type=Optional[float], default=None)
+    sock_read = attr.ib(type=Optional[float], default=None)
+    sock_connect = attr.ib(type=Optional[float], default=None)
 
     # pool_queue_timeout = attr.ib(type=float, default=None)
     # dns_resolution_timeout = attr.ib(type=float, default=None)


### PR DESCRIPTION
* Fix aiohttp.ClientTimeout type annotations to accept Nonefor fields

* Add changelog
(cherry picked from commit 7706b5a)

Co-authored-by: Andrew Svetlov <andrew.svetlov@gmail.com>
