### PR TITLE
Removed deprecation warning in tracing example docs

### DIFF
--- a/CHANGES/3964.doc
+++ b/CHANGES/3964.doc
@@ -1,0 +1,1 @@
+Removed deprecation warning in tracing example docs 

--- a/docs/client_advanced.rst
+++ b/docs/client_advanced.rst
@@ -280,10 +280,10 @@ same request and to the same :class:`TraceConfig` class, perhaps::
 
     async def on_request_start(
             session, trace_config_ctx, params):
-        trace_config_ctx.start = session.loop.time()
+        trace_config_ctx.start = asyncio.get_event_loop().time()
 
     async def on_request_end(session, trace_config_ctx, params):
-        elapsed = session.loop.time() - trace_config_ctx.start
+        elapsed = asyncio.get_event_loop().time() - trace_config_ctx.start
         print("Request took {}".format(elapsed))
 
 


### PR DESCRIPTION
## What do these changes do?

Fixes a documentation example to not emit a deprecation warning.

I've used `asyncio.get_event_loop()` instead of `asyncio.get_running_loop()` because the latter is only available in Python 3.7+.

## Are there changes in behavior for the user?

No.

## Related issue number

https://github.com/aio-libs/aiohttp/issues/3964

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
