### PR TITLE
Suppress pytest warnings due to test util classes

### DIFF
--- a/CHANGES/3660.bugfix
+++ b/CHANGES/3660.bugfix
@@ -1,0 +1,1 @@
+Suppress pytest warnings due to test util classes

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -56,6 +56,7 @@ Chris Moore
 Christopher Schmitt
 Claudiu Popa
 Colin Dunklau
+Cong Xu
 Damien Nadé
 Dan Xu
 Daniel García

--- a/aiohttp/test_utils.py
+++ b/aiohttp/test_utils.py
@@ -74,6 +74,8 @@ def unused_port() -> int:
 
 
 class BaseTestServer(ABC):
+    __test__ = False
+
     def __init__(self,
                  *,
                  scheme: Union[str, object]=sentinel,
@@ -230,6 +232,7 @@ class TestClient:
     To write functional tests for aiohttp based servers.
 
     """
+    __test__ = False
 
     def __init__(self, server: BaseTestServer, *,
                  cookie_jar: Optional[AbstractCookieJar]=None,


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

We are using pytest; by default it collects tests in:
- files that are named `test_*.py`
- classes that are named `Test*`

Unfortunately this matches the `TestServer`/`TestClient` classes in aiohttp. Since they have `__init__()` methods they won't break tests, but there will be warnings:

```
<path>/site-packages/aiohttp/test_utils.py:128
  <path>/site-packages/aiohttp/test_utils.py:128: PytestWarning: cannot collect test class 'TestServer' because it has a __init__ constructor
    class TestServer(BaseTestServer):

<path>/site-packages/aiohttp/test_utils.py:152
  <path>/site-packages/aiohttp/test_utils.py:152: PytestWarning: cannot collect test class 'TestClient' because it has a __init__ constructor
    class TestClient:

-- Docs: https://docs.pytest.org/en/latest/warnings.html
```

The easiest way would be to exclude these tests from pytest collection via `__test__ = False`. See https://stackoverflow.com/q/24614851/2038264

## Are there changes in behavior for the user?

N/A

## Related issue number

N/A

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
