### PR TITLE
[3.5] Change normalize_path_middleware redirect from 301 -> 308 (#3579).

### DIFF
--- a/CHANGES/3579.bugfix
+++ b/CHANGES/3579.bugfix
@@ -1,0 +1,4 @@
+Change normalize_path_middleware to use 308 redirect instead of 301.
+
+This behavior should prevent clients from being unable to use PUT/POST
+methods on endpoints that are redirected because of a trailing slash.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -60,6 +60,7 @@ Cong Xu
 Damien Nadé
 Dan Xu
 Daniel García
+Daniel Grossmann-Kavanagh
 Daniel Nelson
 Danny Song
 David Bibb

--- a/aiohttp/web_middlewares.py
+++ b/aiohttp/web_middlewares.py
@@ -1,7 +1,7 @@
 import re
 from typing import TYPE_CHECKING, Awaitable, Callable, Tuple, Type, TypeVar
 
-from .web_exceptions import HTTPMovedPermanently, _HTTPMove
+from .web_exceptions import HTTPPermanentRedirect, _HTTPMove
 from .web_request import Request
 from .web_response import StreamResponse
 from .web_urldispatcher import SystemRoute
@@ -42,7 +42,7 @@ _Middleware = Callable[[Request, _Handler], Awaitable[StreamResponse]]
 def normalize_path_middleware(
         *, append_slash: bool=True, remove_slash: bool=False,
         merge_slashes: bool=True,
-        redirect_class: Type[_HTTPMove]=HTTPMovedPermanently) -> _Middleware:
+        redirect_class: Type[_HTTPMove]=HTTPPermanentRedirect) -> _Middleware:
     """
     Middleware factory which produces a middleware that normalizes
     the path of a request. By normalizing it means:

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -2871,7 +2871,7 @@ Normalize path middleware
                                         append_slash=True, \
                                         remove_slash=False, \
                                         merge_slashes=True, \
-                                        redirect_class=HTTPMovedPermanently)
+                                        redirect_class=HTTPPermanentRedirect)
 
    Middleware factory which produces a middleware that normalizes
    the path of a request. By normalizing it means:


### PR DESCRIPTION
(cherry picked from commit b80fec60ca1781b7adabb3a88157c741d9d53356)

Co-authored-by: Daniel Grossmann-Kavanagh <kavanagh.daniel@gmail.com>
