### PR TITLE
Fix failed websocket handshake leaving connection hanging

### DIFF
--- a/CHANGES/3380.bugfix
+++ b/CHANGES/3380.bugfix
@@ -1,0 +1,1 @@
+Fix failed websocket handshake leaving connection hanging.

--- a/aiohttp/_http_parser.pyx
+++ b/aiohttp/_http_parser.pyx
@@ -533,6 +533,9 @@ cdef class HttpParser:
         else:
             return messages, False, b''
 
+    def set_upgraded(self, val):
+        self._upgraded = val
+
 
 cdef class HttpRequestParser(HttpParser):
 

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -411,6 +411,13 @@ class HttpParser(abc.ABC):
 
         return (headers, raw_headers, close_conn, encoding, upgrade, chunked)
 
+    def set_upgraded(self, val: bool) -> None:
+        """Set connection upgraded (to websocket) mode.
+
+        :param bool val: new state.
+        """
+        self._upgraded = val
+
 
 class HttpRequestParser(HttpParser):
     """Read request status line. Exception .http_exceptions.BadStatusLine

--- a/aiohttp/web_protocol.py
+++ b/aiohttp/web_protocol.py
@@ -549,6 +549,12 @@ class RequestHandler(BaseProtocol):
         can get exception information. Returns True if the client disconnects
         prematurely.
         """
+        if self._request_parser is not None:
+            self._request_parser.set_upgraded(False)
+            self._upgrade = False
+            if self._message_tail:
+                self._request_parser.feed_data(self._message_tail)
+                self._message_tail = b''
         try:
             prepare_meth = resp.prepare
         except AttributeError:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

It fixes the bug described in #3380, caused by this sequence of events:

1. clients initiates a websocket upgrade
2. server returns a normal HTTP response instead of a websocket response
3. client, with the same connection open, sends further HTTP requests.

The fix involves: if we detect a normal HTTP response instead of a websocket response, in web_protocol,  then we:
1. Reset _upgraded flag in the HttpParser to the default value (False)
2. Reset the _uprade flag in web_protocol back to False;
3. We feed any buffered data, originally intended for the websocket payload parser, back to the the http parser, so that the next normal  HTTP request can be processed.

This way, if websocket request results in a non-websocket response, we go back to normal HTTP mode, for that socket.

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->

## Related issue number

#3380

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
