### PR TITLE
Drop the processed task from all_tasks() list early

### DIFF
--- a/CHANGES/3587.bugfix
+++ b/CHANGES/3587.bugfix
@@ -1,0 +1,1 @@
+Drop the processed task from ``all_tasks()`` list early. It prevents logging about a task with unhandled exception when the server is used in conjunction with ``asyncio.run()``.

--- a/aiohttp/web_protocol.py
+++ b/aiohttp/web_protocol.py
@@ -428,6 +428,8 @@ class RequestHandler(BaseProtocol):
                     resp = self.handle_error(request, 504)
                 except Exception as exc:
                     resp = self.handle_error(request, 500, exc)
+                # Drop the processed task from asyncio.Task.all_tasks() early
+                del task
 
                 try:
                     prepare_meth = resp.prepare


### PR DESCRIPTION
It prevents logging about a task with unhandled exception when the server is used in conjunction with `asyncio.run()`.