### PR TITLE
Type hint istr keys allowed in LooseHeaders

### DIFF
--- a/CHANGES/3976.bugfix
+++ b/CHANGES/3976.bugfix
@@ -1,0 +1,1 @@
+Accept istr keys in LooseHeaders type hints.

--- a/aiohttp/typedefs.py
+++ b/aiohttp/typedefs.py
@@ -13,7 +13,12 @@ from typing import (
 )
 
 from multidict import (
-    CIMultiDict, CIMultiDictProxy, MultiDict, MultiDictProxy, istr)
+    CIMultiDict,
+    CIMultiDictProxy,
+    MultiDict,
+    MultiDictProxy,
+    istr,
+)
 from yarl import URL
 
 DEFAULT_JSON_ENCODER = json.dumps

--- a/aiohttp/typedefs.py
+++ b/aiohttp/typedefs.py
@@ -12,7 +12,8 @@ from typing import (
     Union,
 )
 
-from multidict import CIMultiDict, CIMultiDictProxy, MultiDict, MultiDictProxy
+from multidict import (
+    CIMultiDict, CIMultiDictProxy, MultiDict, MultiDictProxy, istr)
 from yarl import URL
 
 DEFAULT_JSON_ENCODER = json.dumps
@@ -33,7 +34,8 @@ else:
 Byteish = Union[bytes, bytearray, memoryview]
 JSONEncoder = Callable[[Any], str]
 JSONDecoder = Callable[[str], Any]
-LooseHeaders = Union[Mapping[str, str], _CIMultiDict, _CIMultiDictProxy]
+LooseHeaders = Union[Mapping[Union[str, istr], str], _CIMultiDict,
+                     _CIMultiDictProxy]
 RawHeaders = Tuple[Tuple[bytes, bytes], ...]
 StrOrURL = Union[str, URL]
 LooseCookies = Union[Iterable[Tuple[str, 'BaseCookie[str]']],


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
Allows one to use e.g. {hdrs.SOMETHING: ...} as headers per type checks.

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->
No.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
I don't think so.

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
