### PR TITLE
[3.6] Allow caller to control HTTP status when using FileResponse (#4107)

### DIFF
--- a/CHANGES/4106.bugfix
+++ b/CHANGES/4106.bugfix
@@ -1,0 +1,1 @@
+Don't clobber HTTP status when using FileResponse.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -41,6 +41,7 @@ Anton Kasyanov
 Anton Zhdan-Pushkin
 Arthur Darcet
 Ben Bader
+Ben Timby
 Benedikt Reinartz
 Boris Feld
 Boyi Chen

--- a/aiohttp/web_fileresponse.py
+++ b/aiohttp/web_fileresponse.py
@@ -24,7 +24,6 @@ from .log import server_logger
 from .typedefs import LooseHeaders
 from .web_exceptions import (
     HTTPNotModified,
-    HTTPOk,
     HTTPPartialContent,
     HTTPPreconditionFailed,
     HTTPRequestRangeNotSatisfiable,
@@ -245,7 +244,7 @@ class FileResponse(StreamResponse):
             encoding = 'gzip' if gzip else None
             should_set_ct = False
 
-        status = HTTPOk.status_code
+        status = self._status
         file_size = st.st_size
         count = file_size
 
@@ -318,8 +317,8 @@ class FileResponse(StreamResponse):
                 status = HTTPPartialContent.status_code
                 # Even though you are sending the whole file, you should still
                 # return a HTTP 206 for a Range request.
+                self.set_status(status)
 
-        self.set_status(status)
         if should_set_ct:
             self.content_type = ct  # type: ignore
         if encoding:

--- a/tests/test_web_sendfile.py
+++ b/tests/test_web_sendfile.py
@@ -109,3 +109,23 @@ def test_gzip_if_header_present_and_file_not_available(loop) -> None:
 
     assert filepath.open.called
     assert not gz_filepath.open.called
+
+
+def test_status_controlled_by_user(loop) -> None:
+    request = make_mocked_request(
+        'GET', 'http://python.org/logo.png', headers={
+        }
+    )
+
+    filepath = mock.Mock()
+    filepath.name = 'logo.png'
+    filepath.open = mock.mock_open()
+    filepath.stat.return_value = mock.MagicMock()
+    filepath.stat.st_size = 1024
+
+    file_sender = FileResponse(filepath, status=203)
+    file_sender._sendfile = make_mocked_coro(None)
+
+    loop.run_until_complete(file_sender.prepare(request))
+
+    assert file_sender._status == 203


### PR DESCRIPTION

(cherry picked from commit c422ff3f)

Co-authored-by: Ben Timby <btimby@gmail.com>
