### PR TITLE
Fix streamed chunk iterator ending (#3676)

### DIFF
--- a/CHANGES/3676.bugfix
+++ b/CHANGES/3676.bugfix
@@ -1,0 +1,1 @@
+Stop iterating over chunk when last chunk reading provided the end flag.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -163,6 +163,7 @@ Morgan Delahaye-Prat
 Moss Collum
 Mun Gwan-gyeong
 Nicolas Braem
+Nicolas Chapurlat
 Nikolay Kim
 Nikolay Novik
 Oisin Aylward

--- a/aiohttp/streams.py
+++ b/aiohttp/streams.py
@@ -49,14 +49,16 @@ class ChunkTupleAsyncStreamIterator:
 
     def __init__(self, stream: 'StreamReader') -> None:
         self._stream = stream
+        self._hasnext = True
 
     def __aiter__(self) -> 'ChunkTupleAsyncStreamIterator':
         return self
 
     async def __anext__(self) -> Tuple[bytes, bool]:
-        rv = await self._stream.readchunk()
-        if rv == (b'', False):
-            raise StopAsyncIteration  # NOQA
+        if self._hasnext:
+            raise StopAsyncIteration  # NOQA            
+        (rv, end) = await self._stream.readchunk()
+        self._hasnext = not end
         return rv
 
 


### PR DESCRIPTION
Stop iterating over chunk when last chunk reading provided the end flag.