### PR TITLE
Clarify client does not support pipelining in docs

### DIFF
--- a/CHANGES/3310.bugfix
+++ b/CHANGES/3310.bugfix
@@ -1,0 +1,1 @@
+Docs clarification that aiohttp client does not support HTTP Pipelining.

--- a/docs/client_advanced.rst
+++ b/docs/client_advanced.rst
@@ -569,3 +569,8 @@ are changed so that aiohttp itself can wait on the underlying
 connection to close. Please follow issue `#1925
 <https://github.com/aio-libs/aiohttp/issues/1925>`_ for the progress
 on this.
+
+HTTP Pipelining
+---------------
+
+aiohttp does not support HTTP/HTTPS pipelining.


### PR DESCRIPTION
I was confused on the feature set, and I would have benefitted from a
docs clarification like this one.

## What do these changes do?

clarify the docs on the pipelining feature set for aiohttp client

## Are there changes in behavior for the user?

No

## Related issue number

https://github.com/aio-libs/aiohttp/issues/3310

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
