### PR TITLE
Use Brotli instead of brotlipy

### DIFF
--- a/CHANGES/3803.feature
+++ b/CHANGES/3803.feature
@@ -1,0 +1,1 @@
+Use Brotli instead of brotlipy

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -89,6 +89,7 @@ Eugene Chernyshov
 Eugene Naydenov
 Eugene Tolmachev
 Evert Lammerts
+Felix Yan
 FichteFoll
 Frederik Gladhorn
 Frederik Peter Aalund

--- a/docs/client_quickstart.rst
+++ b/docs/client_quickstart.rst
@@ -171,7 +171,7 @@ The ``gzip`` and ``deflate`` transfer-encodings are automatically
 decoded for you.
 
 You can enable ``brotli`` transfer-encodings support,
-just install  `brotlipy <https://github.com/python-hyper/brotlipy>`_.
+just install  `Brotli <https://pypi.org/project/Brotli>`_.
 
 JSON Request
 ============

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -52,7 +52,7 @@ Installing speedups altogether
 ------------------------------
 
 The following will get you ``aiohttp`` along with :term:`chardet`,
-:term:`aiodns` and ``brotlipy`` in one bundle. No need to type
+:term:`aiodns` and ``Brotli`` in one bundle. No need to type
 separate commands anymore!
 
 .. code-block:: bash

--- a/requirements/ci-wheel.txt
+++ b/requirements/ci-wheel.txt
@@ -2,7 +2,7 @@
 attrs==19.1.0
 async-generator==1.10
 async-timeout==3.0.1
-brotlipy==0.7.0
+Brotli==1.0.7
 cchardet==2.1.4
 chardet==3.0.4
 coverage==4.5.3

--- a/setup.py
+++ b/setup.py
@@ -127,7 +127,7 @@ args = dict(
     extras_require={
         'speedups': [
             'aiodns',
-            'brotlipy',
+            'Brotli',
             'cchardet',
         ],
     },

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ deps =
     coverage
     gunicorn
     async-generator
-    brotlipy
+    Brotli
     cython: cython
     -e .
 


### PR DESCRIPTION
brotlipy is stuck at brotli 0.6 and upstream is inactive. Let's switch
to the official binding which is up-to-date.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
