### PR TITLE
[3.5] Add missing comma (#3908)

### DIFF
--- a/tests/test_urldispatch.py
+++ b/tests/test_urldispatch.py
@@ -62,7 +62,7 @@ def test_register_uncommon_http_methods(router) -> None:
         'PROPPATCH',
         'COPY',
         'LOCK',
-        'UNLOCK'
+        'UNLOCK',
         'MOVE',
         'SUBSCRIBE',
         'UNSUBSCRIBE',


### PR DESCRIPTION
The missing comma will implicitly concatenate "UNLOCK" and "MOVE"
(cherry picked from commit 7d74e3d6)

Co-authored-by: Yuchen Ying <cnyegle@gmail.com>
