### PR TITLE
Update docs to clarify proxy support

### DIFF
--- a/CHANGES/4100.doc
+++ b/CHANGES/4100.doc
@@ -1,0 +1,1 @@
+Update docs to reflect proxy support.

--- a/docs/client_advanced.rst
+++ b/docs/client_advanced.rst
@@ -500,7 +500,7 @@ DER with e.g::
 Proxy support
 -------------
 
-aiohttp supports HTTP proxies and HTTP proxies that can be upgraded to HTTPS
+aiohttp supports plain HTTP proxies and HTTP proxies that can be upgraded to HTTPS
 via the HTTP CONNECT method. aiohttp does not support proxies that must be
 connected to via ``https://``. To connect, use the *proxy* parameter::
 

--- a/docs/client_advanced.rst
+++ b/docs/client_advanced.rst
@@ -500,8 +500,9 @@ DER with e.g::
 Proxy support
 -------------
 
-aiohttp supports HTTP/HTTPS proxies. You have to use
-*proxy* parameter::
+aiohttp supports HTTP proxies and HTTP proxies that can be upgraded to HTTPS
+via the HTTP CONNECT method. aiohttp does not support proxies that must be
+connected to via ``https://``. To connect, use the *proxy* parameter::
 
    async with aiohttp.ClientSession() as session:
        async with session.get("http://python.org",


### PR DESCRIPTION
Clarify that, while aiohttp supports proxies that upgrade to HTTPS via CONNECT, it doesn't support proxies that must be connected to via `https://` - https://github.com/aio-libs/aiohttp/issues/4100 .

I had trouble building the library (`cchardet` woudn't compile), so I was unable to preview the docs. Please review for RST syntax errors.

## What do these changes do?

Update docs

## Are there changes in behavior for the user?

None

## Related issue number

Fixes #4100

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
