### PR TITLE
Make web.BaseRequest and web.Request slot-based

### DIFF
--- a/CHANGES/3942.removal
+++ b/CHANGES/3942.removal
@@ -1,0 +1,1 @@
+Make `web.BaseRequest` and `web.Request` slot-based, prevent cunstom request attributes.

--- a/CHANGES/3942.removal
+++ b/CHANGES/3942.removal
@@ -1,1 +1,1 @@
-Make `web.BaseRequest` and `web.Request` slot-based, prevent cunstom request attributes.
+Make `web.BaseRequest`, `web.Request`, `web.StreamResponse`, `web.Response` and `web.WebSocketResponse` slot-based, prevent custom instance attributes.

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -636,6 +636,7 @@ class ClientResponse(HeadersMixin):
                  loop: asyncio.AbstractEventLoop,
                  session: 'ClientSession') -> None:
         assert isinstance(url, URL)
+        super().__init__()
 
         self.method = method
         self.cookies = SimpleCookie()

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -615,12 +615,12 @@ class CeilTimeout(async_timeout.timeout):
 
 class HeadersMixin:
 
-    ATTRS = frozenset([
-        '_content_type', '_content_dict', '_stored_content_type'])
+    __slots__ = ('_content_type', '_content_dict', '_stored_content_type')
 
-    _content_type = None  # type: Optional[str]
-    _content_dict = None  # type: Optional[Dict[str, str]]
-    _stored_content_type = sentinel
+    def __init__(self) -> None:
+        self._content_type = None  # type: Optional[str]
+        self._content_dict = None  # type: Optional[Dict[str, str]]
+        self._stored_content_type = sentinel
 
     def _parse_content_type(self, raw: str) -> None:
         self._stored_content_type = raw

--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -59,13 +59,17 @@ class ContentCoding(enum.Enum):
 
 class StreamResponse(BaseClass, HeadersMixin):
 
-    _length_check = True
+    __slots__ = ('_length_check', '_body', '_keep_alive', '_chunked',
+                 '_compression', '_compression_force', '_cookies', '_req',
+                 '_payload_writer', '_eof_sent', '_body_length', '_state',
+                 '_headers', '_status', '_reason')
 
     def __init__(self, *,
                  status: int=200,
                  reason: Optional[str]=None,
                  headers: Optional[LooseHeaders]=None) -> None:
         super().__init__()
+        self._length_check = True
         self._body = None
         self._keep_alive = None  # type: Optional[bool]
         self._chunked = False
@@ -465,6 +469,11 @@ class StreamResponse(BaseClass, HeadersMixin):
 
 
 class Response(StreamResponse):
+
+    __slots__ = ('_body_payload',
+                 '_compressed_body',
+                 '_zlib_executor_size',
+                 '_zlib_executor')
 
     def __init__(self, *,
                  body: Any=None,

--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -65,6 +65,7 @@ class StreamResponse(BaseClass, HeadersMixin):
                  status: int=200,
                  reason: Optional[str]=None,
                  headers: Optional[LooseHeaders]=None) -> None:
+        super().__init__()
         self._body = None
         self._keep_alive = None  # type: Optional[bool]
         self._chunked = False

--- a/aiohttp/web_ws.py
+++ b/aiohttp/web_ws.py
@@ -45,8 +45,11 @@ class WebSocketReady:
 
 
 class WebSocketResponse(StreamResponse):
-
-    _length_check = False
+    __slots__ = ('_protocols', '_ws_protocol', '_writer', '_reader', '_closed',
+                 '_closing', '_conn_lost', '_close_code', '_loop', '_waiting',
+                 '_exception', '_timeout', '_receive_timeout', '_autoclose',
+                 '_autoping', '_heartbeat', '_heartbeat_cb', '_pong_heartbeat',
+                 '_pong_response_cb', '_compress', '_max_msg_size')
 
     def __init__(self, *,
                  timeout: float=10.0, receive_timeout: Optional[float]=None,
@@ -55,6 +58,7 @@ class WebSocketResponse(StreamResponse):
                  protocols: Iterable[str]=(),
                  compress: bool=True, max_msg_size: int=4*1024*1024) -> None:
         super().__init__(status=101)
+        self._length_check = False
         self._protocols = protocols
         self._ws_protocol = None  # type: Optional[str]
         self._writer = None  # type: Optional[WebSocketWriter]

--- a/tests/test_web_protocol.py
+++ b/tests/test_web_protocol.py
@@ -285,10 +285,12 @@ async def test_unhandled_runtime_error(
     make_srv, transport, request_handler
 ):
 
+    class MyResponse(web.Response):
+        async def write_eof(self, data=b''):
+            raise RuntimeError()
+
     async def handle(request):
-        resp = web.Response()
-        resp.write_eof = mock.Mock()
-        resp.write_eof.side_effect = RuntimeError
+        resp = MyResponse()
         return resp
 
     loop = asyncio.get_event_loop()

--- a/tests/test_web_request.py
+++ b/tests/test_web_request.py
@@ -4,14 +4,14 @@ from collections.abc import MutableMapping
 from unittest import mock
 
 import pytest
-from multidict import CIMultiDict, MultiDict, CIMultiDictProxy
+from multidict import CIMultiDict, CIMultiDictProxy, MultiDict
 from yarl import URL
 
 from aiohttp import HttpVersion, web
 from aiohttp.helpers import DEBUG
+from aiohttp.http_parser import RawRequestMessage
 from aiohttp.streams import StreamReader
 from aiohttp.test_utils import make_mocked_request
-from aiohttp.http_parser import RawRequestMessage
 from aiohttp.web import HTTPRequestEntityTooLarge, HTTPUnsupportedMediaType
 
 

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -80,9 +80,12 @@ async def test_raw_server_do_not_swallow_exceptions(aiohttp_raw_server,
 async def test_raw_server_cancelled_in_write_eof(aiohttp_raw_server,
                                                  aiohttp_client):
 
+    class MyResponse(web.Response):
+        async def write_eof(self, data=b''):
+            raise asyncio.CancelledError("error")
+
     async def handler(request):
-        resp = web.Response(text=str(request.rel_url))
-        resp.write_eof = mock.Mock(side_effect=asyncio.CancelledError("error"))
+        resp = MyResponse(text=str(request.rel_url))
         return resp
 
     loop = asyncio.get_event_loop()

--- a/tests/test_web_websocket.py
+++ b/tests/test_web_websocket.py
@@ -1,11 +1,10 @@
 import asyncio
 from unittest import mock
-from typing import Optional
 
 import pytest
 from multidict import CIMultiDict
 
-from aiohttp import WSMessage, WSMsgType, signals
+from aiohttp import WSMsgType, signals
 from aiohttp.log import ws_logger
 from aiohttp.streams import EofStream
 from aiohttp.test_utils import make_mocked_coro, make_mocked_request
@@ -104,33 +103,6 @@ async def test_nonstarted_receive_json() -> None:
     ws = WebSocketResponse()
     with pytest.raises(RuntimeError):
         await ws.receive_json()
-
-
-async def test_receive_str_nonstring(make_request) -> None:
-    class MyWebSocker(WebSocketResponse):
-        async def receive(self, timeout: Optional[float]=None) -> WSMessage:
-            return WSMessage(WSMsgType.BINARY, b'data', b'')
-
-    req = make_request('GET', '/')
-    ws = WebSocketResponse()
-    await ws.prepare(req)
-
-    with pytest.raises(TypeError):
-        await ws.receive_str()
-
-
-async def test_receive_bytes_nonsbytes(make_request) -> None:
-    req = make_request('GET', '/')
-    ws = WebSocketResponse()
-    await ws.prepare(req)
-
-    async def receive():
-        return WSMessage(WSMsgType.TEXT, 'data', b'')
-
-    ws.receive = receive
-
-    with pytest.raises(TypeError):
-        await ws.receive_bytes()
 
 
 async def test_send_str_nonstring(make_request) -> None:

--- a/tests/test_web_websocket.py
+++ b/tests/test_web_websocket.py
@@ -1,5 +1,6 @@
 import asyncio
 from unittest import mock
+from typing import Optional
 
 import pytest
 from multidict import CIMultiDict
@@ -106,14 +107,13 @@ async def test_nonstarted_receive_json() -> None:
 
 
 async def test_receive_str_nonstring(make_request) -> None:
+    class MyWebSocker(WebSocketResponse):
+        async def receive(self, timeout: Optional[float]=None) -> WSMessage:
+            return WSMessage(WSMsgType.BINARY, b'data', b'')
+
     req = make_request('GET', '/')
     ws = WebSocketResponse()
     await ws.prepare(req)
-
-    async def receive():
-        return WSMessage(WSMsgType.BINARY, b'data', b'')
-
-    ws.receive = receive
 
     with pytest.raises(TypeError):
         await ws.receive_str()


### PR DESCRIPTION
Adding `__slots__` prevents wild objects modification, e.g `request.custom = 123`.
Both *request* and *response* objects support dict-like interface already (`request['custom'] = 123`).