### PR TITLE
Disallow creation of aiohttp objects without running event loop

### DIFF
--- a/CHANGES/3539.removal
+++ b/CHANGES/3539.removal
@@ -1,0 +1,1 @@
+Disallow creation of aiohttp objects (``ClientSession``, ``Connector`` etc.) without running event loop.

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -12,7 +12,6 @@ import platform
 import re
 import sys
 import time
-import warnings
 import weakref
 from collections import namedtuple
 from contextlib import suppress
@@ -45,7 +44,7 @@ from multidict import MultiDict, MultiDictProxy
 from yarl import URL
 
 from . import hdrs
-from .log import client_logger, internal_logger
+from .log import client_logger
 from .typedefs import PathLike  # noqa
 
 __all__ = ('BasicAuth', 'ChainMapProxy')
@@ -266,12 +265,7 @@ def get_running_loop(
     if loop is None:
         loop = asyncio.get_event_loop()
     if not loop.is_running():
-        warnings.warn("The object should be created from async function",
-                      DeprecationWarning, stacklevel=3)
-        if loop.get_debug():
-            internal_logger.warning(
-                "The object should be created from async function",
-                stack_info=True)
+        raise RuntimeError("The object should be created from async function")
     return loop
 
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -447,7 +447,9 @@ def test_proxies_from_env_http_with_auth(mocker) -> None:
 
 
 def test_get_running_loop_not_running(loop) -> None:
-    with pytest.warns(DeprecationWarning):
+    with pytest.raises(
+            RuntimeError,
+            match="The object should be created from async function"):
         helpers.get_running_loop()
 
 


### PR DESCRIPTION
`ClientSession`, `Connector` and others are affected.