### PR TITLE
Provide pytest-aiohttp namespace for pytest fixtures in the doc

### DIFF
--- a/CHANGES/3723.doc
+++ b/CHANGES/3723.doc
@@ -1,0 +1,1 @@
+Provide pytest-aiohttp namespace for pytest fixtures in docs.

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -71,6 +71,8 @@ proxy methods to the client for common operations such as
 Pytest
 ~~~~~~
 
+.. currentmodule:: pytest_aiohttp
+
 The :data:`aiohttp_client` fixture available from pytest-aiohttp_ plugin
 allows you to create a client to make requests to test your app.
 
@@ -234,6 +236,9 @@ Pytest tooling has the following fixtures:
 
 Unittest
 ~~~~~~~~
+
+.. currentmodule:: aiohttp.test_utils
+
 
 To test applications with the standard library's unittest or unittest-based
 functionality, the AioHTTPTestCase is provided::


### PR DESCRIPTION
Fixes #3723