### PR TITLE
Use correct type for add_view

### DIFF
--- a/CHANGES/3633.bugfix
+++ b/CHANGES/3633.bugfix
@@ -1,0 +1,1 @@
+Use correct type for add_view and family

--- a/aiohttp/web_routedef.py
+++ b/aiohttp/web_routedef.py
@@ -10,6 +10,7 @@ from typing import (
     List,
     Optional,
     Sequence,
+    Type,
     Union,
     overload,
 )
@@ -40,7 +41,7 @@ class AbstractRouteDef(abc.ABC):
 
 
 _SimpleHandler = Callable[[Request], Awaitable[StreamResponse]]
-_HandlerType = Union[AbstractView, _SimpleHandler]
+_HandlerType = Union[Type[AbstractView], _SimpleHandler]
 
 
 @attr.s(frozen=True, repr=False, slots=True)
@@ -120,7 +121,7 @@ def delete(path: str, handler: _HandlerType, **kwargs: Any) -> RouteDef:
     return route(hdrs.METH_DELETE, path, handler, **kwargs)
 
 
-def view(path: str, handler: AbstractView, **kwargs: Any) -> RouteDef:
+def view(path: str, handler: Type[AbstractView], **kwargs: Any) -> RouteDef:
     return route(hdrs.METH_ANY, path, handler, **kwargs)
 
 

--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -27,6 +27,7 @@ from typing import (  # noqa
     Set,
     Sized,
     Tuple,
+    Type,
     Union,
     cast,
 )
@@ -123,7 +124,7 @@ class AbstractResource(Sized, Iterable['AbstractRoute']):
 class AbstractRoute(abc.ABC):
 
     def __init__(self, method: str,
-                 handler: Union[_WebHandler, AbstractView], *,
+                 handler: Union[_WebHandler, Type[AbstractView]], *,
                  expect_handler: _ExpectHandler=None,
                  resource: AbstractResource=None) -> None:
 
@@ -296,7 +297,7 @@ class Resource(AbstractResource):
         self._routes = []  # type: List[ResourceRoute]
 
     def add_route(self, method: str,
-                  handler: Union[AbstractView, _WebHandler], *,
+                  handler: Union[Type[AbstractView], _WebHandler], *,
                   expect_handler: Optional[_ExpectHandler]=None
                   ) -> 'ResourceRoute':
 
@@ -825,7 +826,7 @@ class ResourceRoute(AbstractRoute):
     """A route with resource"""
 
     def __init__(self, method: str,
-                 handler: Union[_WebHandler, AbstractView],
+                 handler: Union[_WebHandler, Type[AbstractView]],
                  resource: AbstractResource, *,
                  expect_handler: Optional[_ExpectHandler]=None) -> None:
         super().__init__(method, handler, expect_handler=expect_handler,
@@ -1025,7 +1026,7 @@ class UrlDispatcher(AbstractRouter, Mapping[str, AbstractResource]):
         return resource
 
     def add_route(self, method: str, path: str,
-                  handler: Union[_WebHandler, AbstractView],
+                  handler: Union[_WebHandler, Type[AbstractView]],
                   *, name: Optional[str]=None,
                   expect_handler: Optional[_ExpectHandler]=None
                   ) -> AbstractRoute:
@@ -1112,7 +1113,7 @@ class UrlDispatcher(AbstractRouter, Mapping[str, AbstractResource]):
         """
         return self.add_route(hdrs.METH_DELETE, path, handler, **kwargs)
 
-    def add_view(self, path: str, handler: AbstractView,
+    def add_view(self, path: str, handler: Type[AbstractView],
                  **kwargs: Any) -> AbstractRoute:
         """
         Shortcut for add_route with ANY methods for a class-based view


### PR DESCRIPTION
## What do these changes do?

They are changing the type declaration for `add_view` in router. Previously it said that it was to be `AbstractView` but that required an instance of the `AbstractView` subclass. The documentation stands for it to be the class, hence changing the typing to `Type[AbstractView]`.

## Are there changes in behavior for the user?

No more mypy errors when using `add_view` method/function.

## Related issue number

Fixes #3653

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
