### PR TITLE
Emit warning when there's no ssl.OP_NO_COMPRESSION

### DIFF
--- a/CHANGES/4052.bugfix
+++ b/CHANGES/4052.bugfix
@@ -1,0 +1,3 @@
+Emit a warning when :py:attr:`ssl.OP_NO_COMPRESSION` is
+unavailable because the runtime is built against
+an outdated OpenSSL.

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -849,7 +849,16 @@ class TCPConnector(BaseConnector):
             sslcontext = ssl.SSLContext(ssl.PROTOCOL_SSLv23)
             sslcontext.options |= ssl.OP_NO_SSLv2
             sslcontext.options |= ssl.OP_NO_SSLv3
-            sslcontext.options |= ssl.OP_NO_COMPRESSION
+            try:
+                sslcontext.options |= ssl.OP_NO_COMPRESSION
+            except AttributeError as attr_err:
+                warnings.warn(
+                    '{!s}: The Python interpreter is compiled '
+                    'against OpenSSL < 1.0.0. Ref: '
+                    'https://docs.python.org/3/library/ssl.html'
+                    '#ssl.OP_NO_COMPRESSION'.
+                    format(attr_err),
+                )
             sslcontext.set_default_verify_paths()
             return sslcontext
 

--- a/pytest.ci.ini
+++ b/pytest.ci.ini
@@ -1,6 +1,8 @@
 [pytest]
 addopts = --cov=aiohttp --cov-report term-missing:skip-covered --cov-report xml --junitxml=.test-results/pytest/results.xml -v -rxXs --durations 10
-filterwarnings = error
+filterwarnings =
+    error
+    ignore:module 'ssl' has no attribute 'OP_NO_COMPRESSION'. The Python interpreter is compiled against OpenSSL < 1.0.0. Ref. https.//docs.python.org/3/library/ssl.html#ssl.OP_NO_COMPRESSION:UserWarning
 junit_suite_name = aiohttp_test_suite
 norecursedirs = dist docs build .tox .eggs
 minversion = 3.8.2

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,8 @@
 [pytest]
 addopts = --cov=aiohttp -v -rxXs
-filterwarnings = error
+filterwarnings =
+    error
+    ignore:module 'ssl' has no attribute 'OP_NO_COMPRESSION'. The Python interpreter is compiled against OpenSSL < 1.0.0. Ref. https.//docs.python.org/3/library/ssl.html#ssl.OP_NO_COMPRESSION:UserWarning
 junit_suite_name = aiohttp_test_suite
 norecursedirs = dist docs build .tox .eggs
 minversion = 3.8.2


### PR DESCRIPTION
This prevents AttributeError under python.org interpreter builds for macOS linked against ``OpenSSL<1.0.0``.