### PR TITLE
Store cookies with the same name if they have different paths

### DIFF
--- a/CHANGES/3627.bugfix
+++ b/CHANGES/3627.bugfix
@@ -1,0 +1,1 @@
+Do not overwrite cookies with same name and domain when the path is different.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -108,6 +108,7 @@ Igor Pavlov
 Ingmar Steen
 Jacob Champion
 Jaesung Lee
+Jaime Velasco
 Jake Davis
 Jakob Ackermann
 Jakub Wilk

--- a/tests/test_cookiejar.py
+++ b/tests/test_cookiejar.py
@@ -597,6 +597,21 @@ class TestCookieJarSafe(TestCookieJarBase):
         # Assert that there is a cookie.
         assert len(jar) == 1
 
+    def test_duplicate_cookie_different_folder(self) -> None:
+        async def make_jar():
+            return CookieJar(unsafe=True)
+        jar = self.loop.run_until_complete(make_jar())
+        jar.update_cookies(SimpleCookie('dup="one"; Path=/one/;'))
+        jar.update_cookies(SimpleCookie('dup="two"; Path=/two/;'))
+
+        assert len(jar) == 2
+        jar.update_cookies(SimpleCookie(
+            'dup=""; Expires=Thu, 01 Jan 1970 00:00:00 GMT'))
+        assert len(jar) == 2
+        jar.update_cookies(SimpleCookie(
+            'dup=""; Path=/one/; Expires=Thu, 01 Jan 1970 00:00:00 GMT'))
+        assert len(jar) == 1
+
 
 async def test_dummy_cookie_jar() -> None:
     cookie = SimpleCookie('foo=bar; Domain=example.com;')


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Do not overwrite cookies when they have different paths, even if they have the same name and domain

## Are there changes in behavior for the user?

Without this change, if the server sets the same cookie (for example JSESSIONID) in several paths the cookie will be overwritten after each request and the session will get lost.

With this change aiohttp will do the same as browsers and store both cookies.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
