### PR TITLE
[3.5] Waiters refac (#3568)

### DIFF
--- a/aiohttp/streams.py
+++ b/aiohttp/streams.py
@@ -122,8 +122,8 @@ class StreamReader(AsyncStreamReaderMixin):
         self._buffer = collections.deque()  # type: Deque[bytes]
         self._buffer_offset = 0
         self._eof = False
-        self._waiter = None  # type: Optional[asyncio.Future[bool]]
-        self._eof_waiter = None  # type: Optional[asyncio.Future[bool]]
+        self._waiter = None  # type: Optional[asyncio.Future[None]]
+        self._eof_waiter = None  # type: Optional[asyncio.Future[None]]
         self._exception = None  # type: Optional[BaseException]
         self._timer = timer
         self._eof_callbacks = []  # type: List[Callable[[], None]]
@@ -156,8 +156,8 @@ class StreamReader(AsyncStreamReaderMixin):
 
         waiter = self._eof_waiter
         if waiter is not None:
-            set_exception(waiter, exc)
             self._eof_waiter = None
+            set_exception(waiter, exc)
 
     def on_eof(self, callback: Callable[[], None]) -> None:
         if self._eof:
@@ -174,12 +174,12 @@ class StreamReader(AsyncStreamReaderMixin):
         waiter = self._waiter
         if waiter is not None:
             self._waiter = None
-            set_result(waiter, True)
+            set_result(waiter, None)
 
         waiter = self._eof_waiter
         if waiter is not None:
             self._eof_waiter = None
-            set_result(waiter, True)
+            set_result(waiter, None)
 
         for cb in self._eof_callbacks:
             try:
@@ -240,7 +240,7 @@ class StreamReader(AsyncStreamReaderMixin):
         waiter = self._waiter
         if waiter is not None:
             self._waiter = None
-            set_result(waiter, False)
+            set_result(waiter, None)
 
         if (self._size > self._high_water and
                 not self._protocol._reading_paused):
@@ -279,7 +279,7 @@ class StreamReader(AsyncStreamReaderMixin):
         waiter = self._waiter
         if waiter is not None:
             self._waiter = None
-            set_result(waiter, False)
+            set_result(waiter, None)
 
     async def _wait(self, func_name: str) -> None:
         # StreamReader uses a future to link the protocol feed_data() method
@@ -388,31 +388,29 @@ class StreamReader(AsyncStreamReaderMixin):
         of the data corresponds to the end of a HTTP chunk , otherwise it is
         always False.
         """
-        if self._exception is not None:
-            raise self._exception
+        while True:
+            if self._exception is not None:
+                raise self._exception
 
-        if not self._buffer and not self._eof:
-            if (self._http_chunk_splits and
-                    self._cursor == self._http_chunk_splits[0]):
-                # end of http chunk without available data
-                self._http_chunk_splits = self._http_chunk_splits[1:]
-                return (b"", True)
-            await self._wait('readchunk')
-
-        if not self._buffer and not self._http_chunk_splits:
-            # end of file
-            return (b"", False)
-        elif self._http_chunk_splits is not None:
             while self._http_chunk_splits:
-                pos = self._http_chunk_splits[0]
-                self._http_chunk_splits = self._http_chunk_splits[1:]
+                pos = self._http_chunk_splits.pop(0)
                 if pos == self._cursor:
                     return (b"", True)
                 if pos > self._cursor:
                     return (self._read_nowait(pos-self._cursor), True)
-            return (self._read_nowait(-1), False)
-        else:
-            return (self._read_nowait_chunk(-1), False)
+                internal_logger.warning('Skipping HTTP chunk end due to data '
+                                        'consumption beyond chunk boundary')
+
+            if self._buffer:
+                return (self._read_nowait_chunk(-1), False)
+                # return (self._read_nowait(-1), False)
+
+            if self._eof:
+                # Special case for signifying EOF.
+                # (b'', True) is not a final return value actually.
+                return (b'', False)
+
+            await self._wait('readchunk')
 
     async def readexactly(self, n: int) -> bytes:
         if self._exception is not None:
@@ -467,6 +465,7 @@ class StreamReader(AsyncStreamReaderMixin):
         return data
 
     def _read_nowait(self, n: int) -> bytes:
+        """ Read not more than n bytes, or whole buffer is n == -1 """
         chunks = []
 
         while self._buffer:
@@ -537,7 +536,7 @@ class DataQueue(Generic[_T]):
     def __init__(self, loop: asyncio.AbstractEventLoop) -> None:
         self._loop = loop
         self._eof = False
-        self._waiter = None  # type: Optional[asyncio.Future[bool]]
+        self._waiter = None  # type: Optional[asyncio.Future[None]]
         self._exception = None  # type: Optional[BaseException]
         self._size = 0
         self._buffer = collections.deque()  # type: Deque[Tuple[_T, int]]
@@ -560,8 +559,8 @@ class DataQueue(Generic[_T]):
 
         waiter = self._waiter
         if waiter is not None:
-            set_exception(waiter, exc)
             self._waiter = None
+            set_exception(waiter, exc)
 
     def feed_data(self, data: _T, size: int=0) -> None:
         self._size += size
@@ -570,7 +569,7 @@ class DataQueue(Generic[_T]):
         waiter = self._waiter
         if waiter is not None:
             self._waiter = None
-            set_result(waiter, True)
+            set_result(waiter, None)
 
     def feed_eof(self) -> None:
         self._eof = True
@@ -578,7 +577,7 @@ class DataQueue(Generic[_T]):
         waiter = self._waiter
         if waiter is not None:
             self._waiter = None
-            set_result(waiter, False)
+            set_result(waiter, None)
 
     async def read(self) -> _T:
         if not self._buffer and not self._eof:


### PR DESCRIPTION
* 🐽 streams: change waiters return value to None

This is just a simplifaction. Actually, the value means nothing.

* 🐽 stream.readchunk() refactoring
(cherry picked from commit 36331ce)

Co-authored-by: Коренберг Марк <socketpair@gmail.com>

<!-- Thank you for your contribution! -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
