### PR TITLE
Fix tests that don't throw `DeprecationWarning`

### DIFF
--- a/tests/test_client_session.py
+++ b/tests/test_client_session.py
@@ -16,7 +16,7 @@ from aiohttp import client, hdrs, web
 from aiohttp.client import ClientSession
 from aiohttp.client_reqrep import ClientRequest
 from aiohttp.connector import BaseConnector, TCPConnector
-from aiohttp.helpers import DEBUG, PY_36
+from aiohttp.helpers import PY_36
 
 
 @pytest.fixture

--- a/tests/test_client_session.py
+++ b/tests/test_client_session.py
@@ -663,11 +663,9 @@ def test_client_session_inheritance() -> None:
             pass
 
 
-@pytest.mark.skipif(not DEBUG,
-                    reason="The check is applied in DEBUG mode only")
 async def test_client_session_custom_attr(loop) -> None:
     session = ClientSession(loop=loop)
-    with pytest.warns(DeprecationWarning):
+    with pytest.raises(AttributeError):
         session.custom = None
 
 

--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -6,7 +6,7 @@ from async_generator import async_generator, yield_
 
 from aiohttp import log, web
 from aiohttp.abc import AbstractAccessLogger
-from aiohttp.helpers import DEBUG, PY_36
+from aiohttp.helpers import PY_36
 from aiohttp.test_utils import make_mocked_coro
 
 

--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -280,11 +280,9 @@ def test_app_inheritance() -> None:
             pass
 
 
-@pytest.mark.skipif(not DEBUG,
-                    reason="The check is applied in DEBUG mode only")
 def test_app_custom_attr() -> None:
     app = web.Application()
-    with pytest.warns(DeprecationWarning):
+    with pytest.raises(AttributeError):
         app.custom = None
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
Fixed two old tests that assert throwing `DeprecationWarning` whereas in fact the `AttributeError` is raised. These tests start to be wrong since the `RequestHandler.__slots__` were implemented (see https://github.com/aio-libs/aiohttp/pull/3095).
## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
