### PR TITLE
Specify docs for ClientTimeout.sock_read, add the test

### DIFF
--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -1440,14 +1440,14 @@ ClientTimeout
 
    .. attribute:: sock_connect
 
-      A timeout for connecting to a peer for a new connection, not
+      Timeout for connecting to a peer for a new connection, not
       given from a pool.  See also :attr:`connect`.
 
       :class:`float`, ``None`` by default.
 
    .. attribute:: sock_read
 
-      A timeout for reading a portion of data from a peer.
+      Timeout between two events of reading a portion of data from the peer.
 
       :class:`float`, ``None`` by default.
 


### PR DESCRIPTION

## What do these changes do?

Recently, I was struggling with `ClientTimeout.sock_read`. [The definition in the documentation](https://docs.aiohttp.org/en/stable/client_reference.html#aiohttp.ClientTimeout.sock_read) seems to be unclear: `A timeout for reading a portion of data from a peer`. This definition allows two different interpretations:
1. timeout from the moment of connection established until a piece of data received,
2. timeout between two events of receiving a piece of data.

In fact, the second definition is how `ClientTimeout.sock_read` actually works (to illustrate this, we added the new test `test_timeout_on_read_silence_sock_read_timeout`).

## Are there changes in behavior for the user?

No changes.
<!-- Outline any notable behaviour for the end users. -->

## Related issue number
No issue.
<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
