### PR TITLE
[3.6] Fix typo in code example in testing docs (#4108)

### DIFF
--- a/CHANGES/4108.doc
+++ b/CHANGES/4108.doc
@@ -1,0 +1,1 @@
+Fix typo in code example in testing docs.

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -512,7 +512,7 @@ basis, the TestClient object can be used directly::
 
     with loop_context() as loop:
         app = _create_example_app()
-        client = TestClient(TestSever(app), loop=loop)
+        client = TestClient(TestServer(app), loop=loop)
         loop.run_until_complete(client.start_server())
         root = "http://127.0.0.1:{}".format(port)
 


### PR DESCRIPTION
(cherry picked from commit 3bc5bd6d)

Co-authored-by: Naglis <naglis@users.noreply.github.com>
