### PR TITLE
Close session on error in aiohttp.request (#3628)

### DIFF
--- a/CHANGES/3628.bugfix
+++ b/CHANGES/3628.bugfix
@@ -1,0 +1,1 @@
+Close session created inside method ``aiohttp.request`` when unhandled exception occurs

--- a/CHANGES/3628.bugfix
+++ b/CHANGES/3628.bugfix
@@ -1,1 +1,1 @@
-Close session created inside method ``aiohttp.request`` when unhandled exception occurs
+Close session created inside ``aiohttp.request`` when unhandled exception occurs

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -185,6 +185,7 @@ Rafael Viotti
 Raúl Cumplido
 Required Field
 Robert Lu
+Robert Nikolich
 Roman Podoliaka
 Samuel Colvin
 Sean Hunt

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -1020,8 +1020,12 @@ class _SessionRequestContextManager:
         self._session = session
 
     async def __aenter__(self) -> ClientResponse:
-        async with self._session:
+        try:
             self._resp = await self._coro
+        except BaseException:
+            await self._session.close()
+            raise
+        else:
             return self._resp
 
     async def __aexit__(self,
@@ -1030,6 +1034,7 @@ class _SessionRequestContextManager:
                         tb: Optional[TracebackType]) -> None:
         assert self._resp is not None
         self._resp.close()
+        await self._session.close()
 
 
 def request(

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -1020,8 +1020,9 @@ class _SessionRequestContextManager:
         self._session = session
 
     async def __aenter__(self) -> ClientResponse:
-        self._resp = await self._coro
-        return self._resp
+        async with self._session:
+            self._resp = await self._coro
+            return self._resp
 
     async def __aexit__(self,
                         exc_type: Optional[Type[BaseException]],
@@ -1029,7 +1030,6 @@ class _SessionRequestContextManager:
                         tb: Optional[TracebackType]) -> None:
         assert self._resp is not None
         self._resp.close()
-        await self._session.close()
 
 
 def request(

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -2348,6 +2348,24 @@ async def test_aiohttp_request_context_manager(aiohttp_server) -> None:
         assert resp.status == 200
 
 
+async def test_aiohttp_request_ctx_manager_close_sess_on_error(
+        ssl_ctx, aiohttp_server) -> None:
+    async def handler(request):
+        return web.Response()
+
+    app = web.Application()
+    app.router.add_get('/', handler)
+    server = await aiohttp_server(app, ssl=ssl_ctx)
+
+    cm = aiohttp.request('GET', server.make_url('/'))
+
+    with pytest.raises(aiohttp.ClientConnectionError):
+        async with cm:
+            pass
+
+    assert cm._session.closed
+
+
 async def test_aiohttp_request_ctx_manager_not_found() -> None:
 
     with pytest.raises(aiohttp.ClientConnectionError):


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

`aiohttp.request` implicitly creates `ClientSession` object and passes it to context manager, which is then returned to the caller. If exception occurs inside `__aenter__` of this context manager, session won't be closed.
I consider this PR to be a bugfix.

## Are there changes in behavior for the user?
## Related issue number

#3628 

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
