### PR TITLE
Drop redundant check

### DIFF
--- a/aiohttp/streams.py
+++ b/aiohttp/streams.py
@@ -334,18 +334,6 @@ class StreamReader(AsyncStreamReaderMixin):
         if self._exception is not None:
             raise self._exception
 
-        # migration problem; with DataQueue you have to catch
-        # EofStream exception, so common way is to run payload.read() inside
-        # infinite loop. what can cause real infinite loop with StreamReader
-        # lets keep this code one major release.
-        if __debug__:
-            if self._eof and not self._buffer:
-                self._eof_counter = getattr(self, '_eof_counter', 0) + 1
-                if self._eof_counter > 5:
-                    internal_logger.warning(
-                        'Multiple access to StreamReader in eof state, '
-                        'might be infinite loop.', stack_info=True)
-
         if not n:
             return b''
 

--- a/tests/test_streams.py
+++ b/tests/test_streams.py
@@ -222,20 +222,6 @@ class TestStreamReader:
         data = await stream.read()
         assert data == b''
 
-    async def test_read_eof_infinite(self) -> None:
-        # Read bytes.
-        stream = self._make_one()
-        stream.feed_eof()
-
-        with mock.patch('aiohttp.streams.internal_logger') as internal_logger:
-            await stream.read()
-            await stream.read()
-            await stream.read()
-            await stream.read()
-            await stream.read()
-            await stream.read()
-        assert internal_logger.warning.called
-
     async def test_read_eof_unread_data_no_warning(self) -> None:
         # Read bytes.
         stream = self._make_one()


### PR DESCRIPTION
The check was added in 2014 for one major release.
Now is 2019, the time for removal is gone!