### PR TITLE
[3.6] Fix misleading message in the string representation of `ClientConnectorError` (#4097) (#4120)

### DIFF
--- a/CHANGES/4097.bugfix
+++ b/CHANGES/4097.bugfix
@@ -1,0 +1,1 @@
+Fix misleading message in the string representation of `ClientConnectorError`; `self.ssl == None` means certification checks relaxed, not SSL disabled

--- a/aiohttp/client_exceptions.py
+++ b/aiohttp/client_exceptions.py
@@ -162,8 +162,9 @@ class ClientConnectorError(ClientOSError):
         return self._conn_key.ssl
 
     def __str__(self) -> str:
-        return ('Cannot connect to host {0.host}:{0.port} ssl:{0.ssl} [{1}]'
-                .format(self, self.strerror))
+        return ('Cannot connect to host {0.host}:{0.port} ssl:{1} [{2}]'
+                .format(self, self.ssl if self.ssl is not None else 'default',
+                        self.strerror))
 
     # OSError.__reduce__ does too much black magick
     __reduce__ = BaseException.__reduce__

--- a/tests/test_client_exceptions.py
+++ b/tests/test_client_exceptions.py
@@ -156,8 +156,8 @@ class TestClientConnectorError:
         err = client.ClientConnectorError(
             connection_key=self.connection_key,
             os_error=OSError(errno.ENOENT, 'No such file'))
-        assert str(err) == ("Cannot connect to host example.com:8080 ssl:None "
-                            "[No such file]")
+        assert str(err) == ("Cannot connect to host example.com:8080 ssl:"
+                            "default [No such file]")
 
 
 class TestClientConnectorCertificateError:


### PR DESCRIPTION


(cherry picked from commit ac180b1c)

Co-authored-by: Bryan Kok <Transfusion@users.noreply.github.com>
