### PR TITLE
[3.6] Update docs to clarify proxy support (#4101)

### DIFF
--- a/CHANGES/4100.doc
+++ b/CHANGES/4100.doc
@@ -1,0 +1,1 @@
+Update docs to reflect proxy support.

--- a/docs/client_advanced.rst
+++ b/docs/client_advanced.rst
@@ -500,8 +500,9 @@ DER with e.g::
 Proxy support
 -------------
 
-aiohttp supports HTTP/HTTPS proxies. You have to use
-*proxy* parameter::
+aiohttp supports plain HTTP proxies and HTTP proxies that can be upgraded to HTTPS
+via the HTTP CONNECT method. aiohttp does not support proxies that must be
+connected to via ``https://``. To connect, use the *proxy* parameter::
 
    async with aiohttp.ClientSession() as session:
        async with session.get("http://python.org",


### PR DESCRIPTION
Clarify that, while aiohttp supports proxies that upgrade to HTTPS via CONNECT, it doesn't support proxies that must be connected to via `https://` - https://github.com/aio-libs/aiohttp/issues/4100 .
