### PR TITLE
Use correct style for re-exported imports (for 3.5 branch)

### DIFF
--- a/CHANGES/3868.bugfix
+++ b/CHANGES/3868.bugfix
@@ -1,0 +1,1 @@
+Use correct style for re-exported imports, makes mypy ``--strict`` mode happy.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -73,6 +73,7 @@ Dimitar Dimitrov
 Dmitriy Safonov
 Dmitry Doroshev
 Dmitry Lukashin
+Dmitry Marakasov
 Dmitry Shamov
 Dmitry Trofimov
 Dmytro Bohomiakov

--- a/aiohttp/__init__.py
+++ b/aiohttp/__init__.py
@@ -2,103 +2,117 @@ __version__ = '3.5.4'
 
 from typing import Tuple  # noqa
 
-from . import hdrs
+from . import hdrs as hdrs
+from .client import BaseConnector as BaseConnector
+from .client import ClientConnectionError as ClientConnectionError
 from .client import (
-    BaseConnector,
-    ClientConnectionError,
-    ClientConnectorCertificateError,
-    ClientConnectorError,
-    ClientConnectorSSLError,
-    ClientError,
-    ClientHttpProxyError,
-    ClientOSError,
-    ClientPayloadError,
-    ClientProxyConnectionError,
-    ClientRequest,
-    ClientResponse,
-    ClientResponseError,
-    ClientSession,
-    ClientSSLError,
-    ClientTimeout,
-    ClientWebSocketResponse,
-    ContentTypeError,
-    Fingerprint,
-    InvalidURL,
-    NamedPipeConnector,
-    RequestInfo,
-    ServerConnectionError,
-    ServerDisconnectedError,
-    ServerFingerprintMismatch,
-    ServerTimeoutError,
-    TCPConnector,
-    TooManyRedirects,
-    UnixConnector,
-    WSServerHandshakeError,
-    request,
+    ClientConnectorCertificateError as ClientConnectorCertificateError,
 )
-from .cookiejar import CookieJar, DummyCookieJar
-from .formdata import FormData
-from .helpers import BasicAuth, ChainMapProxy
-from .http import (
-    HttpVersion,
-    HttpVersion10,
-    HttpVersion11,
-    WebSocketError,
-    WSCloseCode,
-    WSMessage,
-    WSMsgType,
-)
+from .client import ClientConnectorError as ClientConnectorError
+from .client import ClientConnectorSSLError as ClientConnectorSSLError
+from .client import ClientError as ClientError
+from .client import ClientHttpProxyError as ClientHttpProxyError
+from .client import ClientOSError as ClientOSError
+from .client import ClientPayloadError as ClientPayloadError
+from .client import ClientProxyConnectionError as ClientProxyConnectionError
+from .client import ClientRequest as ClientRequest
+from .client import ClientResponse as ClientResponse
+from .client import ClientResponseError as ClientResponseError
+from .client import ClientSession as ClientSession
+from .client import ClientSSLError as ClientSSLError
+from .client import ClientTimeout as ClientTimeout
+from .client import ClientWebSocketResponse as ClientWebSocketResponse
+from .client import ContentTypeError as ContentTypeError
+from .client import Fingerprint as Fingerprint
+from .client import InvalidURL as InvalidURL
+from .client import NamedPipeConnector as NamedPipeConnector
+from .client import RequestInfo as RequestInfo
+from .client import ServerConnectionError as ServerConnectionError
+from .client import ServerDisconnectedError as ServerDisconnectedError
+from .client import ServerFingerprintMismatch as ServerFingerprintMismatch
+from .client import ServerTimeoutError as ServerTimeoutError
+from .client import TCPConnector as TCPConnector
+from .client import TooManyRedirects as TooManyRedirects
+from .client import UnixConnector as UnixConnector
+from .client import WSServerHandshakeError as WSServerHandshakeError
+from .client import request as request
+from .cookiejar import CookieJar as CookieJar
+from .cookiejar import DummyCookieJar as DummyCookieJar
+from .formdata import FormData as FormData
+from .helpers import BasicAuth as BasicAuth
+from .helpers import ChainMapProxy as ChainMapProxy
+from .http import HttpVersion as HttpVersion
+from .http import HttpVersion10 as HttpVersion10
+from .http import HttpVersion11 as HttpVersion11
+from .http import WebSocketError as WebSocketError
+from .http import WSCloseCode as WSCloseCode
+from .http import WSMessage as WSMessage
+from .http import WSMsgType as WSMsgType
 from .multipart import (
-    BadContentDispositionHeader,
-    BadContentDispositionParam,
-    BodyPartReader,
-    MultipartReader,
-    MultipartWriter,
-    content_disposition_filename,
-    parse_content_disposition,
+    BadContentDispositionHeader as BadContentDispositionHeader,
 )
-from .payload import (
-    PAYLOAD_REGISTRY,
-    AsyncIterablePayload,
-    BufferedReaderPayload,
-    BytesIOPayload,
-    BytesPayload,
-    IOBasePayload,
-    JsonPayload,
-    Payload,
-    StringIOPayload,
-    StringPayload,
-    TextIOPayload,
-    get_payload,
-    payload_type,
+from .multipart import BadContentDispositionParam as BadContentDispositionParam
+from .multipart import BodyPartReader as BodyPartReader
+from .multipart import MultipartReader as MultipartReader
+from .multipart import MultipartWriter as MultipartWriter
+from .multipart import (
+    content_disposition_filename as content_disposition_filename,
 )
-from .payload_streamer import streamer
-from .resolver import AsyncResolver, DefaultResolver, ThreadedResolver
-from .signals import Signal
-from .streams import (
-    EMPTY_PAYLOAD,
-    DataQueue,
-    EofStream,
-    FlowControlDataQueue,
-    StreamReader,
+from .multipart import parse_content_disposition as parse_content_disposition
+from .payload import PAYLOAD_REGISTRY as PAYLOAD_REGISTRY
+from .payload import AsyncIterablePayload as AsyncIterablePayload
+from .payload import BufferedReaderPayload as BufferedReaderPayload
+from .payload import BytesIOPayload as BytesIOPayload
+from .payload import BytesPayload as BytesPayload
+from .payload import IOBasePayload as IOBasePayload
+from .payload import JsonPayload as JsonPayload
+from .payload import Payload as Payload
+from .payload import StringIOPayload as StringIOPayload
+from .payload import StringPayload as StringPayload
+from .payload import TextIOPayload as TextIOPayload
+from .payload import get_payload as get_payload
+from .payload import payload_type as payload_type
+from .payload_streamer import streamer as streamer
+from .resolver import AsyncResolver as AsyncResolver
+from .resolver import DefaultResolver as DefaultResolver
+from .resolver import ThreadedResolver as ThreadedResolver
+from .signals import Signal as Signal
+from .streams import EMPTY_PAYLOAD as EMPTY_PAYLOAD
+from .streams import DataQueue as DataQueue
+from .streams import EofStream as EofStream
+from .streams import FlowControlDataQueue as FlowControlDataQueue
+from .streams import StreamReader as StreamReader
+from .tracing import TraceConfig as TraceConfig
+from .tracing import (
+    TraceConnectionCreateEndParams as TraceConnectionCreateEndParams,
 )
 from .tracing import (
-    TraceConfig,
-    TraceConnectionCreateEndParams,
-    TraceConnectionCreateStartParams,
-    TraceConnectionQueuedEndParams,
-    TraceConnectionQueuedStartParams,
-    TraceConnectionReuseconnParams,
-    TraceDnsCacheHitParams,
-    TraceDnsCacheMissParams,
-    TraceDnsResolveHostEndParams,
-    TraceDnsResolveHostStartParams,
-    TraceRequestChunkSentParams,
-    TraceRequestEndParams,
-    TraceRequestExceptionParams,
-    TraceRequestRedirectParams,
-    TraceRequestStartParams,
-    TraceResponseChunkReceivedParams,
+    TraceConnectionCreateStartParams as TraceConnectionCreateStartParams,
+)
+from .tracing import (
+    TraceConnectionQueuedEndParams as TraceConnectionQueuedEndParams,
+)
+from .tracing import (
+    TraceConnectionQueuedStartParams as TraceConnectionQueuedStartParams,
+)
+from .tracing import (
+    TraceConnectionReuseconnParams as TraceConnectionReuseconnParams,
+)
+from .tracing import TraceDnsCacheHitParams as TraceDnsCacheHitParams
+from .tracing import TraceDnsCacheMissParams as TraceDnsCacheMissParams
+from .tracing import (
+    TraceDnsResolveHostEndParams as TraceDnsResolveHostEndParams,
+)
+from .tracing import (
+    TraceDnsResolveHostStartParams as TraceDnsResolveHostStartParams,
+)
+from .tracing import TraceRequestChunkSentParams as TraceRequestChunkSentParams
+from .tracing import TraceRequestEndParams as TraceRequestEndParams
+from .tracing import TraceRequestExceptionParams as TraceRequestExceptionParams
+from .tracing import TraceRequestRedirectParams as TraceRequestRedirectParams
+from .tracing import TraceRequestStartParams as TraceRequestStartParams
+from .tracing import (
+    TraceResponseChunkReceivedParams as TraceResponseChunkReceivedParams,
 )
 
 __all__ = (

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -31,41 +31,45 @@ from yarl import URL
 
 from . import hdrs, http, payload
 from .abc import AbstractCookieJar
+from .client_exceptions import ClientConnectionError as ClientConnectionError
 from .client_exceptions import (
-    ClientConnectionError,
-    ClientConnectorCertificateError,
-    ClientConnectorError,
-    ClientConnectorSSLError,
-    ClientError,
-    ClientHttpProxyError,
-    ClientOSError,
-    ClientPayloadError,
-    ClientProxyConnectionError,
-    ClientResponseError,
-    ClientSSLError,
-    ContentTypeError,
-    InvalidURL,
-    ServerConnectionError,
-    ServerDisconnectedError,
-    ServerFingerprintMismatch,
-    ServerTimeoutError,
-    TooManyRedirects,
-    WSServerHandshakeError,
+    ClientConnectorCertificateError as ClientConnectorCertificateError,
 )
-from .client_reqrep import (
-    ClientRequest,
-    ClientResponse,
-    Fingerprint,
-    RequestInfo,
-    _merge_ssl_params,
+from .client_exceptions import ClientConnectorError as ClientConnectorError
+from .client_exceptions import (
+    ClientConnectorSSLError as ClientConnectorSSLError,
 )
-from .client_ws import ClientWebSocketResponse
-from .connector import (
-    BaseConnector,
-    NamedPipeConnector,
-    TCPConnector,
-    UnixConnector,
+from .client_exceptions import ClientError as ClientError
+from .client_exceptions import ClientHttpProxyError as ClientHttpProxyError
+from .client_exceptions import ClientOSError as ClientOSError
+from .client_exceptions import ClientPayloadError as ClientPayloadError
+from .client_exceptions import (
+    ClientProxyConnectionError as ClientProxyConnectionError,
 )
+from .client_exceptions import ClientResponseError as ClientResponseError
+from .client_exceptions import ClientSSLError as ClientSSLError
+from .client_exceptions import ContentTypeError as ContentTypeError
+from .client_exceptions import InvalidURL as InvalidURL
+from .client_exceptions import ServerConnectionError as ServerConnectionError
+from .client_exceptions import (
+    ServerDisconnectedError as ServerDisconnectedError,
+)
+from .client_exceptions import (
+    ServerFingerprintMismatch as ServerFingerprintMismatch,
+)
+from .client_exceptions import ServerTimeoutError as ServerTimeoutError
+from .client_exceptions import TooManyRedirects as TooManyRedirects
+from .client_exceptions import WSServerHandshakeError as WSServerHandshakeError
+from .client_reqrep import ClientRequest as ClientRequest
+from .client_reqrep import ClientResponse as ClientResponse
+from .client_reqrep import Fingerprint as Fingerprint
+from .client_reqrep import RequestInfo as RequestInfo
+from .client_reqrep import _merge_ssl_params
+from .client_ws import ClientWebSocketResponse as ClientWebSocketResponse
+from .connector import BaseConnector as BaseConnector
+from .connector import NamedPipeConnector as NamedPipeConnector
+from .connector import TCPConnector as TCPConnector
+from .connector import UnixConnector as UnixConnector
 from .cookiejar import CookieJar
 from .helpers import (
     DEBUG,

--- a/aiohttp/http.py
+++ b/aiohttp/http.py
@@ -3,34 +3,28 @@ import sys
 from typing import Mapping, Tuple  # noqa
 
 from . import __version__
-from .http_exceptions import HttpProcessingError
-from .http_parser import (
-    HeadersParser,
-    HttpParser,
-    HttpRequestParser,
-    HttpResponseParser,
-    RawRequestMessage,
-    RawResponseMessage,
-)
-from .http_websocket import (
-    WS_CLOSED_MESSAGE,
-    WS_CLOSING_MESSAGE,
-    WS_KEY,
-    WebSocketError,
-    WebSocketReader,
-    WebSocketWriter,
-    WSCloseCode,
-    WSMessage,
-    WSMsgType,
-    ws_ext_gen,
-    ws_ext_parse,
-)
-from .http_writer import (
-    HttpVersion,
-    HttpVersion10,
-    HttpVersion11,
-    StreamWriter,
-)
+from .http_exceptions import HttpProcessingError as HttpProcessingError
+from .http_parser import HeadersParser as HeadersParser
+from .http_parser import HttpParser as HttpParser
+from .http_parser import HttpRequestParser as HttpRequestParser
+from .http_parser import HttpResponseParser as HttpResponseParser
+from .http_parser import RawRequestMessage as RawRequestMessage
+from .http_parser import RawResponseMessage as RawResponseMessage
+from .http_websocket import WS_CLOSED_MESSAGE as WS_CLOSED_MESSAGE
+from .http_websocket import WS_CLOSING_MESSAGE as WS_CLOSING_MESSAGE
+from .http_websocket import WS_KEY as WS_KEY
+from .http_websocket import WebSocketError as WebSocketError
+from .http_websocket import WebSocketReader as WebSocketReader
+from .http_websocket import WebSocketWriter as WebSocketWriter
+from .http_websocket import WSCloseCode as WSCloseCode
+from .http_websocket import WSMessage as WSMessage
+from .http_websocket import WSMsgType as WSMsgType
+from .http_websocket import ws_ext_gen as ws_ext_gen
+from .http_websocket import ws_ext_parse as ws_ext_parse
+from .http_writer import HttpVersion as HttpVersion
+from .http_writer import HttpVersion10 as HttpVersion10
+from .http_writer import HttpVersion11 as HttpVersion11
+from .http_writer import StreamWriter as StreamWriter
 
 __all__ = (
     'HttpProcessingError', 'RESPONSES', 'SERVER_SOFTWARE',

--- a/aiohttp/web.py
+++ b/aiohttp/web.py
@@ -10,122 +10,138 @@ from typing import Any, Awaitable, Callable, List, Optional, Type, Union, cast
 from .abc import AbstractAccessLogger
 from .helpers import all_tasks
 from .log import access_logger
-from .web_app import Application, CleanupError
+from .web_app import Application as Application
+from .web_app import CleanupError as CleanupError
+from .web_exceptions import HTTPAccepted as HTTPAccepted
+from .web_exceptions import HTTPBadGateway as HTTPBadGateway
+from .web_exceptions import HTTPBadRequest as HTTPBadRequest
+from .web_exceptions import HTTPClientError as HTTPClientError
+from .web_exceptions import HTTPConflict as HTTPConflict
+from .web_exceptions import HTTPCreated as HTTPCreated
+from .web_exceptions import HTTPError as HTTPError
+from .web_exceptions import HTTPException as HTTPException
+from .web_exceptions import HTTPExpectationFailed as HTTPExpectationFailed
+from .web_exceptions import HTTPFailedDependency as HTTPFailedDependency
+from .web_exceptions import HTTPForbidden as HTTPForbidden
+from .web_exceptions import HTTPFound as HTTPFound
+from .web_exceptions import HTTPGatewayTimeout as HTTPGatewayTimeout
+from .web_exceptions import HTTPGone as HTTPGone
+from .web_exceptions import HTTPInsufficientStorage as HTTPInsufficientStorage
+from .web_exceptions import HTTPInternalServerError as HTTPInternalServerError
+from .web_exceptions import HTTPLengthRequired as HTTPLengthRequired
+from .web_exceptions import HTTPMethodNotAllowed as HTTPMethodNotAllowed
+from .web_exceptions import HTTPMisdirectedRequest as HTTPMisdirectedRequest
+from .web_exceptions import HTTPMovedPermanently as HTTPMovedPermanently
+from .web_exceptions import HTTPMultipleChoices as HTTPMultipleChoices
 from .web_exceptions import (
-    HTTPAccepted,
-    HTTPBadGateway,
-    HTTPBadRequest,
-    HTTPClientError,
-    HTTPConflict,
-    HTTPCreated,
-    HTTPError,
-    HTTPException,
-    HTTPExpectationFailed,
-    HTTPFailedDependency,
-    HTTPForbidden,
-    HTTPFound,
-    HTTPGatewayTimeout,
-    HTTPGone,
-    HTTPInsufficientStorage,
-    HTTPInternalServerError,
-    HTTPLengthRequired,
-    HTTPMethodNotAllowed,
-    HTTPMisdirectedRequest,
-    HTTPMovedPermanently,
-    HTTPMultipleChoices,
-    HTTPNetworkAuthenticationRequired,
-    HTTPNoContent,
-    HTTPNonAuthoritativeInformation,
-    HTTPNotAcceptable,
-    HTTPNotExtended,
-    HTTPNotFound,
-    HTTPNotImplemented,
-    HTTPNotModified,
-    HTTPOk,
-    HTTPPartialContent,
-    HTTPPaymentRequired,
-    HTTPPermanentRedirect,
-    HTTPPreconditionFailed,
-    HTTPPreconditionRequired,
-    HTTPProxyAuthenticationRequired,
-    HTTPRedirection,
-    HTTPRequestEntityTooLarge,
-    HTTPRequestHeaderFieldsTooLarge,
-    HTTPRequestRangeNotSatisfiable,
-    HTTPRequestTimeout,
-    HTTPRequestURITooLong,
-    HTTPResetContent,
-    HTTPSeeOther,
-    HTTPServerError,
-    HTTPServiceUnavailable,
-    HTTPSuccessful,
-    HTTPTemporaryRedirect,
-    HTTPTooManyRequests,
-    HTTPUnauthorized,
-    HTTPUnavailableForLegalReasons,
-    HTTPUnprocessableEntity,
-    HTTPUnsupportedMediaType,
-    HTTPUpgradeRequired,
-    HTTPUseProxy,
-    HTTPVariantAlsoNegotiates,
-    HTTPVersionNotSupported,
+    HTTPNetworkAuthenticationRequired as HTTPNetworkAuthenticationRequired,
 )
-from .web_fileresponse import FileResponse
+from .web_exceptions import HTTPNoContent as HTTPNoContent
+from .web_exceptions import (
+    HTTPNonAuthoritativeInformation as HTTPNonAuthoritativeInformation,
+)
+from .web_exceptions import HTTPNotAcceptable as HTTPNotAcceptable
+from .web_exceptions import HTTPNotExtended as HTTPNotExtended
+from .web_exceptions import HTTPNotFound as HTTPNotFound
+from .web_exceptions import HTTPNotImplemented as HTTPNotImplemented
+from .web_exceptions import HTTPNotModified as HTTPNotModified
+from .web_exceptions import HTTPOk as HTTPOk
+from .web_exceptions import HTTPPartialContent as HTTPPartialContent
+from .web_exceptions import HTTPPaymentRequired as HTTPPaymentRequired
+from .web_exceptions import HTTPPermanentRedirect as HTTPPermanentRedirect
+from .web_exceptions import HTTPPreconditionFailed as HTTPPreconditionFailed
+from .web_exceptions import (
+    HTTPPreconditionRequired as HTTPPreconditionRequired,
+)
+from .web_exceptions import (
+    HTTPProxyAuthenticationRequired as HTTPProxyAuthenticationRequired,
+)
+from .web_exceptions import HTTPRedirection as HTTPRedirection
+from .web_exceptions import (
+    HTTPRequestEntityTooLarge as HTTPRequestEntityTooLarge,
+)
+from .web_exceptions import (
+    HTTPRequestHeaderFieldsTooLarge as HTTPRequestHeaderFieldsTooLarge,
+)
+from .web_exceptions import (
+    HTTPRequestRangeNotSatisfiable as HTTPRequestRangeNotSatisfiable,
+)
+from .web_exceptions import HTTPRequestTimeout as HTTPRequestTimeout
+from .web_exceptions import HTTPRequestURITooLong as HTTPRequestURITooLong
+from .web_exceptions import HTTPResetContent as HTTPResetContent
+from .web_exceptions import HTTPSeeOther as HTTPSeeOther
+from .web_exceptions import HTTPServerError as HTTPServerError
+from .web_exceptions import HTTPServiceUnavailable as HTTPServiceUnavailable
+from .web_exceptions import HTTPSuccessful as HTTPSuccessful
+from .web_exceptions import HTTPTemporaryRedirect as HTTPTemporaryRedirect
+from .web_exceptions import HTTPTooManyRequests as HTTPTooManyRequests
+from .web_exceptions import HTTPUnauthorized as HTTPUnauthorized
+from .web_exceptions import (
+    HTTPUnavailableForLegalReasons as HTTPUnavailableForLegalReasons,
+)
+from .web_exceptions import HTTPUnprocessableEntity as HTTPUnprocessableEntity
+from .web_exceptions import (
+    HTTPUnsupportedMediaType as HTTPUnsupportedMediaType,
+)
+from .web_exceptions import HTTPUpgradeRequired as HTTPUpgradeRequired
+from .web_exceptions import HTTPUseProxy as HTTPUseProxy
+from .web_exceptions import (
+    HTTPVariantAlsoNegotiates as HTTPVariantAlsoNegotiates,
+)
+from .web_exceptions import HTTPVersionNotSupported as HTTPVersionNotSupported
+from .web_fileresponse import FileResponse as FileResponse
 from .web_log import AccessLogger
-from .web_middlewares import middleware, normalize_path_middleware
-from .web_protocol import (
-    PayloadAccessError,
-    RequestHandler,
-    RequestPayloadError,
+from .web_middlewares import middleware as middleware
+from .web_middlewares import (
+    normalize_path_middleware as normalize_path_middleware,
 )
-from .web_request import BaseRequest, FileField, Request
-from .web_response import (
-    ContentCoding,
-    Response,
-    StreamResponse,
-    json_response,
-)
-from .web_routedef import (
-    AbstractRouteDef,
-    RouteDef,
-    RouteTableDef,
-    StaticDef,
-    delete,
-    get,
-    head,
-    options,
-    patch,
-    post,
-    put,
-    route,
-    static,
-    view,
-)
-from .web_runner import (
-    AppRunner,
-    BaseRunner,
-    BaseSite,
-    GracefulExit,
-    NamedPipeSite,
-    ServerRunner,
-    SockSite,
-    TCPSite,
-    UnixSite,
-)
-from .web_server import Server
-from .web_urldispatcher import (
-    AbstractResource,
-    AbstractRoute,
-    DynamicResource,
-    PlainResource,
-    Resource,
-    ResourceRoute,
-    StaticResource,
-    UrlDispatcher,
-    UrlMappingMatchInfo,
-    View,
-)
-from .web_ws import WebSocketReady, WebSocketResponse, WSMsgType
+from .web_protocol import PayloadAccessError as PayloadAccessError
+from .web_protocol import RequestHandler as RequestHandler
+from .web_protocol import RequestPayloadError as RequestPayloadError
+from .web_request import BaseRequest as BaseRequest
+from .web_request import FileField as FileField
+from .web_request import Request as Request
+from .web_response import ContentCoding as ContentCoding
+from .web_response import Response as Response
+from .web_response import StreamResponse as StreamResponse
+from .web_response import json_response as json_response
+from .web_routedef import AbstractRouteDef as AbstractRouteDef
+from .web_routedef import RouteDef as RouteDef
+from .web_routedef import RouteTableDef as RouteTableDef
+from .web_routedef import StaticDef as StaticDef
+from .web_routedef import delete as delete
+from .web_routedef import get as get
+from .web_routedef import head as head
+from .web_routedef import options as options
+from .web_routedef import patch as patch
+from .web_routedef import post as post
+from .web_routedef import put as put
+from .web_routedef import route as route
+from .web_routedef import static as static
+from .web_routedef import view as view
+from .web_runner import AppRunner as AppRunner
+from .web_runner import BaseRunner as BaseRunner
+from .web_runner import BaseSite as BaseSite
+from .web_runner import GracefulExit as GracefulExit
+from .web_runner import NamedPipeSite as NamedPipeSite
+from .web_runner import ServerRunner as ServerRunner
+from .web_runner import SockSite as SockSite
+from .web_runner import TCPSite as TCPSite
+from .web_runner import UnixSite as UnixSite
+from .web_server import Server as Server
+from .web_urldispatcher import AbstractResource as AbstractResource
+from .web_urldispatcher import AbstractRoute as AbstractRoute
+from .web_urldispatcher import DynamicResource as DynamicResource
+from .web_urldispatcher import PlainResource as PlainResource
+from .web_urldispatcher import Resource as Resource
+from .web_urldispatcher import ResourceRoute as ResourceRoute
+from .web_urldispatcher import StaticResource as StaticResource
+from .web_urldispatcher import UrlDispatcher as UrlDispatcher
+from .web_urldispatcher import UrlMappingMatchInfo as UrlMappingMatchInfo
+from .web_urldispatcher import View as View
+from .web_ws import WebSocketReady as WebSocketReady
+from .web_ws import WebSocketResponse as WebSocketResponse
+from .web_ws import WSMsgType as WSMsgType
 
 __all__ = (
     # web_app

--- a/aiohttp/web_ws.py
+++ b/aiohttp/web_ws.py
@@ -20,10 +20,9 @@ from .http import (
     WebSocketReader,
     WebSocketWriter,
     WSMessage,
-    WSMsgType,
-    ws_ext_gen,
-    ws_ext_parse,
 )
+from .http import WSMsgType as WSMsgType
+from .http import ws_ext_gen, ws_ext_parse
 from .log import ws_logger
 from .streams import EofStream, FlowControlDataQueue
 from .typedefs import JSONDecoder, JSONEncoder


### PR DESCRIPTION
## What do these changes do?

Use correct style for re-exported imports, makes `mypy --strict` happy.

## Are there changes in behavior for the user?

No

## Related issue number

#3868

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist (no new code and functional changes though, so should be covered by existing tests)
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
- [x] Add a new news fragment into the `CHANGES` folder
