### PR TITLE
Problem: ClientResponseError string does not include URL

### DIFF
--- a/CHANGES/3959.bugfix
+++ b/CHANGES/3959.bugfix
@@ -1,0 +1,1 @@
+Add URL to the string representation of ClientResponseError.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -69,6 +69,7 @@ David Bibb
 David Michael Brown
 Denilson Amorim
 Denis Matiychuk
+Dennis Kliban
 Dima Veselov
 Dimitar Dimitrov
 Diogo Dutra da Mata

--- a/aiohttp/client_exceptions.py
+++ b/aiohttp/client_exceptions.py
@@ -61,7 +61,8 @@ class ClientResponseError(ClientError):
         self.headers = headers
         self.history = history
 
-        super().__init__("%s, message='%s'" % (self.status, message))
+        super().__init__("%s, message='%s', url='%s" %
+                         (self.status, message, request_info.real_url))
 
 
 class ContentTypeError(ClientResponseError):

--- a/tests/test_client_exceptions.py
+++ b/tests/test_client_exceptions.py
@@ -1,5 +1,7 @@
 """Tests for client_exceptions.py"""
 
+from unittest import mock
+
 from yarl import URL
 
 from aiohttp import client
@@ -21,13 +23,15 @@ def test_invalid_url() -> None:
 
 
 def test_response_default_status() -> None:
+    request_info = mock.Mock(real_url='http://example.com')
     err = client.ClientResponseError(history=None,
-                                     request_info=None)
+                                     request_info=request_info)
     assert err.status == 0
 
 
 def test_response_status() -> None:
+    request_info = mock.Mock(real_url='http://example.com')
     err = client.ClientResponseError(status=400,
                                      history=None,
-                                     request_info=None)
+                                     request_info=request_info)
     assert err.status == 400


### PR DESCRIPTION
Solution: Add the URL to the ClientResponseError string

The tracebacks produced by unhandled ClientResponseErrors now contains the URL which produced the error. 

```
File "/usr/local/lib/pulp/lib64/python3.6/site-packages/pulpcore/plugin/download/http.py", line 183, in _run
response.raise_for_status()
File "/usr/local/lib/pulp/lib64/python3.6/site-packages/aiohttp/client_reqrep.py", line 944, in raise_for_status
headers=self.headers)
aiohttp.client_exceptions.ClientResponseError: 404, message='Not Found', url='https://badexample.com'
```


## Related issue number

https://github.com/aio-libs/aiohttp/issues/3959

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
