### PR TITLE
Refactor travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -170,7 +170,7 @@ matrix:
 
   include:
   - <<: *mainstream_python_base
-    name: without extensions
+    name: 3.7 without extensions
     env:
       AIOHTTP_NO_EXTENSIONS: "1"
 
@@ -213,7 +213,6 @@ matrix:
 
   - <<: *lint_base
     name: Making sure that CONTRIBUTORS.txt remains sorted
-    language: shell
     install: skip
     script:
     - LC_ALL=C sort -c CONTRIBUTORS.txt
@@ -259,9 +258,9 @@ stages:
 - *doc_stage_name
 - test
 - name: *stage_test_osx_name
-  if: type IN (api, cron)
+  if: type IN (api, cron) OR tag IS present
 - name: *deploy_stage_name
-  if: type IN (api, cron)
+  if: type IN (api, cron) OR tag IS present
 
 
 cache: pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,9 @@ _helpers:
   deploy: &_deploy_defaults
     provider: pypi
     # `skip_cleanup: true` is required to preserve binary wheels, built
-    # inside of manylinux1 docker container during `script` step above.
+    # inside of manylinux1 docker container during `script` step, and
+    # to preserve the generated .c files from the `before_script` stage
+    # in OS X builds.
     skip_cleanup: true
     # `skip_existing: true` is required to skip uploading dists, already
     # present in PYPI instead of failing the whole process.
@@ -116,7 +118,6 @@ _helpers:
   - brew --cache
   deploy:
     <<: *_deploy_defaults
-    skip_cleanup: false
     distributions: bdist_wheel
 
 # OS X test and deploy matrix helpers
@@ -159,12 +160,6 @@ _helpers:
   <<: *_generic_deploy_base
   <<: *mainstream_python_base
   stage: &deploy_stage_name Linux build and deploy
-  deploy:
-    <<: *_deploy_defaults
-    # `skip_cleanup: true` is required to preserve binary wheels, built
-    # inside of manylinux1 docker container during `script` step above.
-    skip_cleanup: true
-
 
 os: linux
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -266,8 +266,7 @@ stages:
 - name: *stage_test_osx_name
   if: type IN (api, cron)
 - name: *deploy_stage_name
-  # This will prevent deploy unless it's a tagged commit:
-  if: tag IS present
+  if: type IN (api, cron)
 
 
 cache: pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ after_success:
 _helpers:
   # anchor nodes to be included elsewhere.
   # names that start with _ are only used in other helpers
-- &_mainstream_python_base
+- &mainstream_python_base
   python: *mainstream_python
 - &_reset_steps
   env: []
@@ -38,7 +38,7 @@ _helpers:
   script: skip
 
 - &lint_base
-  <<: *_mainstream_python_base
+  <<: *mainstream_python_base
   <<: *_reset_steps
   stage: &doc_stage_name docs, linting and pre-test checks
   env:
@@ -174,8 +174,8 @@ matrix:
   - python: nightly
 
   include:
-  - name: 3.7 without extensions
-    python: 3.7
+  - <<: *mainstream_python_base
+    name: without extensions
     env:
       AIOHTTP_NO_EXTENSIONS: "1"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,11 @@ python:
 
 install:
 - &upgrade_python_toolset pip install --upgrade pip wheel setuptools
-- make cythonize
-- pip install -r requirements/ci.txt
+- pip install --upgrade -r requirements/cython.txt
+
+before_script:
+- &cythonize make cythonize
+- &ci_requirements pip install --upgrade -r requirements/ci.txt
 
 script:
 - make cov-ci-run
@@ -24,6 +27,8 @@ after_success:
  - codecov
 
 _helpers:
+  # anchor nodes to be included elsewhere.
+  # names that start with _ are only used in other helpers
 - &_mainstream_python_base
   python: *mainstream_python
 - &_reset_steps
@@ -31,48 +36,21 @@ _helpers:
   before_install: skip
   install: skip
   script: skip
-  after_success: []
-- &_lint_base
-  stage: &doc_stage_name docs, linting and pre-test checks
+
+- &lint_base
   <<: *_mainstream_python_base
   <<: *_reset_steps
-  install:
-  - *upgrade_python_toolset
-  - pip install -U -r requirements/ci.txt
-- &_doc_base
-  <<: *_lint_base
-  install:
-  - *upgrade_python_toolset
-  - pip install -U -r requirements/doc.txt -r requirements/doc-spelling.txt
-  after_failure: cat docs/_build/spelling/output.txt
-  addons:
-    apt:
-      packages:
-      - libenchant-dev
-- &osx_python_base
-  stage: &stage_test_osx_name test under OS X (last chance to fail before deploy available)
-  os: osx
-  language: shell
-  python: *pypy3
+  stage: &doc_stage_name docs, linting and pre-test checks
   env:
-  - &env_pypy3 PYTHON_VERSION=pypy3.6-7.1.1
-  - &env_pyenv PYENV_ROOT="$HOME/.pyenv"
-  - &env_path PATH="$PYENV_ROOT/bin:$PATH"
-  before_install:
-  - brew update
-  - brew install pyenv || brew upgrade pyenv
-  - &ensure_pyenv_preloaded |
-    eval "$(pyenv init -)"
-    eval "$(pyenv virtualenv-init -)"
-  - &install_python pyenv install --skip-existing --keep --verbose "$PYTHON_VERSION"
-  - &switch_python pyenv shell "$PYTHON_VERSION"
-  - &python_version python --version
-  before_cache:
-  - brew --cache
-- &generic_deploy_base
-  stage: &deploy_stage_name deploy (PYPI upload itself runs only for tagged commits)
-  <<: *_mainstream_python_base
-  deploy: &deploy_step
+    AIOHTTP_NO_EXTENSIONS: "1"
+  install:
+  - *upgrade_python_toolset
+  - *ci_requirements
+  before_script: skip
+
+- &_generic_deploy_base
+  <<: *_reset_steps
+  deploy: &_deploy_defaults
     provider: pypi
     # `skip_cleanup: true` is required to preserve binary wheels, built
     # inside of manylinux1 docker container during `script` step above.
@@ -98,37 +76,88 @@ _helpers:
     on:
       tags: true
       all_branches: true
-- &osx_pypi_deploy_base_1011
-  <<: *osx_python_base
-  <<: *generic_deploy_base
-  osx_image: xcode7.3
-  script: skip
-  after_success: []
+
+- &_osx_pypi_deploy_base
+  <<: *_generic_deploy_base
+  stage: &stage_test_osx_name test under OS X (last chance to fail before deploy available)
+  os: osx
+  language: shell
   env:
-  - &env_os1011_msg Build and deploy to PYPI of OS X 10.11 binary wheel=
-  - &env_py36 PYTHON_VERSION=3.6.3
-  - *env_pyenv
-  - *env_path
+  - &env_pyenv PYENV_ROOT="$HOME/.pyenv"
+  - &env_path PATH="$PYENV_ROOT/bin:$PATH"
+  before_install:
+  - brew update
+  - |
+    if brew ls --versions pyenv > /dev/null; then
+      brew outdated pyenv || brew upgrade pyenv
+      if brew ls --versions pyenv-virtualenv > /dev/null; then
+        brew outdated pyenv-virtualenv || brew upgrade pyenv-virtualenv
+      else
+        brew install pyenv-virtualenv
+      fi
+    else
+      brew install pyenv pyenv-virtualenv
+    fi
+  - |
+    eval "$(pyenv init -)"
+    eval "$(pyenv virtualenv-init -)"
+  - pyenv install --skip-existing --keep --verbose "$PYTHON_VERSION"
+  - pyenv shell "$PYTHON_VERSION"
+  - python --version
+  script: skip
+  before_cache:
+  - brew --cache
   deploy:
-    <<: *deploy_step
+    <<: *_deploy_defaults
     skip_cleanup: false
     distributions: bdist_wheel
-- &osx_pypi_deploy_base_1012
-  <<: *osx_pypi_deploy_base_1011
-  osx_image: xcode8.1
-  env:
-  - &env_os1012_msg Build and deploy to PYPI of OS X 10.12 binary wheel=
-  - *env_py36
-  - *env_pyenv
-  - *env_path
+
+# OS X test and deploy matrix helpers
+# These are used to build a matrix, with
+# N OSX image options and M python options,
+# of the form:
+#
+#   - <<: *osx_pypi_deploy_base_<osx version>
+#     name: <build name (optional)>
+#     env: *osx_env_<python version>
+
+# OS X image options
 - &osx_pypi_deploy_base_1010
-  <<: *osx_pypi_deploy_base_1011
+  <<: *_osx_pypi_deploy_base
   osx_image: xcode6.4
-  env:
-  - &env_os1010_msg Build and deploy to PYPI of OS X 10.10 binary wheel=
-  - *env_py36
+- &osx_pypi_deploy_base_1011
+  <<: *_osx_pypi_deploy_base
+  osx_image: xcode7.3
+- &osx_pypi_deploy_base_1012
+  <<: *_osx_pypi_deploy_base
+  osx_image: xcode8.3
+
+# OS X Python options (the _osx_env_<version>
+# key is only needed to provide a container for
+# the &osx_env_<version> YAML anchor).
+- &osx_env_py35
+  - PYTHON_VERSION: "3.5.3"
   - *env_pyenv
   - *env_path
+- &osx_env_py36
+  - PYTHON_VERSION: "3.6.3"
+  - *env_pyenv
+  - *env_path
+- &osx_env_py37
+  - PYTHON_VERSION: "3.7.0"
+  - *env_pyenv
+  - *env_path
+
+- &linux_pypi_deploy_base
+  <<: *_generic_deploy_base
+  <<: *mainstream_python_base
+  stage: &deploy_stage_name Linux build and deploy
+  deploy:
+    <<: *_deploy_defaults
+    # `skip_cleanup: true` is required to preserve binary wheels, built
+    # inside of manylinux1 docker container during `script` step above.
+    skip_cleanup: true
+
 
 os: linux
 
@@ -143,156 +172,86 @@ matrix:
     env:
       AIOHTTP_NO_EXTENSIONS: "1"
 
-  - <<: *_doc_base
+  - <<: *lint_base
     name: Checking docs spelling
+    before_script:
+    - pip install --upgrade -r requirements/doc-spelling.txt
     script:
     - make doc-spelling
+    after_failure: cat docs/_build/spelling/output.txt
+    addons:
+      apt:
+        packages:
+        - libenchant-dev
 
-  - <<: *_doc_base
+  - <<: *lint_base
     name: Checking Towncrier fragments
-    install:
-    - *upgrade_python_toolset
-    - pip install -r requirements/cython.txt
-    - AIOHTTP_NO_EXTENSIONS=1 pip install -r requirements/ci.txt
-    - pip install -r requirements/towncrier.txt
+    before_script:
+    - pip install --upgrade -r requirements/towncrier.txt
     script:
     - towncrier --yes
 
-  - <<: *_lint_base
+  - <<: *lint_base
     name: Linting source code with flake8
-    install:
-    - *upgrade_python_toolset
-    - pip install -r requirements/flake.txt
+    before_script:
+    - pip install --upgrade -r requirements/flake.txt
     script:
     - flake8 aiohttp examples tests
 
-  - <<: *_lint_base
+  - <<: *lint_base
     name: Linting source code with mypy
-    install:
-    - *upgrade_python_toolset
-    - pip install -r requirements/cython.txt
-    - AIOHTTP_NO_EXTENSIONS=1 pip install -r requirements/ci.txt
     script:
     - mypy aiohttp
 
-  - <<: *_lint_base
+  - <<: *lint_base
     name: Verifying distribution package metadata
-    install:
-    - *upgrade_python_toolset
-    - AIOHTTP_NO_EXTENSIONS=1 pip install -r requirements/ci.txt -r requirements/doc.txt
     script:
-    - AIOHTTP_NO_EXTENSIONS=1 python setup.py --verbose sdist bdist_wheel
+    - python setup.py --verbose sdist bdist_wheel
     - twine check dist/*
 
-  - <<: *_lint_base
+  - <<: *lint_base
     name: Making sure that CONTRIBUTORS.txt remains sorted
     language: shell
-    install:
-    - skip
+    install: skip
     script:
     - LC_ALL=C sort -c CONTRIBUTORS.txt
 
-  - <<: *osx_python_base
-    python: 3.5.3
-    env:
-    - &env_py35 PYTHON_VERSION=3.5.3
-    - *env_pyenv
-    - *env_path
-  - <<: *osx_python_base
-    python: *mainstream_python
-    env:
-    - *env_py36
-    - *env_pyenv
-    - *env_path
-  - <<: *osx_python_base
-    python: 3.7
-    env:
-    - &env_py37 PYTHON_VERSION=3.7.0
-    - *env_pyenv
-    - *env_path
-  # pypy3.5-5.10.0 fails under OS X because it's unsupported
+  # Build and deploy MacOS binary wheels for each OSX + Python combo possible
+  - <<: *osx_pypi_deploy_base_1010
+    name: binary wheel python 3.5 on OS X 10.10
+    env: *osx_env_py35
+  - <<: *osx_pypi_deploy_base_1010
+    name: binary wheel python 3.6 on OS X 10.10
+    env: *osx_env_py36
+  - <<: *osx_pypi_deploy_base_1010
+    name: binary wheel python 3.7 on OS X 10.10
+    env: *osx_env_py37
+  - <<: *osx_pypi_deploy_base_1011
+    name: binary wheel python 3.5 on OS X 10.11
+    env: *osx_env_py35
+  - <<: *osx_pypi_deploy_base_1011
+    name: binary wheel python 3.6 on OS X 10.11
+    env: *osx_env_py36
+  - <<: *osx_pypi_deploy_base_1011
+    name: binary wheel python 3.7 on OS X 10.11
+    env: *osx_env_py37
+  - <<: *osx_pypi_deploy_base_1012
+    name: binary wheel python 3.5 on OS X 10.12
+    env: *osx_env_py35
+  - <<: *osx_pypi_deploy_base_1012
+    name: binary wheel python 3.6 on OS X 10.12
+    env: *osx_env_py36
+  - <<: *osx_pypi_deploy_base_1012
+    name: binary wheel python 3.7 on OS X 10.12
+    env: *osx_env_py37
 
   # Build and deploy manylinux1 binary wheels and source distribution
-  - <<: *generic_deploy_base
-    <<: *_reset_steps
-    env: Build and deploy to PYPI of manylinux1 binary wheels for all supported Pythons and source distribution=
+  - <<: *linux_pypi_deploy_base
+    name: Build and deploy source distribution and manylinux1 binary wheels
     services:
     - docker
     script:
-    - pip install -r requirements/cython.txt
-    - pip install -r requirements/ci.txt  # to compile *.c files by Cython
-    - make cythonize
     - ./tools/run_docker.sh "aiohttp"
-    deploy:
-      <<: *deploy_step
-
-    # Build and deploy MacOS binary wheels for each OSX+Python combo possible
-    # OS X 10.10, Python 3.5
-  - <<: *osx_pypi_deploy_base_1010
-    python: 3.5
-    env:
-    - *env_os1010_msg
-    - *env_py35
-    - *env_pyenv
-    - *env_path
-    # OS X 10.10, Python 3.6
-  - <<: *osx_pypi_deploy_base_1010
-    env:
-    - *env_os1010_msg
-    - *env_py36
-    - *env_pyenv
-    - *env_path
-    # OS X 10.10, Python 3.7
-  - <<: *osx_pypi_deploy_base_1010
-    env:
-    - *env_os1010_msg
-    - *env_py37
-    - *env_pyenv
-    - *env_path
-    # OS X 10.11, Python 3.5
-  - <<: *osx_pypi_deploy_base_1011
-    python: 3.5
-    env:
-    - *env_os1011_msg
-    - *env_py35
-    - *env_pyenv
-    - *env_path
-    # OS X 10.11, Python 3.6
-  - <<: *osx_pypi_deploy_base_1011
-    env:
-    - *env_os1011_msg
-    - *env_py36
-    - *env_pyenv
-    - *env_path
-    # OS X 10.11, Python 3.7
-  - <<: *osx_pypi_deploy_base_1011
-    env:
-    - *env_os1011_msg
-    - *env_py37
-    - *env_pyenv
-    - *env_path
-    # OS X 10.12, Python 3.5
-  - <<: *osx_pypi_deploy_base_1012
-    python: 3.5
-    env:
-    - *env_os1012_msg
-    - *env_py35
-    - *env_pyenv
-    - *env_path
-    # OS X 10.12, Python 3.6
-  - <<: *osx_pypi_deploy_base_1012
-    env:
-    - *env_os1012_msg
-    - *env_py36
-    - *env_pyenv
-    - *env_path
-    # OS X 10.12, Python 3.7
-  - <<: *osx_pypi_deploy_base_1012
-    env:
-    - *env_os1012_msg
-    - *env_py37
-    - *env_pyenv
-    - *env_path
 
 stages:
 - *doc_stage_name

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,14 +10,14 @@ python:
 - 3.6
 - &mainstream_python 3.7
 - nightly
-- &pypy3 pypy3.5-6.0.0
+- pypy3.5-6.0.0
 
 install:
 - &upgrade_python_toolset pip install --upgrade pip wheel setuptools
 - pip install --upgrade -r requirements/cython.txt
 
 before_script:
-- &cythonize make cythonize
+- make cythonize
 - &ci_requirements pip install --upgrade -r requirements/ci.txt
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,7 @@
-conditions: v1
-version: "= 0"
 if: >  # Forbid running non-PR pushes from pyup bot
   not (type != pull_request AND branch =~ ^pyup\-scheduled\-update\-)
 
 dist: xenial
-sudo: required
 
 language: python
 
@@ -55,7 +52,7 @@ _helpers:
 - &osx_python_base
   stage: &stage_test_osx_name test under OS X (last chance to fail before deploy available)
   os: osx
-  language: generic
+  language: shell
   python: *pypy3
   env:
   - &env_pypy3 PYTHON_VERSION=pypy3.6-7.1.1
@@ -80,12 +77,12 @@ _helpers:
     # `skip_cleanup: true` is required to preserve binary wheels, built
     # inside of manylinux1 docker container during `script` step above.
     skip_cleanup: true
-    # `skip-existing: true` is required to skip uploading dists, already
+    # `skip_existing: true` is required to skip uploading dists, already
     # present in PYPI instead of failing the whole process.
     # This happens when other CI (AppVeyor etc.) has already uploaded
     # the very same dist (usually sdist).
-    skip-existing: true
-    user: aio-libs-bot
+    skip_existing: true
+    username: aio-libs-bot
     password:
       # Encrypted with `travis encrypt -r aio-libs/aiohttp --api-endpoint 'https://api.travis-ci.com/'`:
       secure: bWF8GkGmjxfisMx+LqOmZgf9EXPT4yBMhiIbN+rU5gs53PJJyn1r287c5zEijnIHlpQaJVwWJ9ZFl1n34y37P1yvhlz0M6esr5K10B9fJ6nkUoAivtOWARcHLQ3bC+WGC/V9S0v0pZ11qFuSNzJzFZqfRabRw0H8muVWGhuBuYp97EdJWCdSNpXqsj2Ts8ytPMYv+5m3iPgXq833svFbWRjZ+HgX8HwvF2lo+ej+tsFJNACbQmj+eQDGlWQZzP2s4/3grHivd2retpqfW1cYgZaZX68/UB2ghsCtkxhcNpGaM8I/n3udAHkPSqz3MC2FJL0RdkyvQ8UZkcmcisQxz0voQM25995BHGWktwpDh7BxFtGJishXV7hiFz9zVOZLM9u5AzIO4hoN770SsZDewWdhzowXPYT8DXiHVg+roEkszg8FeBmisx1cw34CK9H0iLUSQ9EF2vuz8T4bqEpbT6Fyta90wZTvJ7GpJ4yXJXR6VAvLgiX4zXeFdx/4aViz3UzkDJ06qieRuZJWfQ9u2lDxJfqHEVy5IxM5iACagP1XayJiVIN0uFRxNElxTlCMope6ICCOu9fhcGnF15XNw5YpFPYYvph3JU1vC8cYw7ypg8LQGryp1fNM9SXWaGTiV+J/yvsynFiXX6QiyGOwSBIJ9XjZEfRd8i9HaGHw2cw=
@@ -135,7 +132,7 @@ _helpers:
 
 os: linux
 
-jobs:
+matrix:
   fast_finish: true
   allow_failures:
   - python: nightly
@@ -144,7 +141,7 @@ jobs:
   - name: 3.7 without extensions
     python: 3.7
     env:
-      AIOHTTP_NO_EXTENSIONS: 1
+      AIOHTTP_NO_EXTENSIONS: "1"
 
   - <<: *_doc_base
     name: Checking docs spelling
@@ -189,7 +186,7 @@ jobs:
 
   - <<: *_lint_base
     name: Making sure that CONTRIBUTORS.txt remains sorted
-    language: minimal
+    language: shell
     install:
     - skip
     script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -101,8 +101,15 @@ _helpers:
   - |
     eval "$(pyenv init -)"
     eval "$(pyenv virtualenv-init -)"
-  - pyenv install --skip-existing --keep --verbose "$PYTHON_VERSION"
-  - pyenv shell "$PYTHON_VERSION"
+    PYENV_PYTHON_VERSION="$(pyenv install --list \
+      | grep -E "^\\s*$PYTHON_VERSION" \
+      | sort -n -t. -k3 \
+      | tail -n1 \
+      | tr -d '[:space:]' \
+      )"
+    echo $PYENV_PYTHON_VERSION
+  - pyenv install --skip-existing --keep --verbose "$PYENV_PYTHON_VERSION"
+  - pyenv shell "$PYENV_PYTHON_VERSION"
   - python --version
   script: skip
   before_cache:
@@ -136,15 +143,15 @@ _helpers:
 # key is only needed to provide a container for
 # the &osx_env_<version> YAML anchor).
 - &osx_env_py35
-  - PYTHON_VERSION: "3.5.3"
+  - PYTHON_VERSION: "3.5"
   - *env_pyenv
   - *env_path
 - &osx_env_py36
-  - PYTHON_VERSION: "3.6.3"
+  - PYTHON_VERSION: "3.6"
   - *env_pyenv
   - *env_path
 - &osx_env_py37
-  - PYTHON_VERSION: "3.7.0"
+  - PYTHON_VERSION: "3.7"
   - *env_pyenv
   - *env_path
 

--- a/requirements/ci-wheel.txt
+++ b/requirements/ci-wheel.txt
@@ -15,6 +15,7 @@ tox==3.13.2
 trustme==0.5.2
 cryptography==2.7
 twine==1.13.0
+typing_extensions==3.7.4
 yarl==1.3.0
 
 # Using PEP 508 env markers to control dependency on runtimes:
@@ -22,4 +23,3 @@ aiodns==2.0.0; platform_system!="Windows"  # required c-ares will not build on w
 codecov==2.0.15
 uvloop==0.12.1; platform_system!="Windows" and implementation_name=="cpython" and python_version<"3.7" # MagicStack/uvloop#14
 idna-ssl==1.1.0; python_version<"3.7"
-typing_extensions==3.7.2; python_version<"3.7"


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Improve the travis configuration structure and fix the OS X jobs.

- Address travis configuration warnings and remove legacy keys such as `conditions` and `version`.
- Refactor the YAML components to be more effective
- Repair the OSX build matrix (untangle the `env` / `name` confusion, ensure `pyenv-virtualenv` is installed)
- Make it much easier to maintain the OSX job matrix
- Allow the manylinux1 job to run on API and cron triggers too so issues with this step can be found more easily. The OS X jobs were already running on the same condition. Actual deployment (uploading the sdist distribution and wheels to PyPI) still depends on the the revision having a tag.

## What these changes *don't* do:

- fix the 3.8-dev build, that's due to the mypy version aiohttp supports. Mypy 0.670 depends on an older `typed-ast` release that doesn't work on 3.8. See #3928 
- fix the manylinux1 i686 wheel build, that's due to the `cryptography==2.7` pin in `ci-wheel.txt` and cryptography having dropped support for 32-bit builds. See #4018 
- adjust the pypy3 version choice, it's left at pypy3.5-6.0.0.
- adjust the OSX image choices. Travis puts up a big banner for the XCode 6.4 image builds because it dropped support last year.
- generate the OSX jobs with the Travis matrix functionality. That'd require a much bigger re-architecture where the `install`, `before_script` and `script` steps can handle both Linux and OS X environments.

## Future OS X build options

This pull request makes the builds run again, but there is actually no need to switch XCode images. OS X wheels are tied to an SDK release, newer XCode versions can build code against an older SDK release.

The SDK release defaults to the SDK that was used for the Python binary that is running the build. If you download an official Python.org OS X build then you end up building a corresponding wheel version, without the need to switch XCode images. See the [*Wheel Building* page](https://github.com/MacPython/wiki/wiki/Wheel-building) on the MacPython Wiki. The [multibuild project](https://github.com/matthew-brett/multibuild) follows this approach and outputs *combined* wheels. For a given Python version, a single wheel bundling all SDK variants is created, e.g. the matplotlib project has [`..._macosx_10_6_intel.macosx_10_9_intel.macosx_10_9_x86_64.macosx_10_10_intel.macosx_10_10_x86_64.whl` wheels](https://pypi.org/project/matplotlib/3.1.1/#copy-hash-modal-17ab0ed9-407a-4334-bac3-1447b7ef8745).

The multibuild project would also make integrating OS X into a matrix (with or without a separate stage) easier as it already has all the scripts to distinguish between platforms. For examples of their use, see the [Pillows project](https://github.com/radarhere/pillow-wheels/blob/d5f36a1544fe0fd47e5209fe033f50abed2d9425/.travis.yml#L183-L195), or [the 

## Are there changes in behavior for the user?

No, this is purely a CI change.

## Misc

* The `typing_extensions` pin change should perhaps be a separate pull request.
* So could the change to have the linux wheel building stage run on API and cron triggers.
* Presumably this change doesn't warrant towncrier and contributors entries

## Checklist

- [X] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes 
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
