### PR TITLE
WIP: Change normalize_path_middleware redirect from 301 -> 308

### DIFF
--- a/CHANGES/3579.bugfix
+++ b/CHANGES/3579.bugfix
@@ -1,0 +1,4 @@
+Change normalize_path_middleware to use 308 redirect instead of 301.
+
+This behavior should prevent clients from being unable to use PUT/POST
+methods on endpoints that are redirected because of a trailing slash.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -58,6 +58,7 @@ Colin Dunklau
 Damien Nadé
 Dan Xu
 Daniel García
+Daniel Grossmann-Kavanagh
 Daniel Nelson
 Danny Song
 David Bibb

--- a/aiohttp/web_middlewares.py
+++ b/aiohttp/web_middlewares.py
@@ -1,7 +1,7 @@
 import re
 from typing import TYPE_CHECKING, Awaitable, Callable, Tuple, Type, TypeVar
 
-from .web_exceptions import HTTPMove, HTTPMovedPermanently
+from .web_exceptions import HTTPMove, HTTPPermanentRedirect
 from .web_request import Request
 from .web_response import StreamResponse
 from .web_urldispatcher import SystemRoute
@@ -42,7 +42,7 @@ _Middleware = Callable[[Request, _Handler], Awaitable[StreamResponse]]
 def normalize_path_middleware(
         *, append_slash: bool=True, remove_slash: bool=False,
         merge_slashes: bool=True,
-        redirect_class: Type[HTTPMove]=HTTPMovedPermanently) -> _Middleware:
+        redirect_class: Type[HTTPMove]=HTTPPermanentRedirect) -> _Middleware:
     """
     Middleware factory which produces a middleware that normalizes
     the path of a request. By normalizing it means:

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -2828,7 +2828,7 @@ Normalize path middleware
                                         append_slash=True, \
                                         remove_slash=False, \
                                         merge_slashes=True, \
-                                        redirect_class=HTTPMovedPermanently)
+                                        redirect_class=HTTPPermanentRedirect)
 
    Middleware factory which produces a middleware that normalizes
    the path of a request. By normalizing it means:


### PR DESCRIPTION
 Redirect path normalization with `308` `Permanent Redirect` rather than `301` `Moved Permanently`.

The default redirect class is currently HTTPMovedPermanently, which works for GET and HEAD requests, but does not work well for other HTTP methods. Clients will typically handle a `301` response by changing the verb to GET on redirect.

Related RFCs:
- RFC 2616 section-10.3.2 stated that changing the method was an implementation error
- RFC 7231 formally allowed changing the method on 301/302/303.
- RFC 7538 introduced 308 Permanent Redirect to work as 301 was originally intended.

Related aiohttp client behavior:
#3082 - clients being redirected POST -> GET (closed as wontfix)
#2134 - aiohttp client implementation of `308` `Permanent Redirect`

## Are there changes in behavior for the user?
Users will no longer lose POST data during a redirect caused by a missing trailing slash.

## Related issue number

#3578

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
