### PR TITLE
misc docs fix - background tasks example throws a deprecation warning

### DIFF
--- a/CHANGES/3526.doc
+++ b/CHANGES/3526.doc
@@ -1,0 +1,1 @@
+Modify documentation for Background Tasks to remove deprecated usage of event loop.

--- a/docs/web_advanced.rst
+++ b/docs/web_advanced.rst
@@ -956,7 +956,7 @@ signal handlers as shown in the example below::
 
 
   async def start_background_tasks(app):
-      app['redis_listener'] = app.loop.create_task(listen_to_redis(app))
+      app['redis_listener'] = asyncio.create_task(listen_to_redis(app))
 
 
   async def cleanup_background_tasks(app):

--- a/docs/web_advanced.rst
+++ b/docs/web_advanced.rst
@@ -942,7 +942,7 @@ signal handlers as shown in the example below::
 
   async def listen_to_redis(app):
       try:
-          sub = await aioredis.create_redis(('localhost', 6379), loop=app.loop)
+          sub = await aioredis.create_redis(('localhost', 6379))
           ch, *_ = await sub.subscribe('news')
           async for msg in ch.iter(encoding='utf-8'):
               # Forward message to all connected websockets:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
The changes remove some references to event loop in docs as using it is deprecated in aiohttp

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->
There are no changes in behaviour, just docs

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #3526 

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
