### PR TITLE
handle ConnectionResetError, closes #3648

### DIFF
--- a/CHANGES/3648.bugfix
+++ b/CHANGES/3648.bugfix
@@ -1,0 +1,2 @@
+Properly handle ConnectionResetError, to silence the "Cannot write to closing
+transport" exception when clients disconnect uncleanly.

--- a/aiohttp/web_protocol.py
+++ b/aiohttp/web_protocol.py
@@ -439,8 +439,12 @@ class RequestHandler(BaseProtocol):
                         raise RuntimeError("Web-handler should return "
                                            "a response instance, "
                                            "got {!r}".format(resp))
-                await prepare_meth(request)
-                await resp.write_eof()
+                try:
+                    await prepare_meth(request)
+                    await resp.write_eof()
+                except ConnectionResetError:
+                    self.log_debug('Ignored premature client disconnection 2')
+                    break
 
                 # notify server about keep-alive
                 self._keepalive = bool(resp.keep_alive)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Ignore `ConnectionResetError` during web server handler prepare/eof.

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?
no

## Related issue number

#3648 

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
