### PR TITLE
Don't use docstring in tests.

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,11 +19,11 @@ except ImportError:
 pytest_plugins = ['aiohttp.pytest_plugin', 'pytester']
 
 IS_HPUX = sys.platform.startswith('hp-ux')
-"""Specifies whether the current runtime is HP-UX."""
+# Specifies whether the current runtime is HP-UX.
 IS_LINUX = sys.platform.startswith('linux')
-"""Specifies whether the current runtime is HP-UX."""
+# Specifies whether the current runtime is HP-UX.
 IS_UNIX = hasattr(socket, 'AF_UNIX')
-"""Specifies whether the current runtime is *NIX."""
+# Specifies whether the current runtime is *NIX.
 
 needs_unix = pytest.mark.skipif(not IS_UNIX, reason='requires UNIX sockets')
 
@@ -100,23 +100,20 @@ def create_mocked_conn(loop):
 
 @pytest.fixture
 def unix_sockname(tmp_path, tmp_path_factory):
-    """Generate an fs path to the UNIX domain socket for testing.
+    # Generate an fs path to the UNIX domain socket for testing.
 
-    N.B. Different OS kernels have different fs path length limitations
-    for it. For Linux, it's 108, for HP-UX it's 92 (or higher) depending
-    on its version. For for most of the BSDs (Open, Free, macOS) it's
-    mostly 104 but sometimes it can be down to 100.
+    # N.B. Different OS kernels have different fs path length limitations
+    # for it. For Linux, it's 108, for HP-UX it's 92 (or higher) depending
+    # on its version. For for most of the BSDs (Open, Free, macOS) it's
+    # mostly 104 but sometimes it can be down to 100.
 
-    Ref: https://github.com/aio-libs/aiohttp/issues/3572
-    """
+    # Ref: https://github.com/aio-libs/aiohttp/issues/3572
     if not IS_UNIX:
         pytest.skip('requires UNIX sockets')
 
     max_sock_len = 92 if IS_HPUX else 108 if IS_LINUX else 100
-    """Amount of bytes allocated for the UNIX socket path by OS kernel.
-
-    Ref: https://unix.stackexchange.com/a/367012/27133
-    """
+    # Amount of bytes allocated for the UNIX socket path by OS kernel.
+    # Ref: https://unix.stackexchange.com/a/367012/27133
 
     sock_file_name = 'unix.sock'
     unique_prefix = '{!s}-'.format(uuid4())

--- a/tests/test_client_exceptions.py
+++ b/tests/test_client_exceptions.py
@@ -1,4 +1,4 @@
-"""Tests for client_exceptions.py"""
+# Tests for client_exceptions.py
 
 import errno
 import pickle

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -1,4 +1,4 @@
-"""HTTP client functional tests against aiohttp.web server"""
+# HTTP client functional tests against aiohttp.web server
 
 import asyncio
 import datetime

--- a/tests/test_client_response.py
+++ b/tests/test_client_response.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""Tests for aiohttp/client.py"""
+# Tests for aiohttp/client.py
 
 import gc
 import sys

--- a/tests/test_client_ws.py
+++ b/tests/test_client_ws.py
@@ -185,11 +185,10 @@ async def test_ws_connect_err_challenge(loop, ws_key, key_data) -> None:
 
 
 async def test_ws_connect_common_headers(ws_key, loop, key_data) -> None:
-    """Emulate a headers dict being reused for a second ws_connect.
+    # Emulate a headers dict being reused for a second ws_connect.
 
-    In this scenario, we need to ensure that the newly generated secret key
-    is sent to the server, not the stale key.
-    """
+    # In this scenario, we need to ensure that the newly generated secret key
+    # is sent to the server, not the stale key.
     headers = {}
 
     async def test_connection() -> None:

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -1,4 +1,4 @@
-"""Tests of http client with custom Connector"""
+# Tests of http client with custom Connector
 
 import asyncio
 import gc
@@ -28,19 +28,19 @@ from conftest import needs_unix
 
 @pytest.fixture()
 def key():
-    """Connection key"""
+    # Connection key
     return ConnectionKey('localhost', 80, False, None, None, None, None)
 
 
 @pytest.fixture
 def key2():
-    """Connection key"""
+    # Connection key
     return ConnectionKey('localhost', 80, False, None, None, None, None)
 
 
 @pytest.fixture
 def ssl_key():
-    """Connection key"""
+    # Connection key
     return ConnectionKey('localhost', 80, True, None, None, None, None)
 
 

--- a/tests/test_cookiejar.py
+++ b/tests/test_cookiejar.py
@@ -632,7 +632,7 @@ class TestCookieJarSafe(TestCookieJarBase):
         self.assertEqual(cookie["expires"], "")
 
     def test_cookie_not_expired_when_added_after_removal(self) -> None:
-        """Test case for https://github.com/aio-libs/aiohttp/issues/2084"""
+        # Test case for https://github.com/aio-libs/aiohttp/issues/2084
         timestamps = [533588.993, 533588.993, 533588.993,
                       533588.993, 533589.093, 533589.093]
 

--- a/tests/test_http_exceptions.py
+++ b/tests/test_http_exceptions.py
@@ -1,4 +1,4 @@
-"""Tests for http_exceptions.py"""
+# Tests for http_exceptions.py
 
 import pickle
 

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -1,4 +1,4 @@
-"""Tests for aiohttp/protocol.py"""
+# Tests for aiohttp/protocol.py
 
 import asyncio
 import zlib
@@ -41,7 +41,7 @@ def protocol():
 
 @pytest.fixture(params=REQUEST_PARSERS)
 def parser(loop, protocol, request):
-    """Parser implementations"""
+    # Parser implementations
     return request.param(protocol, loop,
                          max_line_size=8190,
                          max_headers=32768,
@@ -50,13 +50,13 @@ def parser(loop, protocol, request):
 
 @pytest.fixture(params=REQUEST_PARSERS)
 def request_cls(request):
-    """Request Parser class"""
+    # Request Parser class
     return request.param
 
 
 @pytest.fixture(params=RESPONSE_PARSERS)
 def response(loop, protocol, request):
-    """Parser implementations"""
+    # Parser implementations
     return request.param(protocol, loop,
                          max_line_size=8190,
                          max_headers=32768,
@@ -65,7 +65,7 @@ def response(loop, protocol, request):
 
 @pytest.fixture(params=RESPONSE_PARSERS)
 def response_cls(request):
-    """Parser implementations"""
+    # Parser implementations
     return request.param
 
 

--- a/tests/test_http_writer.py
+++ b/tests/test_http_writer.py
@@ -1,4 +1,4 @@
-"""Tests for aiohttp/http_writer.py"""
+# Tests for aiohttp/http_writer.py
 import zlib
 from unittest import mock
 

--- a/tests/test_locks.py
+++ b/tests/test_locks.py
@@ -1,4 +1,4 @@
-"""Tests of custom aiohttp locks implementations"""
+# Tests of custom aiohttp locks implementations
 import asyncio
 
 import pytest

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -1264,9 +1264,7 @@ class TestMultipartWriter:
         assert message == b'foo\r\n--:--\r\n'
 
     async def test_preserve_content_disposition_header(self, buf, stream):
-        """
-        https://github.com/aio-libs/aiohttp/pull/3475#issuecomment-451072381
-        """
+        # https://github.com/aio-libs/aiohttp/pull/3475#issuecomment-451072381
         with pathlib.Path(__file__).open('rb') as fobj:
             with aiohttp.MultipartWriter('form-data', boundary=':') as writer:
                 part = writer.append(
@@ -1295,9 +1293,7 @@ class TestMultipartWriter:
         )
 
     async def test_set_content_disposition_override(self, buf, stream):
-        """
-        https://github.com/aio-libs/aiohttp/pull/3475#issuecomment-451072381
-        """
+        # https://github.com/aio-libs/aiohttp/pull/3475#issuecomment-451072381
         with pathlib.Path(__file__).open('rb') as fobj:
             with aiohttp.MultipartWriter('form-data', boundary=':') as writer:
                 part = writer.append(
@@ -1326,9 +1322,7 @@ class TestMultipartWriter:
         )
 
     async def test_reset_content_disposition_header(self, buf, stream):
-        """
-        https://github.com/aio-libs/aiohttp/pull/3475#issuecomment-451072381
-        """
+        # https://github.com/aio-libs/aiohttp/pull/3475#issuecomment-451072381
         with pathlib.Path(__file__).open('rb') as fobj:
             with aiohttp.MultipartWriter('form-data', boundary=':') as writer:
                 part = writer.append(

--- a/tests/test_proxy_functional.py
+++ b/tests/test_proxy_functional.py
@@ -12,7 +12,7 @@ from aiohttp import web
 
 @pytest.fixture
 def proxy_test_server(aiohttp_raw_server, loop, monkeypatch):
-    """Handle all proxy requests and imitate remote server response."""
+    # Handle all proxy requests and imitate remote server response.
 
     _patch_ssl_transport(monkeypatch)
 
@@ -471,7 +471,7 @@ async def xtest_proxy_https_multi_conn_limit(proxy_test_server, loop):
 
 
 def _patch_ssl_transport(monkeypatch):
-    """Make ssl transport substitution to prevent ssl handshake."""
+    # Make ssl transport substitution to prevent ssl handshake.
     def _make_ssl_transport_dummy(self, rawsock, protocol, sslcontext,
                                   waiter=None, **kwargs):
         return self._make_socket_transport(rawsock, protocol, waiter,
@@ -487,7 +487,7 @@ original_is_file = pathlib.Path.is_file
 
 
 def mock_is_file(self):
-    """ make real netrc file invisible in home dir """
+    # make real netrc file invisible in home dir
     if self.name in ['_netrc', '.netrc'] and self.parent == self.home():
         return False
     else:

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -140,7 +140,7 @@ async def test_bad() -> None:
         if IS_PYPY and bool(os.environ.get('PYTHONASYNCIODEBUG'))
         else {'failed': 1, 'passed': 1}
     )
-    """Under PyPy "coroutine 'foobar' was never awaited" does not happen."""
+    # Under PyPy "coroutine 'foobar' was never awaited" does not happen.
     result.assert_outcomes(**expected_outcomes)
 
 

--- a/tests/test_streams.py
+++ b/tests/test_streams.py
@@ -1,4 +1,4 @@
-"""Tests for streams.py"""
+# Tests for streams.py
 
 import abc
 import asyncio
@@ -705,8 +705,7 @@ class TestStreamReader:
             stream.end_http_chunk_receiving()
 
     async def test_readchunk_with_unread(self) -> None:
-        """Test that stream.unread does not break controlled chunk receiving.
-        """
+        # Test that stream.unread does not break controlled chunk receiving.
         stream = self._make_one()
 
         # Send 2 chunks
@@ -745,9 +744,8 @@ class TestStreamReader:
         assert not end_of_chunk
 
     async def test_readchunk_with_other_read_calls(self) -> None:
-        """Test that stream.readchunk works when other read calls are made on
-        the stream.
-        """
+        # Test that stream.readchunk works when other read calls are made on
+        # the stream.
         stream = self._make_one()
 
         stream.begin_http_chunk_receiving()
@@ -782,7 +780,7 @@ class TestStreamReader:
         assert not end_of_chunk
 
     async def test_chunksplits_memory_leak(self) -> None:
-        """ Test for memory leak on chunksplits """
+        # Test for memory leak on chunksplits
         stream = self._make_one()
 
         N = 500
@@ -806,7 +804,7 @@ class TestStreamReader:
         assert abs(after - before) == 0
 
     async def test_read_empty_chunks(self) -> None:
-        """Test that feeding empty chunks does not break stream"""
+        # Test that feeding empty chunks does not break stream
         stream = self._make_one()
 
         # Simulate empty first chunk. This is significant special case
@@ -835,9 +833,8 @@ class TestStreamReader:
         assert data == b'ungzipped data'
 
     async def test_readchunk_separate_http_chunk_tail(self) -> None:
-        """Test that stream.readchunk returns (b'', True) when end of
-        http chunk received after body
-        """
+        # Test that stream.readchunk returns (b'', True) when end of
+        # http chunk received after body
         loop = asyncio.get_event_loop()
         stream = self._make_one()
 
@@ -1278,9 +1275,8 @@ async def test_stream_reader_lines() -> None:
 
 
 async def test_stream_reader_chunks_complete() -> None:
-    """Tests if chunked iteration works if the chunking works out
-    (i.e. the data is divisible by the chunk size)
-    """
+    # Tests if chunked iteration works if the chunking works out
+    # (i.e. the data is divisible by the chunk size)
     chunk_iter = chunkify(DATA, 9)
     async for data in (await create_stream()).iter_chunked(9):
         assert data == next(chunk_iter, None)
@@ -1288,7 +1284,7 @@ async def test_stream_reader_chunks_complete() -> None:
 
 
 async def test_stream_reader_chunks_incomplete() -> None:
-    """Tests if chunked iteration works if the last chunk is incomplete"""
+    # Tests if chunked iteration works if the last chunk is incomplete
     chunk_iter = chunkify(DATA, 8)
     async for data in (await create_stream()).iter_chunked(8):
         assert data == next(chunk_iter, None)
@@ -1296,7 +1292,7 @@ async def test_stream_reader_chunks_incomplete() -> None:
 
 
 async def test_data_queue_empty() -> None:
-    """Tests that async looping yields nothing if nothing is there"""
+    # Tests that async looping yields nothing if nothing is there
     loop = asyncio.get_event_loop()
     buffer = streams.DataQueue(loop)
     buffer.feed_eof()
@@ -1306,7 +1302,7 @@ async def test_data_queue_empty() -> None:
 
 
 async def test_data_queue_items() -> None:
-    """Tests that async looping yields objects identically"""
+    # Tests that async looping yields objects identically
     loop = asyncio.get_event_loop()
     buffer = streams.DataQueue(loop)
 

--- a/tests/test_test_utils.py
+++ b/tests/test_test_utils.py
@@ -76,10 +76,8 @@ def test_client(loop, app) -> None:
 
 
 async def test_aiohttp_client_close_is_idempotent() -> None:
-    """
-    a test client, called multiple times, should
-    not attempt to close the server again.
-    """
+    # a test client, called multiple times, should
+    # not attempt to close the server again.
     app = _create_example_app()
     client = _TestClient(_TestServer(app))
     await client.close()

--- a/tests/test_urldispatch.py
+++ b/tests/test_urldispatch.py
@@ -421,9 +421,7 @@ def test_add_static_append_version_non_exists_file_without_slash(
 
 
 def test_add_static_append_version_follow_symlink(router, tmp_path) -> None:
-    """
-    Tests the access to a symlink, in static folder with apeend_version
-    """
+    # Tests the access to a symlink, in static folder with apeend_version
     symlink_path = tmp_path / 'append_version_symlink'
     symlink_target_path = pathlib.Path(__file__).parent
     pathlib.Path(str(symlink_path)).symlink_to(str(symlink_target_path), True)
@@ -442,9 +440,7 @@ def test_add_static_append_version_follow_symlink(router, tmp_path) -> None:
 
 def test_add_static_append_version_not_follow_symlink(router,
                                                       tmp_path) -> None:
-    """
-    Tests the access to a symlink, in static folder with apeend_version
-    """
+    # Tests the access to a symlink, in static folder with apeend_version
 
     symlink_path = tmp_path / 'append_version_symlink'
     symlink_target_path = pathlib.Path(__file__).parent
@@ -1238,9 +1234,7 @@ def test_prefixed_subapp_resource_canonical(app) -> None:
 
 
 async def test_prefixed_subapp_overlap(app) -> None:
-    """
-    Subapp should not overshadow other subapps with overlapping prefixes
-    """
+    # Subapp should not overshadow other subapps with overlapping prefixes
     subapp1 = web.Application()
     handler1 = make_handler()
     subapp1.router.add_get('/a', handler1)

--- a/tests/test_web_functional.py
+++ b/tests/test_web_functional.py
@@ -260,7 +260,7 @@ async def test_multipart_empty(aiohttp_client) -> None:
 
 
 async def test_multipart_content_transfer_encoding(aiohttp_client) -> None:
-    """For issue #1168"""
+    # For issue #1168
     with multipart.MultipartWriter() as writer:
         writer.append(b'\x00' * 10,
                       headers={'Content-Transfer-Encoding': 'binary'})
@@ -456,17 +456,16 @@ def test_repr_for_application() -> None:
 
 
 async def test_expect_default_handler_unknown(aiohttp_client) -> None:
-    """Test default Expect handler for unknown Expect value.
+    # Test default Expect handler for unknown Expect value.
 
-    A server that does not understand or is unable to comply with any of
-    the expectation values in the Expect field of a request MUST respond
-    with appropriate error status. The server MUST respond with a 417
-    (Expectation Failed) status if any of the expectations cannot be met
-    or, if there are other problems with the request, some other 4xx
-    status.
+    # A server that does not understand or is unable to comply with any of
+    # the expectation values in the Expect field of a request MUST respond
+    # with appropriate error status. The server MUST respond with a 417
+    # (Expectation Failed) status if any of the expectations cannot be met
+    # or, if there are other problems with the request, some other 4xx
+    # status.
 
-    http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.20
-    """
+    # http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.20
     async def handler(request):
         await request.post()
         pytest.xfail('Handler should not proceed to this point in case of '
@@ -1792,7 +1791,7 @@ async def test_request_tracing(aiohttp_server) -> None:
                        socket.AF_INET: '127.0.0.1'}
 
         def __init__(self, fakes):
-            """fakes -- dns -> port dict"""
+            # fakes -- dns -> port dict
             self._fakes = fakes
             self._resolver = aiohttp.DefaultResolver()
 

--- a/tests/test_web_protocol.py
+++ b/tests/test_web_protocol.py
@@ -1,4 +1,4 @@
-"""Tests for aiohttp/server.py"""
+# Tests for aiohttp/server.py
 
 import asyncio
 import platform

--- a/tests/test_web_urldispatcher.py
+++ b/tests/test_web_urldispatcher.py
@@ -31,12 +31,10 @@ async def test_access_root_of_static_handler(tmp_path,
                                              status,
                                              prefix,
                                              data) -> None:
-    """
-    Tests the operation of static file server.
-    Try to access the root of static file server, and make
-    sure that correct HTTP statuses are returned depending if we directory
-    index should be shown or not.
-    """
+    # Tests the operation of static file server.
+    # Try to access the root of static file server, and make
+    # sure that correct HTTP statuses are returned depending if we directory
+    # index should be shown or not.
     my_file = tmp_path / 'my_file'
     my_dir = tmp_path / 'my_dir'
     my_dir.mkdir()
@@ -65,9 +63,7 @@ async def test_access_root_of_static_handler(tmp_path,
 
 
 async def test_follow_symlink(tmp_path, aiohttp_client) -> None:
-    """
-    Tests the access to a symlink, in static folder
-    """
+    # Tests the access to a symlink, in static folder
     data = 'hello world'
 
     my_dir_path = tmp_path / 'my_dir'
@@ -98,9 +94,7 @@ async def test_follow_symlink(tmp_path, aiohttp_client) -> None:
 ])
 async def test_access_to_the_file_with_spaces(tmp_path, aiohttp_client,
                                               dir_name, filename, data):
-    """
-    Checks operation of static files with spaces
-    """
+    # Checks operation of static files with spaces
 
     my_dir_path = tmp_path / dir_name
     if my_dir_path != tmp_path:
@@ -124,11 +118,9 @@ async def test_access_to_the_file_with_spaces(tmp_path, aiohttp_client,
 
 async def test_access_non_existing_resource(tmp_path,
                                             aiohttp_client) -> None:
-    """
-    Tests accessing non-existing resource
-    Try to access a non-exiting resource and make sure that 404 HTTP status
-    returned.
-    """
+    # Tests accessing non-existing resource
+    # Try to access a non-exiting resource and make sure that 404 HTTP status
+    # returned.
     app = web.Application()
 
     # Register global static route:
@@ -148,9 +140,7 @@ async def test_access_non_existing_resource(tmp_path,
 async def test_url_escaping(aiohttp_client,
                             registered_path,
                             request_url) -> None:
-    """
-    Tests accessing a resource with
-    """
+    # Tests accessing a resource with
     app = web.Application()
 
     async def handler(request):
@@ -180,11 +170,9 @@ async def test_handler_metadata_persistence() -> None:
 
 async def test_unauthorized_folder_access(tmp_path,
                                           aiohttp_client) -> None:
-    """
-    Tests the unauthorized access to a folder of static file server.
-    Try to list a folder content of static file server when server does not
-    have permissions to do so for the folder.
-    """
+    # Tests the unauthorized access to a folder of static file server.
+    # Try to list a folder content of static file server when server does not
+    # have permissions to do so for the folder.
     my_dir = tmp_path / 'my_dir'
     my_dir.mkdir()
 
@@ -207,9 +195,7 @@ async def test_unauthorized_folder_access(tmp_path,
 
 
 async def test_access_symlink_loop(tmp_path, aiohttp_client) -> None:
-    """
-    Tests the access to a looped symlink, which could not be resolved.
-    """
+    # Tests the access to a looped symlink, which could not be resolved.
     my_dir_path = tmp_path / 'my_symlink'
     pathlib.Path(str(my_dir_path)).symlink_to(str(my_dir_path), True)
 
@@ -225,11 +211,9 @@ async def test_access_symlink_loop(tmp_path, aiohttp_client) -> None:
 
 
 async def test_access_special_resource(tmp_path, aiohttp_client) -> None:
-    """
-    Tests the access to a resource that is neither a file nor a directory.
-    Checks that if a special resource is accessed (f.e. named pipe or UNIX
-    domain socket) then 404 HTTP status returned.
-    """
+    # Tests the access to a resource that is neither a file nor a directory.
+    # Checks that if a special resource is accessed (f.e. named pipe or UNIX
+    # domain socket) then 404 HTTP status returned.
     app = web.Application()
 
     with mock.patch('pathlib.Path.__new__') as path_constructor:
@@ -266,9 +250,7 @@ def test_system_route() -> None:
 
 
 async def test_allow_head(aiohttp_client) -> None:
-    """
-    Test allow_head on routes.
-    """
+    # Test allow_head on routes.
     app = web.Application()
 
     async def handler(_):
@@ -299,10 +281,8 @@ async def test_allow_head(aiohttp_client) -> None:
     '/{a}',
 ])
 def test_reuse_last_added_resource(path) -> None:
-    """
-    Test that adding a route with the same name and path of the last added
-    resource doesn't create a new resource.
-    """
+    # Test that adding a route with the same name and path of the last added
+    # resource doesn't create a new resource.
     app = web.Application()
 
     async def handler(request):

--- a/tests/test_web_websocket_functional.py
+++ b/tests/test_web_websocket_functional.py
@@ -1,4 +1,4 @@
-"""HTTP websocket server functional tests"""
+# HTTP websocket server functional tests
 
 import asyncio
 

--- a/tests/test_websocket_handshake.py
+++ b/tests/test_websocket_handshake.py
@@ -1,4 +1,4 @@
-"""Tests for http/websocket.py"""
+# Tests for http/websocket.py
 
 import base64
 import os

--- a/tests/test_websocket_parser.py
+++ b/tests/test_websocket_parser.py
@@ -22,7 +22,7 @@ from aiohttp.http_websocket import (
 
 def build_frame(message, opcode, use_mask=False, noheader=False, is_fin=True,
                 compress=False):
-    """Send a frame over the websocket with message as its payload."""
+    # Send a frame over the websocket with message as its payload.
     if compress:
         compressobj = zlib.compressobj(wbits=-9)
         message = compressobj.compress(message)
@@ -70,7 +70,7 @@ def build_frame(message, opcode, use_mask=False, noheader=False, is_fin=True,
 
 
 def build_close_frame(code=1000, message=b'', noheader=False):
-    """Close the websocket, sending the specified code and message."""
+    # Close the websocket, sending the specified code and message.
     if isinstance(message, str):  # pragma: no cover
         message = message.encode('utf-8')
     return build_frame(

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -1,4 +1,4 @@
-"""Tests for aiohttp/worker.py"""
+# Tests for aiohttp/worker.py
 import asyncio
 import os
 import socket


### PR DESCRIPTION
1. Test code is not a part of public API
2. Test runners display test docstring instead of test function if present,
   it complicates the code navigation, e.g. opening a failed test in editor, etc.
