### PR TITLE
Update Resolvers description in Client reference docs

### DIFF
--- a/CHANGES/3642.doc
+++ b/CHANGES/3642.doc
@@ -1,0 +1,1 @@
+Modify documentation for Resolvers to make it clear that asynchronous resolver is not used by default when aiodns is installed.

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -862,15 +862,14 @@ TCPConnector
       If *limit* is ``0`` the connector has no limit (default: 0).
 
    :param aiohttp.abc.AbstractResolver resolver: custom resolver
-      instance to use.  ``aiohttp.DefaultResolver`` by
-      default (asynchronous if ``aiodns>=1.1`` is installed).
+      instance to use. ``aiohttp.DefaultResolver`` by default.
 
       Custom resolvers allow to resolve hostnames differently than the
       way the host is configured.
 
-      The resolver is ``aiohttp.ThreadedResolver`` by default,
-      asynchronous version is pretty robust but might fail in
-      very rare cases.
+      The resolver is ``aiohttp.ThreadedResolver`` by default. Asynchronous
+      version ``aiohttp.AsyncResolver`` (requires ``aiodns>=1.1``) is pretty
+      robust but might fail in very rare cases.
 
    :param int family: TCP socket family, both IPv4 and IPv6 by default.
                       For *IPv4* only use :const:`socket.AF_INET`,


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

From the docs it seems like asynchronous Resolver is used by default when `aiodns` is installed. It's not true since: https://github.com/aio-libs/aiohttp/commit/9fbb7d708375e0ba01d435c1e8cf41912381c0fc This change should make it clear.

## Are there changes in behavior for the user?

No.

## Related issue number

No.

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
