### PR TITLE
Replaced 'URL' with 'StrOrURL'

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -106,6 +106,7 @@ Igor Davydenko
 Igor Mozharovsky
 Igor Pavlov
 Ingmar Steen
+Ivan Tung
 Jacob Champion
 Jaesung Lee
 Jake Davis

--- a/aiohttp/abc.py
+++ b/aiohttp/abc.py
@@ -20,7 +20,7 @@ from multidict import CIMultiDict  # noqa
 from yarl import URL
 
 from .helpers import get_running_loop
-from .typedefs import LooseCookies
+from .typedefs import LooseCookies, StrOrURL
 
 if TYPE_CHECKING:  # pragma: no cover
     from .web_request import BaseRequest, Request
@@ -156,7 +156,7 @@ class AbstractCookieJar(Sized, IterableBase):
         """Update cookies."""
 
     @abstractmethod
-    def filter_cookies(self, request_url: URL) -> 'BaseCookie[str]':
+    def filter_cookies(self, request_url: StrOrURL) -> 'BaseCookie[str]':
         """Return the jar's cookies filtered by their attributes."""
 
 

--- a/aiohttp/cookiejar.py
+++ b/aiohttp/cookiejar.py
@@ -24,7 +24,7 @@ from yarl import URL
 
 from .abc import AbstractCookieJar
 from .helpers import is_ip_address
-from .typedefs import LooseCookies, PathLike
+from .typedefs import LooseCookies, PathLike, StrOrURL
 
 __all__ = ('CookieJar', 'DummyCookieJar')
 
@@ -185,7 +185,7 @@ class CookieJar(AbstractCookieJar):
 
         self._do_expiration()
 
-    def filter_cookies(self, request_url: URL=URL()) -> 'BaseCookie[str]':
+    def filter_cookies(self, request_url: StrOrURL=URL()) -> 'BaseCookie[str]':
         """Returns this jar's cookies filtered by their attributes."""
         self._do_expiration()
         request_url = URL(request_url)
@@ -353,5 +353,5 @@ class DummyCookieJar(AbstractCookieJar):
                        response_url: URL=URL()) -> None:
         pass
 
-    def filter_cookies(self, request_url: URL) -> 'BaseCookie[str]':
+    def filter_cookies(self, request_url: StrOrURL) -> 'BaseCookie[str]':
         return SimpleCookie()


### PR DESCRIPTION
filter_cookies() can already accept strings as shown in https://docs.aiohttp.org/en/stable/client_advanced.html#custom-cookies. However, its typing does not reflect that.

## What do these changes do?

Users can use string URLs in filter_cookies() without the linter bothering them about the type.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."