### PR TITLE
[3.5] fixed type annotation in method add_view in UrlDispatcher (#3880)

### DIFF
--- a/CHANGES/3880.bugfix
+++ b/CHANGES/3880.bugfix
@@ -1,0 +1,1 @@
+Fixed type annotation for add_view method of UrlDispatcher to accept any subclass of View

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -107,6 +107,7 @@ Igor Alexandrov
 Igor Davydenko
 Igor Mozharovsky
 Igor Pavlov
+Ilya Chichak
 Ingmar Steen
 Jacob Champion
 Jaesung Lee


### PR DESCRIPTION
(cherry picked from commit 049101ba)

Co-authored-by: Ilya Chichak <ilyachch@gmail.com>
