### PR TITLE
Make tests not to fail in debug mode

### DIFF
--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -19,7 +19,11 @@ async def test_simple_server(aiohttp_raw_server, aiohttp_client) -> None:
 
 
 async def test_raw_server_not_http_exception(aiohttp_raw_server,
-                                             aiohttp_client):
+                                             aiohttp_client,
+                                             loop):
+    # disable debug mode not to print traceback
+    loop.set_debug(False)
+
     exc = RuntimeError("custom runtime error")
 
     async def handler(request):
@@ -125,7 +129,12 @@ async def test_raw_server_not_http_exception_debug(aiohttp_raw_server,
         exc_info=exc)
 
 
-async def test_raw_server_html_exception(aiohttp_raw_server, aiohttp_client):
+async def test_raw_server_html_exception(aiohttp_raw_server,
+                                         aiohttp_client,
+                                         loop):
+    # disable debug mode not to print traceback
+    loop.set_debug(False)
+
     exc = RuntimeError("custom runtime error")
 
     async def handler(request):


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
This PR fixes two tests failing in debug mode.
## What do these changes do?
In debug mode (with `PYTHONASYNCIODEBUG=1` or `-X dev`) two tests fail on `master`:
- `test_raw_server_not_http_exception`
- `test_raw_server_html_exception`

<details>
  <summary>Click here to expand the details</summary>

```
___________________________________________________________________________________ test_raw_server_not_http_exception[pyloop] ____________________________________________________________________________________

aiohttp_raw_server = <function aiohttp_raw_server.<locals>.go at 0x7fc85a694170>, aiohttp_client = <function aiohttp_client.<locals>.go at 0x7fc85a694d40>

    async def test_raw_server_not_http_exception(aiohttp_raw_server,
                                                 aiohttp_client):
        exc = RuntimeError("custom runtime error")
    
        async def handler(request):
            raise exc
    
        logger = mock.Mock()
        server = await aiohttp_raw_server(handler, logger=logger)
        cli = await aiohttp_client(server)
        resp = await cli.get('/path/to')
        assert resp.status == 500
        assert resp.headers['Content-Type'].startswith('text/plain')
    
        txt = await resp.text()
        assert txt.startswith('500 Internal Server Error')
>       assert 'Traceback' not in txt
E       assert 'Traceback' not in '500 Internal Server ...ustom runtime error\n'
E         'Traceback' is contained here:
E           500 Internal Server Error
E           
E           Traceback (most recent call last):
E         ? +++++++++
E             File "/home/ay/github/opensource/aiohttp/aiohttp/web_protocol.py", line 405, in _handle_request
E               resp = await self._request_handler(request)...
E         
E         ...Full output truncated (4 lines hidden), use '-vv' to show

tests/test_web_server.py:37: AssertionError
------------------------------------------------------------------------------------------------ Captured log call ------------------------------------------------------------------------------------------------
INFO     aiohttp.access:web_log.py:235 127.0.0.1 [16/Aug/2019:17:12:13 +0300] "GET /path/to HTTP/1.1" 500 539 "-" "Python/3.7 aiohttp/4.0.0a0"
_____________________________________________________________________________________ test_raw_server_html_exception[pyloop] ______________________________________________________________________________________

aiohttp_raw_server = <function aiohttp_raw_server.<locals>.go at 0x7fc85a694c20>, aiohttp_client = <function aiohttp_client.<locals>.go at 0x7fc85a6943b0>

    async def test_raw_server_html_exception(aiohttp_raw_server, aiohttp_client):
        exc = RuntimeError("custom runtime error")
    
        async def handler(request):
            raise exc
    
        logger = mock.Mock()
        server = await aiohttp_raw_server(handler, logger=logger)
        cli = await aiohttp_client(server)
        resp = await cli.get('/path/to', headers={'Accept': 'text/html'})
        assert resp.status == 500
        assert resp.headers['Content-Type'].startswith('text/html')
    
        txt = await resp.text()
>       assert txt == (
            '<html><head><title>500 Internal Server Error</title></head><body>\n'
            '<h1>500 Internal Server Error</h1>\n'
            'Server got itself in trouble\n'
            '</body></html>\n'
        )
E       AssertionError: assert '<html><head>...ody></html>\n' == '<html><head><...ody></html>\n'
E           <html><head><title>500 Internal Server Error</title></head><body>
E           <h1>500 Internal Server Error</h1>
E         + Server got itself in trouble
E         - <h2>Traceback:</h2>
E         - <pre>Traceback (most recent call last):
E         -   File &quot;/home/ay/github/opensource/aiohttp/aiohttp/web_protocol.py&quot;, line 405, in _handle_request
E         -     resp = await self._request_handler(request)...
E         
E         ...Full output truncated (6 lines hidden), use '-vv' to show

tests/test_web_server.py:139: AssertionError
```

</details>

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?
no.
<!-- Outline any notable behaviour for the end users. -->

## Related issue number
no issue for that.
<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
