### PR TITLE
[3.5] Make sure the closing boundary is written when calling 'write' on an empty MultipartWriter (#3520)

### DIFF
--- a/aiohttp/multipart.py
+++ b/aiohttp/multipart.py
@@ -718,6 +718,9 @@ class MultipartWriter(Payload):
     def __len__(self) -> int:
         return len(self._parts)
 
+    def __bool__(self) -> bool:
+        return True
+
     _valid_tchar_regex = re.compile(br"\A[!#$%&'*+\-.^_`|~\w]+\Z")
     _invalid_qdtext_char_regex = re.compile(br"[\x00-\x08\x0A-\x1F\x7F]")
 
@@ -836,9 +839,6 @@ class MultipartWriter(Payload):
     @property
     def size(self) -> Optional[int]:
         """Size of the payload."""
-        if not self._parts:
-            return 0
-
         total = 0
         for part, encoding, te_encoding in self._parts:
             if encoding or te_encoding or part.size is None:
@@ -856,9 +856,6 @@ class MultipartWriter(Payload):
     async def write(self, writer: Any,
                     close_boundary: bool=True) -> None:
         """Write body."""
-        if not self._parts:
-            return
-
         for part, encoding, te_encoding in self._parts:
             await writer.write(b'--' + self._boundary + b'\r\n')
             await writer.write(part._binary_headers)

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -730,7 +730,7 @@ class TestMultipartReader:
 
 
 async def test_writer(writer) -> None:
-    assert writer.size == 0
+    assert writer.size == 7
     assert writer.boundary == ':'
 
 
@@ -846,6 +846,11 @@ async def test_writer_write_no_close_boundary(buf, stream) -> None:
          b'Content-Length: 11\r\n\r\n'
          b'one=1&two=2'
          b'\r\n') == bytes(buf))
+
+
+async def test_writer_write_no_parts(buf, stream, writer) -> None:
+    await writer.write(stream)
+    assert b'--:--\r\n' == bytes(buf)
 
 
 async def test_writer_serialize_with_content_encoding_gzip(buf, stream,

--- a/tests/test_web_functional.py
+++ b/tests/test_web_functional.py
@@ -234,7 +234,27 @@ async def test_multipart(aiohttp_client) -> None:
     app.router.add_post('/', handler)
     client = await aiohttp_client(app)
 
-    resp = await client.post('/', data=writer, headers=writer.headers)
+    resp = await client.post('/', data=writer)
+    assert 200 == resp.status
+    await resp.release()
+
+
+async def test_multipart_empty(aiohttp_client) -> None:
+    with multipart.MultipartWriter() as writer:
+        pass
+
+    async def handler(request):
+        reader = await request.multipart()
+        assert isinstance(reader, multipart.MultipartReader)
+        async for part in reader:
+            assert False, 'Unexpected part found in reader: {!r}'.format(part)
+        return web.Response()
+
+    app = web.Application()
+    app.router.add_post('/', handler)
+    client = await aiohttp_client(app)
+
+    resp = await client.post('/', data=writer)
     assert 200 == resp.status
     await resp.release()
 
@@ -264,7 +284,7 @@ async def test_multipart_content_transfer_encoding(aiohttp_client) -> None:
     app.router.add_post('/', handler)
     client = await aiohttp_client(app)
 
-    resp = await client.post('/', data=writer, headers=writer.headers)
+    resp = await client.post('/', data=writer)
     assert 200 == resp.status
     await resp.release()
 


### PR DESCRIPTION


(cherry picked from commit 0ad5d902)

Co-authored-by: Arthur Darcet <arthur+github@darcet.fr>

<!-- Thank you for your contribution! -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
