### PR TITLE
Disable implicit switch-back to pure python mode.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -156,7 +156,6 @@ jobs:
     install:
     - *upgrade_python_toolset
     - pip install -r requirements/cython.txt
-    - pip install -r requirements/ci.txt
     - pip install -r requirements/towncrier.txt
     script:
     - towncrier --yes

--- a/.travis.yml
+++ b/.travis.yml
@@ -156,6 +156,7 @@ jobs:
     install:
     - *upgrade_python_toolset
     - pip install -r requirements/cython.txt
+    - AIOHTTP_NO_EXTENSIONS=1 pip install -r requirements/ci.txt
     - pip install -r requirements/towncrier.txt
     script:
     - towncrier --yes

--- a/.travis.yml
+++ b/.travis.yml
@@ -184,7 +184,7 @@ jobs:
     - *upgrade_python_toolset
     - AIOHTTP_NO_EXTENSIONS=1 pip install -r requirements/ci.txt -r requirements/doc.txt
     script:
-    - python setup.py check --metadata --restructuredtext --strict --verbose sdist bdist_wheel
+    - AIOHTTP_NO_EXTENSIONS=1 python setup.py --verbose sdist bdist_wheel
     - twine check dist/*
 
   - <<: *_lint_base

--- a/.travis.yml
+++ b/.travis.yml
@@ -174,7 +174,7 @@ jobs:
     install:
     - *upgrade_python_toolset
     - pip install -r requirements/cython.txt
-    - pip install -r requirements/ci.txt
+    - AIOHTTP_NO_EXTENSIONS=1 pip install -r requirements/ci.txt
     script:
     - mypy aiohttp
 
@@ -182,8 +182,7 @@ jobs:
     name: Verifying distribution package metadata
     install:
     - *upgrade_python_toolset
-    - pip install -r requirements/cython.txt
-    - pip install -r requirements/ci.txt -r requirements/doc.txt
+    - AIOHTTP_NO_EXTENSIONS=1 pip install -r requirements/ci.txt -r requirements/doc.txt
     script:
     - python setup.py check --metadata --restructuredtext --strict --verbose sdist bdist_wheel
     - twine check dist/*

--- a/CHANGES/3828.feature
+++ b/CHANGES/3828.feature
@@ -1,0 +1,4 @@
+Disable implicit switch-back to pure python mode. The build fails loudly if aiohttp
+cannot be compiled with C Accellerators.  Use AIOHTTP_NO_EXTENSIONS=1 to explicitly
+disable C Extensions complication and switch to Pure-Python mode.  Note that Pure-Python
+mode is significantly slower than compiled one.

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 import codecs
+import os
 import pathlib
 import re
 import sys
@@ -11,6 +12,10 @@ from setuptools import Extension, setup
 
 if sys.version_info < (3, 5, 3):
     raise RuntimeError("aiohttp 3.x requires Python 3.5.3+")
+
+
+NO_EXTENSIONS = bool(os.environ.get('AIOHTTP_NO_EXTENSIONS'))  # type: bool
+
 
 here = pathlib.Path(__file__).parent
 
@@ -132,16 +137,17 @@ args = dict(
         ],
     },
     include_package_data=True,
-    ext_modules=extensions,
-    cmdclass=dict(build_ext=ve_build_ext),
 )
 
-try:
-    setup(**args)
-except BuildFailed:
-    print("************************************************************")
-    print("Cannot compile C accelerator module, use pure python version")
-    print("************************************************************")
-    del args['ext_modules']
-    del args['cmdclass']
+if not NO_EXTENSIONS:
+    print("**********************")
+    print("* Accellerated build *")
+    print("**********************")
+    setup(ext_modules=extensions,
+          cmdclass=dict(build_ext=ve_build_ext),
+          **args)
+else:
+    print("*********************")
+    print("* Pure Python build *")
+    print("*********************")
     setup(**args)


### PR DESCRIPTION
The build fails loudly if aiohttp cannot be compiled with C Accellerators.
Use AIOHTTP_NO_EXTENSIONS=1 to explicitly disable C Extensions complication and switch to Pure-Python mode.
Note that Pure-Python mode is significantly slower than compiled one.
