### PR TITLE
Fix manylinux build by explicit pip version upgrading

### DIFF
--- a/requirements/ci-wheel.txt
+++ b/requirements/ci-wheel.txt
@@ -13,6 +13,7 @@ pytest-cov==2.7.1
 pytest-mock==1.10.4
 tox==3.12.1
 trustme==0.5.2
+cryptography==2.7
 twine==1.13.0
 yarl==1.3.0
 

--- a/tools/build-wheels.sh
+++ b/tools/build-wheels.sh
@@ -46,9 +46,10 @@ echo
 echo
 echo "Compile wheels"
 for PYTHON in ${PYTHON_VERSIONS}; do
-    /opt/python/${PYTHON}/bin/pip install -r "${WORKDIR_PATH}/requirements/cython.txt"
-    /opt/python/${PYTHON}/bin/pip install -r "${WORKDIR_PATH}/requirements/wheel.txt"
-    /opt/python/${PYTHON}/bin/pip wheel "${SRC_DIR}/" --no-deps -w "${ORIG_WHEEL_DIR}/${PYTHON}" -v
+    /opt/python/${PYTHON}/bin/python -m pip install -U pip
+    /opt/python/${PYTHON}/bin/python -m pip install -r "${WORKDIR_PATH}/requirements/cython.txt"
+    /opt/python/${PYTHON}/bin/python -m pip install -r "${WORKDIR_PATH}/requirements/wheel.txt"
+    /opt/python/${PYTHON}/bin/python -m pip wheel "${SRC_DIR}/" --no-deps -w "${ORIG_WHEEL_DIR}/${PYTHON}" -v
 done
 
 echo


### PR DESCRIPTION
`cryptography` cannot be installed with outdated `pip`.
