### PR TITLE
[3.5] Fix issue #3644: PY38: web_protocol.RequestHandler mismatch _keepalive field with __slots__ (#3727)

### DIFF
--- a/CHANGES/3644.bugfix
+++ b/CHANGES/3644.bugfix
@@ -1,0 +1,1 @@
+Fix _keepalive field in __slots__ of web_protocol.RequestHandler.

--- a/aiohttp/web_protocol.py
+++ b/aiohttp/web_protocol.py
@@ -107,7 +107,7 @@ class RequestHandler(BaseProtocol):
     """
     KEEPALIVE_RESCHEDULE_DELAY = 1
 
-    __slots__ = ('_request_count', '_keep_alive', '_manager',
+    __slots__ = ('_request_count', '_keepalive', '_manager',
                  '_request_handler', '_request_factory', '_tcp_keepalive',
                  '_keepalive_time', '_keepalive_handle', '_keepalive_timeout',
                  '_lingering_time', '_messages', '_message_tail',


### PR DESCRIPTION
(cherry picked from commit bfb99eb9)

Co-authored-by: Artem Yushkovskiy <artem.yushkovskiy@neuromation.io>
