### PR TITLE
fix typo code snippet in  web quickstart doc 

### DIFF
--- a/docs/web_quickstart.rst
+++ b/docs/web_quickstart.rst
@@ -226,7 +226,7 @@ Routes can also be given a *name*::
 Which can then be used to access and build a *URL* for that resource later (e.g.
 in a :ref:`request handler <aiohttp-web-handler>`)::
 
-   url == request.app.router['root'].url_for().with_query({"a": "b", "c": "d"})
+   url = request.app.router['root'].url_for().with_query({"a": "b", "c": "d"})
    assert url == URL('/root?a=b&c=d')
 
 A more interesting example is building *URLs* for :ref:`variable


### PR DESCRIPTION
fix typo in 'Reverse URL constructing' code snippet   : 'url == ...' instead of 'url = ...'
