### PR TITLE
[3.5] Suppress pytest warnings due to test util classes (#3660)

### DIFF
--- a/CHANGES/3660.bugfix
+++ b/CHANGES/3660.bugfix
@@ -1,0 +1,1 @@
+Suppress pytest warnings due to test util classes

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -56,6 +56,7 @@ Chris Moore
 Christopher Schmitt
 Claudiu Popa
 Colin Dunklau
+Cong Xu
 Damien Nadé
 Dan Xu
 Daniel García

--- a/aiohttp/test_utils.py
+++ b/aiohttp/test_utils.py
@@ -74,6 +74,8 @@ def unused_port() -> int:
 
 
 class BaseTestServer(ABC):
+    __test__ = False
+
     def __init__(self,
                  *,
                  scheme: Union[str, object]=sentinel,
@@ -230,6 +232,7 @@ class TestClient:
     To write functional tests for aiohttp based servers.
 
     """
+    __test__ = False
 
     def __init__(self, server: BaseTestServer, *,
                  cookie_jar: Optional[AbstractCookieJar]=None,


### PR DESCRIPTION
(cherry picked from commit e6cbce3d)

Co-authored-by: Cong <congusbongus@gmail.com>
