### PR TITLE
Preserve handler function attributes across middlewares

### DIFF
--- a/CHANGES/4174.bugfix
+++ b/CHANGES/4174.bugfix
@@ -1,0 +1,1 @@
+Preserve view handler function attributes across middlewares

--- a/aiohttp/web_app.py
+++ b/aiohttp/web_app.py
@@ -1,7 +1,7 @@
 import asyncio
 import logging
 import warnings
-from functools import partial
+from functools import partial, update_wrapper
 from typing import (  # noqa
     TYPE_CHECKING,
     Any,
@@ -325,7 +325,9 @@ class Application(MutableMapping[str, Any]):
                 for app in match_info.apps[::-1]:
                     assert app.pre_frozen, "middleware handlers are not ready"
                     for m in app._middlewares_handlers:  # noqa
-                        handler = partial(m, handler=handler)
+                        handler = update_wrapper(
+                            partial(m, handler=handler), handler
+                        )
 
             resp = await handler(request)
 

--- a/tests/test_web_middleware.py
+++ b/tests/test_web_middleware.py
@@ -49,8 +49,18 @@ async def test_middleware_chain(loop, aiohttp_client) -> None:
     async def handler(request):
         return web.Response(text='OK')
 
+    handler.annotation = "annotation_value"
+
+    async def handler2(request):
+        return web.Response(text='OK')
+
+    middleware_annotation_seen_values = []
+
     def make_middleware(num):
         async def middleware(request, handler):
+            middleware_annotation_seen_values.append(
+                getattr(handler, "annotation", None)
+            )
             resp = await handler(request)
             resp.text = resp.text + '[{}]'.format(num)
             return resp
@@ -60,11 +70,67 @@ async def test_middleware_chain(loop, aiohttp_client) -> None:
     app.middlewares.append(make_middleware(1))
     app.middlewares.append(make_middleware(2))
     app.router.add_route('GET', '/', handler)
+    app.router.add_route('GET', '/r2', handler2)
     client = await aiohttp_client(app)
     resp = await client.get('/')
     assert 200 == resp.status
     txt = await resp.text()
     assert 'OK[2][1]' == txt
+    assert middleware_annotation_seen_values == [
+        'annotation_value', 'annotation_value'
+    ]
+
+    # check that attributes from handler are not applied to handler2
+    resp = await client.get('/r2')
+    assert 200 == resp.status
+    assert middleware_annotation_seen_values == [
+        'annotation_value', 'annotation_value', None, None
+    ]
+
+
+async def test_middleware_subapp(loop, aiohttp_client) -> None:
+    async def sub_handler(request):
+        return web.Response(text='OK')
+
+    sub_handler.annotation = "annotation_value"
+
+    async def handler(request):
+        return web.Response(text='OK')
+
+    middleware_annotation_seen_values = []
+
+    def make_middleware(num):
+        async def middleware(request, handler):
+            annotation = getattr(handler, "annotation", None)
+            if annotation is not None:
+                middleware_annotation_seen_values.append(
+                    "{}/{}".format(annotation, num)
+                )
+            return await handler(request)
+        return middleware
+
+    app = web.Application()
+    app.middlewares.append(make_middleware(1))
+    app.router.add_route('GET', '/r2', handler)
+
+    subapp = web.Application()
+    subapp.middlewares.append(make_middleware(2))
+    subapp.router.add_route('GET', '/', sub_handler)
+    app.add_subapp("/sub", subapp)
+
+    client = await aiohttp_client(app)
+    resp = await client.get('/sub/')
+    assert 200 == resp.status
+    await resp.text()
+    assert middleware_annotation_seen_values == [
+        'annotation_value/1', 'annotation_value/2'
+    ]
+
+    # check that attributes from sub_handler are not applied to handler
+    del middleware_annotation_seen_values[:]
+    resp = await client.get('/r2')
+    assert 200 == resp.status
+    assert middleware_annotation_seen_values == []
 
 
 @pytest.fixture


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?
When using middlewares (such as the hidden middleware implicitly added by subapps), it fixes the functools.partial() usage on the handler view, to copy any attributes from the view function.

## Are there changes in behavior for the user?

Now any attributes added to a view handler function, e.g. by a decorator, are seen by all the middlewares in the chain.

Before this change, attributes we only seen by a middleware in the case of the last middleware (first to run), and only for the main Application, for subapps that wasn't true.

## Related issue number

#4174 

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
