### PR TITLE
Don't set Host header to host:None if port is not provided

### DIFF
--- a/CHANGES/4039.bugfix
+++ b/CHANGES/4039.bugfix
@@ -1,0 +1,1 @@
+For URLs like "unix://localhost/..." set Host HTTP header to "localhost" instead of "localhost:None".

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -315,7 +315,7 @@ class ClientRequest:
         netloc = cast(str, self.url.raw_host)
         if helpers.is_ipv6_address(netloc):
             netloc = '[{}]'.format(netloc)
-        if not self.url.is_default_port():
+        if self.url.port is not None and not self.url.is_default_port():
             netloc += ':' + str(self.url.port)
         self.headers[hdrs.HOST] = netloc
 

--- a/tests/test_client_request.py
+++ b/tests/test_client_request.py
@@ -199,6 +199,11 @@ def test_host_port_nondefault_wss(make_request) -> None:
     assert req.is_ssl()
 
 
+def test_host_port_none_port(make_request) -> None:
+    req = make_request('get', 'unix://localhost/path')
+    assert req.headers['Host'] == 'localhost'
+
+
 def test_host_port_err(make_request) -> None:
     with pytest.raises(ValueError):
         make_request('get', 'http://python.org:123e/')


### PR DESCRIPTION
Fixes #4039