### PR TITLE
Drop setup.py test support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -83,16 +83,6 @@ def read(f):
     return (here / f).read_text('utf-8').strip()
 
 
-NEEDS_PYTEST = {'pytest', 'test'}.intersection(sys.argv)
-pytest_runner = ['pytest-runner'] if NEEDS_PYTEST else []
-
-tests_require = [
-    'pytest', 'gunicorn',
-    'pytest-timeout', 'async-generator',
-    'pytest-xdist',
-]
-
-
 args = dict(
     name='aiohttp',
     version=version,
@@ -141,8 +131,6 @@ args = dict(
             'cchardet',
         ],
     },
-    tests_require=tests_require,
-    setup_requires=pytest_runner,
     include_package_data=True,
     ext_modules=extensions,
     cmdclass=dict(build_ext=ve_build_ext),


### PR DESCRIPTION
Closes #3518

We decided to not support `setup.py test` facility anymore.
Use `make test` now.
@webknjaz has a plan to add `tox` configuration -- it would be a nice addition.
`tox` can be used by CI and users who comfortable with this workflow.
For now on my daily aiohttp hacking I personally prefer old good makefiles