### PR TITLE
Drop custom compilation command

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,17 +11,16 @@ if sys.version_info < (3, 5, 3):
 
 
 NO_EXTENSIONS = bool(os.environ.get('AIOHTTP_NO_EXTENSIONS'))  # type: bool
+HERE = pathlib.Path(__file__).parent
+IS_GIT_REPO = (HERE / '.git').exists()
+
 
 if sys.implementation.name != "cpython":
     NO_EXTENSIONS = True
 
 
-here = pathlib.Path(__file__).parent
-
-IS_GIT_REPO = (here / '.git').exists()
-
 if (IS_GIT_REPO and
-        not (here / 'vendor/http-parser/README.md').exists()):
+        not (HERE / 'vendor/http-parser/README.md').exists()):
     print("Install submodules when building from git clone", file=sys.stderr)
     print("Hint:", file=sys.stderr)
     print("  git submodule update --init", file=sys.stderr)
@@ -45,7 +44,7 @@ extensions = [Extension('aiohttp._websocket', ['aiohttp/_websocket.c']),
                         ['aiohttp/_http_writer.c'])]
 
 
-txt = (here / 'aiohttp' / '__init__.py').read_text('utf-8')
+txt = (HERE / 'aiohttp' / '__init__.py').read_text('utf-8')
 try:
     version = re.findall(r"^__version__ = '([^']+)'\r?$",
                          txt, re.M)[0]
@@ -64,7 +63,7 @@ install_requires = [
 
 
 def read(f):
-    return (here / f).read_text('utf-8').strip()
+    return (HERE / f).read_text('utf-8').strip()
 
 
 args = dict(

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,7 @@
-import codecs
 import os
 import pathlib
 import re
 import sys
-from distutils.command.build_ext import build_ext
-from distutils.errors import (CCompilerError, DistutilsExecError,
-                              DistutilsPlatformError)
 
 from setuptools import Extension, setup
 
@@ -22,7 +18,8 @@ if sys.implementation.name != "cpython":
 
 here = pathlib.Path(__file__).parent
 
-if (here / '.git').exists() and not (here / 'vendor/http-parser/README.md').exists():
+if ((here / '.git').exists() and
+        not (here / 'vendor/http-parser/README.md').exists()):
     print("Install submodules when building from git clone", file=sys.stderr)
     print("Hint:", file=sys.stderr)
     print("  git submodule update --init", file=sys.stderr)
@@ -44,28 +41,6 @@ extensions = [Extension('aiohttp._websocket', ['aiohttp/_websocket.c']),
                         ['aiohttp/_helpers.c']),
               Extension('aiohttp._http_writer',
                         ['aiohttp/_http_writer.c'])]
-
-
-class BuildFailed(Exception):
-    pass
-
-
-class ve_build_ext(build_ext):
-    # This class allows C extension building to fail.
-
-    def run(self):
-        try:
-            build_ext.run(self)
-        except (DistutilsPlatformError, FileNotFoundError):
-            raise BuildFailed()
-
-    def build_extension(self, ext):
-        try:
-            build_ext.build_extension(self, ext)
-        except (CCompilerError, DistutilsExecError,
-                DistutilsPlatformError, ValueError):
-            raise BuildFailed()
-
 
 
 txt = (here / 'aiohttp' / '__init__.py').read_text('utf-8')
@@ -146,9 +121,7 @@ if not NO_EXTENSIONS:
     print("**********************")
     print("* Accellerated build *")
     print("**********************")
-    setup(ext_modules=extensions,
-          cmdclass=dict(build_ext=ve_build_ext),
-          **args)
+    setup(ext_modules=extensions, **args)
 else:
     print("*********************")
     print("* Pure Python build *")

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,9 @@ if sys.implementation.name != "cpython":
 
 here = pathlib.Path(__file__).parent
 
-if ((here / '.git').exists() and
+IS_GIT_REPO = (here / '.git').exists()
+
+if (IS_GIT_REPO and
         not (here / 'vendor/http-parser/README.md').exists()):
     print("Install submodules when building from git clone", file=sys.stderr)
     print("Hint:", file=sys.stderr)


### PR DESCRIPTION
Builtin realization does everything that we need
after strict splitting on accelerated and pure Python builds.
