### PR TITLE
Document that ClientRequest.request et al.'s data parameter also accepts a list or tuple of lists or tuples of length two

### DIFF
--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -265,8 +265,8 @@ The client session supports the context manager protocol for self closing.
                      - :class:`str` with preferably url-encoded content
                        (**Warning:** content will not be encoded by *aiohttp*)
 
-      :param data: Dictionary, bytes, or file-like object to
-                   send in the body of the request (optional)
+      :param data: Dictionary, list/tuple of lists/tuples of length two, bytes, or
+                   file-like object to send in the body of the request (optional)
 
       :param json: Any json compatible python object
                    (optional). *json* and *data* parameters could not
@@ -399,8 +399,8 @@ The client session supports the context manager protocol for self closing.
 
       :param url: Request URL, :class:`str` or :class:`~yarl.URL`
 
-      :param data: Dictionary, bytes, or file-like object to
-                   send in the body of the request (optional)
+      :param data: Dictionary, list/tuple of lists/tuples of length two, bytes, or
+                   file-like object to send in the body of the request (optional)
 
       :return ClientResponse: a :class:`client response
                               <ClientResponse>` object.
@@ -418,8 +418,8 @@ The client session supports the context manager protocol for self closing.
 
       :param url: Request URL, :class:`str` or :class:`~yarl.URL`
 
-      :param data: Dictionary, bytes, or file-like object to
-                   send in the body of the request (optional)
+      :param data: Dictionary, list/tuple of lists/tuples of length two, bytes, or
+                   file-like object to send in the body of the request (optional)
 
       :return ClientResponse: a :class:`client response
                               <ClientResponse>` object.
@@ -488,8 +488,8 @@ The client session supports the context manager protocol for self closing.
 
       :param url: Request URL, :class:`str` or :class:`~yarl.URL`
 
-      :param data: Dictionary, bytes, or file-like object to
-                   send in the body of the request (optional)
+      :param data: Dictionary, list/tuple of lists/tuples of length two, bytes, or
+                   file-like object to send in the body of the request (optional)
 
 
       :return ClientResponse: a :class:`client response
@@ -630,8 +630,8 @@ certification chaining.
    :param dict params: Parameters to be sent in the query
                        string of the new request (optional)
 
-   :param data: Dictionary, bytes, or file-like object to
-                send in the body of the request (optional)
+   :param data: Dictionary, list/tuple of lists/tuples of length two, bytes, or
+                file-like object to send in the body of the request (optional)
 
    :param json: Any json compatible python object (optional). *json* and *data*
                 parameters could not be used at the same time.


### PR DESCRIPTION
## What do these changes do?

In addition to a dictionary, `aiohttp.formdata.FormData` also accepts a list or a tuple containing lists or tuples of length two, e.g. `session.request(..., data = (('key', 'value'), ('foo', 'bar')), ...)`. This can be used to enforce a particular order of the fields, which is not guaranteed with dictionaries (although you could use `collections.OrderedDict`). However, this usage was so-far undocumented.

## Are there changes in behavior for the user?

No.

## Related issue number

None.

## Checklist

(Only a change in documentation, so none of these are relevant.)

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
