### PR TITLE
Use sanitized URL as Location header in redirects

### DIFF
--- a/CHANGES/3613.bugfix
+++ b/CHANGES/3613.bugfix
@@ -1,0 +1,1 @@
+Use sanitized URL as Location header in redirects

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -152,6 +152,7 @@ Mathias Fröjdman
 Matthieu Hauglustaine
 Matthieu Rigal
 Michael Ihnatenko
+Mikhail Burshteyn
 Mikhail Kashkin
 Mikhail Lukyanchenko
 Mikhail Nacharov

--- a/aiohttp/web_exceptions.py
+++ b/aiohttp/web_exceptions.py
@@ -203,8 +203,8 @@ class HTTPMove(HTTPRedirection):
             raise ValueError("HTTP redirects need a location to redirect to.")
         super().__init__(headers=headers, reason=reason,
                          text=text, content_type=content_type)
-        self.headers['Location'] = str(location)
         self._location = URL(location)
+        self.headers['Location'] = str(self.location)
 
     @property
     def location(self) -> URL:

--- a/tests/test_web_exceptions.py
+++ b/tests/test_web_exceptions.py
@@ -133,6 +133,11 @@ def test_HTTPFound_empty_location() -> None:
         web.HTTPFound(location=None)
 
 
+def test_HTTPFound_location_CRLF() -> None:
+    exc = web.HTTPFound(location='/redirect\r\n')
+    assert '\r\n' not in exc.headers['Location']
+
+
 async def test_HTTPMethodNotAllowed() -> None:
     exc = web.HTTPMethodNotAllowed('GET', ['POST', 'PUT'])
     assert 'GET' == exc.method


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

When performing HTTP redirects (e.g. using `raise HTTPFound(location)`), the URL in the Location header is now passed through `URL` constructor and thus sanitized. Most importantly, any CRLF in the location will be escaped, which will prevent [HTTP Response Splitting attacks](https://www.owasp.org/index.php/HTTP_Response_Splitting).

## Are there changes in behavior for the user?

None unless the user's code is vulnerable.

## Related issue number

None

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
