### PR TITLE
CI: Fix i686 manylinux build

### DIFF
--- a/requirements/ci-wheel.txt
+++ b/requirements/ci-wheel.txt
@@ -13,12 +13,13 @@ pytest-cov==2.7.1
 pytest-mock==1.10.4
 tox==3.13.2
 trustme==0.5.2
-cryptography==2.7
 twine==1.13.0
 yarl==1.3.0
 
 # Using PEP 508 env markers to control dependency on runtimes:
 aiodns==2.0.0; platform_system!="Windows"  # required c-ares will not build on windows
+cryptography==2.7; platform_system!="Linux" or platform_machine!="i686"
+cryptography==2.6.1; platform_system=="Linux" and platform_machine=="i686"  # See #4018
 codecov==2.0.15
 uvloop==0.12.1; platform_system!="Windows" and implementation_name=="cpython" and python_version<"3.7" # MagicStack/uvloop#14
 idna-ssl==1.1.0; python_version<"3.7"

--- a/requirements/ci-wheel.txt
+++ b/requirements/ci-wheel.txt
@@ -12,14 +12,13 @@ pytest==5.1.1
 pytest-cov==2.7.1
 pytest-mock==1.10.4
 tox==3.13.2
-trustme==0.5.2
 twine==1.13.0
 yarl==1.3.0
 
 # Using PEP 508 env markers to control dependency on runtimes:
 aiodns==2.0.0; platform_system!="Windows"  # required c-ares will not build on windows
-cryptography==2.7; platform_system!="Linux" or platform_machine!="i686"
-cryptography==2.6.1; platform_system=="Linux" and platform_machine=="i686"  # See #4018
+cryptography==2.7; platform_machine!="i686" # no 32-bit wheels
+trustme==0.5.2; platform_machine!="i686"    # no 32-bit wheels
 codecov==2.0.15
 uvloop==0.12.1; platform_system!="Windows" and implementation_name=="cpython" and python_version<"3.7" # MagicStack/uvloop#14
 idna-ssl==1.1.0; python_version<"3.7"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,12 @@ from unittest import mock
 from uuid import uuid4
 
 import pytest
-import trustme
+
+try:
+    import trustme
+    TRUSTME = True
+except ImportError:
+    TRUSTME = False
 
 pytest_plugins = ['aiohttp.pytest_plugin', 'pytester']
 
@@ -25,6 +30,8 @@ needs_unix = pytest.mark.skipif(not IS_UNIX, reason='requires UNIX sockets')
 
 @pytest.fixture
 def tls_certificate_authority():
+    if not TRUSTME:
+        pytest.xfail("trustme fails on 32bit Linux")
     return trustme.CA()
 
 


### PR DESCRIPTION
## What do these changes do?

The cryptography project has stopped providing 32-bit wheels, 2.6.1 is the last version that still has a wheel available.

This makes it possible to run tests against the i686 32-bit wheel built in Travis again.

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

None, this is a CI build fix only.

## Related issue number

This fixes #4018
