### PR TITLE
Use Iterable hint instead of Sequence

### DIFF
--- a/CHANGES/4125.feature
+++ b/CHANGES/4125.feature
@@ -1,0 +1,1 @@
+Use `Iterable` hint instead of `Sequence` for `Application` `middleware` parameter.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -223,6 +223,7 @@ Simon Kennedy
 Sin-Woo Bang
 Stanislas Plum
 Stanislav Prokop
+Stefan Tjarks
 Stepan Pletnev
 Stephen Granade
 Steven Seguin

--- a/aiohttp/web_app.py
+++ b/aiohttp/web_app.py
@@ -75,7 +75,7 @@ class Application(MutableMapping[str, Any]):
 
     def __init__(self, *,
                  logger: logging.Logger=web_logger,
-                 middlewares: Sequence[_Middleware]=(),
+                 middlewares: Iterable[_Middleware]=(),
                  handler_args: Mapping[str, Any]=None,
                  client_max_size: int=1024**2,
                  debug: Any=...  # mypy doesn't support ellipsis


### PR DESCRIPTION
Given that the `FrozenList` type hint is `Union[List[_T], Iterable[_T]]`
the Application middleware type should not restrict to `Sequence` and
support all `Iterable` types.

<!-- Thank you for your contribution! -->

## What do these changes do?

In my application I pass a generator type as the middleware argument to create a web.Application. mypy complains that it is not a `Sequence` type as hinted in the class. I feel the Sequence hint is
to restrictive and an Iterable is the better choice.

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

No.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
None

## Checklist

- [x] I think the code is well written
- [-] Unit tests for the changes exist
- [-] Documentation reflects the changes
- [-] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [-] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
