### PR TITLE
Fix graceful shutdown

### DIFF
--- a/CHANGES/3638.bugfix
+++ b/CHANGES/3638.bugfix
@@ -1,0 +1,2 @@
+Fix dropped connections on graceful shutdown
+This fixes a bug introduced in dd30b2af1fd0d643e02ef5023f1d8a68a75b5301

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -25,6 +25,7 @@ Alexey Firsov
 Alexey Popravka
 Alexey Stepanov
 Amin Etesamian
+Amit BL
 Amy Boyle
 Anders Melchiorsen
 Andrei Ursulenko

--- a/aiohttp/web.py
+++ b/aiohttp/web.py
@@ -105,7 +105,7 @@ from .web_runner import (
     AppRunner,
     BaseRunner,
     BaseSite,
-    GracefulExit,
+    ForceExit,
     ServerRunner,
     SockSite,
     TCPSite,
@@ -225,7 +225,7 @@ __all__ = (
     'AppRunner',
     'BaseRunner',
     'BaseSite',
-    'GracefulExit',
+    'ForceExit',
     'ServerRunner',
     'SockSite',
     'TCPSite',
@@ -344,8 +344,8 @@ async def _run_app(app: Union[Application, Awaitable[Application]], *,
             names = sorted(str(s.name) for s in runner.sites)
             print("======== Running on {} ========\n"
                   "(Press CTRL+C to quit)".format(', '.join(names)))
-        while True:
-            await asyncio.sleep(3600)  # sleep forever by 1 hour intervals
+
+        await runner.wait_for_close()
     finally:
         await runner.cleanup()
 
@@ -413,7 +413,7 @@ def run_app(app: Union[Application, Awaitable[Application]], *,
                                          handle_signals=handle_signals,
                                          reuse_address=reuse_address,
                                          reuse_port=reuse_port))
-    except (GracefulExit, KeyboardInterrupt):  # pragma: no cover
+    except (ForceExit, KeyboardInterrupt):  # pragma: no cover
         pass
     finally:
         _cancel_all_tasks(loop)

--- a/aiohttp/web_runner.py
+++ b/aiohttp/web_runner.py
@@ -207,8 +207,10 @@ class BaseRunner(ABC):
 
     async def wait_for_close(self) -> None:
         if self._close_event is None:
-            raise RuntimeError("Signal handling is not enabled")
-        await self._close_event.wait()
+            while True:
+                await asyncio.sleep(3600)
+        else:
+            await self._close_event.wait()
 
     async def cleanup(self) -> None:
         loop = asyncio.get_event_loop()

--- a/aiohttp/web_runner.py
+++ b/aiohttp/web_runner.py
@@ -161,14 +161,14 @@ class SockSite(BaseSite):
 
 
 class BaseRunner(ABC):
-    __slots__ = ('_handle_signals', '_kwargs', '_server', '_sites', '_close_event')
+    __slots__ = ('_handle_signals', '_kwargs', '_server', '_sites',
+                 '_close_event')
 
     def __init__(self, *, handle_signals: bool=False, **kwargs: Any) -> None:
         self._handle_signals = handle_signals
         self._kwargs = kwargs
         self._server = None  # type: Optional[Server]
         self._sites = []  # type: List[BaseSite]
-        self._close_event = asyncio.Event()
 
     @property
     def server(self) -> Optional[Server]:
@@ -195,6 +195,7 @@ class BaseRunner(ABC):
 
         if self._handle_signals:
             try:
+                self._close_event = asyncio.Event()
                 loop.add_signal_handler(signal.SIGINT, self.close)
                 loop.add_signal_handler(signal.SIGTERM, self.close)
             except NotImplementedError:  # pragma: no cover


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

Graceful shutdown not working properly since commit https://github.com/aio-libs/aiohttp/commit/dd30b2af1fd0d643e02ef5023f1d8a68a75b5301
When a long running request is in progress, and the server is being gracefully closed, all handlers are  immediately stopped the client receive a empty response.

These changes make the server stop accepting new connections, process existing ones properly and then exit.

## Are there changes in behavior for the user?

On first SIGINT/SIGTERM the server will try to gracefully close all handlers and quit.
If for some reason a handler is stuck, sending a second SIGINT/SIGTERM will force the server to quit immediately 

<!-- Outline any notable behaviour for the end users. -->

## Related issue number

#3638 
<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [X] I think the code is well written
- [X] Unit tests for the changes exist
- [X] Documentation reflects the changes
- [X] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [X] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
