### PR TITLE
Add missing section comment to __all__ definition of aiohttp

### DIFF
--- a/aiohttp/__init__.py
+++ b/aiohttp/__init__.py
@@ -176,6 +176,7 @@ __all__ = (
     'ThreadedResolver',
     # signals
     'Signal',
+    # streams
     'DataQueue',
     'EMPTY_PAYLOAD',
     'EofStream',


### PR DESCRIPTION
## What do these changes do?

`__all__` entries in aiohttp are diveded into sections in accordance of what subpackage they come from by comments. One comment for `streams` is missing, add it.

## Are there changes in behavior for the user?

No

## Related issue number

None

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist (cosmetic change, not needed)
- [ ] Documentation reflects the changes (cosmetic change, not needed)
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt` (done in #3872)
- [ ] Add a new news fragment into the `CHANGES` folder (cosmetic change, not needed)