### PR TITLE
Fix minor typo in client_quickstart.rst

### DIFF
--- a/docs/client_quickstart.rst
+++ b/docs/client_quickstart.rst
@@ -108,7 +108,7 @@ is not encoded by library. Note that ``+`` is not encoded::
    Canonization encodes *host* part by :term:`IDNA` codec and applies
    :term:`requoting` to *path* and *query* parts.
 
-   For example ``URL('http://example.com/путь%30?a=%31')`` is converted to
+   For example ``URL('http://example.com/путь/%30?a=%31')`` is converted to
    ``URL('http://example.com/%D0%BF%D1%83%D1%82%D1%8C/0?a=1')``.
 
    Sometimes canonization is not desirable if server accepts exact


### PR DESCRIPTION
## What do these changes do?

There has been a typo in URL-encoding example: a `/` was missing.
https://github.com/aio-libs/aiohttp/blob/d036e3845aabf7ef3ee892a007640d2a55263b86/docs/client_quickstart.rst

## Are there changes in behavior for the user?

This pull commit does only affect the documentation.

## Related issue number

This is not a tracked issue.

## Checklist

- [0] I think the code is well written
- [0] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [0] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [DO I HAVE TO?] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
