### PR TITLE
Update documentation reference to the default access logger

### DIFF
--- a/CHANGES/3783.doc
+++ b/CHANGES/3783.doc
@@ -1,1 +1,1 @@
-Update documentation reference to AccessLogger.
+Update documentation reference to the default access logger.

--- a/CHANGES/3783.doc
+++ b/CHANGES/3783.doc
@@ -1,0 +1,1 @@
+Update documentation reference to AccessLogger.

--- a/docs/logging.rst
+++ b/docs/logging.rst
@@ -93,7 +93,7 @@ The default access log format is::
 
 *access_log_class* introduced.
 
-Example of a drop-in replacement for :class:`aiohttp.web_log.AccessLogger`::
+Example of a drop-in replacement for the default access logger::
 
   from aiohttp.abc import AbstractAccessLogger
 

--- a/docs/logging.rst
+++ b/docs/logging.rst
@@ -93,7 +93,7 @@ The default access log format is::
 
 *access_log_class* introduced.
 
-Example of a drop-in replacement for :class:`aiohttp.helpers.AccessLogger`::
+Example of a drop-in replacement for :class:`aiohttp.web_log.AccessLogger`::
 
   from aiohttp.abc import AbstractAccessLogger
 


### PR DESCRIPTION
## What do these changes do?

Update the documentation to reflect the proper path to `AccessLogger`, which has been `aiohttp.web_log.AccessLogger` instead of `aiohttp.helpers.AccessLogger` since https://github.com/aio-libs/aiohttp/commit/94832099a35bbc3ddc2e4ec33b8bc57847cf9670.

## Are there changes in behavior for the user?

No

## Related issue number

N/A

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [X] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
