### PR TITLE
[3.5] Permit empty reason strings in ClientResponse.raise_for_status (#3533)

### DIFF
--- a/CHANGES/3532.bugfix
+++ b/CHANGES/3532.bugfix
@@ -1,0 +1,2 @@
+Raise a ClientResponseError instead of an AssertionError for a blank
+HTTP Reason Phrase.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -120,6 +120,7 @@ Joel Watts
 Jon Nabozny
 Joongi Kim
 Josep Cugat
+Joshu Coats
 Julia Tsemusheva
 Julien Duponchelle
 Jungkook Park

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -932,7 +932,8 @@ class ClientResponse(HeadersMixin):
 
     def raise_for_status(self) -> None:
         if 400 <= self.status:
-            assert self.reason  # always not None for started response
+            # reason should always be not None for a started response
+            assert self.reason is not None
             self.release()
             raise ClientResponseError(
                 self.request_info,

--- a/tests/test_client_response.py
+++ b/tests/test_client_response.py
@@ -668,6 +668,24 @@ def test_raise_for_status_4xx() -> None:
     assert response.closed
 
 
+def test_raise_for_status_4xx_without_reason() -> None:
+    response = ClientResponse('get', URL('http://def-cl-resp.org'),
+                              request_info=mock.Mock(),
+                              writer=mock.Mock(),
+                              continue100=None,
+                              timer=TimerNoop(),
+                              traces=[],
+                              loop=mock.Mock(),
+                              session=mock.Mock())
+    response.status = 404
+    response.reason = ''
+    with pytest.raises(aiohttp.ClientResponseError) as cm:
+        response.raise_for_status()
+    assert str(cm.value.status) == '404'
+    assert str(cm.value.message) == ''
+    assert response.closed
+
+
 def test_resp_host() -> None:
     response = ClientResponse('get', URL('http://del-cl-resp.org'),
                               request_info=mock.Mock(),


### PR DESCRIPTION

(cherry picked from commit f590bfd)

Co-authored-by: Joshu Coats <rhwlo@users.noreply.github.com>
