### PR TITLE
Send custom per-request cookies even if session jar is empty

### DIFF
--- a/CHANGES/3515.bugfix
+++ b/CHANGES/3515.bugfix
@@ -1,0 +1,1 @@
+Send custom per-request cookies even if session jar is empty

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -430,7 +430,7 @@ class ClientSession:
                         tmp_cookie_jar = CookieJar()
                         tmp_cookie_jar.update_cookies(cookies)
                         req_cookies = tmp_cookie_jar.filter_cookies(url)
-                        if session_cookies and req_cookies:
+                        if req_cookies:
                             session_cookies.load(req_cookies)
 
                     cookies = session_cookies


### PR DESCRIPTION
The issue was reported in gitter chat