### PR TITLE
Fix missing brackets for IPv6 in proxy CONNECT request

### DIFF
--- a/CHANGES/3841.bugfix
+++ b/CHANGES/3841.bugfix
@@ -1,0 +1,1 @@
+Fix missing brackets for IPv6 in proxy CONNECT request

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -169,6 +169,7 @@ Mitchell Ferree
 Morgan Delahaye-Prat
 Moss Collum
 Mun Gwan-gyeong
+Navid Sheikhol
 Nicolas Braem
 Nikolay Kim
 Nikolay Novik

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -540,7 +540,10 @@ class ClientRequest:
         # - not CONNECT proxy must send absolute form URI
         # - most common is origin form URI
         if self.method == hdrs.METH_CONNECT:
-            path = '{}:{}'.format(self.url.raw_host, self.url.port)
+            connect_host = cast(str, self.url.raw_host)
+            if helpers.is_ipv6_address(connect_host):
+                connect_host = '[{}]'.format(connect_host)
+            path = '{}:{}'.format(connect_host, self.url.port)
         elif self.proxy and not self.is_ssl():
             path = str(self.url)
         else:

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -540,7 +540,8 @@ class ClientRequest:
         # - not CONNECT proxy must send absolute form URI
         # - most common is origin form URI
         if self.method == hdrs.METH_CONNECT:
-            connect_host = cast(str, self.url.raw_host)
+            connect_host = self.url.raw_host
+            assert connect_host is not None
             if helpers.is_ipv6_address(connect_host):
                 connect_host = '[{}]'.format(connect_host)
             path = '{}:{}'.format(connect_host, self.url.port)


### PR DESCRIPTION
https://github.com/aio-libs/aiohttp/issues/3841

<!-- Thank you for your contribution! -->

## What do these changes do?

Ensures IPv6 addresses are wrapped in brackets in `CONNECT` requests to proxies.

## Are there changes in behavior for the user?

No

## Related issue number

#3841

# Checklist

- [X] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [X] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [X] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
