### PR TITLE
Add the missing TestClient.scheme property

### DIFF
--- a/CHANGES/3721.bugfix
+++ b/CHANGES/3721.bugfix
@@ -1,0 +1,1 @@
+Add the missing `TestClient.scheme` property.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -79,6 +79,7 @@ Dustin J. Mitchell
 Eduard Iskandarov
 Eli Ribble
 Elizabeth Leddy
+Emil Melnikov
 Enrique Saez
 Eric Sheng
 Erich Healy

--- a/aiohttp/test_utils.py
+++ b/aiohttp/test_utils.py
@@ -253,6 +253,10 @@ class TestClient:
         await self._server.start_server(loop=self._loop)
 
     @property
+    def scheme(self) -> Union[str, object]:
+        return self._server.scheme
+
+    @property
     def host(self) -> str:
         return self._server.host
 

--- a/tests/test_test_utils.py
+++ b/tests/test_test_utils.py
@@ -217,8 +217,9 @@ def test_make_mocked_request_transport() -> None:
 
 async def test_test_client_props(loop) -> None:
     app = _create_example_app()
-    client = _TestClient(_TestServer(app, host='127.0.0.1', loop=loop),
-                         loop=loop)
+    server = _TestServer(app, scheme='http', host='127.0.0.1', loop=loop)
+    client = _TestClient(server, loop=loop)
+    assert client.scheme == 'http'
     assert client.host == '127.0.0.1'
     assert client.port is None
     async with client:
@@ -233,8 +234,9 @@ async def test_test_client_raw_server_props(loop) -> None:
     async def hello(request):
         return web.Response(body=_hello_world_bytes)
 
-    client = _TestClient(_RawTestServer(hello, host='127.0.0.1', loop=loop),
-                         loop=loop)
+    server = _RawTestServer(hello, scheme='http', host='127.0.0.1', loop=loop)
+    client = _TestClient(server, loop=loop)
+    assert client.scheme == 'http'
     assert client.host == '127.0.0.1'
     assert client.port is None
     async with client:


### PR DESCRIPTION
## What do these changes do?

Add the missing `TestClient.scheme` property that is mentioned in the [testing documentation](https://docs.aiohttp.org/en/latest/testing.html#aiohttp.test_utils.TestClient.scheme) but has not been implemented.

## Are there changes in behavior for the user?

Users can access the `scheme` property of the test client:
```python
async def test_spam(aiohttp_client):
    client = aiohttp_client(my_app_factory())
    assert client.scheme == 'http'
```

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
