### PR TITLE
[3.6] Update docs/client_reference.rst timeout line (#4194)

### DIFF
--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -1545,7 +1545,7 @@ ClientTimeout
 
    .. attribute:: total
 
-      Total timeout for the whole request.
+      Total number of seconds for the whole request.
 
       :class:`float`, ``None`` by default.
 


### PR DESCRIPTION
Specify the unit of measure of the timeout.
(cherry picked from commit 32ce31ca)

Co-authored-by: Andrea Giacomo Baldan <a.g.baldan@gmail.com>
