### PR TITLE
Forbid changing frozen app properties

### DIFF
--- a/CHANGES/3948.removal
+++ b/CHANGES/3948.removal
@@ -1,0 +1,1 @@
+Forbid changing frozen app properties.

--- a/aiohttp/web_app.py
+++ b/aiohttp/web_app.py
@@ -125,10 +125,8 @@ class Application(MutableMapping[str, Any]):
 
     def _check_frozen(self) -> None:
         if self._frozen:
-            warnings.warn("Changing state of started or joined "
-                          "application is deprecated",
-                          DeprecationWarning,
-                          stacklevel=3)
+            raise RuntimeError("Changing state of started or joined "
+                               "application is forbidden")
 
     def __setitem__(self, key: str, value: Any) -> None:
         self._check_frozen()

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -83,27 +83,6 @@ def cli(loop, aiohttp_client):
     return loop.run_until_complete(aiohttp_client(create_stateful_app()))
 
 
-async def test_set_value(cli) -> None:
-    resp = await cli.post('/', data={'value': 'foo'})
-    assert resp.status == 200
-    text = await resp.text()
-    assert text == 'thanks for the data'
-    assert cli.server.app['value'] == 'foo'
-
-
-async def test_get_value(cli) -> None:
-    resp = await cli.get('/')
-    assert resp.status == 200
-    text = await resp.text()
-    assert text == 'value: unknown'
-    with pytest.warns(DeprecationWarning):
-        cli.server.app['value'] = 'bar'
-    resp = await cli.get('/')
-    assert resp.status == 200
-    text = await resp.text()
-    assert text == 'value: bar'
-
-
 def test_noncoro() -> None:
     assert True
 
@@ -137,7 +116,7 @@ async def test_custom_port_test_server(aiohttp_server, aiohttp_unused_port):
 """)
     testdir.makeconftest(CONFTEST)
     result = testdir.runpytest('-p', 'no:sugar', '--aiohttp-loop=pyloop')
-    result.assert_outcomes(passed=10)
+    result.assert_outcomes(passed=8)
 
 
 def test_warning_checks(testdir) -> None:

--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -450,3 +450,10 @@ def test_app_forbid_nonslot_attr():
         app.unknow_attr
     with pytest.raises(AttributeError):
         app.unknow_attr = 1
+
+
+def test_forbid_changing_frozen_app() -> None:
+    app = web.Application()
+    app.freeze()
+    with pytest.raises(RuntimeError):
+        app['key'] = 'value'


### PR DESCRIPTION
The following code was raising deprecation and forbidden now.

```
app.freeze()
app['foo'] = 'bar'
```