### PR TITLE
fix handler argument annotations

### DIFF
--- a/aiohttp/web_routedef.py
+++ b/aiohttp/web_routedef.py
@@ -10,6 +10,7 @@ from typing import (
     List,
     Optional,
     Sequence,
+    Type,
     Union,
     overload,
 )
@@ -40,7 +41,7 @@ class AbstractRouteDef(abc.ABC):
 
 
 _SimpleHandler = Callable[[Request], Awaitable[StreamResponse]]
-_HandlerType = Union[AbstractView, _SimpleHandler]
+_HandlerType = Union[Type[AbstractView], _SimpleHandler]
 
 
 @attr.s(frozen=True, repr=False, slots=True)
@@ -120,7 +121,7 @@ def delete(path: str, handler: _HandlerType, **kwargs: Any) -> RouteDef:
     return route(hdrs.METH_DELETE, path, handler, **kwargs)
 
 
-def view(path: str, handler: AbstractView, **kwargs: Any) -> RouteDef:
+def view(path: str, handler: Type[AbstractView], **kwargs: Any) -> RouteDef:
     return route(hdrs.METH_ANY, path, handler, **kwargs)
 
 

--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -27,6 +27,7 @@ from typing import (  # noqa
     Set,
     Sized,
     Tuple,
+    Type,
     Union,
     cast,
 )
@@ -123,7 +124,7 @@ class AbstractResource(Sized, Iterable['AbstractRoute']):
 class AbstractRoute(abc.ABC):
 
     def __init__(self, method: str,
-                 handler: Union[_WebHandler, AbstractView], *,
+                 handler: Union[_WebHandler, Type[AbstractView]], *,
                  expect_handler: _ExpectHandler=None,
                  resource: AbstractResource=None) -> None:
 
@@ -296,7 +297,7 @@ class Resource(AbstractResource):
         self._routes = []  # type: List[ResourceRoute]
 
     def add_route(self, method: str,
-                  handler: Union[AbstractView, _WebHandler], *,
+                  handler: Union[Type[AbstractView], _WebHandler], *,
                   expect_handler: Optional[_ExpectHandler]=None
                   ) -> 'ResourceRoute':
 
@@ -825,7 +826,7 @@ class ResourceRoute(AbstractRoute):
     """A route with resource"""
 
     def __init__(self, method: str,
-                 handler: Union[_WebHandler, AbstractView],
+                 handler: Union[_WebHandler, Type[AbstractView]],
                  resource: AbstractResource, *,
                  expect_handler: Optional[_ExpectHandler]=None) -> None:
         super().__init__(method, handler, expect_handler=expect_handler,
@@ -1025,7 +1026,7 @@ class UrlDispatcher(AbstractRouter, Mapping[str, AbstractResource]):
         return resource
 
     def add_route(self, method: str, path: str,
-                  handler: Union[_WebHandler, AbstractView],
+                  handler: Union[_WebHandler, Type[AbstractView]],
                   *, name: Optional[str]=None,
                   expect_handler: Optional[_ExpectHandler]=None
                   ) -> AbstractRoute:
@@ -1112,7 +1113,7 @@ class UrlDispatcher(AbstractRouter, Mapping[str, AbstractResource]):
         """
         return self.add_route(hdrs.METH_DELETE, path, handler, **kwargs)
 
-    def add_view(self, path: str, handler: AbstractView,
+    def add_view(self, path: str, handler: Type[AbstractView],
                  **kwargs: Any) -> AbstractRoute:
         """
         Shortcut for add_route with ANY methods for a class-based view


### PR DESCRIPTION
This pull request wants to make `handler` annotation correct.

When using Mypy to check following code,

```Python
from aiohttp import web


class MyView(web.View):
    async def get(self):
        return web.Response(text="Hello world")


app = web.Application()
app.add_routes([web.view('/', MyView)])  # line 10
web.run_app(app)
```

It will report

```
t.py:10: error: Argument 2 to "view" has incompatible type "Type[MyView]"; expected "AbstractView"                                                                                           
```

`web.view` accepts subclass of `AbstractView` type variable as `handler`, instead of an instance.

resolve #3653