### PR TITLE
removed transfer-encoding header from websocket responses #3798

### DIFF
--- a/CHANGES/3798.feature
+++ b/CHANGES/3798.feature
@@ -1,0 +1,1 @@
+Removed `Transfer-Encoding: chunked` header from websocket responses to be compatible with more http proxy servers.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -90,6 +90,7 @@ Eugene Naydenov
 Eugene Tolmachev
 Evert Lammerts
 FichteFoll
+Florian Scheffler
 Frederik Gladhorn
 Frederik Peter Aalund
 Gabriel Tremblay

--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -371,13 +371,10 @@ class StreamResponse(BaseClass, HeadersMixin):
         if self._compression:
             await self._start_compression(request)
 
-        if all([
-            'websocket' == headers.get(hdrs.UPGRADE, '').lower().strip(),
-            'upgrade' == headers.get(hdrs.CONNECTION, '').lower()
-        ]):
-            websocket_response = True
-        else:
-            websocket_response = False
+        websocket_response = (
+            'websocket' == headers.get(hdrs.UPGRADE, '').lower().strip() and
+            'upgrade' == headers.get(hdrs.CONNECTION, '').lower().strip()
+        )
 
         if self._chunked:
             if version != HttpVersion11:
@@ -385,7 +382,7 @@ class StreamResponse(BaseClass, HeadersMixin):
                     "Using chunked encoding is forbidden "
                     "for HTTP/{0.major}.{0.minor}".format(request.version))
             writer.enable_chunking()
-            if websocket_response is False:
+            if not websocket_response:
                 headers[hdrs.TRANSFER_ENCODING] = 'chunked'
             if hdrs.CONTENT_LENGTH in headers:
                 del headers[hdrs.CONTENT_LENGTH]
@@ -394,7 +391,7 @@ class StreamResponse(BaseClass, HeadersMixin):
             if writer.length is None:
                 if version >= HttpVersion11:
                     writer.enable_chunking()
-                    if websocket_response is False:
+                    if not websocket_response:
                         headers[hdrs.TRANSFER_ENCODING] = 'chunked'
                     if hdrs.CONTENT_LENGTH in headers:
                         del headers[hdrs.CONTENT_LENGTH]

--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -371,19 +371,13 @@ class StreamResponse(BaseClass, HeadersMixin):
         if self._compression:
             await self._start_compression(request)
 
-        websocket_response = (
-            'websocket' == headers.get(hdrs.UPGRADE, '').lower().strip() and
-            'upgrade' == headers.get(hdrs.CONNECTION, '').lower().strip()
-        )
-
         if self._chunked:
             if version != HttpVersion11:
                 raise RuntimeError(
                     "Using chunked encoding is forbidden "
                     "for HTTP/{0.major}.{0.minor}".format(request.version))
             writer.enable_chunking()
-            if not websocket_response:
-                headers[hdrs.TRANSFER_ENCODING] = 'chunked'
+            headers[hdrs.TRANSFER_ENCODING] = 'chunked'
             if hdrs.CONTENT_LENGTH in headers:
                 del headers[hdrs.CONTENT_LENGTH]
         elif self._length_check:
@@ -391,8 +385,7 @@ class StreamResponse(BaseClass, HeadersMixin):
             if writer.length is None:
                 if version >= HttpVersion11:
                     writer.enable_chunking()
-                    if not websocket_response:
-                        headers[hdrs.TRANSFER_ENCODING] = 'chunked'
+                    headers[hdrs.TRANSFER_ENCODING] = 'chunked'
                     if hdrs.CONTENT_LENGTH in headers:
                         del headers[hdrs.CONTENT_LENGTH]
                 else:

--- a/aiohttp/web_ws.py
+++ b/aiohttp/web_ws.py
@@ -179,7 +179,6 @@ class WebSocketResponse(StreamResponse):
         response_headers = CIMultiDict(  # type: ignore
             {hdrs.UPGRADE: 'websocket',
              hdrs.CONNECTION: 'upgrade',
-             hdrs.TRANSFER_ENCODING: 'chunked',
              hdrs.SEC_WEBSOCKET_ACCEPT: accept_val})
 
         notakeover = False

--- a/aiohttp/web_ws.py
+++ b/aiohttp/web_ws.py
@@ -47,6 +47,8 @@ class WebSocketReady:
 
 class WebSocketResponse(StreamResponse):
 
+    _length_check = False
+
     def __init__(self, *,
                  timeout: float=10.0, receive_timeout: Optional[float]=None,
                  autoclose: bool=True, autoping: bool=True,

--- a/tests/test_web_websocket.py
+++ b/tests/test_web_websocket.py
@@ -502,3 +502,11 @@ async def test_send_with_per_message_deflate(make_request, mocker) -> None:
 
     await ws.send_json('[{}]', compress=9)
     writer_send.assert_called_with('"[{}]"', binary=False, compress=9)
+
+
+async def test_no_transfer_encoding_header(make_request, mocker) -> None:
+    req = make_request('GET', '/')
+    ws = WebSocketResponse()
+    await ws._start(req)
+
+    assert 'Transfer-Encoding' not in ws.headers

--- a/tests/test_websocket_handshake.py
+++ b/tests/test_websocket_handshake.py
@@ -261,3 +261,13 @@ def test_handshake_compress_multi_ext_wbits() -> None:
     assert 'Sec-Websocket-Extensions' in headers
     assert headers['Sec-Websocket-Extensions'] == 'permessage-deflate'
     assert compress == 15
+
+
+def test_handshake_no_transfer_encoding() -> None:
+    hdrs, sec_key = gen_ws_headers()
+    req = make_mocked_request('GET', '/', headers=hdrs)
+
+    ws = web.WebSocketResponse()
+    headers, _, compress, notakeover = ws._handshake(req)
+
+    assert 'Transfer-Encoding' not in headers


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

<!-- Please give a short brief about these changes. -->
This PR provides a compatibility update for websockets and http proxy servers as described in #3798 
When the request is a websockets connection upgrade we no longer add the `Transfer-Encoding: chunked` to the response headers.

## Are there changes in behavior for the user?
This change increases compatibility with http proxy servers.

<!-- Outline any notable behaviour for the end users. -->

## Related issue number
#3798

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [ ] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
