### PR TITLE
[3.5] Set reason to an empty string if it is missing (_http_parser.pyx) (#3909)

### DIFF
--- a/CHANGES/3906.bugfix
+++ b/CHANGES/3906.bugfix
@@ -1,0 +1,1 @@
+Made cython HTTP parser set Reason-Phrase of the response to an empty string if it is missing.

--- a/aiohttp/_http_parser.pyx
+++ b/aiohttp/_http_parser.pyx
@@ -576,7 +576,8 @@ cdef class HttpResponseParser(HttpParser):
         if self._buf:
             self._reason = self._buf.decode('utf-8', 'surrogateescape')
             PyByteArray_Resize(self._buf, 0)
-
+        else:
+            self._reason = self._reason or ''
 
 cdef int cb_on_message_begin(cparser.http_parser* parser) except -1:
     cdef HttpParser pyparser = <HttpParser>parser.data

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -626,7 +626,7 @@ def test_http_response_parser_no_reason(response) -> None:
 
     assert msg.version == (1, 1)
     assert msg.code == 200
-    assert not msg.reason
+    assert msg.reason == ''
 
 
 def test_http_response_parser_bad(response) -> None:


### PR DESCRIPTION
(cherry picked from commit 8d1f0670)

Co-authored-by: Alexey <forestbiiird@gmail.com>
