### PR TITLE
Fix ctrl+c on windows

### DIFF
--- a/CHANGES/3725.bugfix
+++ b/CHANGES/3725.bugfix
@@ -1,0 +1,1 @@
+Fix killing server with ctrl+c on windows.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -153,6 +153,7 @@ Martin Richard
 Mathias Fröjdman
 Matthieu Hauglustaine
 Matthieu Rigal
+Michael Himing
 Michael Ihnatenko
 Mikhail Burshteyn
 Mikhail Kashkin

--- a/aiohttp/web.py
+++ b/aiohttp/web.py
@@ -345,7 +345,7 @@ async def _run_app(app: Union[Application, Awaitable[Application]], *,
             print("======== Running on {} ========\n"
                   "(Press CTRL+C to quit)".format(', '.join(names)))
         while True:
-            await asyncio.sleep(3600)  # sleep forever by 1 hour intervals
+            await asyncio.sleep(1)  # sleep forever by 1 second intervals
     finally:
         await runner.cleanup()
 


### PR DESCRIPTION
## What do these changes do?

When trying to kill the `web.run_app` server on windows with ctrl+c, it hangs until something else, for example a network request, wakes up the event loop. With this change it should stop within one second.

## Are there changes in behavior for the user?

No

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
