### PR TITLE
Fix backport of redirect URL fix to 3.5

### DIFF
--- a/aiohttp/web_exceptions.py
+++ b/aiohttp/web_exceptions.py
@@ -163,8 +163,8 @@ class _HTTPMove(HTTPRedirection):
             raise ValueError("HTTP redirects need a location to redirect to.")
         super().__init__(headers=headers, reason=reason,
                          body=body, text=text, content_type=content_type)
-        self.location = URL(location)
-        self.headers['Location'] = str(self.location)
+        self.headers['Location'] = str(URL(location))
+        self.location = location
 
 
 class HTTPMultipleChoices(_HTTPMove):


### PR DESCRIPTION
Fix issues after #3614 (backport of #3613 to 3.5).

`_HTTPMove.location` is again the `location` parameter unchanged, no longer unconditionally converted to `URL` (which broke a test and might be seen as breaking by the users).