### PR TITLE
fix local_addr annotation in TCPConnector.__init__

### DIFF
--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -714,7 +714,7 @@ class TCPConnector(BaseConnector):
                  use_dns_cache: bool=True, ttl_dns_cache: int=10,
                  family: int=0,
                  ssl: Union[None, bool, Fingerprint, SSLContext]=None,
-                 local_addr: Optional[str]=None,
+                 local_addr: Optional[Tuple[str, int]]=None,
                  resolver: Optional[AbstractResolver]=None,
                  keepalive_timeout: Union[None, float, object]=sentinel,
                  force_close: bool=False,


### PR DESCRIPTION
From the [doc](https://docs.aiohttp.org/en/stable/client_reference.html#tcpconnector)

- local_addr (tuple) – tuple of `(local_host, local_port)` used to bind socket locally if specified.

resolve #3639