### PR TITLE
Use `if __name__ == '__main__':` in server examples docs

### DIFF
--- a/CHANGES/3775.doc
+++ b/CHANGES/3775.doc
@@ -1,0 +1,1 @@
+use ``if __name__ == '__main__':`` in server examples.

--- a/README.rst
+++ b/README.rst
@@ -106,7 +106,8 @@ An example using a simple server:
                     web.get('/echo', wshandle),
                     web.get('/{name}', handle)])
 
-    web.run_app(app)
+    if __name__ == '__main__':
+        web.run_app(app)
 
 
 Documentation

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -76,8 +76,9 @@ Client example::
             html = await fetch(session, 'http://python.org')
             print(html)
 
-    loop = asyncio.get_event_loop()
-    loop.run_until_complete(main())
+    if __name__ == '__main__':
+        loop = asyncio.get_event_loop()
+        loop.run_until_complete(main())
 
 Server example::
 
@@ -92,7 +93,8 @@ Server example::
     app.add_routes([web.get('/', handle),
                     web.get('/{name}', handle)])
 
-    web.run_app(app)
+    if __name__ == '__main__':
+        web.run_app(app)
 
 
 For more information please visit :ref:`aiohttp-client` and


### PR DESCRIPTION
## What do these changes do?

Make it slightly easier to use the default examples with aiohttp-devtools etc.

## Are there changes in behavior for the user?

no

## Related issue number

fix #3775

## Checklist

- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
