### PR TITLE
Fix documentation structure

### DIFF
--- a/docs/abc.rst
+++ b/docs/abc.rst
@@ -1,11 +1,9 @@
+.. module:: aiohttp.abc
+
 .. _aiohttp-abc:
 
 Abstract Base Classes
 =====================
-
-.. module:: aiohttp
-
-.. currentmodule:: aiohttp
 
 Abstract routing
 ----------------

--- a/docs/client_advanced.rst
+++ b/docs/client_advanced.rst
@@ -1,9 +1,9 @@
+.. currentmodule:: aiohttp
+
 .. _aiohttp-client-advanced:
 
 Advanced Client Usage
 =====================
-
-.. currentmodule:: aiohttp
 
 .. _aiohttp-client-session:
 

--- a/docs/client_quickstart.rst
+++ b/docs/client_quickstart.rst
@@ -1,10 +1,10 @@
+.. currentmodule:: aiohttp
+
 .. _aiohttp-client-quickstart:
 
 ===================
  Client Quickstart
 ===================
-
-.. currentmodule:: aiohttp
 
 Eager to get started? This page gives a good introduction in how to
 get started with aiohttp client API.

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -1,11 +1,9 @@
+.. currentmodule:: aiohttp
+
 .. _aiohttp-client-reference:
 
 Client Reference
 ================
-
-.. module:: aiohttp
-.. currentmodule:: aiohttp
-
 
 Client Session
 --------------

--- a/docs/logging.rst
+++ b/docs/logging.rst
@@ -1,10 +1,9 @@
+.. currentmodule:: aiohttp
+
 .. _aiohttp-logging:
 
 Logging
 =======
-
-.. currentmodule:: aiohttp
-
 
 *aiohttp* uses standard :mod:`logging` for tracking the
 library activity.

--- a/docs/multipart.rst
+++ b/docs/multipart.rst
@@ -1,4 +1,4 @@
-.. module:: aiohttp
+.. currentmodule:: aiohttp
 
 .. _aiohttp-multipart:
 

--- a/docs/multipart_reference.rst
+++ b/docs/multipart_reference.rst
@@ -1,4 +1,4 @@
-.. module:: aiohttp
+.. currentmodule:: aiohttp
 
 .. _aiohttp-multipart-reference:
 
@@ -200,5 +200,5 @@ Multipart reference
                                   when streaming (``multipart/x-mixed-replace``)
 
       .. versionadded:: 3.4
-         
+
          Support ``close_boundary`` argument.

--- a/docs/signals.rst
+++ b/docs/signals.rst
@@ -1,7 +1,7 @@
+.. currentmodule:: aiohttp
+
 Signals
 =======
-
-.. currentmodule:: aiohttp
 
 Signal is a list of registered asynchronous callbacks.
 

--- a/docs/streams.rst
+++ b/docs/streams.rst
@@ -1,10 +1,9 @@
+.. currentmodule:: aiohttp
+
 .. _aiohttp-streams:
 
 Streaming API
 =============
-
-.. module:: aiohttp
-.. currentmodule:: aiohttp
 
 
 ``aiohttp`` uses streams for retrieving *BODIES*:

--- a/docs/structures.rst
+++ b/docs/structures.rst
@@ -1,13 +1,11 @@
+.. currentmodule:: aiohttp
+
+
 .. _aiohttp-structures:
 
 
 Common data structures
 ======================
-
-.. module:: aiohttp
-
-.. currentmodule:: aiohttp
-
 
 Common data structures used by *aiohttp* internally.
 

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -1,9 +1,9 @@
+.. module:: aiohttp.test_utils
+
 .. _aiohttp-testing:
 
 Testing
 =======
-
-.. currentmodule:: aiohttp.test_utils
 
 Testing aiohttp web servers
 ---------------------------

--- a/docs/tracing_reference.rst
+++ b/docs/tracing_reference.rst
@@ -1,9 +1,9 @@
+.. currentmodule:: aiohttp
+
 .. _aiohttp-client-tracing-reference:
 
 Tracing Reference
 =================
-
-.. currentmodule:: aiohttp
 
 .. versionadded:: 3.0
 

--- a/docs/utilities.rst
+++ b/docs/utilities.rst
@@ -1,12 +1,11 @@
+.. currentmodule:: aiohttp
+
 .. _aiohttp-utilities:
 
 Utilities
 =========
 
 Miscellaneous API Shared between Client And Server.
-
-.. currentmodule:: aiohttp
-
 
 .. toctree::
    :name: utilities

--- a/docs/web_advanced.rst
+++ b/docs/web_advanced.rst
@@ -1,10 +1,9 @@
+.. currentmodule:: aiohttp.web
+
 .. _aiohttp-web-advanced:
 
 Web Server Advanced
 ===================
-
-.. currentmodule:: aiohttp.web
-
 
 Unicode support
 ---------------

--- a/docs/web_exceptions.rst
+++ b/docs/web_exceptions.rst
@@ -1,9 +1,9 @@
+.. currentmodule:: aiohttp.web
+
 .. _aiohttp-web-exceptions:
 
 Web Server Exceptions
 =====================
-
-.. currentmodule:: aiohttp.web
 
 Overview
 --------

--- a/docs/web_lowlevel.rst
+++ b/docs/web_lowlevel.rst
@@ -1,9 +1,9 @@
+.. currentmodule:: aiohttp.web
+
 .. _aiohttp-web-lowlevel:
 
 Low Level Server
 ================
-
-.. currentmodule:: aiohttp.web
 
 
 This topic describes :mod:`aiohttp.web` based *low level* API.

--- a/docs/web_quickstart.rst
+++ b/docs/web_quickstart.rst
@@ -1,10 +1,9 @@
+.. currentmodule:: aiohttp.web
+
 .. _aiohttp-web-quickstart:
 
 Web Server Quickstart
 =====================
-
-.. currentmodule:: aiohttp.web
-
 
 Run a Simple Web Server
 -----------------------
@@ -55,8 +54,8 @@ emphasize their equality, switching from one style to another is very
 trivial.
 
 .. note::
-   You can get a powerful aiohttp template by running one command. 
-   To do this, simply use our `boilerplate for quick start with aiohttp 
+   You can get a powerful aiohttp template by running one command.
+   To do this, simply use our `boilerplate for quick start with aiohttp
    <https://create-aio-app.readthedocs.io/pages/aiohttp_quick_start.html>`_.
 
 

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -1,11 +1,9 @@
+.. currentmodule:: aiohttp.web
+
 .. _aiohttp-web-reference:
 
 Server Reference
 ================
-
-.. module:: aiohttp.web
-
-.. currentmodule:: aiohttp.web
 
 .. _aiohttp-web-request:
 

--- a/docs/websocket_utilities.rst
+++ b/docs/websocket_utilities.rst
@@ -1,7 +1,8 @@
+.. currentmodule:: aiohttp
+
+
 WebSocket utilities
 ===================
-
-.. currentmodule:: aiohttp
 
 .. class:: WSCloseCode
 
@@ -154,5 +155,3 @@ WebSocket utilities
       Returns parsed JSON data.
 
       :param loads: optional JSON decoder function.
-
-


### PR DESCRIPTION
* Remove duplicate error generated by the latest sphinx
* Fix `py-modindex.html`: now it correctly enumerates `aiohttp`, `aiohttp.abc`, `aiohttp.web` and `aiohttp.test_utils`. Internal modules are not exposed (and was never exposed).