### PR TITLE
Add missing comma

### DIFF
--- a/tests/test_urldispatch.py
+++ b/tests/test_urldispatch.py
@@ -62,7 +62,7 @@ def test_register_uncommon_http_methods(router) -> None:
         'PROPPATCH',
         'COPY',
         'LOCK',
-        'UNLOCK'
+        'UNLOCK',
         'MOVE',
         'SUBSCRIBE',
         'UNSUBSCRIBE',


### PR DESCRIPTION
The missing comma will implicitly concatenate "UNLOCK" and "MOVE".

There's no behavior change to the end users as this only changes the test.

A trivial change, no related issue, did not go through the checklist :-)