### PR TITLE
[3.6] Add the URL to the ClientResponseError repr string.

### DIFF
--- a/CHANGES/3959.bugfix
+++ b/CHANGES/3959.bugfix
@@ -1,0 +1,1 @@
+Add URL to the string representation of ClientResponseError.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -68,6 +68,7 @@ David Bibb
 David Michael Brown
 Denilson Amorim
 Denis Matiychuk
+Dennis Kliban
 Dima Veselov
 Dimitar Dimitrov
 Dmitriy Safonov

--- a/aiohttp/client_exceptions.py
+++ b/aiohttp/client_exceptions.py
@@ -73,7 +73,8 @@ class ClientResponseError(ClientError):
         self.headers = headers
         self.history = history
 
-        super().__init__("%s, message='%s'" % (self.status, message))
+        super().__init__("%s, message='%s', url='%s" %
+                         (self.status, message, request_info.real_url))
 
     @property
     def code(self) -> int:

--- a/tests/test_client_exceptions.py
+++ b/tests/test_client_exceptions.py
@@ -39,10 +39,11 @@ def test_response_status() -> None:
 
 
 def test_response_deprecated_code_property() -> None:
+    request_info = mock.Mock(real_url='http://example.com')
     with pytest.warns(DeprecationWarning):
         err = client.ClientResponseError(code=400,
                                          history=None,
-                                         request_info=None)
+                                         request_info=request_info)
     with pytest.warns(DeprecationWarning):
         assert err.code == err.status
     with pytest.warns(DeprecationWarning):

--- a/tests/test_client_exceptions.py
+++ b/tests/test_client_exceptions.py
@@ -1,5 +1,7 @@
 """Tests for client_exceptions.py"""
 
+from unittest import mock
+
 import pytest
 from yarl import URL
 
@@ -22,15 +24,17 @@ def test_invalid_url() -> None:
 
 
 def test_response_default_status() -> None:
+    request_info = mock.Mock(real_url='http://example.com')
     err = client.ClientResponseError(history=None,
-                                     request_info=None)
+                                     request_info=request_info)
     assert err.status == 0
 
 
 def test_response_status() -> None:
+    request_info = mock.Mock(real_url='http://example.com')
     err = client.ClientResponseError(status=400,
                                      history=None,
-                                     request_info=None)
+                                     request_info=request_info)
     assert err.status == 400
 
 


### PR DESCRIPTION
(cherry picked from commit 38a1ec48ef8fe86bbdbb5fc586f519545220f2d9)

Co-authored-by: Dennis Kliban <dkliban@redhat.com>
