### PR TITLE
Set reason to an empty string if it is missing (_http_parser.pyx)

### DIFF
--- a/CHANGES/3906.bugfix
+++ b/CHANGES/3906.bugfix
@@ -1,0 +1,1 @@
+Made cython HTTP parser set Reason-Phrase of the response to an empty string if it is missing.

--- a/aiohttp/_http_parser.pyx
+++ b/aiohttp/_http_parser.pyx
@@ -576,7 +576,8 @@ cdef class HttpResponseParser(HttpParser):
         if self._buf:
             self._reason = self._buf.decode('utf-8', 'surrogateescape')
             PyByteArray_Resize(self._buf, 0)
-
+        else:
+            self._reason = self._reason or ''
 
 cdef int cb_on_message_begin(cparser.http_parser* parser) except -1:
     cdef HttpParser pyparser = <HttpParser>parser.data

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -626,7 +626,7 @@ def test_http_response_parser_no_reason(response) -> None:
 
     assert msg.version == (1, 1)
     assert msg.code == 200
-    assert not msg.reason
+    assert msg.reason == ''
 
 
 def test_http_response_parser_bad(response) -> None:


### PR DESCRIPTION
Resolve https://github.com/aio-libs/aiohttp/issues/3906

Test that if reason is missing, it is set to an empty string rather than any falsy value.

Make cython parser set it to en empty string if it is missing. `self._reason = self._reason or ''` is because `_on_status_complete` is called from two places and when it's called the second time, reason may already be set.