### PR TITLE
Fix the string representation of `ServerDisconnectedError`

### DIFF
--- a/CHANGES/4175.bugfix
+++ b/CHANGES/4175.bugfix
@@ -1,0 +1,1 @@
+Fix the string representation of `ServerDisconnectedError`.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -129,6 +129,7 @@ Jake Davis
 Jakob Ackermann
 Jakub Wilk
 Jashandeep Sohi
+Jens Steinhauser
 Jeongkyu Shin
 Jeroen van der Heijden
 Jesus Cea

--- a/aiohttp/client_exceptions.py
+++ b/aiohttp/client_exceptions.py
@@ -160,11 +160,11 @@ class ServerDisconnectedError(ServerConnectionError):
     """Server disconnected."""
 
     def __init__(self, message: Optional[str]=None) -> None:
-        self.message = message
         if message is None:
-            self.args = ()
-        else:
-            self.args = (message,)
+            message = 'Server disconnected'
+
+        self.args = (message,)
+        self.message = message
 
 
 class ServerTimeoutError(ServerConnectionError, asyncio.TimeoutError):

--- a/tests/test_client_exceptions.py
+++ b/tests/test_client_exceptions.py
@@ -178,7 +178,7 @@ class TestClientConnectorCertificateError:
 class TestServerDisconnectedError:
     def test_ctor(self) -> None:
         err = client.ServerDisconnectedError()
-        assert err.message is None
+        assert err.message == 'Server disconnected'
 
         err = client.ServerDisconnectedError(message='No connection')
         assert err.message == 'No connection'
@@ -194,7 +194,12 @@ class TestServerDisconnectedError:
 
     def test_repr(self) -> None:
         err = client.ServerDisconnectedError()
-        assert repr(err) == "ServerDisconnectedError()"
+        if sys.version_info < (3, 7):
+            assert repr(err) == ("ServerDisconnectedError"
+                                 "('Server disconnected',)")
+        else:
+            assert repr(err) == ("ServerDisconnectedError"
+                                 "('Server disconnected')")
 
         err = client.ServerDisconnectedError(message='No connection')
         if sys.version_info < (3, 7):
@@ -204,7 +209,7 @@ class TestServerDisconnectedError:
 
     def test_str(self) -> None:
         err = client.ServerDisconnectedError()
-        assert str(err) == ''
+        assert str(err) == 'Server disconnected'
 
         err = client.ServerDisconnectedError(message='No connection')
         assert str(err) == 'No connection'

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -2680,9 +2680,11 @@ async def test_request_conn_closed(aiohttp_client) -> None:
     app.router.add_get('/', handler)
 
     client = await aiohttp_client(app)
-    with pytest.raises(aiohttp.ServerDisconnectedError):
+    with pytest.raises(aiohttp.ServerDisconnectedError) as excinfo:
         resp = await client.get('/')
         await resp.read()
+
+    assert str(excinfo.value) != ''
 
 
 async def test_dont_close_explicit_connector(aiohttp_client) -> None:


### PR DESCRIPTION
## What do these changes do?

These changes make sure that the string representation of `ServerDisconnectedError` is always a valid, human readable string.

## Are there changes in behavior for the user?

The user will never be surprised after calling `str()` on an instance of `ServerDisconnectedError`.

## Related issue number

Fixes #4175.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
- [x] Add a new news fragment into the `CHANGES` folder