### PR TITLE
Update multipart.rst

### DIFF
--- a/docs/multipart.rst
+++ b/docs/multipart.rst
@@ -196,7 +196,7 @@ content. Providing `close_boundary = False` prevents this.::
         status=200,
         reason='OK',
         headers={
-            'Content-Type': 'multipart/x-mixed-replace;boundary=--%s' % my_boundary
+            'Content-Type': 'multipart/x-mixed-replace;boundary={}'.format(my_boundary)
         }
     )
     while True:


### PR DESCRIPTION
The boundary should not start with -- in http headers, only in the body.
At least according to:
https://www.w3.org/Protocols/rfc1341/7_2_Multipart.html

<!-- Thank you for your contribution! -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
