### PR TITLE
Use no-extensions mode for non-cpython, e.g. pypy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,9 @@ if sys.version_info < (3, 5, 3):
 
 NO_EXTENSIONS = bool(os.environ.get('AIOHTTP_NO_EXTENSIONS'))  # type: bool
 
+if sys.implementation.name != "cpython":
+    NO_EXTENSIONS = True
+
 
 here = pathlib.Path(__file__).parent
 


### PR DESCRIPTION
While PyPy supports C Extensions via cpyext this mode is famously slow.
There is no reason for compiled extensions for non-CPython