### PR TITLE
Drop a test that requires 1GB of memory

### DIFF
--- a/tests/test_payload.py
+++ b/tests/test_payload.py
@@ -1,11 +1,9 @@
-import asyncio
 from io import StringIO
-from unittest import mock
 
 import pytest
 from async_generator import async_generator
 
-from aiohttp import payload, streams
+from aiohttp import payload
 
 
 @pytest.fixture

--- a/tests/test_payload.py
+++ b/tests/test_payload.py
@@ -113,21 +113,3 @@ def test_async_iterable_payload_not_async_iterable() -> None:
 
     with pytest.raises(TypeError):
         payload.AsyncIterablePayload(object())
-
-
-async def test_stream_reader_long_lines() -> None:
-    loop = asyncio.get_event_loop()
-    DATA = b'0' * 1024 ** 3
-
-    stream = streams.StreamReader(mock.Mock(), loop=loop)
-    stream.feed_data(DATA)
-    stream.feed_eof()
-    body = payload.get_payload(stream)
-
-    writer = mock.Mock()
-    writer.write.return_value = loop.create_future()
-    writer.write.return_value.set_result(None)
-    await body.write(writer)
-    writer.write.assert_called_once_with(mock.ANY)
-    (chunk,), _ = writer.write.call_args
-    assert len(chunk) == len(DATA)


### PR DESCRIPTION
This is not acceptable, sorry.
I have no choice but should drop this test entirely.
It also has a mock inside which is a bad sign -- the test doesn't test too much but the own mock.