### PR TITLE
[3.6] Use version: ~> 1.0, remove conditions: v1 (#4162)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
-conditions: v1
-version: "= 0"
+version: ~> 1.0
 if: >  # Forbid running non-PR pushes from pyup bot
   not (type != pull_request AND branch =~ ^pyup\-scheduled\-update\-)
 


### PR DESCRIPTION
The version requirement `= 0` advertised in early development stages was an unfortunate choice, as this is going to be the opt-out once the new build config validation feature will be rolled out further. Please use `~> 1.0` instead.

The conditions version `v1` is now the default, so this key can be removed.
(cherry picked from commit f104e750)

Co-authored-by: Sven Fuchs <me@svenfuchs.com>
