### PR TITLE
new style middleware default

### DIFF
--- a/CHANGES/3569.feature
+++ b/CHANGES/3569.feature
@@ -1,0 +1,2 @@
+Make new style middleware default, depreciate the @middleware decorator and
+remove support for old-style middleware.

--- a/aiohttp/web_app.py
+++ b/aiohttp/web_app.py
@@ -53,12 +53,9 @@ if TYPE_CHECKING:  # pragma: no cover
     _RespPrepareSignal = Signal[Callable[[Request, StreamResponse],
                                          Awaitable[None]]]
     _Handler = Callable[[Request], Awaitable[StreamResponse]]
-    _Middleware = Union[Callable[[Request, _Handler],
-                                 Awaitable[StreamResponse]],
-                        Callable[['Application', _Handler],  # old-style
-                                 Awaitable[_Handler]]]
+    _Middleware = Callable[[Request, _Handler], Awaitable[StreamResponse]]
     _Middlewares = FrozenList[_Middleware]
-    _MiddlewaresHandlers = Optional[Sequence[Tuple[_Middleware, bool]]]
+    _MiddlewaresHandlers = Optional[Sequence[_Middleware]]
     _Subapps = List['Application']
 else:
     # No type checker mode, skip types
@@ -390,17 +387,9 @@ class Application(MutableMapping[str, Any]):
             self._loop,
             client_max_size=self._client_max_size)
 
-    def _prepare_middleware(self) -> Iterator[Tuple[_Middleware, bool]]:
-        for m in reversed(self._middlewares):
-            if getattr(m, '__middleware_version__', None) == 1:
-                yield m, True
-            else:
-                warnings.warn('old-style middleware "{!r}" deprecated, '
-                              'see #2252'.format(m),
-                              DeprecationWarning, stacklevel=2)
-                yield m, False
-
-        yield _fix_request_current_app(self), True
+    def _prepare_middleware(self) -> Iterator[_Middleware]:
+        yield from reversed(self._middlewares)
+        yield _fix_request_current_app
 
     async def _handle(self, request: Request) -> StreamResponse:
         loop = asyncio.get_event_loop()
@@ -426,11 +415,8 @@ class Application(MutableMapping[str, Any]):
 
             if self._run_middlewares:
                 for app in match_info.apps[::-1]:
-                    for m, new_style in app._middlewares_handlers:  # type: ignore  # noqa
-                        if new_style:
-                            handler = partial(m, handler=handler)
-                        else:
-                            handler = await m(app, handler)  # type: ignore
+                    for m in app._middlewares_handlers:  # noqa
+                        handler = partial(m, handler=handler)
 
             resp = await handler(request)
 

--- a/aiohttp/web_app.py
+++ b/aiohttp/web_app.py
@@ -415,7 +415,7 @@ class Application(MutableMapping[str, Any]):
 
             if self._run_middlewares:
                 for app in match_info.apps[::-1]:
-                    for m in app._middlewares_handlers:  # noqa
+                    for m in app._middlewares_handlers:  # type: ignore  # noqa
                         handler = partial(m, handler=handler)
 
             resp = await handler(request)

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -353,7 +353,6 @@ response::
         # don't do this!
         cached = web.Response(status=200, text='Hi, I am cached!')
 
-        @web.middleware
         async def middleware(request, handler):
             # ignoring response for the sake of this example
             _res = handler(request)

--- a/docs/web_advanced.rst
+++ b/docs/web_advanced.rst
@@ -483,11 +483,17 @@ response. For example, here's a simple *middleware* which appends
 
     from aiohttp.web import middleware
 
-    @middleware
     async def middleware(request, handler):
         resp = await handler(request)
         resp.text = resp.text + ' wink'
         return resp
+
+.. warning::
+
+   As of version ``4.0.0`` "new-style" middleware is default and the
+   ``@middleware`` decorator is not required (and is deprecated), you can
+   simply remove the decorator. "Old-style" middleware (a coroutine which
+   returned a coroutine) is not longer supported.
 
 .. note::
 
@@ -531,14 +537,12 @@ The following code demonstrates middlewares execution order::
        print('Handler function called')
        return web.Response(text="Hello")
 
-   @web.middleware
    async def middleware1(request, handler):
        print('Middleware 1 called')
        response = await handler(request)
        print('Middleware 1 finished')
        return response
 
-   @web.middleware
    async def middleware2(request, handler):
        print('Middleware 2 called')
        response = await handler(request)
@@ -567,7 +571,6 @@ a JSON REST service::
 
     from aiohttp import web
 
-    @web.middleware
     async def error_middleware(request, handler):
         try:
             response = await handler(request)
@@ -586,17 +589,19 @@ a JSON REST service::
 Middleware Factory
 ^^^^^^^^^^^^^^^^^^
 
-A *middleware factory* is a function that creates a middleware with passed arguments. For example, here's a trivial *middleware factory*::
+A *middleware factory* is a function that creates a middleware with passed
+arguments. For example, here's a trivial *middleware factory*::
 
     def middleware_factory(text):
-        @middleware
         async def sample_middleware(request, handler):
             resp = await handler(request)
             resp.text = resp.text + text
             return resp
         return sample_middleware
 
-Remember that contrary to regular middlewares you need the result of a middleware factory not the function itself. So when passing a middleware factory to an app you actually need to call it::
+Remember that contrary to regular middlewares you need the result of a
+middleware factory not the function itself. So when passing a middleware
+factory to an app you actually need to call it::
 
     app = web.Application(middlewares=[middleware_factory(' wink')])
 

--- a/docs/web_advanced.rst
+++ b/docs/web_advanced.rst
@@ -493,7 +493,7 @@ response. For example, here's a simple *middleware* which appends
    As of version ``4.0.0`` "new-style" middleware is default and the
    ``@middleware`` decorator is not required (and is deprecated), you can
    simply remove the decorator. "Old-style" middleware (a coroutine which
-   returned a coroutine) is not longer supported.
+   returned a coroutine) is no longer supported.
 
 .. note::
 

--- a/examples/web_rewrite_headers_middleware.py
+++ b/examples/web_rewrite_headers_middleware.py
@@ -10,7 +10,6 @@ async def handler(request):
     return web.Response(text="Everything is fine")
 
 
-@web.middleware
 async def middleware(request, handler):
     try:
         response = await handler(request)

--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -246,7 +246,6 @@ def test_app_run_middlewares() -> None:
     root.freeze()
     assert root._run_middlewares is False
 
-    @web.middleware
     async def middleware(request, handler):
         return await handler(request)
 

--- a/tests/test_web_functional.py
+++ b/tests/test_web_functional.py
@@ -1348,7 +1348,6 @@ async def test_subapp_middleware_context(aiohttp_client,
     values = []
 
     def show_app_context(appname):
-        @web.middleware
         async def middleware(request, handler):
             values.append('{}: {}'.format(
                 appname, request.app['my_value']))

--- a/tests/test_web_middleware.py
+++ b/tests/test_web_middleware.py
@@ -10,7 +10,6 @@ async def test_middleware_modifies_response(loop, aiohttp_client) -> None:
     async def handler(request):
         return web.Response(body=b'OK')
 
-    @web.middleware
     async def middleware(request, handler):
         resp = await handler(request)
         assert 200 == resp.status
@@ -32,7 +31,6 @@ async def test_middleware_handles_exception(loop, aiohttp_client) -> None:
     async def handler(request):
         raise RuntimeError('Error text')
 
-    @web.middleware
     async def middleware(request, handler):
         with pytest.raises(RuntimeError) as ctx:
             await handler(request)
@@ -54,7 +52,6 @@ async def test_middleware_chain(loop, aiohttp_client) -> None:
         return web.Response(text='OK')
 
     def make_middleware(num):
-        @web.middleware
         async def middleware(request, handler):
             resp = await handler(request)
             resp.text = resp.text + '[{}]'.format(num)
@@ -298,128 +295,31 @@ async def test_bug_3669(aiohttp_client):
 
 
 async def test_old_style_middleware(loop, aiohttp_client) -> None:
-    async def handler(request):
+    async def view_handler(request):
         return web.Response(body=b'OK')
 
-    async def middleware_factory(app, handler):
-
-        async def middleware(request):
+    with pytest.warns(DeprecationWarning, match='Middleware decorator is'):
+        @web.middleware
+        async def middleware(request, handler):
             resp = await handler(request)
             assert 200 == resp.status
             resp.set_status(201)
             resp.text = resp.text + '[old style middleware]'
             return resp
-        return middleware
 
-    with pytest.warns(DeprecationWarning) as warning_checker:
-        app = web.Application()
-        app.middlewares.append(middleware_factory)
-        app.router.add_route('GET', '/', handler)
-        client = await aiohttp_client(app)
-        resp = await client.get('/')
-        assert 201 == resp.status
-        txt = await resp.text()
-        assert 'OK[old style middleware]' == txt
-
-    assert len(warning_checker) == 1
-    msg = str(warning_checker.list[0].message)
-    assert re.match('^old-style middleware '
-                    '"<function test_old_style_middleware.<locals>.'
-                    'middleware_factory at 0x[0-9a-fA-F]+>" '
-                    'deprecated, see #2252$',
-                    msg)
-
-
-async def test_mixed_middleware(loop, aiohttp_client) -> None:
-    async def handler(request):
-        return web.Response(body=b'OK')
-
-    async def m_old1(app, handler):
-        async def middleware(request):
-            resp = await handler(request)
-            resp.text += '[old style 1]'
-            return resp
-        return middleware
-
-    @web.middleware
-    async def m_new1(request, handler):
-        resp = await handler(request)
-        resp.text += '[new style 1]'
-        return resp
-
-    async def m_old2(app, handler):
-        async def middleware(request):
-            resp = await handler(request)
-            resp.text += '[old style 2]'
-            return resp
-        return middleware
-
-    @web.middleware
-    async def m_new2(request, handler):
-        resp = await handler(request)
-        resp.text += '[new style 2]'
-        return resp
-
-    middlewares = m_old1, m_new1, m_old2, m_new2
-
-    with pytest.warns(DeprecationWarning) as w:
-        app = web.Application(middlewares=middlewares)
-        app.router.add_route('GET', '/', handler)
-        client = await aiohttp_client(app)
-        resp = await client.get('/')
-        assert 200 == resp.status
-        txt = await resp.text()
-        assert 'OK[new style 2][old style 2][new style 1][old style 1]' == txt
-
-    assert len(w) == 2
-    tmpl = ('^old-style middleware '
-            '"<function test_mixed_middleware.<locals>.'
-            '{} at 0x[0-9a-fA-F]+>" '
-            'deprecated, see #2252$')
-    p1 = tmpl.format('m_old1')
-    p2 = tmpl.format('m_old2')
-
-    assert re.match(p2, str(w.list[0].message))
-    assert re.match(p1, str(w.list[1].message))
-
-
-async def test_old_style_middleware_class(loop, aiohttp_client) -> None:
-    async def handler(request):
-        return web.Response(body=b'OK')
-
-    class Middleware:
-        async def __call__(self, app, handler):
-            async def middleware(request):
-                resp = await handler(request)
-                assert 200 == resp.status
-                resp.set_status(201)
-                resp.text = resp.text + '[old style middleware]'
-                return resp
-            return middleware
-
-    with pytest.warns(DeprecationWarning) as warning_checker:
-        app = web.Application()
-        app.middlewares.append(Middleware())
-        app.router.add_route('GET', '/', handler)
-        client = await aiohttp_client(app)
-        resp = await client.get('/')
-        assert 201 == resp.status
-        txt = await resp.text()
-        assert 'OK[old style middleware]' == txt
-
-    assert len(warning_checker) == 1
-    msg = str(warning_checker.list[0].message)
-    assert re.match('^old-style middleware '
-                    '"<test_web_middleware.test_old_style_middleware_class.'
-                    '<locals>.Middleware object '
-                    'at 0x[0-9a-fA-F]+>" deprecated, see #2252$', msg)
+    app = web.Application(middlewares=[middleware])
+    app.router.add_route('GET', '/', view_handler)
+    client = await aiohttp_client(app)
+    resp = await client.get('/')
+    assert 201 == resp.status
+    txt = await resp.text()
+    assert 'OK[old style middleware]' == txt
 
 
 async def test_new_style_middleware_class(loop, aiohttp_client) -> None:
     async def handler(request):
         return web.Response(body=b'OK')
 
-    @web.middleware
     class Middleware:
         async def __call__(self, request, handler):
             resp = await handler(request)
@@ -446,7 +346,6 @@ async def test_new_style_middleware_method(loop, aiohttp_client) -> None:
         return web.Response(body=b'OK')
 
     class Middleware:
-        @web.middleware
         async def call(self, request, handler):
             resp = await handler(request)
             assert 200 == resp.status

--- a/tests/test_web_middleware.py
+++ b/tests/test_web_middleware.py
@@ -1,5 +1,3 @@
-import re
-
 import pytest
 from yarl import URL
 


### PR DESCRIPTION
## Are there changes in behavior for the user?

Old style middleware will no longer work, the `@middleware` decorator still exists but is depricated.

## Related issue number

fix #3569

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."