### PR TITLE
On exit, cancel the main task first

### DIFF
--- a/CHANGES/3805.bugfix
+++ b/CHANGES/3805.bugfix
@@ -1,0 +1,1 @@
+Fix tasks cancellation order on exit. The run_app task needs to be cancelled first for cleanup hooks to run with all tasks intact.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -242,6 +242,7 @@ Vaibhav Sagar
 Vamsi Krishna Avula
 Vasiliy Faronov
 Vasyl Baran
+Victor Collod
 Victor Kovtun
 Vikas Kawadia
 Viktor Danyliuk


### PR DESCRIPTION
Otherwise, some tasks might be cancelled before cleanup hooks run. Fixes #3593

<!-- Thank you for your contribution! -->

## What do these changes do?

Fix tasks cancellation order on exit. The run_app task needs to be cancelled first for cleanup hooks to run with all tasks intact.

## Are there changes in behavior for the user?

It fixes #3593, and renames _cancel_all_tasks to _cancel_tasks.

## Related issue number

#3593

## Checklist

- [X] I think the code is well written
- [ ] Unit tests for the changes exist
- [X] Documentation reflects the changes
- [X] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [X] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
