### PR TITLE
Improve documentation for BaseRequest.path and BaseRequest.raw_path

### DIFF
--- a/CHANGES/3791.doc
+++ b/CHANGES/3791.doc
@@ -1,0 +1,1 @@
+Improve documentation for ``web.BaseRequest.path`` and ``web.BaseRequest.raw_path``.

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -161,7 +161,7 @@ and :ref:`aiohttp-web-signals` handlers.
    .. attribute:: path
 
       The URL including *PATH INFO* without the host or scheme. e.g.,
-      ``/app/blog``. The path is URL-unquoted. For raw path info see
+      ``/app/blog``. The path is URL-decoded. For raw path info see
       :attr:`raw_path`.
 
       Read-only :class:`str` property.
@@ -169,11 +169,11 @@ and :ref:`aiohttp-web-signals` handlers.
    .. attribute:: raw_path
 
       The URL including raw *PATH INFO* without the host or scheme.
-      Warning, the path may be quoted and may contain invalid URL
+      Warning, the path may be URL-encoded and may contain invalid URL
       characters, e.g.
       ``/my%2Fpath%7Cwith%21some%25strange%24characters``.
 
-      For unquoted version please take a look on :attr:`path`.
+      For URL-decoded version please take a look on :attr:`path`.
 
       Read-only :class:`str` property.
 

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -169,7 +169,7 @@ and :ref:`aiohttp-web-signals` handlers.
    .. attribute:: raw_path
 
       The URL including raw *PATH INFO* without the host or scheme.
-      Warning, the path may be quoted and may contains non valid URL
+      Warning, the path may be quoted and may contain invalid URL
       characters, e.g.
       ``/my%2Fpath%7Cwith%21some%25strange%24characters``.
 


### PR DESCRIPTION
## What do these changes do?

Fix grammatical mistakes in [the documentation for `BaseRequest.raw_path`](https://docs.aiohttp.org/en/latest/web_reference.html#aiohttp.web.BaseRequest.raw_path) and change "quoted" to "URL-encoded" and "unquoted" to "URL-decoded" in [the documentation for `BaseRequest.path`](https://docs.aiohttp.org/en/latest/web_reference.html#aiohttp.web.BaseRequest.path) and `BaseRequest.raw_path`.
The latter change improves the coherence of the documentation, as the term, (un)quoted, can be ambiguous/unclear.

## Are there changes in behavior for the user?

No

## Related issue number

N/A

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [X] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
