### PR TITLE
[3.5] Fix #3632: Add support for Named Pipes to Site and Connector under Windows.

### DIFF
--- a/CHANGES/3629.feature
+++ b/CHANGES/3629.feature
@@ -1,0 +1,1 @@
+Add support for Named Pipes (Site and Connector) under Windows. This feature requires Proactor event loop to work.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -25,6 +25,7 @@ Alexey Firsov
 Alexey Popravka
 Alexey Stepanov
 Amin Etesamian
+Amit Tulshyan
 Amy Boyle
 Anders Melchiorsen
 Andrei Ursulenko

--- a/aiohttp/__init__.py
+++ b/aiohttp/__init__.py
@@ -24,6 +24,7 @@ from .client import (
     ContentTypeError,
     Fingerprint,
     InvalidURL,
+    NamedPipeConnector,
     RequestInfo,
     ServerConnectionError,
     ServerDisconnectedError,
@@ -131,6 +132,7 @@ __all__ = (
     'TCPConnector',
     'TooManyRedirects',
     'UnixConnector',
+    'NamedPipeConnector',
     'WSServerHandshakeError',
     'request',
     # cookiejar

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -60,7 +60,12 @@ from .client_reqrep import (
     _merge_ssl_params,
 )
 from .client_ws import ClientWebSocketResponse
-from .connector import BaseConnector, TCPConnector, UnixConnector
+from .connector import (
+    BaseConnector,
+    NamedPipeConnector,
+    TCPConnector,
+    UnixConnector,
+)
 from .cookiejar import CookieJar
 from .helpers import (
     DEBUG,
@@ -114,6 +119,7 @@ __all__ = (
     'BaseConnector',
     'TCPConnector',
     'UnixConnector',
+    'NamedPipeConnector',
     # client_ws
     'ClientWebSocketResponse',
     # client

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -64,7 +64,8 @@ except ImportError:  # pragma: no cover
     SSLContext = object  # type: ignore
 
 
-__all__ = ('BaseConnector', 'TCPConnector', 'UnixConnector')
+__all__ = ('BaseConnector', 'TCPConnector', 'UnixConnector',
+           'NamedPipeConnector')
 
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -1122,6 +1123,59 @@ class UnixConnector(BaseConnector):
             with CeilTimeout(timeout.sock_connect):
                 _, proto = await self._loop.create_unix_connection(
                     self._factory, self._path)
+        except OSError as exc:
+            raise ClientConnectorError(req.connection_key, exc) from exc
+
+        return cast(ResponseHandler, proto)
+
+
+class NamedPipeConnector(BaseConnector):
+    """Named pipe connector.
+
+    Only supported by the proactor event loop.
+    See also: https://docs.python.org/3.7/library/asyncio-eventloop.html
+
+    path - Windows named pipe path.
+    keepalive_timeout - (optional) Keep-alive timeout.
+    force_close - Set to True to force close and do reconnect
+        after each request (and between redirects).
+    limit - The total number of simultaneous connections.
+    limit_per_host - Number of simultaneous connections to one host.
+    loop - Optional event loop.
+    """
+
+    def __init__(self, path: str, force_close: bool=False,
+                 keepalive_timeout: Union[object, float, None]=sentinel,
+                 limit: int=100, limit_per_host: int=0,
+                 loop: Optional[asyncio.AbstractEventLoop]=None) -> None:
+        super().__init__(force_close=force_close,
+                         keepalive_timeout=keepalive_timeout,
+                         limit=limit, limit_per_host=limit_per_host, loop=loop)
+        if not isinstance(self._loop, asyncio.ProactorEventLoop):  # type: ignore # noqa
+            raise RuntimeError("Named Pipes only available in proactor "
+                               "loop under windows")
+        self._path = path
+
+    @property
+    def path(self) -> str:
+        """Path to the named pipe."""
+        return self._path
+
+    async def _create_connection(self, req: 'ClientRequest',
+                                 traces: List['Trace'],
+                                 timeout: 'ClientTimeout') -> ResponseHandler:
+        try:
+            with CeilTimeout(timeout.sock_connect):
+                _, proto = await self._loop.create_pipe_connection(  # type: ignore # noqa
+                    self._factory, self._path
+                )
+                # the drain is required so that the connection_made is called
+                # and transport is set otherwise it is not set before the
+                # `assert conn.transport is not None`
+                # in client.py's _request method
+                await asyncio.sleep(0)
+                # other option is to manually set transport like
+                # `proto.transport = trans`
         except OSError as exc:
             raise ClientConnectorError(req.connection_key, exc) from exc
 

--- a/aiohttp/web.py
+++ b/aiohttp/web.py
@@ -106,6 +106,7 @@ from .web_runner import (
     BaseRunner,
     BaseSite,
     GracefulExit,
+    NamedPipeSite,
     ServerRunner,
     SockSite,
     TCPSite,
@@ -230,6 +231,7 @@ __all__ = (
     'SockSite',
     'TCPSite',
     'UnixSite',
+    'NamedPipeSite',
     # web_server
     'Server',
     # web_urldispatcher

--- a/docs/client_advanced.rst
+++ b/docs/client_advanced.rst
@@ -397,6 +397,17 @@ If your HTTP server uses UNIX domain sockets you can use
   session = aiohttp.ClientSession(connector=conn)
 
 
+Named pipes in Windows
+^^^^^^^^^^^^^^^^^^^^^^
+
+If your HTTP server uses Named pipes you can use
+:class:`~aiohttp.NamedPipeConnector`::
+
+  conn = aiohttp.NamedPipeConnector(path=r'\\.\pipe\<name-of-pipe>')
+  session = aiohttp.ClientSession(connector=conn)
+
+It will only work with the ProactorEventLoop
+
 SSL control for TCP sockets
 ---------------------------
 

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -2539,7 +2539,7 @@ application on specific TCP or Unix socket, e.g.::
    .. attribute:: sites
 
       A read-only :class:`set` of served sites (:class:`TCPSite` /
-      :class:`UnixSite` / :class:`SockSite` instances).
+      :class:`UnixSite` / :class:`NamedPipeSite` / :class:`SockSite` instances).
 
    .. comethod:: setup()
 
@@ -2686,6 +2686,18 @@ application on specific TCP or Unix socket, e.g.::
                        connections, see :meth:`socket.listen` for details.
 
                        ``128`` by default.
+
+.. class:: NamedPipeSite(runner, path, *, shutdown_timeout=60.0)
+
+   Serve a runner on Named Pipe in Windows.
+
+   :param runner: a runner to serve.
+
+   :param str path: PATH of named pipe to listen.
+
+   :param float shutdown_timeout: a timeout for closing opened
+                                  connections on :meth:`BaseSite.stop`
+                                  call.
 
 .. class:: SockSite(runner, sock, *, \
                    shutdown_timeout=60.0, ssl_context=None, \

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ import platform
 import shutil
 import ssl
 import tempfile
+import uuid
 
 import pytest
 import trustme
@@ -73,3 +74,9 @@ def tls_certificate_pem_bytes(tls_certificate):
 def tls_certificate_fingerprint_sha256(tls_certificate_pem_bytes):
     tls_cert_der = ssl.PEM_cert_to_DER_cert(tls_certificate_pem_bytes.decode())
     return hashlib.sha256(tls_cert_der).digest()
+
+
+@pytest.fixture
+def pipe_name():
+    name = r'\\.\pipe\{}'.format(uuid.uuid4().hex)
+    return name

--- a/tests/test_web_runner.py
+++ b/tests/test_web_runner.py
@@ -114,3 +114,26 @@ async def test_addresses(make_runner, shorttmpdir) -> None:
     actual_addrs = runner.addresses
     expected_host, expected_post = _sock.getsockname()[:2]
     assert actual_addrs == [(expected_host, expected_post), path]
+
+
+@pytest.mark.skipif(platform.system() != "Windows",
+                    reason="Proactor Event loop present only in Windows")
+async def test_named_pipe_runner_wrong_loop(app, pipe_name) -> None:
+    runner = web.AppRunner(app)
+    await runner.setup()
+    with pytest.raises(RuntimeError):
+        web.NamedPipeSite(runner, pipe_name)
+
+
+@pytest.mark.skipif(platform.system() != "Windows",
+                    reason="Proactor Event loop present only in Windows")
+async def test_named_pipe_runner_proactor_loop(
+    proactor_loop,
+    app,
+    pipe_name
+) -> None:
+    runner = web.AppRunner(app)
+    await runner.setup()
+    pipe = web.NamedPipeSite(runner, pipe_name)
+    await pipe.start()
+    await runner.cleanup()


### PR DESCRIPTION

(cherry picked from commit edc7c0fea7ed56c413b9ae2736495ab2b280aae4)

Co-authored-by: Andrew Svetlov <andrew.svetlov@gmail.com>
