### PR TITLE
[WIP] Allow None in ClientResponse.reason

### DIFF
--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -936,14 +936,12 @@ class ClientResponse(HeadersMixin):
 
     def raise_for_status(self) -> None:
         if 400 <= self.status:
-            # reason should always be not None for a started response
-            assert self.reason is not None
             self.release()
             raise ClientResponseError(
                 self.request_info,
                 self.history,
                 status=self.status,
-                message=self.reason,
+                message=self.reason if self.reason is not None else '',
                 headers=self.headers)
 
     def _cleanup_writer(self) -> None:


### PR DESCRIPTION
## What do these changes do?

*Since the work in https://github.com/aio-libs/aiohttp/pull/3533 is apparently slated for v4.0, this is a backport to v3.5.*

Work around an `AssertionError` in v3.5 on `ClientResponse.raise_for_status()`, when the status is 400 or greater and the `ClientResponse.reason` is `None` (as opposed to an empty string or something else). The reason is meant purely for "human consumption" and the client's behavior shouldn't depend on it.

However, I feel like this might be the wrong place to make this fix. Perhaps real problem is that `message.reason` is allowed to be None, rather than defaulting to an empty string. See, for instance, the expected behavior in Requests: https://github.com/kennethreitz/requests/blob/bedd9284c9646e50c10b3defdf519d4ba479e2c7/requests/models.py#L920-L931

This PR is WIP -- should add some kind of test for this, as well as fill out the rest of the checklist items (CONTRIBUTORS.txt, CHANGES). Is any documentation change necessary?

## Are there changes in behavior for the user?

None, other than fixing the unexpected `AssertionError`s.

## Related issue number

https://github.com/aio-libs/aiohttp/issues/3532
https://github.com/aio-libs/aiohttp/pull/3533

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
