### PR TITLE
fixed type annotation in method add_view in UrlDispatcher

### DIFF
--- a/CHANGES/3880.bugfix
+++ b/CHANGES/3880.bugfix
@@ -1,0 +1,1 @@
+Fixed type annotation for add_view method of UrlDispatcher to accept any subclass of View

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -110,6 +110,7 @@ Igor Alexandrov
 Igor Davydenko
 Igor Mozharovsky
 Igor Pavlov
+Ilya Chichak
 Ingmar Steen
 Ivan Larin
 Jacob Champion

--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -27,6 +27,7 @@ from typing import (  # noqa
     Set,
     Sized,
     Tuple,
+    Type,
     Union,
     cast,
 )
@@ -1112,7 +1113,7 @@ class UrlDispatcher(AbstractRouter, Mapping[str, AbstractResource]):
         """
         return self.add_route(hdrs.METH_DELETE, path, handler, **kwargs)
 
-    def add_view(self, path: str, handler: AbstractView,
+    def add_view(self, path: str, handler: Type[AbstractView],
                  **kwargs: Any) -> AbstractRoute:
         """
         Shortcut for add_route with ANY methods for a class-based view


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Fixes type annotation in method add_view in UrlDispatcher
If user passes View subclass to add_view method, type checkers shows, the expected type `AbstractView`, not provided class. 

## Are there changes in behavior for the user?

No

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist (No new functions are added or changed, so it covered with existing tests)
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
