### PR TITLE
[3.5] Removed transfer-encoding header from websocket responses #3798…

### DIFF
--- a/CHANGES/3798.feature
+++ b/CHANGES/3798.feature
@@ -1,0 +1,1 @@
+Removed `Transfer-Encoding: chunked` header from websocket responses to be compatible with more http proxy servers.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -90,6 +90,7 @@ Eugene Naydenov
 Eugene Tolmachev
 Evert Lammerts
 FichteFoll
+Florian Scheffler
 Frederik Gladhorn
 Frederik Peter Aalund
 Gabriel Tremblay

--- a/aiohttp/web_ws.py
+++ b/aiohttp/web_ws.py
@@ -46,6 +46,8 @@ class WebSocketReady:
 
 class WebSocketResponse(StreamResponse):
 
+    _length_check = False
+
     def __init__(self, *,
                  timeout: float=10.0, receive_timeout: Optional[float]=None,
                  autoclose: bool=True, autoping: bool=True,
@@ -178,7 +180,6 @@ class WebSocketResponse(StreamResponse):
         response_headers = CIMultiDict(  # type: ignore
             {hdrs.UPGRADE: 'websocket',
              hdrs.CONNECTION: 'upgrade',
-             hdrs.TRANSFER_ENCODING: 'chunked',
              hdrs.SEC_WEBSOCKET_ACCEPT: accept_val})
 
         notakeover = False

--- a/tests/test_web_websocket.py
+++ b/tests/test_web_websocket.py
@@ -502,3 +502,11 @@ async def test_send_with_per_message_deflate(make_request, mocker) -> None:
 
     await ws.send_json('[{}]', compress=9)
     writer_send.assert_called_with('"[{}]"', binary=False, compress=9)
+
+
+async def test_no_transfer_encoding_header(make_request, mocker) -> None:
+    req = make_request('GET', '/')
+    ws = WebSocketResponse()
+    await ws._start(req)
+
+    assert 'Transfer-Encoding' not in ws.headers

--- a/tests/test_websocket_handshake.py
+++ b/tests/test_websocket_handshake.py
@@ -261,3 +261,13 @@ def test_handshake_compress_multi_ext_wbits() -> None:
     assert 'Sec-Websocket-Extensions' in headers
     assert headers['Sec-Websocket-Extensions'] == 'permessage-deflate'
     assert compress == 15
+
+
+def test_handshake_no_transfer_encoding() -> None:
+    hdrs, sec_key = gen_ws_headers()
+    req = make_mocked_request('GET', '/', headers=hdrs)
+
+    ws = web.WebSocketResponse()
+    headers, _, compress, notakeover = ws._handshake(req)
+
+    assert 'Transfer-Encoding' not in headers


### PR DESCRIPTION
… (#3800)

(cherry picked from commit 79c1ca41)

Co-authored-by: Florian S <nebularazer@gmail.com>
