### PR TITLE
tests: unix_sockname: use tmp_path

### DIFF
--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -43,9 +43,8 @@ def ssl_key():
 
 
 @pytest.fixture
-def unix_sockname(tmpdir):
-    sock_path = tmpdir / 'socket.sock'
-    return str(sock_path)
+def unix_sockname(tmp_path):
+    return str(tmp_path / 'socket.sock')
 
 
 @pytest.fixture


### PR DESCRIPTION
Ref: https://github.com/aio-libs/aiohttp/issues/3551

The intention from/in https://github.com/aio-libs/aiohttp/issues/3551 is not really clear to me.

Mainly via https://github.com/aio-libs/aiohttp/pull/3553#discussion_r249247018, but should be done in other places then also?

@asvetlov 
Please consider picking it up.

