### PR TITLE
Ability to use contextvars in logger

### DIFF
--- a/CHANGES/3787.feature
+++ b/CHANGES/3787.feature
@@ -1,0 +1,1 @@
+Added ability to use contextvars in logger

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -141,6 +141,7 @@ Kay Zheng
 Kimmo Parviainen-Jalanko
 Kirill Klenov
 Kirill Malovitsa
+Konstantin Valetov
 Kyrylo Perevozchikov
 Lars P. Søndergaard
 Louis-Philippe Huberdeau

--- a/tests/test_web_protocol.py
+++ b/tests/test_web_protocol.py
@@ -362,7 +362,7 @@ async def test_handle_uncompleted_pipe(
         b'GET / HTTP/1.1\r\n'
         b'Host: example.com\r\n'
         b'Content-Length: 0\r\n\r\n')
-    await asyncio.sleep(0)
+    await asyncio.sleep(0.01)
 
     # with exception
     request_handler.side_effect = handle_with_error()
@@ -373,7 +373,7 @@ async def test_handle_uncompleted_pipe(
 
     assert srv._task_handler
 
-    await asyncio.sleep(0)
+    await asyncio.sleep(0.01)
 
     await srv._task_handler
     assert normal_completed
@@ -585,7 +585,7 @@ async def test_content_length_0(srv, request_handler) -> None:
         b'GET / HTTP/1.1\r\n'
         b'Host: example.org\r\n'
         b'Content-Length: 0\r\n\r\n')
-    await asyncio.sleep(0)
+    await asyncio.sleep(0.01)
 
     assert request_handler.called
     assert request_handler.call_args[0][0].content == streams.EMPTY_PAYLOAD
@@ -702,7 +702,7 @@ async def test_pipeline_response_order(
         b'GET / HTTP/1.1\r\n'
         b'Host: example.com\r\n'
         b'Content-Length: 0\r\n\r\n')
-    await asyncio.sleep(0)
+    await asyncio.sleep(0.01)
 
     # second
 
@@ -720,7 +720,7 @@ async def test_pipeline_response_order(
         b'GET / HTTP/1.1\r\n'
         b'Host: example.com\r\n'
         b'Content-Length: 0\r\n\r\n')
-    await asyncio.sleep(0)
+    await asyncio.sleep(0.01)
 
     assert srv._task_handler is not None
 
@@ -835,4 +835,4 @@ Host: localhost:{port}\r
     writer.write(b"x")
     writer.close()
     await asyncio.sleep(0.1)
-    logger.debug.assert_called_with('Ignored premature client disconnection 2')
+    logger.debug.assert_called_with('Ignored premature client disconnection.')

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -89,7 +89,7 @@ async def test_raw_server_cancelled_in_write_eof(aiohttp_raw_server,
     with pytest.raises(client.ClientPayloadError):
         await resp.read()
 
-    logger.debug.assert_called_with('Ignored premature client disconnection ')
+    logger.debug.assert_called_with('Ignored premature client disconnection')
 
 
 async def test_raw_server_not_http_exception_debug(aiohttp_raw_server,


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

As we discussed in issue below, I extracted and put some logic from `start` method into `_handle_request` method, but I don't like signature of the new method and a lot of tests are failed now. I tried to fix them, but no luck. Seems like we need to rethink the idea, but I need some directions.

## Are there changes in behavior for the user?

No

## Related issue number

https://github.com/aio-libs/aiohttp/issues/3787

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
