### PR TITLE
[Documentation] Add Mariner to "Built with" page

### DIFF
--- a/docs/built_with.rst
+++ b/docs/built_with.rst
@@ -23,3 +23,4 @@ project, pointing to `<https://github.com/aio-libs/aiohttp>`_.
 * `Home Assistant <https://home-assistant.io>`_ Home Automation Platform.
 * `Backend.AI <https://backend.ai>`_ Code execution API service.
 * `doh-proxy <https://github.com/facebookexperimental/doh-proxy>`_ DNS Over HTTPS Proxy.
+* `Mariner <https://gitlab.com/radek-sprta/mariner>`_ Command-line torrent searcher.


### PR DESCRIPTION
I have noticed you a have a list of project build with aiohttp in your documentation, so I have added mine :]. Mariner is a command-line torrent searcher build on top of aiohttp.

<!-- Thank you for your contribution! -->

## What do these changes do?

Add [Mariner](https://gitlab.com/radek-sprta/mariner)  to "Built with" page.
<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

No.
<!-- Outline any notable behaviour for the end users. -->

## Checklist

- [x ] Documentation reflects the changes
- [x]  Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
