### PR TITLE
Fix overshadowing of overlapped subapp prefixes (#3701).

### DIFF
--- a/CHANGES/3701.bugfix
+++ b/CHANGES/3701.bugfix
@@ -1,0 +1,1 @@
+Fix overshadowing of overlapped subbaps prefixes.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -84,6 +84,7 @@ Eric Sheng
 Erich Healy
 Eugene Chernyshov
 Eugene Naydenov
+Eugene Nikolaiev
 Eugene Tolmachev
 Evert Lammerts
 FichteFoll

--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -698,7 +698,8 @@ class PrefixedSubAppResource(PrefixResource):
                 'prefix': self._prefix}
 
     async def resolve(self, request: Request) -> _Resolve:
-        if not request.url.raw_path.startswith(self._prefix):
+        if not request.url.raw_path.startswith(self._prefix + '/') and \
+                request.url.raw_path != self._prefix:
             return None, set()
         match_info = await self._app.router.resolve(request)
         match_info.add_app(self._app)

--- a/tests/test_urldispatch.py
+++ b/tests/test_urldispatch.py
@@ -1246,3 +1246,47 @@ def test_prefixed_subapp_resource_canonical(app) -> None:
     subapp = web.Application()
     res = subapp.add_subapp(canonical, subapp)
     assert res.canonical == canonical
+
+
+async def test_prefixed_subapp_overlap(app) -> None:
+    """
+    Subapp should not overshadow other subapps with overlapping prefixes
+    """
+    subapp1 = web.Application()
+    handler1 = make_handler()
+    subapp1.router.add_get('/a', handler1)
+    app.add_subapp('/s', subapp1)
+
+    subapp2 = web.Application()
+    handler2 = make_handler()
+    subapp2.router.add_get('/b', handler2)
+    app.add_subapp('/ss', subapp2)
+
+    match_info = await app.router.resolve(make_mocked_request('GET', '/s/a'))
+    assert match_info.route.handler is handler1
+    match_info = await app.router.resolve(make_mocked_request('GET', '/ss/b'))
+    assert match_info.route.handler is handler2
+
+
+async def test_prefixed_subapp_empty_route(app) -> None:
+    subapp = web.Application()
+    handler = make_handler()
+    subapp.router.add_get('', handler)
+    app.add_subapp('/s', subapp)
+
+    match_info = await app.router.resolve(make_mocked_request('GET', '/s'))
+    assert match_info.route.handler is handler
+    match_info = await app.router.resolve(make_mocked_request('GET', '/s/'))
+    assert "<MatchInfoError 404: Not Found>" == repr(match_info)
+
+
+async def test_prefixed_subapp_root_route(app) -> None:
+    subapp = web.Application()
+    handler = make_handler()
+    subapp.router.add_get('/', handler)
+    app.add_subapp('/s', subapp)
+
+    match_info = await app.router.resolve(make_mocked_request('GET', '/s/'))
+    assert match_info.route.handler is handler
+    match_info = await app.router.resolve(make_mocked_request('GET', '/s'))
+    assert "<MatchInfoError 404: Not Found>" == repr(match_info)


### PR DESCRIPTION
## What do these changes do?

Fix for issue #3701 - overshadowing of overlapped subapp prefixes.

The fix allows different subapps to have prefixes with overlapping beginning. The following didn't work properly before - the second subapp prefix was hidden by the first one as subapp prefixes matching was performed by `startswith` only, so the first added app won:
```
    app.add_subapp('/qwe/', create_subapp01())
    app.add_subapp('/qwerty/', create_subapp02())
```

## Are there changes in behavior for the user?

Subapps with overlapping prefixes can now be used without unexpected overshadowing.

## Related issue number

#3701

## Notes

+ I have considered storing the value of `self._prefix + '/'` in an attribute for optimization but was not sure to do that because it adds complexity. Please let me know if such optimization is desired - I can dig further.

+ Without adding `request.url.raw_path != self._prefix` to the comparison the existing behavior of matching empty and root subapp routes would have changed. That didn't break any existing test though, so I have added 2 more tests to make sure this works as before - `test_urldispatch.py/test_prefixed_subapp_empty_route` and `test_urldispatch.py/test_prefixed_subapp_root_route`

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes.
_Please let me know if any documentation change is required._
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
- [x] Add a new news fragment into the `CHANGES` folder
 