### PR TITLE
[3.6] Removed deprecation warning in tracing example docs (#3965)

### DIFF
--- a/CHANGES/3964.doc
+++ b/CHANGES/3964.doc
@@ -1,0 +1,1 @@
+Removed deprecation warning in tracing example docs 

--- a/docs/client_advanced.rst
+++ b/docs/client_advanced.rst
@@ -280,10 +280,10 @@ same request and to the same :class:`TraceConfig` class, perhaps::
 
     async def on_request_start(
             session, trace_config_ctx, params):
-        trace_config_ctx.start = session.loop.time()
+        trace_config_ctx.start = asyncio.get_event_loop().time()
 
     async def on_request_end(session, trace_config_ctx, params):
-        elapsed = session.loop.time() - trace_config_ctx.start
+        elapsed = asyncio.get_event_loop().time() - trace_config_ctx.start
         print("Request took {}".format(elapsed))
 
 


### PR DESCRIPTION
(cherry picked from commit 81c141d4)

Co-authored-by: Josep Cugat <jcugat@gmail.com>
