### PR TITLE
Fix issue #3644: PY38: web_protocol.RequestHandler mismatch _keepalive field with __slots__

### DIFF
--- a/CHANGES/3644.bugfix
+++ b/CHANGES/3644.bugfix
@@ -1,0 +1,1 @@
+Fix _keepalive field in __slots__ of web_protocol.RequestHandler.

--- a/aiohttp/web_protocol.py
+++ b/aiohttp/web_protocol.py
@@ -106,7 +106,7 @@ class RequestHandler(BaseProtocol):
     """
     KEEPALIVE_RESCHEDULE_DELAY = 1
 
-    __slots__ = ('_request_count', '_keep_alive', '_manager',
+    __slots__ = ('_request_count', '_keepalive', '_manager',
                  '_request_handler', '_request_factory', '_tcp_keepalive',
                  '_keepalive_time', '_keepalive_handle', '_keepalive_timeout',
                  '_lingering_time', '_messages', '_message_tail',


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Fix issue https://github.com/aio-libs/aiohttp/issues/3644

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

No, only fixes work on Python 3.8
<!-- Outline any notable behaviour for the end users. -->

## Related issue number
https://github.com/aio-libs/aiohttp/issues/3644
<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
  * will be checked by CI tests on Python 3.8 (to-do)
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
