### PR TITLE
[3.6] Fix #4039: Don't set Host header to host:None if port is not provided (#4040)

### DIFF
--- a/CHANGES/4039.bugfix
+++ b/CHANGES/4039.bugfix
@@ -1,0 +1,1 @@
+For URLs like "unix://localhost/..." set Host HTTP header to "localhost" instead of "localhost:None".

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -367,7 +367,7 @@ class ClientRequest:
         netloc = cast(str, self.url.raw_host)
         if helpers.is_ipv6_address(netloc):
             netloc = '[{}]'.format(netloc)
-        if not self.url.is_default_port():
+        if self.url.port is not None and not self.url.is_default_port():
             netloc += ':' + str(self.url.port)
         self.headers[hdrs.HOST] = netloc
 

--- a/tests/test_client_request.py
+++ b/tests/test_client_request.py
@@ -204,6 +204,11 @@ def test_host_port_nondefault_wss(make_request) -> None:
     assert req.is_ssl()
 
 
+def test_host_port_none_port(make_request) -> None:
+    req = make_request('get', 'unix://localhost/path')
+    assert req.headers['Host'] == 'localhost'
+
+
 def test_host_port_err(make_request) -> None:
     with pytest.raises(ValueError):
         make_request('get', 'http://python.org:123e/')


### PR DESCRIPTION

(cherry picked from commit db760f71)

Co-authored-by: Andrew Svetlov <andrew.svetlov@gmail.com>
