### PR TITLE
Fix redirects with changing cookie values

### DIFF
--- a/CHANGES/3576.bugfix
+++ b/CHANGES/3576.bugfix
@@ -1,0 +1,1 @@
+Fix an issue where cookies would sometimes not be set during a redirect.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -26,6 +26,7 @@ Alexey Popravka
 Alexey Stepanov
 Amin Etesamian
 Amy Boyle
+Anders Melchiorsen
 Andrei Ursulenko
 Andrej Antonov
 Andrew Leech

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -432,7 +432,6 @@ class ClientSession:
                         if req_cookies:
                             all_cookies.load(req_cookies)
 
-
                     if proxy is not None:
                         proxy = URL(proxy)
                     elif self._trust_env:

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -423,16 +423,15 @@ class ClientSession:
                                          "with AUTH argument or credentials "
                                          "encoded in URL")
 
-                    session_cookies = self._cookie_jar.filter_cookies(url)
+                    all_cookies = self._cookie_jar.filter_cookies(url)
 
                     if cookies is not None:
                         tmp_cookie_jar = CookieJar()
                         tmp_cookie_jar.update_cookies(cookies)
                         req_cookies = tmp_cookie_jar.filter_cookies(url)
                         if req_cookies:
-                            session_cookies.load(req_cookies)
+                            all_cookies.load(req_cookies)
 
-                    cookies = session_cookies
 
                     if proxy is not None:
                         proxy = URL(proxy)
@@ -446,7 +445,7 @@ class ClientSession:
                     req = self._request_class(
                         method, url, params=params, headers=headers,
                         skip_auto_headers=skip_headers, data=data,
-                        cookies=cookies, auth=auth, version=version,
+                        cookies=all_cookies, auth=auth, version=version,
                         compress=compress, chunked=chunked,
                         expect100=expect100, loop=self._loop,
                         response_class=self._response_class,

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -1884,6 +1884,34 @@ async def test_cookies_per_request(aiohttp_client) -> None:
     resp.close()
 
 
+async def test_cookies_redirect(aiohttp_client) -> None:
+
+    async def redirect1(request):
+        ret = web.Response(status=301, headers={'Location': '/redirect2'})
+        ret.set_cookie('c', '1')
+        return ret
+
+    async def redirect2(request):
+        ret = web.Response(status=301, headers={'Location': '/'})
+        ret.set_cookie('c', '2')
+        return ret
+
+    async def handler(request):
+        assert request.cookies.keys() == {'c'}
+        assert request.cookies['c'] == '2'
+        return web.Response()
+
+    app = web.Application()
+    app.router.add_get('/redirect1', redirect1)
+    app.router.add_get('/redirect2', redirect2)
+    app.router.add_get('/', handler)
+
+    client = await aiohttp_client(app)
+    resp = await client.get('/redirect1')
+    assert 200 == resp.status
+    resp.close()
+
+
 async def test_cookies_on_empty_session_jar(aiohttp_client) -> None:
     async def handler(request):
         assert 'custom-cookie' in request.cookies


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

Fix an issue where cookies would sometimes not be set during a redirect.

When looping due to a redirect, the `cookies` variable from the previous loop would clobber the `cookies` argument introduced in #3396.

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [X] I think the code is well written
- [X] Unit tests for the changes exist
- [X] Documentation reflects the changes
- [X] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [X] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."