### PR TITLE
[3.6] Don't use docstring in tests. (#4163)

### DIFF
--- a/tests/test_client_exceptions.py
+++ b/tests/test_client_exceptions.py
@@ -1,4 +1,4 @@
-"""Tests for client_exceptions.py"""
+# Tests for client_exceptions.py
 
 import errno
 import pickle

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -1,4 +1,4 @@
-"""HTTP client functional tests against aiohttp.web server"""
+# HTTP client functional tests against aiohttp.web server
 
 import asyncio
 import datetime

--- a/tests/test_client_response.py
+++ b/tests/test_client_response.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-"""Tests for aiohttp/client.py"""
+# Tests for aiohttp/client.py
 
 import gc
 import sys

--- a/tests/test_client_ws.py
+++ b/tests/test_client_ws.py
@@ -186,11 +186,10 @@ async def test_ws_connect_err_challenge(loop, ws_key, key_data) -> None:
 
 
 async def test_ws_connect_common_headers(ws_key, loop, key_data) -> None:
-    """Emulate a headers dict being reused for a second ws_connect.
+    # Emulate a headers dict being reused for a second ws_connect.
 
-    In this scenario, we need to ensure that the newly generated secret key
-    is sent to the server, not the stale key.
-    """
+    # In this scenario, we need to ensure that the newly generated secret key
+    # is sent to the server, not the stale key.
     headers = {}
 
     async def test_connection() -> None:

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -1,4 +1,4 @@
-"""Tests of http client with custom Connector"""
+# Tests of http client with custom Connector
 
 import asyncio
 import gc
@@ -27,19 +27,19 @@ from aiohttp.tracing import Trace
 
 @pytest.fixture()
 def key():
-    """Connection key"""
+    # Connection key
     return ConnectionKey('localhost', 80, False, None, None, None, None)
 
 
 @pytest.fixture
 def key2():
-    """Connection key"""
+    # Connection key
     return ConnectionKey('localhost', 80, False, None, None, None, None)
 
 
 @pytest.fixture
 def ssl_key():
-    """Connection key"""
+    # Connection key
     return ConnectionKey('localhost', 80, True, None, None, None, None)
 
 

--- a/tests/test_cookiejar.py
+++ b/tests/test_cookiejar.py
@@ -626,7 +626,7 @@ class TestCookieJarSafe(TestCookieJarBase):
         self.assertEqual(cookie["expires"], "")
 
     def test_cookie_not_expired_when_added_after_removal(self) -> None:
-        """Test case for https://github.com/aio-libs/aiohttp/issues/2084"""
+        # Test case for https://github.com/aio-libs/aiohttp/issues/2084
         timestamps = [533588.993, 533588.993, 533588.993,
                       533588.993, 533589.093, 533589.093]
 

--- a/tests/test_http_exceptions.py
+++ b/tests/test_http_exceptions.py
@@ -1,4 +1,4 @@
-"""Tests for http_exceptions.py"""
+# Tests for http_exceptions.py
 
 import pickle
 

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -1,4 +1,4 @@
-"""Tests for aiohttp/protocol.py"""
+# Tests for aiohttp/protocol.py
 
 import asyncio
 import zlib
@@ -41,7 +41,7 @@ def protocol():
 
 @pytest.fixture(params=REQUEST_PARSERS)
 def parser(loop, protocol, request):
-    """Parser implementations"""
+    # Parser implementations
     return request.param(protocol, loop,
                          max_line_size=8190,
                          max_headers=32768,
@@ -50,13 +50,13 @@ def parser(loop, protocol, request):
 
 @pytest.fixture(params=REQUEST_PARSERS)
 def request_cls(request):
-    """Request Parser class"""
+    # Request Parser class
     return request.param
 
 
 @pytest.fixture(params=RESPONSE_PARSERS)
 def response(loop, protocol, request):
-    """Parser implementations"""
+    # Parser implementations
     return request.param(protocol, loop,
                          max_line_size=8190,
                          max_headers=32768,
@@ -65,7 +65,7 @@ def response(loop, protocol, request):
 
 @pytest.fixture(params=RESPONSE_PARSERS)
 def response_cls(request):
-    """Parser implementations"""
+    # Parser implementations
     return request.param
 
 

--- a/tests/test_http_writer.py
+++ b/tests/test_http_writer.py
@@ -1,4 +1,4 @@
-"""Tests for aiohttp/http_writer.py"""
+# Tests for aiohttp/http_writer.py
 import zlib
 from unittest import mock
 

--- a/tests/test_locks.py
+++ b/tests/test_locks.py
@@ -1,4 +1,4 @@
-"""Tests of custom aiohttp locks implementations"""
+# Tests of custom aiohttp locks implementations
 import asyncio
 
 import pytest

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -1055,9 +1055,7 @@ class TestMultipartWriter:
         assert message == b'foo\r\n--:--\r\n'
 
     async def test_preserve_content_disposition_header(self, buf, stream):
-        """
-        https://github.com/aio-libs/aiohttp/pull/3475#issuecomment-451072381
-        """
+        # https://github.com/aio-libs/aiohttp/pull/3475#issuecomment-451072381
         with open(__file__, 'rb') as fobj:
             with aiohttp.MultipartWriter('form-data', boundary=':') as writer:
                 part = writer.append(
@@ -1086,9 +1084,7 @@ class TestMultipartWriter:
         )
 
     async def test_set_content_disposition_override(self, buf, stream):
-        """
-        https://github.com/aio-libs/aiohttp/pull/3475#issuecomment-451072381
-        """
+        # https://github.com/aio-libs/aiohttp/pull/3475#issuecomment-451072381
         with open(__file__, 'rb') as fobj:
             with aiohttp.MultipartWriter('form-data', boundary=':') as writer:
                 part = writer.append(
@@ -1117,9 +1113,7 @@ class TestMultipartWriter:
         )
 
     async def test_reset_content_disposition_header(self, buf, stream):
-        """
-        https://github.com/aio-libs/aiohttp/pull/3475#issuecomment-451072381
-        """
+        # https://github.com/aio-libs/aiohttp/pull/3475#issuecomment-451072381
         with open(__file__, 'rb') as fobj:
             with aiohttp.MultipartWriter('form-data', boundary=':') as writer:
                 part = writer.append(

--- a/tests/test_proxy_functional.py
+++ b/tests/test_proxy_functional.py
@@ -12,7 +12,7 @@ from aiohttp import web
 
 @pytest.fixture
 def proxy_test_server(aiohttp_raw_server, loop, monkeypatch):
-    """Handle all proxy requests and imitate remote server response."""
+    # Handle all proxy requests and imitate remote server response.
 
     _patch_ssl_transport(monkeypatch)
 
@@ -471,7 +471,7 @@ async def xtest_proxy_https_multi_conn_limit(proxy_test_server, loop):
 
 
 def _patch_ssl_transport(monkeypatch):
-    """Make ssl transport substitution to prevent ssl handshake."""
+    # Make ssl transport substitution to prevent ssl handshake.
     def _make_ssl_transport_dummy(self, rawsock, protocol, sslcontext,
                                   waiter=None, **kwargs):
         return self._make_socket_transport(rawsock, protocol, waiter,
@@ -487,7 +487,7 @@ original_is_file = pathlib.Path.is_file
 
 
 def mock_is_file(self):
-    """ make real netrc file invisible in home dir """
+    # make real netrc file invisible in home dir
     if self.name in ['_netrc', '.netrc'] and self.parent == self.home():
         return False
     else:

--- a/tests/test_pytest_plugin.py
+++ b/tests/test_pytest_plugin.py
@@ -172,7 +172,7 @@ async def test_bad() -> None:
         if IS_PYPY and bool(os.environ.get('PYTHONASYNCIODEBUG'))
         else {'failed': 1, 'passed': 1}
     )
-    """Under PyPy "coroutine 'foobar' was never awaited" does not happen."""
+    # Under PyPy "coroutine 'foobar' was never awaited" does not happen.
     result.assert_outcomes(**expected_outcomes)
 
 

--- a/tests/test_streams.py
+++ b/tests/test_streams.py
@@ -1,4 +1,4 @@
-"""Tests for streams.py"""
+# Tests for streams.py
 
 import abc
 import asyncio
@@ -725,8 +725,7 @@ class TestStreamReader:
             stream.end_http_chunk_receiving()
 
     async def test_readchunk_with_unread(self) -> None:
-        """Test that stream.unread does not break controlled chunk receiving.
-        """
+        # Test that stream.unread does not break controlled chunk receiving.
         stream = self._make_one()
 
         # Send 2 chunks
@@ -765,9 +764,8 @@ class TestStreamReader:
         assert not end_of_chunk
 
     async def test_readchunk_with_other_read_calls(self) -> None:
-        """Test that stream.readchunk works when other read calls are made on
-        the stream.
-        """
+        # Test that stream.readchunk works when other read calls are made on
+        # the stream.
         stream = self._make_one()
 
         stream.begin_http_chunk_receiving()
@@ -802,7 +800,7 @@ class TestStreamReader:
         assert not end_of_chunk
 
     async def test_chunksplits_memory_leak(self) -> None:
-        """ Test for memory leak on chunksplits """
+        # Test for memory leak on chunksplits
         stream = self._make_one()
 
         N = 500
@@ -826,7 +824,7 @@ class TestStreamReader:
         assert abs(after - before) == 0
 
     async def test_read_empty_chunks(self) -> None:
-        """Test that feeding empty chunks does not break stream"""
+        # Test that feeding empty chunks does not break stream
         stream = self._make_one()
 
         # Simulate empty first chunk. This is significant special case
@@ -855,9 +853,8 @@ class TestStreamReader:
         assert data == b'ungzipped data'
 
     async def test_readchunk_separate_http_chunk_tail(self) -> None:
-        """Test that stream.readchunk returns (b'', True) when end of
-        http chunk received after body
-        """
+        # Test that stream.readchunk returns (b'', True) when end of
+        # http chunk received after body
         loop = asyncio.get_event_loop()
         stream = self._make_one()
 
@@ -1299,9 +1296,8 @@ async def test_stream_reader_lines() -> None:
 
 
 async def test_stream_reader_chunks_complete() -> None:
-    """Tests if chunked iteration works if the chunking works out
-    (i.e. the data is divisible by the chunk size)
-    """
+    # Tests if chunked iteration works if the chunking works out
+    # (i.e. the data is divisible by the chunk size)
     chunk_iter = chunkify(DATA, 9)
     async for data in (await create_stream()).iter_chunked(9):
         assert data == next(chunk_iter, None)
@@ -1309,7 +1305,7 @@ async def test_stream_reader_chunks_complete() -> None:
 
 
 async def test_stream_reader_chunks_incomplete() -> None:
-    """Tests if chunked iteration works if the last chunk is incomplete"""
+    # Tests if chunked iteration works if the last chunk is incomplete
     chunk_iter = chunkify(DATA, 8)
     async for data in (await create_stream()).iter_chunked(8):
         assert data == next(chunk_iter, None)
@@ -1317,7 +1313,7 @@ async def test_stream_reader_chunks_incomplete() -> None:
 
 
 async def test_data_queue_empty() -> None:
-    """Tests that async looping yields nothing if nothing is there"""
+    # Tests that async looping yields nothing if nothing is there
     loop = asyncio.get_event_loop()
     buffer = streams.DataQueue(loop)
     buffer.feed_eof()
@@ -1327,7 +1323,7 @@ async def test_data_queue_empty() -> None:
 
 
 async def test_data_queue_items() -> None:
-    """Tests that async looping yields objects identically"""
+    # Tests that async looping yields objects identically
     loop = asyncio.get_event_loop()
     buffer = streams.DataQueue(loop)
 

--- a/tests/test_test_utils.py
+++ b/tests/test_test_utils.py
@@ -90,10 +90,8 @@ async def test_with_client_fails(loop) -> None:
 
 
 async def test_aiohttp_client_close_is_idempotent() -> None:
-    """
-    a test client, called multiple times, should
-    not attempt to close the server again.
-    """
+    # a test client, called multiple times, should
+    # not attempt to close the server again.
     app = _create_example_app()
     client = _TestClient(_TestServer(app))
     await client.close()

--- a/tests/test_urldispatch.py
+++ b/tests/test_urldispatch.py
@@ -415,9 +415,7 @@ def test_add_static_append_version_non_exists_file_without_slash(
 
 
 def test_add_static_append_version_follow_symlink(router, tmpdir) -> None:
-    """
-    Tests the access to a symlink, in static folder with apeend_version
-    """
+    # Tests the access to a symlink, in static folder with apeend_version
     tmp_dir_path = str(tmpdir)
     symlink_path = os.path.join(tmp_dir_path, 'append_version_symlink')
     symlink_target_path = os.path.dirname(__file__)
@@ -436,9 +434,7 @@ def test_add_static_append_version_follow_symlink(router, tmpdir) -> None:
 
 
 def test_add_static_append_version_not_follow_symlink(router, tmpdir) -> None:
-    """
-    Tests the access to a symlink, in static folder with apeend_version
-    """
+    # Tests the access to a symlink, in static folder with apeend_version
     tmp_dir_path = str(tmpdir)
     symlink_path = os.path.join(tmp_dir_path, 'append_version_symlink')
     symlink_target_path = os.path.dirname(__file__)
@@ -1249,9 +1245,7 @@ def test_prefixed_subapp_resource_canonical(app) -> None:
 
 
 async def test_prefixed_subapp_overlap(app) -> None:
-    """
-    Subapp should not overshadow other subapps with overlapping prefixes
-    """
+    # Subapp should not overshadow other subapps with overlapping prefixes
     subapp1 = web.Application()
     handler1 = make_handler()
     subapp1.router.add_get('/a', handler1)

--- a/tests/test_web_functional.py
+++ b/tests/test_web_functional.py
@@ -261,7 +261,7 @@ async def test_multipart_empty(aiohttp_client) -> None:
 
 
 async def test_multipart_content_transfer_encoding(aiohttp_client) -> None:
-    """For issue #1168"""
+    # For issue #1168
     with multipart.MultipartWriter() as writer:
         writer.append(b'\x00' * 10,
                       headers={'Content-Transfer-Encoding': 'binary'})
@@ -457,17 +457,16 @@ def test_repr_for_application() -> None:
 
 
 async def test_expect_default_handler_unknown(aiohttp_client) -> None:
-    """Test default Expect handler for unknown Expect value.
+    # Test default Expect handler for unknown Expect value.
 
-    A server that does not understand or is unable to comply with any of
-    the expectation values in the Expect field of a request MUST respond
-    with appropriate error status. The server MUST respond with a 417
-    (Expectation Failed) status if any of the expectations cannot be met
-    or, if there are other problems with the request, some other 4xx
-    status.
+    # A server that does not understand or is unable to comply with any of
+    # the expectation values in the Expect field of a request MUST respond
+    # with appropriate error status. The server MUST respond with a 417
+    # (Expectation Failed) status if any of the expectations cannot be met
+    # or, if there are other problems with the request, some other 4xx
+    # status.
 
-    http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.20
-    """
+    # http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.20
     async def handler(request):
         await request.post()
         pytest.xfail('Handler should not proceed to this point in case of '
@@ -1858,7 +1857,7 @@ async def test_request_tracing(aiohttp_server) -> None:
                        socket.AF_INET: '127.0.0.1'}
 
         def __init__(self, fakes):
-            """fakes -- dns -> port dict"""
+            # fakes -- dns -> port dict
             self._fakes = fakes
             self._resolver = aiohttp.DefaultResolver()
 

--- a/tests/test_web_protocol.py
+++ b/tests/test_web_protocol.py
@@ -1,4 +1,4 @@
-"""Tests for aiohttp/server.py"""
+# Tests for aiohttp/server.py
 
 import asyncio
 import platform

--- a/tests/test_web_urldispatcher.py
+++ b/tests/test_web_urldispatcher.py
@@ -52,12 +52,10 @@ async def test_access_root_of_static_handler(tmp_dir_path,
                                              status,
                                              prefix,
                                              data) -> None:
-    """
-    Tests the operation of static file server.
-    Try to access the root of static file server, and make
-    sure that correct HTTP statuses are returned depending if we directory
-    index should be shown or not.
-    """
+    # Tests the operation of static file server.
+    # Try to access the root of static file server, and make
+    # sure that correct HTTP statuses are returned depending if we directory
+    # index should be shown or not.
     # Put a file inside tmp_dir_path:
     my_file_path = os.path.join(tmp_dir_path, 'my_file')
     with open(my_file_path, 'w') as fw:
@@ -87,9 +85,7 @@ async def test_access_root_of_static_handler(tmp_dir_path,
 
 
 async def test_follow_symlink(tmp_dir_path, aiohttp_client) -> None:
-    """
-    Tests the access to a symlink, in static folder
-    """
+    # Tests the access to a symlink, in static folder
     data = 'hello world'
 
     my_dir_path = os.path.join(tmp_dir_path, 'my_dir')
@@ -120,9 +116,7 @@ async def test_follow_symlink(tmp_dir_path, aiohttp_client) -> None:
 ])
 async def test_access_to_the_file_with_spaces(tmp_dir_path, aiohttp_client,
                                               dir_name, filename, data):
-    """
-    Checks operation of static files with spaces
-    """
+    # Checks operation of static files with spaces
 
     my_dir_path = os.path.join(tmp_dir_path, dir_name)
 
@@ -148,11 +142,9 @@ async def test_access_to_the_file_with_spaces(tmp_dir_path, aiohttp_client,
 
 async def test_access_non_existing_resource(tmp_dir_path,
                                             aiohttp_client) -> None:
-    """
-    Tests accessing non-existing resource
-    Try to access a non-exiting resource and make sure that 404 HTTP status
-    returned.
-    """
+    # Tests accessing non-existing resource
+    # Try to access a non-exiting resource and make sure that 404 HTTP status
+    # returned.
     app = web.Application()
 
     # Register global static route:
@@ -172,9 +164,7 @@ async def test_access_non_existing_resource(tmp_dir_path,
 async def test_url_escaping(aiohttp_client,
                             registered_path,
                             request_url) -> None:
-    """
-    Tests accessing a resource with
-    """
+    # Tests accessing a resource with
     app = web.Application()
 
     async def handler(request):
@@ -212,11 +202,9 @@ async def test_handler_metadata_persistence() -> None:
 
 async def test_unauthorized_folder_access(tmp_dir_path,
                                           aiohttp_client) -> None:
-    """
-    Tests the unauthorized access to a folder of static file server.
-    Try to list a folder content of static file server when server does not
-    have permissions to do so for the folder.
-    """
+    # Tests the unauthorized access to a folder of static file server.
+    # Try to list a folder content of static file server when server does not
+    # have permissions to do so for the folder.
     my_dir_path = os.path.join(tmp_dir_path, 'my_dir')
     os.mkdir(my_dir_path)
 
@@ -239,9 +227,7 @@ async def test_unauthorized_folder_access(tmp_dir_path,
 
 
 async def test_access_symlink_loop(tmp_dir_path, aiohttp_client) -> None:
-    """
-    Tests the access to a looped symlink, which could not be resolved.
-    """
+    # Tests the access to a looped symlink, which could not be resolved.
     my_dir_path = os.path.join(tmp_dir_path, 'my_symlink')
     os.symlink(my_dir_path, my_dir_path)
 
@@ -257,11 +243,9 @@ async def test_access_symlink_loop(tmp_dir_path, aiohttp_client) -> None:
 
 
 async def test_access_special_resource(tmp_dir_path, aiohttp_client) -> None:
-    """
-    Tests the access to a resource that is neither a file nor a directory.
-    Checks that if a special resource is accessed (f.e. named pipe or UNIX
-    domain socket) then 404 HTTP status returned.
-    """
+    # Tests the access to a resource that is neither a file nor a directory.
+    # Checks that if a special resource is accessed (f.e. named pipe or UNIX
+    # domain socket) then 404 HTTP status returned.
     app = web.Application()
 
     with mock.patch('pathlib.Path.__new__') as path_constructor:
@@ -330,9 +314,7 @@ async def test_412_is_returned(aiohttp_client) -> None:
 
 
 async def test_allow_head(aiohttp_client) -> None:
-    """
-    Test allow_head on routes.
-    """
+    # Test allow_head on routes.
     app = web.Application()
 
     async def handler(_):
@@ -363,10 +345,8 @@ async def test_allow_head(aiohttp_client) -> None:
     '/{a}',
 ])
 def test_reuse_last_added_resource(path) -> None:
-    """
-    Test that adding a route with the same name and path of the last added
-    resource doesn't create a new resource.
-    """
+    # Test that adding a route with the same name and path of the last added
+    # resource doesn't create a new resource.
     app = web.Application()
 
     async def handler(request):

--- a/tests/test_web_websocket_functional.py
+++ b/tests/test_web_websocket_functional.py
@@ -1,4 +1,4 @@
-"""HTTP websocket server functional tests"""
+# HTTP websocket server functional tests
 
 import asyncio
 

--- a/tests/test_websocket_handshake.py
+++ b/tests/test_websocket_handshake.py
@@ -1,4 +1,4 @@
-"""Tests for http/websocket.py"""
+# Tests for http/websocket.py
 
 import base64
 import os

--- a/tests/test_websocket_parser.py
+++ b/tests/test_websocket_parser.py
@@ -22,7 +22,7 @@ from aiohttp.http_websocket import (
 
 def build_frame(message, opcode, use_mask=False, noheader=False, is_fin=True,
                 compress=False):
-    """Send a frame over the websocket with message as its payload."""
+    # Send a frame over the websocket with message as its payload.
     if compress:
         compressobj = zlib.compressobj(wbits=-9)
         message = compressobj.compress(message)
@@ -70,7 +70,7 @@ def build_frame(message, opcode, use_mask=False, noheader=False, is_fin=True,
 
 
 def build_close_frame(code=1000, message=b'', noheader=False):
-    """Close the websocket, sending the specified code and message."""
+    # Close the websocket, sending the specified code and message.
     if isinstance(message, str):  # pragma: no cover
         message = message.encode('utf-8')
     return build_frame(

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -1,4 +1,4 @@
-"""Tests for aiohttp/worker.py"""
+# Tests for aiohttp/worker.py
 import asyncio
 import os
 import socket


### PR DESCRIPTION
1. Test code is not a part of public API
2. Test runners display test docstring instead of test function if present,
   it complicates the code navigation, e.g. opening a failed test in editor etc.
(cherry picked from commit 18648802dd0c5a0ccb1f3d882dc54df9c614e4bd)

Co-authored-by: Andrew Svetlov <andrew.svetlov@gmail.com>
