### PR TITLE
Clarify WebSocket quickstart example

### DIFF
--- a/CHANGES/3559.doc
+++ b/CHANGES/3559.doc
@@ -1,0 +1,1 @@
+Clarified WebSocketResponse closure in quickstart example.

--- a/docs/web_quickstart.rst
+++ b/docs/web_quickstart.rst
@@ -594,6 +594,8 @@ with the peer::
         await ws.prepare(request)
 
         async for msg in ws:
+            # ws.__next__() automatically terminates the loop
+            # after ws.close() or ws.exception() is called
             if msg.type == aiohttp.WSMsgType.TEXT:
                 if msg.data == 'close':
                     await ws.close()
@@ -601,7 +603,7 @@ with the peer::
                     await ws.send_str(msg.data + '/answer')
             elif msg.type == aiohttp.WSMsgType.ERROR:
                 print('ws connection closed with exception %s' %
-                      ws.exception())
+                      ws.exception())                
 
         print('websocket connection closed')
 

--- a/docs/web_quickstart.rst
+++ b/docs/web_quickstart.rst
@@ -603,7 +603,7 @@ with the peer::
                     await ws.send_str(msg.data + '/answer')
             elif msg.type == aiohttp.WSMsgType.ERROR:
                 print('ws connection closed with exception %s' %
-                      ws.exception())                
+                      ws.exception())
 
         print('websocket connection closed')
 


### PR DESCRIPTION
## What do these changes do?

I initially thought this example was missing some "break"
calls before realising that WebSocketResponse would be
taking care of the loop termination internally.

I suspect I may not be the only person to make that
mistake, so this proposes an inline comment in the
example pointing out what is actually going on.

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

No

## Related issue number

N/A

## Checklist

- [-] I think the code is well written
- [-] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [-] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
