### PR TITLE
Drop test on raising `ClientConnectionError` when requesting a host with wrong DNS name

### DIFF
--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -2348,13 +2348,6 @@ async def test_aiohttp_request_context_manager(aiohttp_server) -> None:
         assert resp.status == 200
 
 
-async def test_aiohttp_request_ctx_manager_not_found() -> None:
-
-    with pytest.raises(aiohttp.ClientConnectionError):
-        async with aiohttp.request('GET', 'http://wrong-dns-name.com'):
-            assert False, "never executed"  # pragma: no cover
-
-
 async def test_aiohttp_request_coroutine(aiohttp_server) -> None:
     async def handler(request):
         return web.Response()


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?
Drop test `test_aiohttp_request_ctx_manager_not_found` because sometimes this test flakes. Anyways, this functionality is covered in other tests, for example `test_request_conn_error`.

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?
Nope
<!-- Outline any notable behaviour for the end users. -->

## Related issue number
no issue sorry 
<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
