### PR TITLE
Make exceptions pickleable.

### DIFF
--- a/CHANGES/4077.feature
+++ b/CHANGES/4077.feature
@@ -1,0 +1,1 @@
+Made exceptions pickleable. Also changed the repr of some exceptions.

--- a/aiohttp/client_exceptions.py
+++ b/aiohttp/client_exceptions.py
@@ -60,9 +60,21 @@ class ClientResponseError(ClientError):
         self.message = message
         self.headers = headers
         self.history = history
+        self.args = (request_info, history)
 
-        super().__init__("%s, message='%s', url='%s" %
-                         (self.status, message, request_info.real_url))
+    def __str__(self) -> str:
+        return ("%s, message=%r, url=%r" %
+                (self.status, self.message, self.request_info.real_url))
+
+    def __repr__(self) -> str:
+        args = "%r, %r" % (self.request_info, self.history)
+        if self.status != 0:
+            args += ", status=%r" % (self.status,)
+        if self.message != '':
+            args += ", message=%r" % (self.message,)
+        if self.headers is not None:
+            args += ", headers=%r" % (self.headers,)
+        return "%s(%s)" % (type(self).__name__, args)
 
 
 class ContentTypeError(ClientResponseError):
@@ -105,6 +117,7 @@ class ClientConnectorError(ClientOSError):
         self._conn_key = connection_key
         self._os_error = os_error
         super().__init__(os_error.errno, os_error.strerror)
+        self.args = (connection_key, os_error)
 
     @property
     def os_error(self) -> OSError:
@@ -126,6 +139,9 @@ class ClientConnectorError(ClientOSError):
         return ('Cannot connect to host {0.host}:{0.port} ssl:{0.ssl} [{1}]'
                 .format(self, self.strerror))
 
+    # OSError.__reduce__ does too much black magick
+    __reduce__ = BaseException.__reduce__
+
 
 class ClientProxyConnectionError(ClientConnectorError):
     """Proxy connection error.
@@ -144,6 +160,10 @@ class ServerDisconnectedError(ServerConnectionError):
 
     def __init__(self, message: Optional[str]=None) -> None:
         self.message = message
+        if message is None:
+            self.args = ()
+        else:
+            self.args = (message,)
 
 
 class ServerTimeoutError(ServerConnectionError, asyncio.TimeoutError):
@@ -159,9 +179,10 @@ class ServerFingerprintMismatch(ServerConnectionError):
         self.got = got
         self.host = host
         self.port = port
+        self.args = (expected, got, host, port)
 
     def __repr__(self) -> str:
-        return '<{} expected={} got={} host={} port={}>'.format(
+        return '<{} expected={!r} got={!r} host={!r} port={!r}>'.format(
             self.__class__.__name__, self.expected, self.got,
             self.host, self.port)
 
@@ -220,6 +241,7 @@ class ClientConnectorCertificateError(*cert_errors_bases):  # type: ignore
                  ConnectionKey, certificate_error: Exception) -> None:
         self._conn_key = connection_key
         self._certificate_error = certificate_error
+        self.args = (connection_key, certificate_error)
 
     @property
     def certificate_error(self) -> Exception:

--- a/aiohttp/http_websocket.py
+++ b/aiohttp/http_websocket.py
@@ -91,7 +91,10 @@ class WebSocketError(Exception):
 
     def __init__(self, code: int, message: str) -> None:
         self.code = code
-        super().__init__(message)
+        super().__init__(code, message)
+
+    def __str__(self) -> str:
+        return self.args[1]
 
 
 class WSHandshakeError(Exception):

--- a/aiohttp/web_exceptions.py
+++ b/aiohttp/web_exceptions.py
@@ -1,6 +1,6 @@
 import warnings
 from http import HTTPStatus
-from typing import Any, Dict, Iterable, List, Optional, Set, Type, cast  # noqa
+from typing import Any, Iterable, Optional, Set, Tuple
 
 from multidict import CIMultiDict
 from yarl import URL
@@ -119,10 +119,10 @@ class HTTPException(Exception):
         elif hdrs.CONTENT_TYPE not in real_headers and text:
             real_headers[hdrs.CONTENT_TYPE] = 'text/plain'
 
-        super().__init__(reason)
-
+        self._reason = reason
         self._text = text
         self._headers = real_headers
+        self.args = ()
 
     def __bool__(self) -> bool:
         return True
@@ -133,7 +133,7 @@ class HTTPException(Exception):
 
     @property
     def reason(self) -> str:
-        return self.args[0]
+        return self._reason
 
     @property
     def text(self) -> Optional[str]:
@@ -142,6 +142,17 @@ class HTTPException(Exception):
     @property
     def headers(self) -> 'CIMultiDict[str]':
         return self._headers
+
+    def __str__(self) -> str:
+        return self.reason
+
+    def __repr__(self) -> str:
+        return "<%s: %s>" % (self.__class__.__name__, self.reason)
+
+    __reduce__ = object.__reduce__
+
+    def __getnewargs__(self) -> Tuple[Any, ...]:
+        return self.args
 
 
 class HTTPError(HTTPException):

--- a/tests/test_client_exceptions.py
+++ b/tests/test_client_exceptions.py
@@ -2,6 +2,7 @@
 
 import errno
 import pickle
+import sys
 
 from aiohttp import client, client_reqrep
 
@@ -196,7 +197,10 @@ class TestServerDisconnectedError:
         assert repr(err) == "ServerDisconnectedError()"
 
         err = client.ServerDisconnectedError(message='No connection')
-        assert repr(err) == "ServerDisconnectedError('No connection')"
+        if sys.version_info < (3, 7):
+            assert repr(err) == "ServerDisconnectedError('No connection',)"
+        else:
+            assert repr(err) == "ServerDisconnectedError('No connection')"
 
     def test_str(self) -> None:
         err = client.ServerDisconnectedError()

--- a/tests/test_client_exceptions.py
+++ b/tests/test_client_exceptions.py
@@ -1,37 +1,258 @@
 """Tests for client_exceptions.py"""
 
-from unittest import mock
+import errno
+import pickle
 
-from yarl import URL
-
-from aiohttp import client
-
-
-def test_fingerprint_mismatch() -> None:
-    err = client.ServerFingerprintMismatch('exp', 'got', 'host', 8888)
-    expected = ('<ServerFingerprintMismatch expected=exp'
-                ' got=got host=host port=8888>')
-    assert expected == repr(err)
+from aiohttp import client, client_reqrep
 
 
-def test_invalid_url() -> None:
-    url = URL('http://example.com')
-    err = client.InvalidURL(url)
-    assert err.args[0] is url
-    assert err.url is url
-    assert repr(err) == "<InvalidURL http://example.com>"
+class TestClientResponseError:
+    request_info = client.RequestInfo(url='http://example.com',
+                                      method='GET',
+                                      headers={},
+                                      real_url='http://example.com')
+
+    def test_default_status(self) -> None:
+        err = client.ClientResponseError(history=(),
+                                         request_info=self.request_info)
+        assert err.status == 0
+
+    def test_status(self) -> None:
+        err = client.ClientResponseError(status=400,
+                                         history=(),
+                                         request_info=self.request_info)
+        assert err.status == 400
+
+    def test_pickle(self) -> None:
+        err = client.ClientResponseError(request_info=self.request_info,
+                                         history=())
+        for proto in range(pickle.HIGHEST_PROTOCOL + 1):
+            pickled = pickle.dumps(err, proto)
+            err2 = pickle.loads(pickled)
+            assert err2.request_info == self.request_info
+            assert err2.history == ()
+            assert err2.status == 0
+            assert err2.message == ''
+            assert err2.headers is None
+
+        err = client.ClientResponseError(request_info=self.request_info,
+                                         history=(),
+                                         status=400,
+                                         message='Something wrong',
+                                         headers={})
+        err.foo = 'bar'
+        for proto in range(pickle.HIGHEST_PROTOCOL + 1):
+            pickled = pickle.dumps(err, proto)
+            err2 = pickle.loads(pickled)
+            assert err2.request_info == self.request_info
+            assert err2.history == ()
+            assert err2.status == 400
+            assert err2.message == 'Something wrong'
+            assert err2.headers == {}
+            assert err2.foo == 'bar'
+
+    def test_repr(self) -> None:
+        err = client.ClientResponseError(request_info=self.request_info,
+                                         history=())
+        assert repr(err) == ("ClientResponseError(%r, ())" %
+                             (self.request_info,))
+
+        err = client.ClientResponseError(request_info=self.request_info,
+                                         history=(),
+                                         status=400,
+                                         message='Something wrong',
+                                         headers={})
+        assert repr(err) == ("ClientResponseError(%r, (), status=400, "
+                             "message='Something wrong', headers={})" %
+                             (self.request_info,))
+
+    def test_str(self) -> None:
+        err = client.ClientResponseError(request_info=self.request_info,
+                                         history=(),
+                                         status=400,
+                                         message='Something wrong',
+                                         headers={})
+        assert str(err) == ("400, message='Something wrong', "
+                            "url='http://example.com'")
 
 
-def test_response_default_status() -> None:
-    request_info = mock.Mock(real_url='http://example.com')
-    err = client.ClientResponseError(history=None,
-                                     request_info=request_info)
-    assert err.status == 0
+class TestClientConnectorError:
+    connection_key = client_reqrep.ConnectionKey(
+        host='example.com', port=8080,
+        is_ssl=False, ssl=None,
+        proxy=None, proxy_auth=None, proxy_headers_hash=None)
+
+    def test_ctor(self) -> None:
+        err = client.ClientConnectorError(
+            connection_key=self.connection_key,
+            os_error=OSError(errno.ENOENT, 'No such file'))
+        assert err.errno == errno.ENOENT
+        assert err.strerror == 'No such file'
+        assert err.os_error.errno == errno.ENOENT
+        assert err.os_error.strerror == 'No such file'
+        assert err.host == 'example.com'
+        assert err.port == 8080
+        assert err.ssl is None
+
+    def test_pickle(self) -> None:
+        err = client.ClientConnectorError(
+            connection_key=self.connection_key,
+            os_error=OSError(errno.ENOENT, 'No such file'))
+        err.foo = 'bar'
+        for proto in range(pickle.HIGHEST_PROTOCOL + 1):
+            pickled = pickle.dumps(err, proto)
+            err2 = pickle.loads(pickled)
+            assert err2.errno == errno.ENOENT
+            assert err2.strerror == 'No such file'
+            assert err2.os_error.errno == errno.ENOENT
+            assert err2.os_error.strerror == 'No such file'
+            assert err2.host == 'example.com'
+            assert err2.port == 8080
+            assert err2.ssl is None
+            assert err2.foo == 'bar'
+
+    def test_repr(self) -> None:
+        os_error = OSError(errno.ENOENT, 'No such file')
+        err = client.ClientConnectorError(connection_key=self.connection_key,
+                                          os_error=os_error)
+        assert repr(err) == ("ClientConnectorError(%r, %r)" %
+                             (self.connection_key, os_error))
+
+    def test_str(self) -> None:
+        err = client.ClientConnectorError(
+            connection_key=self.connection_key,
+            os_error=OSError(errno.ENOENT, 'No such file'))
+        assert str(err) == ("Cannot connect to host example.com:8080 ssl:None "
+                            "[No such file]")
 
 
-def test_response_status() -> None:
-    request_info = mock.Mock(real_url='http://example.com')
-    err = client.ClientResponseError(status=400,
-                                     history=None,
-                                     request_info=request_info)
-    assert err.status == 400
+class TestClientConnectorCertificateError:
+    connection_key = client_reqrep.ConnectionKey(
+        host='example.com', port=8080,
+        is_ssl=False, ssl=None,
+        proxy=None, proxy_auth=None, proxy_headers_hash=None)
+
+    def test_ctor(self) -> None:
+        certificate_error = Exception('Bad certificate')
+        err = client.ClientConnectorCertificateError(
+            connection_key=self.connection_key,
+            certificate_error=certificate_error)
+        assert err.certificate_error == certificate_error
+        assert err.host == 'example.com'
+        assert err.port == 8080
+        assert err.ssl is False
+
+    def test_pickle(self) -> None:
+        certificate_error = Exception('Bad certificate')
+        err = client.ClientConnectorCertificateError(
+            connection_key=self.connection_key,
+            certificate_error=certificate_error)
+        err.foo = 'bar'
+        for proto in range(pickle.HIGHEST_PROTOCOL + 1):
+            pickled = pickle.dumps(err, proto)
+            err2 = pickle.loads(pickled)
+            assert err2.certificate_error.args == ('Bad certificate',)
+            assert err2.host == 'example.com'
+            assert err2.port == 8080
+            assert err2.ssl is False
+            assert err2.foo == 'bar'
+
+    def test_repr(self) -> None:
+        certificate_error = Exception('Bad certificate')
+        err = client.ClientConnectorCertificateError(
+            connection_key=self.connection_key,
+            certificate_error=certificate_error)
+        assert repr(err) == ("ClientConnectorCertificateError(%r, %r)" %
+                             (self.connection_key, certificate_error))
+
+    def test_str(self) -> None:
+        certificate_error = Exception('Bad certificate')
+        err = client.ClientConnectorCertificateError(
+            connection_key=self.connection_key,
+            certificate_error=certificate_error)
+        assert str(err) == ("Cannot connect to host example.com:8080 ssl:False"
+                            " [Exception: ('Bad certificate',)]")
+
+
+class TestServerDisconnectedError:
+    def test_ctor(self) -> None:
+        err = client.ServerDisconnectedError()
+        assert err.message is None
+
+        err = client.ServerDisconnectedError(message='No connection')
+        assert err.message == 'No connection'
+
+    def test_pickle(self) -> None:
+        err = client.ServerDisconnectedError(message='No connection')
+        err.foo = 'bar'
+        for proto in range(pickle.HIGHEST_PROTOCOL + 1):
+            pickled = pickle.dumps(err, proto)
+            err2 = pickle.loads(pickled)
+            assert err2.message == 'No connection'
+            assert err2.foo == 'bar'
+
+    def test_repr(self) -> None:
+        err = client.ServerDisconnectedError()
+        assert repr(err) == "ServerDisconnectedError()"
+
+        err = client.ServerDisconnectedError(message='No connection')
+        assert repr(err) == "ServerDisconnectedError('No connection')"
+
+    def test_str(self) -> None:
+        err = client.ServerDisconnectedError()
+        assert str(err) == ''
+
+        err = client.ServerDisconnectedError(message='No connection')
+        assert str(err) == 'No connection'
+
+
+class TestServerFingerprintMismatch:
+    def test_ctor(self) -> None:
+        err = client.ServerFingerprintMismatch(expected=b'exp', got=b'got',
+                                               host='example.com', port=8080)
+        assert err.expected == b'exp'
+        assert err.got == b'got'
+        assert err.host == 'example.com'
+        assert err.port == 8080
+
+    def test_pickle(self) -> None:
+        err = client.ServerFingerprintMismatch(expected=b'exp', got=b'got',
+                                               host='example.com', port=8080)
+        err.foo = 'bar'
+        for proto in range(pickle.HIGHEST_PROTOCOL + 1):
+            pickled = pickle.dumps(err, proto)
+            err2 = pickle.loads(pickled)
+            assert err2.expected == b'exp'
+            assert err2.got == b'got'
+            assert err2.host == 'example.com'
+            assert err2.port == 8080
+            assert err2.foo == 'bar'
+
+    def test_repr(self) -> None:
+        err = client.ServerFingerprintMismatch(b'exp', b'got',
+                                               'example.com', 8080)
+        assert repr(err) == ("<ServerFingerprintMismatch expected=b'exp' "
+                             "got=b'got' host='example.com' port=8080>")
+
+
+class TestInvalidURL:
+    def test_ctor(self) -> None:
+        err = client.InvalidURL(url=':wrong:url:')
+        assert err.url == ':wrong:url:'
+
+    def test_pickle(self) -> None:
+        err = client.InvalidURL(url=':wrong:url:')
+        err.foo = 'bar'
+        for proto in range(pickle.HIGHEST_PROTOCOL + 1):
+            pickled = pickle.dumps(err, proto)
+            err2 = pickle.loads(pickled)
+            assert err2.url == ':wrong:url:'
+            assert err2.foo == 'bar'
+
+    def test_repr(self) -> None:
+        err = client.InvalidURL(url=':wrong:url:')
+        assert repr(err) == "<InvalidURL :wrong:url:>"
+
+    def test_str(self) -> None:
+        err = client.InvalidURL(url=':wrong:url:')
+        assert str(err) == ':wrong:url:'

--- a/tests/test_client_ws_functional.py
+++ b/tests/test_client_ws_functional.py
@@ -487,7 +487,8 @@ async def test_recv_protocol_error(aiohttp_client) -> None:
     msg = await resp.receive()
     assert msg.type == aiohttp.WSMsgType.ERROR
     assert type(msg.data) is aiohttp.WebSocketError
-    assert msg.data.args[0] == 'Received frame with non-zero reserved bits'
+    assert msg.data.code == aiohttp.WSCloseCode.PROTOCOL_ERROR
+    assert str(msg.data) == 'Received frame with non-zero reserved bits'
     assert msg.extra is None
     await resp.close()
 

--- a/tests/test_http_exceptions.py
+++ b/tests/test_http_exceptions.py
@@ -1,20 +1,149 @@
 """Tests for http_exceptions.py"""
 
+import pickle
+
 from aiohttp import http_exceptions
 
 
-def test_bad_status_line1() -> None:
-    err = http_exceptions.BadStatusLine(b'')
-    assert str(err) == "b''"
+class TestHttpProcessingError:
+    def test_ctor(self) -> None:
+        err = http_exceptions.HttpProcessingError(
+            code=500, message='Internal error', headers={})
+        assert err.code == 500
+        assert err.message == 'Internal error'
+        assert err.headers == {}
+
+    def test_pickle(self) -> None:
+        err = http_exceptions.HttpProcessingError(
+            code=500, message='Internal error', headers={})
+        err.foo = 'bar'
+        for proto in range(pickle.HIGHEST_PROTOCOL + 1):
+            pickled = pickle.dumps(err, proto)
+            err2 = pickle.loads(pickled)
+            assert err2.code == 500
+            assert err2.message == 'Internal error'
+            assert err2.headers == {}
+            assert err2.foo == 'bar'
+
+    def test_str(self) -> None:
+        err = http_exceptions.HttpProcessingError(
+            code=500, message='Internal error', headers={})
+        assert str(err) == "500, message='Internal error'"
+
+    def test_repr(self) -> None:
+        err = http_exceptions.HttpProcessingError(
+            code=500, message='Internal error', headers={})
+        assert repr(err) == ("<HttpProcessingError: 500, "
+                             "message='Internal error'>")
 
 
-def test_bad_status_line2() -> None:
-    err = http_exceptions.BadStatusLine('Test')
-    assert str(err) == 'Test'
+class TestBadHttpMessage:
+    def test_ctor(self) -> None:
+        err = http_exceptions.BadHttpMessage('Bad HTTP message', headers={})
+        assert err.code == 400
+        assert err.message == 'Bad HTTP message'
+        assert err.headers == {}
+
+    def test_pickle(self) -> None:
+        err = http_exceptions.BadHttpMessage(
+            message='Bad HTTP message', headers={})
+        err.foo = 'bar'
+        for proto in range(pickle.HIGHEST_PROTOCOL + 1):
+            pickled = pickle.dumps(err, proto)
+            err2 = pickle.loads(pickled)
+            assert err2.code == 400
+            assert err2.message == 'Bad HTTP message'
+            assert err2.headers == {}
+            assert err2.foo == 'bar'
+
+    def test_str(self) -> None:
+        err = http_exceptions.BadHttpMessage(
+            message='Bad HTTP message', headers={})
+        assert str(err) == "400, message='Bad HTTP message'"
+
+    def test_repr(self) -> None:
+        err = http_exceptions.BadHttpMessage(
+            message='Bad HTTP message', headers={})
+        assert repr(err) == "<BadHttpMessage: 400, message='Bad HTTP message'>"
 
 
-def test_http_error_exception() -> None:
-    exc = http_exceptions.HttpProcessingError(
-        code=500, message='Internal error')
-    assert exc.code == 500
-    assert exc.message == 'Internal error'
+class TestLineTooLong:
+    def test_ctor(self) -> None:
+        err = http_exceptions.LineTooLong('spam', '10', '12')
+        assert err.code == 400
+        assert err.message == 'Got more than 10 bytes (12) when reading spam.'
+        assert err.headers is None
+
+    def test_pickle(self) -> None:
+        err = http_exceptions.LineTooLong(
+            line='spam', limit='10', actual_size='12')
+        err.foo = 'bar'
+        for proto in range(pickle.HIGHEST_PROTOCOL + 1):
+            pickled = pickle.dumps(err, proto)
+            err2 = pickle.loads(pickled)
+            assert err2.code == 400
+            assert err2.message == ('Got more than 10 bytes (12) '
+                                    'when reading spam.')
+            assert err2.headers is None
+            assert err2.foo == 'bar'
+
+    def test_str(self) -> None:
+        err = http_exceptions.LineTooLong(
+            line='spam', limit='10', actual_size='12')
+        assert str(err) == ("400, message='Got more than 10 bytes (12) "
+                            "when reading spam.'")
+
+    def test_repr(self) -> None:
+        err = http_exceptions.LineTooLong(
+            line='spam', limit='10', actual_size='12')
+        assert repr(err) == ("<LineTooLong: 400, message='Got more than "
+                             "10 bytes (12) when reading spam.'>")
+
+
+class TestInvalidHeader:
+    def test_ctor(self) -> None:
+        err = http_exceptions.InvalidHeader('X-Spam')
+        assert err.code == 400
+        assert err.message == 'Invalid HTTP Header: X-Spam'
+        assert err.headers is None
+
+    def test_pickle(self) -> None:
+        err = http_exceptions.InvalidHeader(hdr='X-Spam')
+        err.foo = 'bar'
+        for proto in range(pickle.HIGHEST_PROTOCOL + 1):
+            pickled = pickle.dumps(err, proto)
+            err2 = pickle.loads(pickled)
+            assert err2.code == 400
+            assert err2.message == 'Invalid HTTP Header: X-Spam'
+            assert err2.headers is None
+            assert err2.foo == 'bar'
+
+    def test_str(self) -> None:
+        err = http_exceptions.InvalidHeader(hdr='X-Spam')
+        assert str(err) == "400, message='Invalid HTTP Header: X-Spam'"
+
+    def test_repr(self) -> None:
+        err = http_exceptions.InvalidHeader(hdr='X-Spam')
+        assert repr(err) == ("<InvalidHeader: 400, "
+                             "message='Invalid HTTP Header: X-Spam'>")
+
+
+class TestBadStatusLine:
+    def test_ctor(self) -> None:
+        err = http_exceptions.BadStatusLine('Test')
+        assert err.line == 'Test'
+        assert str(err) == 'Test'
+
+    def test_ctor2(self) -> None:
+        err = http_exceptions.BadStatusLine(b'')
+        assert err.line == "b''"
+        assert str(err) == "b''"
+
+    def test_pickle(self) -> None:
+        err = http_exceptions.BadStatusLine('Test')
+        err.foo = 'bar'
+        for proto in range(pickle.HIGHEST_PROTOCOL + 1):
+            pickled = pickle.dumps(err, proto)
+            err2 = pickle.loads(pickled)
+            assert err2.line == 'Test'
+            assert err2.foo == 'bar'

--- a/tests/test_websocket_parser.py
+++ b/tests/test_websocket_parser.py
@@ -1,3 +1,4 @@
+import pickle
 import random
 import struct
 import zlib
@@ -483,3 +484,20 @@ def test_compressed_msg_too_large(out) -> None:
     with pytest.raises(WebSocketError) as ctx:
         parser._feed_data(data)
     assert ctx.value.code == WSCloseCode.MESSAGE_TOO_BIG
+
+
+class TestWebSocketError:
+    def test_ctor(self) -> None:
+        err = WebSocketError(WSCloseCode.PROTOCOL_ERROR, 'Something invalid')
+        assert err.code == WSCloseCode.PROTOCOL_ERROR
+        assert str(err) == 'Something invalid'
+
+    def test_pickle(self) -> None:
+        err = WebSocketError(WSCloseCode.PROTOCOL_ERROR, 'Something invalid')
+        err.foo = 'bar'
+        for proto in range(pickle.HIGHEST_PROTOCOL + 1):
+            pickled = pickle.dumps(err, proto)
+            err2 = pickle.loads(pickled)
+            assert err2.code == WSCloseCode.PROTOCOL_ERROR
+            assert str(err2) == 'Something invalid'
+            assert err2.foo == 'bar'


### PR DESCRIPTION
Exceptions in `client_exceptions.py`, `http_exceptions.py`, `web_exceptions.py` and `http_websocket.py` are now pickleable. They now can be passed to other processes in multiprocessing.

Also changed the repr of some exceptions. They no longer have the form of incorrect call `typename(somestring)`, but have a form `typename(correct_pos_and_kw_args)` or `<typename some string or attributes>`.

Closes #4077.