### PR TITLE
[3.5] Send custom per-request cookies even if session jar is empty (#3515)

### DIFF
--- a/CHANGES/3515.bugfix
+++ b/CHANGES/3515.bugfix
@@ -1,0 +1,1 @@
+Send custom per-request cookies even if session jar is empty

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -440,7 +440,7 @@ class ClientSession:
                         tmp_cookie_jar = CookieJar()
                         tmp_cookie_jar.update_cookies(cookies)
                         req_cookies = tmp_cookie_jar.filter_cookies(url)
-                        if session_cookies and req_cookies:
+                        if req_cookies:
                             session_cookies.load(req_cookies)
 
                     cookies = session_cookies


### PR DESCRIPTION
* Send custom per-request cookies even if session jar is empty

(cherry picked from commit a86af67e)

Co-authored-by: Andrew Svetlov <andrew.svetlov@gmail.com>
