### PR TITLE
Make Unix socket writable for other user (says, Nginx)

### DIFF
--- a/CHANGES/4002.bugfix
+++ b/CHANGES/4002.bugfix
@@ -1,0 +1,1 @@
+Make Unix socket writable for other user (says, Nginx)

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -179,10 +179,10 @@ Morgan Delahaye-Prat
 Moss Collum
 Mun Gwan-gyeong
 Navid Sheikhol
+Nguyễn Hồng Quân
 Nicolas Braem
 Nikolay Kim
 Nikolay Novik
-Nguyễn Hồng Quân
 Oisin Aylward
 Olaf Conradi
 Pahaz Blinov

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -182,6 +182,7 @@ Navid Sheikhol
 Nicolas Braem
 Nikolay Kim
 Nikolay Novik
+Nguyễn Hồng Quân
 Oisin Aylward
 Olaf Conradi
 Pahaz Blinov

--- a/aiohttp/web_runner.py
+++ b/aiohttp/web_runner.py
@@ -138,7 +138,7 @@ class UnixSite(BaseSite):
             ssl=self._ssl_context, backlog=self._backlog)
         # create_unix_server sets file permission as rwxr-xr-x, which is not
         # helpful in practice, so we fix it.
-        os.chmod(self._path, 0o666)
+        os.chmod(self._path, 0o664)
 
 
 class NamedPipeSite(BaseSite):

--- a/aiohttp/web_runner.py
+++ b/aiohttp/web_runner.py
@@ -1,3 +1,4 @@
+import os
 import asyncio
 import signal
 import socket
@@ -135,6 +136,8 @@ class UnixSite(BaseSite):
         self._server = await loop.create_unix_server(
             server, self._path,
             ssl=self._ssl_context, backlog=self._backlog)
+        # create_unix_server sets file permission as rwxr-xr-x, which is not helpful in practice, so we fix it.
+        os.chmod(self._path, 0o666)
 
 
 class NamedPipeSite(BaseSite):

--- a/aiohttp/web_runner.py
+++ b/aiohttp/web_runner.py
@@ -136,8 +136,8 @@ class UnixSite(BaseSite):
         self._server = await loop.create_unix_server(
             server, self._path,
             ssl=self._ssl_context, backlog=self._backlog)
-        # create_unix_server sets file permission as rwxr-xr-x, which is not helpful in practice,
-        # so we fix it.
+        # create_unix_server sets file permission as rwxr-xr-x, which is not
+        # helpful in practice, so we fix it.
         os.chmod(self._path, 0o666)
 
 

--- a/aiohttp/web_runner.py
+++ b/aiohttp/web_runner.py
@@ -136,7 +136,8 @@ class UnixSite(BaseSite):
         self._server = await loop.create_unix_server(
             server, self._path,
             ssl=self._ssl_context, backlog=self._backlog)
-        # create_unix_server sets file permission as rwxr-xr-x, which is not helpful in practice, so we fix it.
+        # create_unix_server sets file permission as rwxr-xr-x, which is not helpful in practice,
+        # so we fix it.
         os.chmod(self._path, 0o666)
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Fix the permission of Unix socket domain created by `web.run_app(path=...)`

## Are there changes in behavior for the user?

No

## Related issue number

No

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
