### PR TITLE
[3.5] Update multipart.rst (#3903)

### DIFF
--- a/docs/multipart.rst
+++ b/docs/multipart.rst
@@ -196,7 +196,7 @@ content. Providing `close_boundary = False` prevents this.::
         status=200,
         reason='OK',
         headers={
-            'Content-Type': 'multipart/x-mixed-replace;boundary=--%s' % my_boundary
+            'Content-Type': 'multipart/x-mixed-replace;boundary={}'.format(my_boundary)
         }
     )
     while True:


### PR DESCRIPTION
The boundary should not start with -- in http headers, only in the body.
At least according to:
https://www.w3.org/Protocols/rfc1341/7_2_Multipart.html
(cherry picked from commit 64a86982)

Co-authored-by: Ten10 <jonkeinan@gmail.com>
