### PR TITLE
[3.6] Make exceptions pickleable. (#4095)

### DIFF
--- a/CHANGES/4077.feature
+++ b/CHANGES/4077.feature
@@ -1,0 +1,1 @@
+Made exceptions pickleable. Also changed the repr of some exceptions.

--- a/aiohttp/client_exceptions.py
+++ b/aiohttp/client_exceptions.py
@@ -72,9 +72,21 @@ class ClientResponseError(ClientError):
         self.message = message
         self.headers = headers
         self.history = history
+        self.args = (request_info, history)
 
-        super().__init__("%s, message='%s', url='%s" %
-                         (self.status, message, request_info.real_url))
+    def __str__(self) -> str:
+        return ("%s, message=%r, url=%r" %
+                (self.status, self.message, self.request_info.real_url))
+
+    def __repr__(self) -> str:
+        args = "%r, %r" % (self.request_info, self.history)
+        if self.status != 0:
+            args += ", status=%r" % (self.status,)
+        if self.message != '':
+            args += ", message=%r" % (self.message,)
+        if self.headers is not None:
+            args += ", headers=%r" % (self.headers,)
+        return "%s(%s)" % (type(self).__name__, args)
 
     @property
     def code(self) -> int:
@@ -131,6 +143,7 @@ class ClientConnectorError(ClientOSError):
         self._conn_key = connection_key
         self._os_error = os_error
         super().__init__(os_error.errno, os_error.strerror)
+        self.args = (connection_key, os_error)
 
     @property
     def os_error(self) -> OSError:
@@ -152,6 +165,9 @@ class ClientConnectorError(ClientOSError):
         return ('Cannot connect to host {0.host}:{0.port} ssl:{0.ssl} [{1}]'
                 .format(self, self.strerror))
 
+    # OSError.__reduce__ does too much black magick
+    __reduce__ = BaseException.__reduce__
+
 
 class ClientProxyConnectionError(ClientConnectorError):
     """Proxy connection error.
@@ -170,6 +186,10 @@ class ServerDisconnectedError(ServerConnectionError):
 
     def __init__(self, message: Optional[str]=None) -> None:
         self.message = message
+        if message is None:
+            self.args = ()
+        else:
+            self.args = (message,)
 
 
 class ServerTimeoutError(ServerConnectionError, asyncio.TimeoutError):
@@ -185,9 +205,10 @@ class ServerFingerprintMismatch(ServerConnectionError):
         self.got = got
         self.host = host
         self.port = port
+        self.args = (expected, got, host, port)
 
     def __repr__(self) -> str:
-        return '<{} expected={} got={} host={} port={}>'.format(
+        return '<{} expected={!r} got={!r} host={!r} port={!r}>'.format(
             self.__class__.__name__, self.expected, self.got,
             self.host, self.port)
 
@@ -246,6 +267,7 @@ class ClientConnectorCertificateError(*cert_errors_bases):  # type: ignore
                  ConnectionKey, certificate_error: Exception) -> None:
         self._conn_key = connection_key
         self._certificate_error = certificate_error
+        self.args = (connection_key, certificate_error)
 
     @property
     def certificate_error(self) -> Exception:

--- a/aiohttp/http_websocket.py
+++ b/aiohttp/http_websocket.py
@@ -100,7 +100,10 @@ class WebSocketError(Exception):
 
     def __init__(self, code: int, message: str) -> None:
         self.code = code
-        super().__init__(message)
+        super().__init__(code, message)
+
+    def __str__(self) -> str:
+        return self.args[1]
 
 
 class WSHandshakeError(Exception):

--- a/tests/test_client_exceptions.py
+++ b/tests/test_client_exceptions.py
@@ -1,33 +1,83 @@
 """Tests for client_exceptions.py"""
 
+import errno
+import pickle
+import sys
 from unittest import mock
 
 import pytest
-from yarl import URL
 
-from aiohttp import client
-
-
-def test_fingerprint_mismatch() -> None:
-    err = client.ServerFingerprintMismatch('exp', 'got', 'host', 8888)
-    expected = ('<ServerFingerprintMismatch expected=exp'
-                ' got=got host=host port=8888>')
-    assert expected == repr(err)
+from aiohttp import client, client_reqrep
 
 
-def test_invalid_url() -> None:
-    url = URL('http://example.com')
-    err = client.InvalidURL(url)
-    assert err.args[0] is url
-    assert err.url is url
-    assert repr(err) == "<InvalidURL http://example.com>"
+class TestClientResponseError:
+    request_info = client.RequestInfo(url='http://example.com',
+                                      method='GET',
+                                      headers={},
+                                      real_url='http://example.com')
 
+    def test_default_status(self) -> None:
+        err = client.ClientResponseError(history=(),
+                                         request_info=self.request_info)
+        assert err.status == 0
 
-def test_response_default_status() -> None:
-    request_info = mock.Mock(real_url='http://example.com')
-    err = client.ClientResponseError(history=None,
-                                     request_info=request_info)
-    assert err.status == 0
+    def test_status(self) -> None:
+        err = client.ClientResponseError(status=400,
+                                         history=(),
+                                         request_info=self.request_info)
+        assert err.status == 400
+
+    def test_pickle(self) -> None:
+        err = client.ClientResponseError(request_info=self.request_info,
+                                         history=())
+        for proto in range(pickle.HIGHEST_PROTOCOL + 1):
+            pickled = pickle.dumps(err, proto)
+            err2 = pickle.loads(pickled)
+            assert err2.request_info == self.request_info
+            assert err2.history == ()
+            assert err2.status == 0
+            assert err2.message == ''
+            assert err2.headers is None
+
+        err = client.ClientResponseError(request_info=self.request_info,
+                                         history=(),
+                                         status=400,
+                                         message='Something wrong',
+                                         headers={})
+        err.foo = 'bar'
+        for proto in range(pickle.HIGHEST_PROTOCOL + 1):
+            pickled = pickle.dumps(err, proto)
+            err2 = pickle.loads(pickled)
+            assert err2.request_info == self.request_info
+            assert err2.history == ()
+            assert err2.status == 400
+            assert err2.message == 'Something wrong'
+            assert err2.headers == {}
+            assert err2.foo == 'bar'
+
+    def test_repr(self) -> None:
+        err = client.ClientResponseError(request_info=self.request_info,
+                                         history=())
+        assert repr(err) == ("ClientResponseError(%r, ())" %
+                             (self.request_info,))
+
+        err = client.ClientResponseError(request_info=self.request_info,
+                                         history=(),
+                                         status=400,
+                                         message='Something wrong',
+                                         headers={})
+        assert repr(err) == ("ClientResponseError(%r, (), status=400, "
+                             "message='Something wrong', headers={})" %
+                             (self.request_info,))
+
+    def test_str(self) -> None:
+        err = client.ClientResponseError(request_info=self.request_info,
+                                         history=(),
+                                         status=400,
+                                         message='Something wrong',
+                                         headers={})
+        assert str(err) == ("400, message='Something wrong', "
+                            "url='http://example.com'")
 
 
 def test_response_status() -> None:
@@ -58,3 +108,188 @@ def test_response_both_code_and_status() -> None:
                                    status=400,
                                    history=None,
                                    request_info=None)
+
+
+class TestClientConnectorError:
+    connection_key = client_reqrep.ConnectionKey(
+        host='example.com', port=8080,
+        is_ssl=False, ssl=None,
+        proxy=None, proxy_auth=None, proxy_headers_hash=None)
+
+    def test_ctor(self) -> None:
+        err = client.ClientConnectorError(
+            connection_key=self.connection_key,
+            os_error=OSError(errno.ENOENT, 'No such file'))
+        assert err.errno == errno.ENOENT
+        assert err.strerror == 'No such file'
+        assert err.os_error.errno == errno.ENOENT
+        assert err.os_error.strerror == 'No such file'
+        assert err.host == 'example.com'
+        assert err.port == 8080
+        assert err.ssl is None
+
+    def test_pickle(self) -> None:
+        err = client.ClientConnectorError(
+            connection_key=self.connection_key,
+            os_error=OSError(errno.ENOENT, 'No such file'))
+        err.foo = 'bar'
+        for proto in range(pickle.HIGHEST_PROTOCOL + 1):
+            pickled = pickle.dumps(err, proto)
+            err2 = pickle.loads(pickled)
+            assert err2.errno == errno.ENOENT
+            assert err2.strerror == 'No such file'
+            assert err2.os_error.errno == errno.ENOENT
+            assert err2.os_error.strerror == 'No such file'
+            assert err2.host == 'example.com'
+            assert err2.port == 8080
+            assert err2.ssl is None
+            assert err2.foo == 'bar'
+
+    def test_repr(self) -> None:
+        os_error = OSError(errno.ENOENT, 'No such file')
+        err = client.ClientConnectorError(connection_key=self.connection_key,
+                                          os_error=os_error)
+        assert repr(err) == ("ClientConnectorError(%r, %r)" %
+                             (self.connection_key, os_error))
+
+    def test_str(self) -> None:
+        err = client.ClientConnectorError(
+            connection_key=self.connection_key,
+            os_error=OSError(errno.ENOENT, 'No such file'))
+        assert str(err) == ("Cannot connect to host example.com:8080 ssl:None "
+                            "[No such file]")
+
+
+class TestClientConnectorCertificateError:
+    connection_key = client_reqrep.ConnectionKey(
+        host='example.com', port=8080,
+        is_ssl=False, ssl=None,
+        proxy=None, proxy_auth=None, proxy_headers_hash=None)
+
+    def test_ctor(self) -> None:
+        certificate_error = Exception('Bad certificate')
+        err = client.ClientConnectorCertificateError(
+            connection_key=self.connection_key,
+            certificate_error=certificate_error)
+        assert err.certificate_error == certificate_error
+        assert err.host == 'example.com'
+        assert err.port == 8080
+        assert err.ssl is False
+
+    def test_pickle(self) -> None:
+        certificate_error = Exception('Bad certificate')
+        err = client.ClientConnectorCertificateError(
+            connection_key=self.connection_key,
+            certificate_error=certificate_error)
+        err.foo = 'bar'
+        for proto in range(pickle.HIGHEST_PROTOCOL + 1):
+            pickled = pickle.dumps(err, proto)
+            err2 = pickle.loads(pickled)
+            assert err2.certificate_error.args == ('Bad certificate',)
+            assert err2.host == 'example.com'
+            assert err2.port == 8080
+            assert err2.ssl is False
+            assert err2.foo == 'bar'
+
+    def test_repr(self) -> None:
+        certificate_error = Exception('Bad certificate')
+        err = client.ClientConnectorCertificateError(
+            connection_key=self.connection_key,
+            certificate_error=certificate_error)
+        assert repr(err) == ("ClientConnectorCertificateError(%r, %r)" %
+                             (self.connection_key, certificate_error))
+
+    def test_str(self) -> None:
+        certificate_error = Exception('Bad certificate')
+        err = client.ClientConnectorCertificateError(
+            connection_key=self.connection_key,
+            certificate_error=certificate_error)
+        assert str(err) == ("Cannot connect to host example.com:8080 ssl:False"
+                            " [Exception: ('Bad certificate',)]")
+
+
+class TestServerDisconnectedError:
+    def test_ctor(self) -> None:
+        err = client.ServerDisconnectedError()
+        assert err.message is None
+
+        err = client.ServerDisconnectedError(message='No connection')
+        assert err.message == 'No connection'
+
+    def test_pickle(self) -> None:
+        err = client.ServerDisconnectedError(message='No connection')
+        err.foo = 'bar'
+        for proto in range(pickle.HIGHEST_PROTOCOL + 1):
+            pickled = pickle.dumps(err, proto)
+            err2 = pickle.loads(pickled)
+            assert err2.message == 'No connection'
+            assert err2.foo == 'bar'
+
+    def test_repr(self) -> None:
+        err = client.ServerDisconnectedError()
+        assert repr(err) == "ServerDisconnectedError()"
+
+        err = client.ServerDisconnectedError(message='No connection')
+        if sys.version_info < (3, 7):
+            assert repr(err) == "ServerDisconnectedError('No connection',)"
+        else:
+            assert repr(err) == "ServerDisconnectedError('No connection')"
+
+    def test_str(self) -> None:
+        err = client.ServerDisconnectedError()
+        assert str(err) == ''
+
+        err = client.ServerDisconnectedError(message='No connection')
+        assert str(err) == 'No connection'
+
+
+class TestServerFingerprintMismatch:
+    def test_ctor(self) -> None:
+        err = client.ServerFingerprintMismatch(expected=b'exp', got=b'got',
+                                               host='example.com', port=8080)
+        assert err.expected == b'exp'
+        assert err.got == b'got'
+        assert err.host == 'example.com'
+        assert err.port == 8080
+
+    def test_pickle(self) -> None:
+        err = client.ServerFingerprintMismatch(expected=b'exp', got=b'got',
+                                               host='example.com', port=8080)
+        err.foo = 'bar'
+        for proto in range(pickle.HIGHEST_PROTOCOL + 1):
+            pickled = pickle.dumps(err, proto)
+            err2 = pickle.loads(pickled)
+            assert err2.expected == b'exp'
+            assert err2.got == b'got'
+            assert err2.host == 'example.com'
+            assert err2.port == 8080
+            assert err2.foo == 'bar'
+
+    def test_repr(self) -> None:
+        err = client.ServerFingerprintMismatch(b'exp', b'got',
+                                               'example.com', 8080)
+        assert repr(err) == ("<ServerFingerprintMismatch expected=b'exp' "
+                             "got=b'got' host='example.com' port=8080>")
+
+
+class TestInvalidURL:
+    def test_ctor(self) -> None:
+        err = client.InvalidURL(url=':wrong:url:')
+        assert err.url == ':wrong:url:'
+
+    def test_pickle(self) -> None:
+        err = client.InvalidURL(url=':wrong:url:')
+        err.foo = 'bar'
+        for proto in range(pickle.HIGHEST_PROTOCOL + 1):
+            pickled = pickle.dumps(err, proto)
+            err2 = pickle.loads(pickled)
+            assert err2.url == ':wrong:url:'
+            assert err2.foo == 'bar'
+
+    def test_repr(self) -> None:
+        err = client.InvalidURL(url=':wrong:url:')
+        assert repr(err) == "<InvalidURL :wrong:url:>"
+
+    def test_str(self) -> None:
+        err = client.InvalidURL(url=':wrong:url:')
+        assert str(err) == ':wrong:url:'

--- a/tests/test_client_ws_functional.py
+++ b/tests/test_client_ws_functional.py
@@ -454,7 +454,8 @@ async def test_recv_protocol_error(aiohttp_client) -> None:
     msg = await resp.receive()
     assert msg.type == aiohttp.WSMsgType.ERROR
     assert type(msg.data) is aiohttp.WebSocketError
-    assert msg.data.args[0] == 'Received frame with non-zero reserved bits'
+    assert msg.data.code == aiohttp.WSCloseCode.PROTOCOL_ERROR
+    assert str(msg.data) == 'Received frame with non-zero reserved bits'
     assert msg.extra is None
     await resp.close()
 

--- a/tests/test_http_exceptions.py
+++ b/tests/test_http_exceptions.py
@@ -1,20 +1,149 @@
 """Tests for http_exceptions.py"""
 
+import pickle
+
 from aiohttp import http_exceptions
 
 
-def test_bad_status_line1() -> None:
-    err = http_exceptions.BadStatusLine(b'')
-    assert str(err) == "b''"
+class TestHttpProcessingError:
+    def test_ctor(self) -> None:
+        err = http_exceptions.HttpProcessingError(
+            code=500, message='Internal error', headers={})
+        assert err.code == 500
+        assert err.message == 'Internal error'
+        assert err.headers == {}
+
+    def test_pickle(self) -> None:
+        err = http_exceptions.HttpProcessingError(
+            code=500, message='Internal error', headers={})
+        err.foo = 'bar'
+        for proto in range(pickle.HIGHEST_PROTOCOL + 1):
+            pickled = pickle.dumps(err, proto)
+            err2 = pickle.loads(pickled)
+            assert err2.code == 500
+            assert err2.message == 'Internal error'
+            assert err2.headers == {}
+            assert err2.foo == 'bar'
+
+    def test_str(self) -> None:
+        err = http_exceptions.HttpProcessingError(
+            code=500, message='Internal error', headers={})
+        assert str(err) == "500, message='Internal error'"
+
+    def test_repr(self) -> None:
+        err = http_exceptions.HttpProcessingError(
+            code=500, message='Internal error', headers={})
+        assert repr(err) == ("<HttpProcessingError: 500, "
+                             "message='Internal error'>")
 
 
-def test_bad_status_line2() -> None:
-    err = http_exceptions.BadStatusLine('Test')
-    assert str(err) == 'Test'
+class TestBadHttpMessage:
+    def test_ctor(self) -> None:
+        err = http_exceptions.BadHttpMessage('Bad HTTP message', headers={})
+        assert err.code == 400
+        assert err.message == 'Bad HTTP message'
+        assert err.headers == {}
+
+    def test_pickle(self) -> None:
+        err = http_exceptions.BadHttpMessage(
+            message='Bad HTTP message', headers={})
+        err.foo = 'bar'
+        for proto in range(pickle.HIGHEST_PROTOCOL + 1):
+            pickled = pickle.dumps(err, proto)
+            err2 = pickle.loads(pickled)
+            assert err2.code == 400
+            assert err2.message == 'Bad HTTP message'
+            assert err2.headers == {}
+            assert err2.foo == 'bar'
+
+    def test_str(self) -> None:
+        err = http_exceptions.BadHttpMessage(
+            message='Bad HTTP message', headers={})
+        assert str(err) == "400, message='Bad HTTP message'"
+
+    def test_repr(self) -> None:
+        err = http_exceptions.BadHttpMessage(
+            message='Bad HTTP message', headers={})
+        assert repr(err) == "<BadHttpMessage: 400, message='Bad HTTP message'>"
 
 
-def test_http_error_exception() -> None:
-    exc = http_exceptions.HttpProcessingError(
-        code=500, message='Internal error')
-    assert exc.code == 500
-    assert exc.message == 'Internal error'
+class TestLineTooLong:
+    def test_ctor(self) -> None:
+        err = http_exceptions.LineTooLong('spam', '10', '12')
+        assert err.code == 400
+        assert err.message == 'Got more than 10 bytes (12) when reading spam.'
+        assert err.headers is None
+
+    def test_pickle(self) -> None:
+        err = http_exceptions.LineTooLong(
+            line='spam', limit='10', actual_size='12')
+        err.foo = 'bar'
+        for proto in range(pickle.HIGHEST_PROTOCOL + 1):
+            pickled = pickle.dumps(err, proto)
+            err2 = pickle.loads(pickled)
+            assert err2.code == 400
+            assert err2.message == ('Got more than 10 bytes (12) '
+                                    'when reading spam.')
+            assert err2.headers is None
+            assert err2.foo == 'bar'
+
+    def test_str(self) -> None:
+        err = http_exceptions.LineTooLong(
+            line='spam', limit='10', actual_size='12')
+        assert str(err) == ("400, message='Got more than 10 bytes (12) "
+                            "when reading spam.'")
+
+    def test_repr(self) -> None:
+        err = http_exceptions.LineTooLong(
+            line='spam', limit='10', actual_size='12')
+        assert repr(err) == ("<LineTooLong: 400, message='Got more than "
+                             "10 bytes (12) when reading spam.'>")
+
+
+class TestInvalidHeader:
+    def test_ctor(self) -> None:
+        err = http_exceptions.InvalidHeader('X-Spam')
+        assert err.code == 400
+        assert err.message == 'Invalid HTTP Header: X-Spam'
+        assert err.headers is None
+
+    def test_pickle(self) -> None:
+        err = http_exceptions.InvalidHeader(hdr='X-Spam')
+        err.foo = 'bar'
+        for proto in range(pickle.HIGHEST_PROTOCOL + 1):
+            pickled = pickle.dumps(err, proto)
+            err2 = pickle.loads(pickled)
+            assert err2.code == 400
+            assert err2.message == 'Invalid HTTP Header: X-Spam'
+            assert err2.headers is None
+            assert err2.foo == 'bar'
+
+    def test_str(self) -> None:
+        err = http_exceptions.InvalidHeader(hdr='X-Spam')
+        assert str(err) == "400, message='Invalid HTTP Header: X-Spam'"
+
+    def test_repr(self) -> None:
+        err = http_exceptions.InvalidHeader(hdr='X-Spam')
+        assert repr(err) == ("<InvalidHeader: 400, "
+                             "message='Invalid HTTP Header: X-Spam'>")
+
+
+class TestBadStatusLine:
+    def test_ctor(self) -> None:
+        err = http_exceptions.BadStatusLine('Test')
+        assert err.line == 'Test'
+        assert str(err) == 'Test'
+
+    def test_ctor2(self) -> None:
+        err = http_exceptions.BadStatusLine(b'')
+        assert err.line == "b''"
+        assert str(err) == "b''"
+
+    def test_pickle(self) -> None:
+        err = http_exceptions.BadStatusLine('Test')
+        err.foo = 'bar'
+        for proto in range(pickle.HIGHEST_PROTOCOL + 1):
+            pickled = pickle.dumps(err, proto)
+            err2 = pickle.loads(pickled)
+            assert err2.line == 'Test'
+            assert err2.foo == 'bar'

--- a/tests/test_websocket_parser.py
+++ b/tests/test_websocket_parser.py
@@ -1,3 +1,4 @@
+import pickle
 import random
 import struct
 import zlib
@@ -493,3 +494,20 @@ def test_compressed_msg_too_large(out) -> None:
     with pytest.raises(WebSocketError) as ctx:
         parser._feed_data(data)
     assert ctx.value.code == WSCloseCode.MESSAGE_TOO_BIG
+
+
+class TestWebSocketError:
+    def test_ctor(self) -> None:
+        err = WebSocketError(WSCloseCode.PROTOCOL_ERROR, 'Something invalid')
+        assert err.code == WSCloseCode.PROTOCOL_ERROR
+        assert str(err) == 'Something invalid'
+
+    def test_pickle(self) -> None:
+        err = WebSocketError(WSCloseCode.PROTOCOL_ERROR, 'Something invalid')
+        err.foo = 'bar'
+        for proto in range(pickle.HIGHEST_PROTOCOL + 1):
+            pickled = pickle.dumps(err, proto)
+            err2 = pickle.loads(pickled)
+            assert err2.code == WSCloseCode.PROTOCOL_ERROR
+            assert str(err2) == 'Something invalid'
+            assert err2.foo == 'bar'


### PR DESCRIPTION
Also change the repr of some exceptions..
(cherry picked from commit dd9db9a09b7593b18d6f171431e5126470e0301f)

Co-authored-by: Serhiy Storchaka <storchaka@gmail.com>


`web_exception.py` (`HTTPException` and derived classes) are not backported; they are derived from regular `web.Response` in Python 3.6 which is not pickable by definition