### PR TITLE
Fix memory leak

### DIFF
--- a/CHANGES/3631.bugfix
+++ b/CHANGES/3631.bugfix
@@ -1,0 +1,1 @@
+Fixes issue with `StreamReader.readline` infinitely growing list `self._http_chunk_splits` when iterating over streamed POST data line by line

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -152,6 +152,7 @@ Martin Richard
 Mathias Fröjdman
 Matthieu Hauglustaine
 Matthieu Rigal
+Matthijs van der Kroon
 Michael Ihnatenko
 Mikhail Burshteyn
 Mikhail Kashkin

--- a/aiohttp/__init__.py
+++ b/aiohttp/__init__.py
@@ -14,11 +14,11 @@ from .client import (
     ClientOSError,
     ClientPayloadError,
     ClientProxyConnectionError,
-    ClientResponse,
     ClientRequest,
+    ClientResponse,
     ClientResponseError,
-    ClientSSLError,
     ClientSession,
+    ClientSSLError,
     ClientTimeout,
     ClientWebSocketResponse,
     ContentTypeError,
@@ -32,9 +32,8 @@ from .client import (
     TCPConnector,
     UnixConnector,
     WSServerHandshakeError,
-    request
+    request,
 )
-
 from .cookiejar import CookieJar, DummyCookieJar
 from .formdata import FormData
 from .helpers import BasicAuth, ChainMapProxy
@@ -42,12 +41,11 @@ from .http import (
     HttpVersion,
     HttpVersion10,
     HttpVersion11,
-    WSMsgType,
+    WebSocketError,
     WSCloseCode,
     WSMessage,
-    WebSocketError
+    WSMsgType,
 )
-
 from .multipart import (
     BadContentDispositionHeader,
     BadContentDispositionParam,
@@ -55,37 +53,32 @@ from .multipart import (
     MultipartReader,
     MultipartWriter,
     content_disposition_filename,
-    parse_content_disposition
+    parse_content_disposition,
 )
-
 from .payload import (
+    PAYLOAD_REGISTRY,
     AsyncIterablePayload,
     BufferedReaderPayload,
     BytesIOPayload,
     BytesPayload,
     IOBasePayload,
     JsonPayload,
-    PAYLOAD_REGISTRY,
     Payload,
     StringIOPayload,
     StringPayload,
     TextIOPayload,
     get_payload,
-    payload_type
+    payload_type,
 )
-
 from .resolver import AsyncResolver, DefaultResolver, ThreadedResolver
-
 from .signals import Signal
-
 from .streams import (
-    DataQueue,
     EMPTY_PAYLOAD,
+    DataQueue,
     EofStream,
     FlowControlDataQueue,
-    StreamReader
+    StreamReader,
 )
-
 from .tracing import (
     TraceConfig,
     TraceConnectionCreateEndParams,
@@ -102,7 +95,7 @@ from .tracing import (
     TraceRequestExceptionParams,
     TraceRequestRedirectParams,
     TraceRequestStartParams,
-    TraceResponseChunkReceivedParams
+    TraceResponseChunkReceivedParams,
 )
 
 __all__ = (

--- a/aiohttp/_helpers.pyi
+++ b/aiohttp/_helpers.pyi
@@ -1,5 +1,6 @@
 from typing import Any
 
+
 class reify:
     def __init__(self, wrapped: Any) -> None: ...
 

--- a/aiohttp/frozenlist.pyi
+++ b/aiohttp/frozenlist.pyi
@@ -1,5 +1,14 @@
-from typing import (Generic, Iterable, Iterator, List, MutableSequence,
-                    Optional, TypeVar, Union, overload)
+from typing import (
+    Generic,
+    Iterable,
+    Iterator,
+    List,
+    MutableSequence,
+    Optional,
+    TypeVar,
+    Union,
+    overload,
+)
 
 _T = TypeVar('_T')
 _Arg = Union[List[_T], Iterable[_T]]

--- a/aiohttp/signals.pyi
+++ b/aiohttp/signals.pyi
@@ -2,7 +2,6 @@ from typing import Any, Generic, TypeVar
 
 from aiohttp.frozenlist import FrozenList
 
-
 __all__ = ('Signal',)
 
 

--- a/aiohttp/streams.py
+++ b/aiohttp/streams.py
@@ -328,6 +328,9 @@ class StreamReader(AsyncStreamReaderMixin):
             if not_enough:
                 await self._wait('readline')
 
+        # fixes memory leak: https://github.com/aio-libs/aiohttp/issues/3631
+        self._http_chunk_splits = []
+
         return b''.join(line)
 
     async def read(self, n: int=-1) -> bytes:


### PR DESCRIPTION
## What do these changes do?

Fixes issue with `StreamReader.readline` infinitely growing list `self._http_chunk_splits` when iterating over streamed POST data line by line.

## Are there changes in behavior for the user?

None, apart from aiohttp server no longer OOMing on large POST uploads.

## Related issue number

#3631

## Checklist

- [v] I think the code is well written
- [ ] Unit tests for the changes exist
No, the `test_streams.py` (which looks like the obvious place to test this) always instantiate a `StreamReader` from scratch and perform tests on this class in isolation. I can confirm that the bug that this PR fixes does not occur in isolation and so I was not able to adjust the tests to verify the corrected behavior. In other words, the memory leak is the result of interactions with the `StreamReader` class with other aiohttp internals. Writing proper tests for this require a level of knowledge of aiohttp that is above my head. Tests also do not pass, but the failing tests already failed prior to the changes in this PR.
- [ ] Documentation reflects the changes
I don't believe this is applicable
- [v] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [v] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
