### PR TITLE
CI: fix typing_extensions handling for manylinux build

### DIFF
--- a/requirements/ci-wheel.txt
+++ b/requirements/ci-wheel.txt
@@ -15,6 +15,7 @@ tox==3.13.2
 trustme==0.5.2
 cryptography==2.7
 twine==1.13.0
+typing_extensions==3.7.4
 yarl==1.3.0
 
 # Using PEP 508 env markers to control dependency on runtimes:
@@ -22,4 +23,3 @@ aiodns==2.0.0; platform_system!="Windows"  # required c-ares will not build on w
 codecov==2.0.15
 uvloop==0.12.1; platform_system!="Windows" and implementation_name=="cpython" and python_version<"3.7" # MagicStack/uvloop#14
 idna-ssl==1.1.0; python_version<"3.7"
-typing_extensions==3.7.2; python_version<"3.7"


### PR DESCRIPTION
## What do these changes do?

typing_extensions is now an unconditional dependency; move it to the latest
release.

This only affects the manylinux1_* docker container builds, which uses this requirements.txt file and runs tests against the wheels it built, on 3.7.


## Related issue number

Fixes #4024
