### PR TITLE
[3.6] Use Iterable hint instead of Sequence (#4125)

### DIFF
--- a/CHANGES/4125.feature
+++ b/CHANGES/4125.feature
@@ -1,0 +1,1 @@
+Use `Iterable` hint instead of `Sequence` for `Application` `middleware` parameter.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -216,6 +216,7 @@ Simon Kennedy
 Sin-Woo Bang
 Stanislas Plum
 Stanislav Prokop
+Stefan Tjarks
 Stepan Pletnev
 Stephen Granade
 Steven Seguin

--- a/aiohttp/web_app.py
+++ b/aiohttp/web_app.py
@@ -88,7 +88,7 @@ class Application(MutableMapping[str, Any]):
     def __init__(self, *,
                  logger: logging.Logger=web_logger,
                  router: Optional[UrlDispatcher]=None,
-                 middlewares: Sequence[_Middleware]=(),
+                 middlewares: Iterable[_Middleware]=(),
                  handler_args: Mapping[str, Any]=None,
                  client_max_size: int=1024**2,
                  loop: Optional[asyncio.AbstractEventLoop]=None,


### PR DESCRIPTION
Given that the `FrozenList` type hint is `Union[List[_T], Iterable[_T]]`
the Application middleware type should not restrict to `Sequence` and
support all `Iterable` types..
(cherry picked from commit 847539567a13e78c9df892b218fdd4e530f0a44c)

Co-authored-by: Stefan T <66305+stj@users.noreply.github.com>
