### PR TITLE
Drop deprecated lowercase fields of WsMsgType

### DIFF
--- a/CHANGES/2835.removal
+++ b/CHANGES/2835.removal
@@ -1,0 +1,1 @@
+Drop lowercased enum items of ``WSMsgType`` (text, binary, ...), use uppercased items instead (TEXT, BINARY, ...).

--- a/aiohttp/http_websocket.py
+++ b/aiohttp/http_websocket.py
@@ -52,15 +52,6 @@ class WSMsgType(IntEnum):
     CLOSED = 0x101
     ERROR = 0x102
 
-    text = TEXT
-    binary = BINARY
-    ping = PING
-    pong = PONG
-    close = CLOSE
-    closing = CLOSING
-    closed = CLOSED
-    error = ERROR
-
 
 WS_KEY = b'258EAFA5-E914-47DA-95CA-C5AB0DC85B11'
 

--- a/examples/server_simple.py
+++ b/examples/server_simple.py
@@ -13,11 +13,11 @@ async def wshandle(request):
     await ws.prepare(request)
 
     async for msg in ws:
-        if msg.type == web.WSMsgType.text:
+        if msg.type == web.WSMsgType.TEXT:
             await ws.send_str("Hello, {}".format(msg.data))
-        elif msg.type == web.WSMsgType.binary:
+        elif msg.type == web.WSMsgType.BINARY:
             await ws.send_bytes(msg.data)
-        elif msg.type == web.WSMsgType.close:
+        elif msg.type == web.WSMsgType.CLOSE:
             break
 
     return ws

--- a/tests/autobahn/client.py
+++ b/tests/autobahn/client.py
@@ -18,11 +18,11 @@ async def client(loop, url, name):
         while True:
             msg = await ws.receive()
 
-            if msg.type == aiohttp.WSMsgType.text:
+            if msg.type == aiohttp.WSMsgType.TEXT:
                 await ws.send_str(msg.data)
-            elif msg.type == aiohttp.WSMsgType.binary:
+            elif msg.type == aiohttp.WSMsgType.BINARY:
                 await ws.send_bytes(msg.data)
-            elif msg.type == aiohttp.WSMsgType.close:
+            elif msg.type == aiohttp.WSMsgType.CLOSE:
                 await ws.close()
                 break
             else:

--- a/tests/autobahn/server.py
+++ b/tests/autobahn/server.py
@@ -17,11 +17,11 @@ async def wshandler(request):
     while True:
         msg = await ws.receive()
 
-        if msg.type == web.WSMsgType.text:
+        if msg.type == web.WSMsgType.TEXT:
             await ws.send_str(msg.data)
-        elif msg.type == web.WSMsgType.binary:
+        elif msg.type == web.WSMsgType.BINARY:
             await ws.send_bytes(msg.data)
-        elif msg.type == web.WSMsgType.close:
+        elif msg.type == web.WSMsgType.CLOSE:
             await ws.close()
             break
         else:

--- a/tests/test_client_ws_functional.py
+++ b/tests/test_client_ws_functional.py
@@ -535,7 +535,7 @@ async def test_heartbeat(aiohttp_client, ceil) -> None:
         ws = web.WebSocketResponse(autoping=False)
         await ws.prepare(request)
         msg = await ws.receive()
-        if msg.type == aiohttp.WSMsgType.ping:
+        if msg.type == aiohttp.WSMsgType.PING:
             ping_received = True
         await ws.close()
         return ws
@@ -560,7 +560,7 @@ async def test_heartbeat_no_pong(aiohttp_client, ceil) -> None:
         ws = web.WebSocketResponse(autoping=False)
         await ws.prepare(request)
         msg = await ws.receive()
-        if msg.type == aiohttp.WSMsgType.ping:
+        if msg.type == aiohttp.WSMsgType.PING:
             ping_received = True
         await ws.receive()
         return ws

--- a/tests/test_web_websocket_functional.py
+++ b/tests/test_web_websocket_functional.py
@@ -659,7 +659,7 @@ async def test_heartbeat(loop, aiohttp_client, ceil) -> None:
     ws = await client.ws_connect('/', autoping=False)
     msg = await ws.receive()
 
-    assert msg.type == aiohttp.WSMsgType.ping
+    assert msg.type == aiohttp.WSMsgType.PING
 
     await ws.close()
 
@@ -686,7 +686,7 @@ async def test_heartbeat_no_pong(loop, aiohttp_client, ceil) -> None:
     client = await aiohttp_client(app)
     ws = await client.ws_connect('/', autoping=False)
     msg = await ws.receive()
-    assert msg.type == aiohttp.WSMsgType.ping
+    assert msg.type == aiohttp.WSMsgType.PING
     await ws.receive()
 
     assert cancelled

--- a/tests/test_websocket_parser.py
+++ b/tests/test_websocket_parser.py
@@ -412,16 +412,6 @@ def test_websocket_mask_cython_empty() -> None:
     assert message == bytearray()
 
 
-def test_msgtype_aliases() -> None:
-    assert aiohttp.WSMsgType.TEXT == aiohttp.WSMsgType.text
-    assert aiohttp.WSMsgType.BINARY == aiohttp.WSMsgType.binary
-    assert aiohttp.WSMsgType.PING == aiohttp.WSMsgType.ping
-    assert aiohttp.WSMsgType.PONG == aiohttp.WSMsgType.pong
-    assert aiohttp.WSMsgType.CLOSE == aiohttp.WSMsgType.close
-    assert aiohttp.WSMsgType.CLOSED == aiohttp.WSMsgType.closed
-    assert aiohttp.WSMsgType.ERROR == aiohttp.WSMsgType.error
-
-
 def test_parse_compress_frame_single(parser) -> None:
     parser.parse_frame(struct.pack('!BB', 0b11000001, 0b00000001))
     res = parser.parse_frame(b'1')


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
Drop lower-cased attrs in WSMsgType enum
## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?
Yes: lower-cased attrs in WSMsgType enum are not supported anymore.
<!-- Outline any notable behaviour for the end users. -->

## Related issue number
https://github.com/aio-libs/aiohttp/issues/2835
<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
