### PR TITLE
Fix handling of expired cookies so they are not stored in CookieJar

### DIFF
--- a/CHANGES/4063.bugfix
+++ b/CHANGES/4063.bugfix
@@ -1,0 +1,1 @@
+Fix handling of expired cookies so they are not stored in CookieJar.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -4,6 +4,7 @@ A. Jesse Jiryu Davis
 Adam Cooper
 Adam Mills
 Adrián Chaves
+Alan Tse
 Alec Hanefeld
 Alejandro Gómez
 Aleksandr Danshyn

--- a/aiohttp/cookiejar.py
+++ b/aiohttp/cookiejar.py
@@ -169,9 +169,13 @@ class CookieJar(AbstractCookieJar):
             if max_age:
                 try:
                     delta_seconds = int(max_age)
-                    self._expire_cookie(datetime.datetime.now(
-                        datetime.timezone.utc) +
-                        datetime.timedelta(seconds=delta_seconds),
+                    try:
+                        max_age_expiration = (
+                            datetime.datetime.now(datetime.timezone.utc) +
+                            datetime.timedelta(seconds=delta_seconds))
+                    except OverflowError:
+                        max_age_expiration = self.MAX_TIME
+                    self._expire_cookie(max_age_expiration,
                         domain, name)
                 except ValueError:
                     cookie["max-age"] = ""

--- a/aiohttp/cookiejar.py
+++ b/aiohttp/cookiejar.py
@@ -185,8 +185,7 @@ class CookieJar(AbstractCookieJar):
                 if expires:
                     expire_time = self._parse_date(expires)
                     if expire_time:
-                        self._expire_cookie(datetime.datetime.fromtimestamp(
-                            expire_time.timestamp(), tz=datetime.timezone.utc),
+                        self._expire_cookie(expire_time,
                             domain, name)
                     else:
                         cookie["expires"] = ""

--- a/aiohttp/cookiejar.py
+++ b/aiohttp/cookiejar.py
@@ -55,7 +55,7 @@ class CookieJar(AbstractCookieJar):
         self._cookies = defaultdict(SimpleCookie)  #type: DefaultDict[str, SimpleCookie]  # noqa
         self._host_only_cookies = set()  # type: Set[Tuple[str, str]]
         self._unsafe = unsafe
-        self._next_expiration: datetime.datetime = self._next_whole_second()
+        self._next_expiration = self._next_whole_second()
         self._expirations = {}  # type: Dict[Tuple[str, str], datetime.datetime]
 
     def save(self, file_path: PathLike) -> None:

--- a/aiohttp/cookiejar.py
+++ b/aiohttp/cookiejar.py
@@ -175,7 +175,9 @@ class CookieJar(AbstractCookieJar):
                 if expires:
                     expire_time = self._parse_date(expires)
                     if expire_time:
-                        self._expire_cookie(expire_time.timestamp(),
+                        diff = (expire_time.timestamp() -
+                                datetime.datetime.now().timestamp())
+                        self._expire_cookie(diff,
                                             domain, name)
                     else:
                         cookie["expires"] = ""

--- a/aiohttp/cookiejar.py
+++ b/aiohttp/cookiejar.py
@@ -6,7 +6,6 @@ import re
 import warnings
 from collections import defaultdict
 from http.cookies import BaseCookie, Morsel, SimpleCookie  # noqa
-from math import ceil
 from typing import (  # noqa
     DefaultDict,
     Dict,
@@ -48,15 +47,16 @@ class CookieJar(AbstractCookieJar):
 
     DATE_YEAR_RE = re.compile(r"(\d{2,4})")
 
-    MAX_TIME = 2051215261.0  # so far in future (2035-01-01)
+    MAX_TIME: datetime.datetime = datetime.datetime.max.replace(
+        tzinfo=datetime.timezone.utc)
 
     def __init__(self, *, unsafe: bool=False) -> None:
         self._loop = get_running_loop()
         self._cookies = defaultdict(SimpleCookie)  #type: DefaultDict[str, SimpleCookie]  # noqa
         self._host_only_cookies = set()  # type: Set[Tuple[str, str]]
         self._unsafe = unsafe
-        self._next_expiration = ceil(self._loop.time())
-        self._expirations = {}  # type: Dict[Tuple[str, str], int]
+        self._next_expiration: datetime.datetime = self._next_whole_second()
+        self._expirations: Dict[Tuple[str, str], datetime.datetime] = {}
 
     def save(self, file_path: PathLike) -> None:
         file_path = pathlib.Path(file_path)
@@ -71,7 +71,7 @@ class CookieJar(AbstractCookieJar):
     def clear(self) -> None:
         self._cookies.clear()
         self._host_only_cookies.clear()
-        self._next_expiration = ceil(self._loop.time())
+        self._next_expiration = self._next_whole_second()
         self._expirations.clear()
 
     def __iter__(self) -> 'Iterator[Morsel[str]]':
@@ -82,8 +82,16 @@ class CookieJar(AbstractCookieJar):
     def __len__(self) -> int:
         return sum(1 for i in self)
 
+    def _next_whole_second(self) -> datetime.datetime:
+        """Return current time rounded up to the next whole second."""
+        return (
+            datetime.datetime.now(
+                datetime.timezone.utc).replace(microsecond=0) +
+            datetime.timedelta(seconds=0)
+        )
+
     def _do_expiration(self) -> None:
-        now = self._loop.time()
+        now: datetime.datetime = datetime.datetime.now(datetime.timezone.utc)
         if self._next_expiration > now:
             return
         if not self._expirations:
@@ -102,12 +110,16 @@ class CookieJar(AbstractCookieJar):
         for key in to_del:
             del expirations[key]
 
-        self._next_expiration = ceil(next_expiration)
+        try:
+            self._next_expiration = (next_expiration.replace(microsecond=0) +
+                                     datetime.timedelta(seconds=1))
+        except OverflowError:
+            self._next_expiration = self.MAX_TIME
 
-    def _expire_cookie(self, when: float, domain: str, name: str) -> None:
-        iwhen = int(when)
-        self._next_expiration = min(self._next_expiration, iwhen)
-        self._expirations[(domain, name)] = iwhen
+    def _expire_cookie(self, when: datetime.datetime, domain: str, name: str
+                       ) -> None:
+        self._next_expiration = min(self._next_expiration, when)
+        self._expirations[(domain, name)] = when
 
     def update_cookies(self,
                        cookies: LooseCookies,
@@ -165,8 +177,10 @@ class CookieJar(AbstractCookieJar):
             if max_age:
                 try:
                     delta_seconds = int(max_age)
-                    self._expire_cookie(self._loop.time() + delta_seconds,
-                                        domain, name)
+                    self._expire_cookie(datetime.datetime.now(
+                        datetime.timezone.utc) +
+                        datetime.timedelta(seconds=delta_seconds),
+                        domain, name)
                 except ValueError:
                     cookie["max-age"] = ""
 
@@ -175,10 +189,9 @@ class CookieJar(AbstractCookieJar):
                 if expires:
                     expire_time = self._parse_date(expires)
                     if expire_time:
-                        diff = (expire_time.timestamp() -
-                                datetime.datetime.now().timestamp())
-                        self._expire_cookie(diff,
-                                            domain, name)
+                        self._expire_cookie(datetime.datetime.fromtimestamp(
+                            expire_time.timestamp(), tz=datetime.timezone.utc),
+                            domain, name)
                     else:
                         cookie["expires"] = ""
 

--- a/aiohttp/cookiejar.py
+++ b/aiohttp/cookiejar.py
@@ -91,7 +91,7 @@ class CookieJar(AbstractCookieJar):
         )
 
     def _do_expiration(self) -> None:
-        now: datetime.datetime = datetime.datetime.now(datetime.timezone.utc)
+        now = datetime.datetime.now(datetime.timezone.utc)
         if self._next_expiration > now:
             return
         if not self._expirations:

--- a/aiohttp/cookiejar.py
+++ b/aiohttp/cookiejar.py
@@ -47,7 +47,7 @@ class CookieJar(AbstractCookieJar):
 
     DATE_YEAR_RE = re.compile(r"(\d{2,4})")
 
-    MAX_TIME: datetime.datetime = datetime.datetime.max.replace(
+    MAX_TIME = datetime.datetime.max.replace(
         tzinfo=datetime.timezone.utc)
 
     def __init__(self, *, unsafe: bool=False) -> None:

--- a/aiohttp/cookiejar.py
+++ b/aiohttp/cookiejar.py
@@ -176,7 +176,7 @@ class CookieJar(AbstractCookieJar):
                     except OverflowError:
                         max_age_expiration = self.MAX_TIME
                     self._expire_cookie(max_age_expiration,
-                        domain, name)
+                                        domain, name)
                 except ValueError:
                     cookie["max-age"] = ""
 
@@ -186,7 +186,7 @@ class CookieJar(AbstractCookieJar):
                     expire_time = self._parse_date(expires)
                     if expire_time:
                         self._expire_cookie(expire_time,
-                            domain, name)
+                                            domain, name)
                     else:
                         cookie["expires"] = ""
 

--- a/aiohttp/cookiejar.py
+++ b/aiohttp/cookiejar.py
@@ -56,7 +56,7 @@ class CookieJar(AbstractCookieJar):
         self._host_only_cookies = set()  # type: Set[Tuple[str, str]]
         self._unsafe = unsafe
         self._next_expiration: datetime.datetime = self._next_whole_second()
-        self._expirations: Dict[Tuple[str, str], datetime.datetime] = {}
+        self._expirations = {}  # type: Dict[Tuple[str, str], datetime.datetime]
 
     def save(self, file_path: PathLike) -> None:
         file_path = pathlib.Path(file_path)

--- a/aiohttp/cookiejar.py
+++ b/aiohttp/cookiejar.py
@@ -22,7 +22,7 @@ from typing import (  # noqa
 from yarl import URL
 
 from .abc import AbstractCookieJar
-from .helpers import get_running_loop, is_ip_address
+from .helpers import get_running_loop, is_ip_address, next_whole_second
 from .typedefs import LooseCookies, PathLike
 
 __all__ = ('CookieJar', 'DummyCookieJar')
@@ -55,8 +55,8 @@ class CookieJar(AbstractCookieJar):
         self._cookies = defaultdict(SimpleCookie)  #type: DefaultDict[str, SimpleCookie]  # noqa
         self._host_only_cookies = set()  # type: Set[Tuple[str, str]]
         self._unsafe = unsafe
-        self._next_expiration = self._next_whole_second()
-        self._expirations = {}  # type: Dict[Tuple[str, str], datetime.datetime]
+        self._next_expiration = next_whole_second()
+        self._expirations = {}  # type: Dict[Tuple[str, str], datetime.datetime]  # noqa: E501
 
     def save(self, file_path: PathLike) -> None:
         file_path = pathlib.Path(file_path)
@@ -71,7 +71,7 @@ class CookieJar(AbstractCookieJar):
     def clear(self) -> None:
         self._cookies.clear()
         self._host_only_cookies.clear()
-        self._next_expiration = self._next_whole_second()
+        self._next_expiration = next_whole_second()
         self._expirations.clear()
 
     def __iter__(self) -> 'Iterator[Morsel[str]]':
@@ -81,14 +81,6 @@ class CookieJar(AbstractCookieJar):
 
     def __len__(self) -> int:
         return sum(1 for i in self)
-
-    def _next_whole_second(self) -> datetime.datetime:
-        """Return current time rounded up to the next whole second."""
-        return (
-            datetime.datetime.now(
-                datetime.timezone.utc).replace(microsecond=0) +
-            datetime.timedelta(seconds=0)
-        )
 
     def _do_expiration(self) -> None:
         now = datetime.datetime.now(datetime.timezone.utc)

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -4,6 +4,7 @@ import asyncio
 import base64
 import binascii
 import cgi
+import datetime
 import functools
 import inspect
 import netrc
@@ -454,6 +455,15 @@ is_ipv6_address = functools.partial(_is_ip_address, _ipv6_regex, _ipv6_regexb)
 def is_ip_address(
         host: Optional[Union[str, bytes, bytearray, memoryview]]) -> bool:
     return is_ipv4_address(host) or is_ipv6_address(host)
+
+
+def next_whole_second() -> datetime.datetime:
+    """Return current time rounded up to the next whole second."""
+    return (
+        datetime.datetime.now(
+            datetime.timezone.utc).replace(microsecond=0) +
+        datetime.timedelta(seconds=0)
+    )
 
 
 _cached_current_datetime = None  # type: Optional[int]

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -1,6 +1,7 @@
 setuptools-git==1.2
 mypy==0.720; implementation_name=="cpython"
 mypy-extensions==0.4.1; implementation_name=="cpython"
+freezegun==0.3.12
 
 -r ci-wheel.txt
 -r doc.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,4 +1,3 @@
 -r ci.txt
 -r towncrier.txt
 cherry_picker==1.3.2; python_version>="3.6"
-freezegun==0.3.12

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,3 +1,4 @@
 -r ci.txt
 -r towncrier.txt
 cherry_picker==1.3.2; python_version>="3.6"
+freezegun==0.3.12

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -2044,7 +2044,7 @@ async def test_set_cookies_max_age_overflow(aiohttp_client) -> None:
         return ret
 
     overflow = int(datetime.datetime.max.timestamp() -
-                   datetime.datetime.now().timestamp() + 1000)
+                   datetime.datetime.now().timestamp()) + 1000
     empty = None
     try:
         empty = datetime.datetime(overflow)

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -2044,11 +2044,11 @@ async def test_set_cookies_max_age_overflow(aiohttp_client) -> None:
         return ret
 
     overflow = int(datetime.datetime.max.replace(
-        tzinfo=datetime.timezone.utc).timestamp() -
-        datetime.datetime.now(datetime.timezone.utc).timestamp()) + 1000
+        tzinfo=datetime.timezone.utc).timestamp())
     empty = None
     try:
-        empty = datetime.datetime(overflow)
+        empty = (datetime.datetime.now(datetime.timezone.utc) +
+                 datetime.timedelta(seconds=overflow))
     except OverflowError as ex:
         assert isinstance(ex, OverflowError)
     assert not isinstance(empty, datetime.datetime)
@@ -2060,7 +2060,7 @@ async def test_set_cookies_max_age_overflow(aiohttp_client) -> None:
     assert 200 == resp.status
     for cookie in client.session.cookie_jar:
         if cookie.key == 'overflow':
-            assert int(cookie['max-age']) <= int(overflow)
+            assert int(cookie['max-age']) == int(overflow)
     resp.close()
 
 

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -2043,8 +2043,9 @@ async def test_set_cookies_max_age_overflow(aiohttp_client) -> None:
                         " Max-Age=" + str(overflow) + "; ")
         return ret
 
-    overflow = int(datetime.datetime.max.timestamp() -
-                   datetime.datetime.now().timestamp()) + 1000
+    overflow = int(datetime.datetime.max.replace(
+        tzinfo=datetime.timezone.utc).timestamp() -
+        datetime.datetime.now(datetime.timezone.utc).timestamp()) + 1000
     empty = None
     try:
         empty = datetime.datetime(overflow)

--- a/tests/test_cookiejar.py
+++ b/tests/test_cookiejar.py
@@ -170,6 +170,18 @@ async def test_constructor(loop, cookies_to_send, cookies_to_receive) -> None:
     assert jar._loop is loop
 
 
+async def test_constructor_with_expired(loop, cookies_to_send_with_expired,
+                                        cookies_to_receive) -> None:
+    jar = CookieJar()
+    jar.update_cookies(cookies_to_send_with_expired)
+    jar_cookies = SimpleCookie()
+    for cookie in jar:
+        dict.__setitem__(jar_cookies, cookie.key, cookie)
+    expected_cookies = cookies_to_send_with_expired
+    assert jar_cookies != expected_cookies
+    assert jar._loop is loop
+
+
 async def test_save_load(
     tmp_path, loop, cookies_to_send, cookies_to_receive
 ) -> None:

--- a/tests/test_cookiejar.py
+++ b/tests/test_cookiejar.py
@@ -7,6 +7,7 @@ from http.cookies import SimpleCookie
 from unittest import mock
 
 import pytest
+from freezegun import freeze_time
 from yarl import URL
 
 from aiohttp import CookieJar, DummyCookieJar
@@ -14,6 +15,32 @@ from aiohttp import CookieJar, DummyCookieJar
 
 @pytest.fixture
 def cookies_to_send():
+    return SimpleCookie(
+        "shared-cookie=first; "
+        "domain-cookie=second; Domain=example.com; "
+        "subdomain1-cookie=third; Domain=test1.example.com; "
+        "subdomain2-cookie=fourth; Domain=test2.example.com; "
+        "dotted-domain-cookie=fifth; Domain=.example.com; "
+        "different-domain-cookie=sixth; Domain=different.org; "
+        "secure-cookie=seventh; Domain=secure.com; Secure; "
+        "no-path-cookie=eighth; Domain=pathtest.com; "
+        "path1-cookie=nineth; Domain=pathtest.com; Path=/; "
+        "path2-cookie=tenth; Domain=pathtest.com; Path=/one; "
+        "path3-cookie=eleventh; Domain=pathtest.com; Path=/one/two; "
+        "path4-cookie=twelfth; Domain=pathtest.com; Path=/one/two/; "
+        "expires-cookie=thirteenth; Domain=expirestest.com; Path=/;"
+        " Expires=Tue, 1 Jan 2039 12:00:00 GMT; "
+        "max-age-cookie=fourteenth; Domain=maxagetest.com; Path=/;"
+        " Max-Age=60; "
+        "invalid-max-age-cookie=fifteenth; Domain=invalid-values.com; "
+        " Max-Age=string; "
+        "invalid-expires-cookie=sixteenth; Domain=invalid-values.com; "
+        " Expires=string;"
+    )
+
+
+@pytest.fixture
+def cookies_to_send_with_expired():
     return SimpleCookie(
         "shared-cookie=first; "
         "domain-cookie=second; Domain=example.com; "
@@ -314,7 +341,7 @@ class TestCookieJarSafe(TestCookieJarBase):
             "path3-cookie=eleventh; Domain=pathtest.com; Path=/one/two; "
             "path4-cookie=twelfth; Domain=pathtest.com; Path=/one/two/; "
             "expires-cookie=thirteenth; Domain=expirestest.com; Path=/;"
-            " Expires=Tue, 1 Jan 1980 12:00:00 GMT; "
+            " Expires=Tue, 1 Jan 2039 12:00:00 GMT; "
             "max-age-cookie=fourteenth; Domain=maxagetest.com; Path=/;"
             " Max-Age=60; "
             "invalid-max-age-cookie=fifteenth; Domain=invalid-values.com; "
@@ -340,10 +367,19 @@ class TestCookieJarSafe(TestCookieJarBase):
         self.jar = self.loop.run_until_complete(make_jar())
 
     def timed_request(self, url, update_time, send_time):
-        with mock.patch.object(self.loop, 'time', return_value=update_time):
+        if isinstance(update_time, int):
+            update_time = datetime.timedelta(seconds=update_time)
+        elif isinstance(update_time, float):
+            update_time = datetime.datetime.fromtimestamp(update_time)
+        if isinstance(send_time, int):
+            send_time = datetime.timedelta(seconds=send_time)
+        elif isinstance(send_time, float):
+            send_time = datetime.datetime.fromtimestamp(send_time)
+
+        with freeze_time(update_time):
             self.jar.update_cookies(self.cookies_to_send)
 
-        with mock.patch.object(self.loop, 'time', return_value=send_time):
+        with freeze_time(send_time):
             cookies_sent = self.jar.filter_cookies(URL(url))
 
         self.jar.clear()

--- a/tests/test_cookiejar.py
+++ b/tests/test_cookiejar.py
@@ -353,7 +353,7 @@ class TestCookieJarSafe(TestCookieJarBase):
             "path3-cookie=eleventh; Domain=pathtest.com; Path=/one/two; "
             "path4-cookie=twelfth; Domain=pathtest.com; Path=/one/two/; "
             "expires-cookie=thirteenth; Domain=expirestest.com; Path=/;"
-            " Expires=Tue, 1 Jan 2039 12:00:00 GMT; "
+            " Expires=Tue, 1 Jan 1980 12:00:00 GMT; "
             "max-age-cookie=fourteenth; Domain=maxagetest.com; Path=/;"
             " Max-Age=60; "
             "invalid-max-age-cookie=fifteenth; Domain=invalid-values.com; "


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?
<!-- Please give a short brief about these changes. -->
Properly schedule expiration date for cookies that are provided to the CookieJar with a date in the past which will result in such cookies being immediately expired by `_do_expiration()`.  Currently, the expiration date is set to the `timestamp()` (i.e., unix timestamp) which will make almost all values far in the future since it's compared to the `event_loop.time()` which increments from the start of the loop.

Marked WIP because this fix breaks the tests in `tests/test_cookiejar.py` for `test_constructor` and `TestCookieJarSafe.test_expires`.  I believe there are incorrect assumptions about behavior but I wanted to verify the test assumptions before making changes to the test suite. Mainly, should expired cookies be stored in the CookieJar and just never sent in requests? Or should they automatically be deleted?
The current test suite assumes expired cookies will not be deleted automatically.

I can complete the PR and the remaining steps once I understand the architecture.

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->
CookieJar will automatically reject expired cookies and not store in the CookieJar
## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
#4063 
## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
