### PR TITLE
Fix prompt disfunction

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -109,6 +109,7 @@ Günther Jena
 Hans Adema
 Harmon Y.
 Hu Bo
+Hugh Young
 Hugo Herter
 Hynek Schlawack
 Igor Alexandrov

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ if sys.implementation.name != "cpython":
 here = pathlib.Path(__file__).parent
 
 
-if (here / '.git').exists() and not (here / 'vendor/http-parser/README.md'):
+if (here / '.git').exists() and not (here / 'vendor/http-parser/README.md').exists():
     print("Install submodules when building from git clone", file=sys.stderr)
     print("Hint:", file=sys.stderr)
     print("  git submodule update --init", file=sys.stderr)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

An extremely minimal change making an if-arm in `setup.py` which would never execute behave as expected.
The original statement missed a check method `.exists()` after the second `Path`:

```python
if (here / '.git').exists() and not (here / 'vendor/http-parser/README.md'):   # <- Here is supposed to have a ``.exists()`` method.
```

In this PR, it's added.

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

Those who want to build `aiohttp` through github will get a clear hint when building fails.

<!-- Outline any notable behaviour for the end users. -->

## Related issue number

This is introduced in PR #3189 to fix issue #3162.

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

-   [x] I think the code is well written
-   [ ] Unit tests for the changes exist
-   [ ] Documentation reflects the changes
-   [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
    -   The format is &lt;Name&gt; &lt;Surname&gt;.
    -   Please keep alphabetical order, the file is sorted by names.
-   [ ] Add a new news fragment into the `CHANGES` folder
    -   name it `<issue_id>.<type>` for example (588.bugfix)
    -   if you don't have an `issue_id` change it to the pr id after creating the pr
    -   ensure type is one of the following:
    -   `.feature`: Signifying a new feature.
    -   `.bugfix`: Signifying a bug fix.
    -   `.doc`: Signifying a documentation improvement.
    -   `.removal`: Signifying a deprecation or removal of public API.
    -   `.misc`: A ticket has been closed, but it is not of interest to users.
    -   Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."