### PR TITLE
[3.5] misc docs fix - background tasks example throws a deprecation warning (#3529)

### DIFF
--- a/CHANGES/3526.doc
+++ b/CHANGES/3526.doc
@@ -1,0 +1,1 @@
+Modify documentation for Background Tasks to remove deprecated usage of event loop.

--- a/docs/web_advanced.rst
+++ b/docs/web_advanced.rst
@@ -942,7 +942,7 @@ signal handlers as shown in the example below::
 
   async def listen_to_redis(app):
       try:
-          sub = await aioredis.create_redis(('localhost', 6379), loop=app.loop)
+          sub = await aioredis.create_redis(('localhost', 6379))
           ch, *_ = await sub.subscribe('news')
           async for msg in ch.iter(encoding='utf-8'):
               # Forward message to all connected websockets:
@@ -956,7 +956,7 @@ signal handlers as shown in the example below::
 
 
   async def start_background_tasks(app):
-      app['redis_listener'] = app.loop.create_task(listen_to_redis(app))
+      app['redis_listener'] = asyncio.create_task(listen_to_redis(app))
 
 
   async def cleanup_background_tasks(app):


### PR DESCRIPTION
(cherry picked from commit 2d8aa120)

Co-authored-by: Goran Cetušić <goran.cetusic@gmail.com>
