### PR TITLE
make sure the closing boundary is written when calling 'write' on an empty MultipartWriter

### DIFF
--- a/aiohttp/multipart.py
+++ b/aiohttp/multipart.py
@@ -721,6 +721,9 @@ class MultipartWriter(Payload):
     def __len__(self) -> int:
         return len(self._parts)
 
+    def __bool__(self) -> bool:
+        return True
+
     _valid_tchar_regex = re.compile(br"\A[!#$%&'*+\-.^_`|~\w]+\Z")
     _invalid_qdtext_char_regex = re.compile(br"[\x00-\x08\x0A-\x1F\x7F]")
 
@@ -849,9 +852,6 @@ class MultipartWriter(Payload):
     @property
     def size(self) -> Optional[int]:
         """Size of the payload."""
-        if not self._parts:
-            return 0
-
         total = 0
         for part, encoding, te_encoding in self._parts:
             if encoding or te_encoding or part.size is None:
@@ -869,9 +869,6 @@ class MultipartWriter(Payload):
     async def write(self, writer: Any,
                     close_boundary: bool=True) -> None:
         """Write body."""
-        if not self._parts:
-            return
-
         for part, encoding, te_encoding in self._parts:
             await writer.write(b'--' + self._boundary + b'\r\n')
             await writer.write(part._binary_headers)

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -730,7 +730,7 @@ class TestMultipartReader:
 
 
 async def test_writer(writer) -> None:
-    assert writer.size == 0
+    assert writer.size == 7
     assert writer.boundary == ':'
 
 
@@ -846,6 +846,11 @@ async def test_writer_write_no_close_boundary(buf, stream) -> None:
          b'Content-Length: 11\r\n\r\n'
          b'one=1&two=2'
          b'\r\n') == bytes(buf))
+
+
+async def test_writer_write_no_parts(buf, stream, writer) -> None:
+    await writer.write(stream)
+    assert b'--:--\r\n' == bytes(buf)
 
 
 async def test_writer_serialize_with_content_encoding_gzip(buf, stream,

--- a/tests/test_web_functional.py
+++ b/tests/test_web_functional.py
@@ -234,7 +234,27 @@ async def test_multipart(aiohttp_client) -> None:
     app.router.add_post('/', handler)
     client = await aiohttp_client(app)
 
-    resp = await client.post('/', data=writer, headers=writer.headers)
+    resp = await client.post('/', data=writer)
+    assert 200 == resp.status
+    await resp.release()
+
+
+async def test_multipart_empty(aiohttp_client) -> None:
+    with multipart.MultipartWriter() as writer:
+        pass
+
+    async def handler(request):
+        reader = await request.multipart()
+        assert isinstance(reader, multipart.MultipartReader)
+        async for part in reader:
+            assert False, 'Unexpected part found in reader: {!r}'.format(part)
+        return web.Response()
+
+    app = web.Application()
+    app.router.add_post('/', handler)
+    client = await aiohttp_client(app)
+
+    resp = await client.post('/', data=writer)
     assert 200 == resp.status
     await resp.release()
 
@@ -264,7 +284,7 @@ async def test_multipart_content_transfer_encoding(aiohttp_client) -> None:
     app.router.add_post('/', handler)
     client = await aiohttp_client(app)
 
-    resp = await client.post('/', data=writer, headers=writer.headers)
+    resp = await client.post('/', data=writer)
     assert 200 == resp.status
     await resp.release()
 


### PR DESCRIPTION
The MultipartWriter class produces an empty body when it represents an "empty" payload (ie no parameters are present).
If I'm not mistaken, this is not a valid way to represent an empty payload, and it actually breaks the MultipartReader: the Content-Type header should be set even for an empty payload (with a boundary), and the "end of message" token `--BOUNDARY--\r\n` should still be in the body

For instance, this client
```python
import aiohttp
import asyncio

async def main():
	with aiohttp.MultipartWriter() as body:
		pass
	async with aiohttp.ClientSession() as session:
		async with session.get('http://0.0.0.0:8080', data=body) as resp:
			print(await resp.read())
			print(resp)

asyncio.run(main())
```

will crash this server:
```python
from aiohttp import web

async def handler(request):
	reader = await request.multipart()
	print([p async for p in reader])
	return web.Response(text="Ok.")

app = web.Application()
app.add_routes([web.get('/', handler)])
web.run_app(app)
```


The proposed change makes the MultipartWriter output the end-of-message token even if the payload is empty.

I've added a regression test (that fails against master, so that's another way to reproduce what my example above does)

The PR also modifies the other `web_functionnal` tests to remove the explicit `headers` argument, AFAIK the documented way of using MultipartWriter is _not_ to manually copy the headers.


Let me know if this change is acceptable, and if you consider this a feature, bugfix, … (ie how should I document this)

Thanks!