### PR TITLE
Drop deprecated timeouts in `ClientSession` constructor

### DIFF
--- a/CHANGES/3890.removal
+++ b/CHANGES/3890.removal
@@ -1,1 +1,1 @@
-Drop deprecated `read_timeout` and `conn_timeout` in `ClientSession` constructor.
+Drop deprecated `read_timeout` and `conn_timeout` in `ClientSession` constructor, please use `timeout` argument instead.

--- a/CHANGES/3890.removal
+++ b/CHANGES/3890.removal
@@ -1,0 +1,1 @@
+Drop deprecated `read_timeout` and `conn_timeout` in `ClientSession` constructor.

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -188,8 +188,6 @@ class ClientSession:
                  cookie_jar: Optional[AbstractCookieJar]=None,
                  connector_owner: bool=True,
                  raise_for_status: bool=False,
-                 read_timeout: Union[float, object]=sentinel,
-                 conn_timeout: Optional[float]=None,
                  timeout: Union[object, ClientTimeout]=sentinel,
                  auto_decompress: bool=True,
                  trust_env: bool=False,
@@ -231,29 +229,8 @@ class ClientSession:
         self._json_serialize = json_serialize
         if timeout is sentinel:
             self._timeout = DEFAULT_TIMEOUT
-            if read_timeout is not sentinel:
-                warnings.warn("read_timeout is deprecated, "
-                              "use timeout argument instead",
-                              DeprecationWarning,
-                              stacklevel=2)
-                self._timeout = attr.evolve(self._timeout, total=read_timeout)
-            if conn_timeout is not None:
-                self._timeout = attr.evolve(self._timeout,
-                                            connect=conn_timeout)
-                warnings.warn("conn_timeout is deprecated, "
-                              "use timeout argument instead",
-                              DeprecationWarning,
-                              stacklevel=2)
         else:
             self._timeout = timeout  # type: ignore
-            if read_timeout is not sentinel:
-                raise ValueError("read_timeout and timeout parameters "
-                                 "conflict, please setup "
-                                 "timeout.read")
-            if conn_timeout is not None:
-                raise ValueError("conn_timeout and timeout parameters "
-                                 "conflict, please setup "
-                                 "timeout.connect")
         self._raise_for_status = raise_for_status
         self._auto_decompress = auto_decompress
         self._trust_env = trust_env

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -41,8 +41,7 @@ The client session supports the context manager protocol for self closing.
                          headers=None, skip_auto_headers=None, \
                          auth=None, json_serialize=json.dumps, \
                          version=aiohttp.HttpVersion11, \
-                         cookie_jar=None, read_timeout=None, \
-                         conn_timeout=None, \
+                         cookie_jar=None,
                          timeout=sentinel, \
                          raise_for_status=False, \
                          connector_owner=True, \
@@ -131,22 +130,6 @@ The client session supports the context manager protocol for self closing.
         total timeout by default.
 
       .. versionadded:: 3.3
-
-   :param float read_timeout: Request operations timeout. ``read_timeout`` is
-      cumulative for all request operations (request, redirects, responses,
-      data consuming). By default, the read timeout is 5*60 seconds.
-      Use ``None`` or ``0`` to disable timeout checks.
-
-      .. deprecated:: 3.3
-
-         Use ``timeout`` parameter instead.
-
-   :param float conn_timeout: timeout for connection establishing
-      (optional). Values ``0`` or ``None`` mean no timeout.
-
-      .. deprecated:: 3.3
-
-         Use ``timeout`` parameter instead.
 
    :param bool connector_owner:
 

--- a/tests/test_client_session.py
+++ b/tests/test_client_session.py
@@ -673,23 +673,6 @@ async def test_client_session_timeout_args(loop) -> None:
     session1 = ClientSession(loop=loop)
     assert session1._timeout == client.DEFAULT_TIMEOUT
 
-    with pytest.warns(DeprecationWarning):
-        session2 = ClientSession(loop=loop,
-                                 read_timeout=20*60,
-                                 conn_timeout=30*60)
-    assert session2._timeout == client.ClientTimeout(total=20*60,
-                                                     connect=30*60)
-
-    with pytest.raises(ValueError):
-        ClientSession(loop=loop,
-                      timeout=client.ClientTimeout(total=10*60),
-                      read_timeout=20*60)
-
-    with pytest.raises(ValueError):
-        ClientSession(loop=loop,
-                      timeout=client.ClientTimeout(total=10 * 60),
-                      conn_timeout=30 * 60)
-
 
 async def test_requote_redirect_url_default() -> None:
     session = ClientSession()


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?
Drop deprecated arguments ``read_timeout`` and ``conn_timeout`` in ``ClientSession`` constructor.

## Are there changes in behavior for the user?
no more arguments ``read_timeout`` and ``conn_timeout`` in ``ClientSession`` constructor.

<!-- Outline any notable behaviour for the end users. -->

## Related issue number
closes https://github.com/aio-libs/aiohttp/issues/3890
<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
