### PR TITLE
[3.6] Fix the string representation of `ServerDisconnectedError` (#4188)

### DIFF
--- a/CHANGES/4175.bugfix
+++ b/CHANGES/4175.bugfix
@@ -1,0 +1,1 @@
+Fix the string representation of `ServerDisconnectedError`.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -124,6 +124,7 @@ Jake Davis
 Jakob Ackermann
 Jakub Wilk
 Jashandeep Sohi
+Jens Steinhauser
 Jeongkyu Shin
 Jeroen van der Heijden
 Jesus Cea

--- a/aiohttp/client_exceptions.py
+++ b/aiohttp/client_exceptions.py
@@ -186,11 +186,11 @@ class ServerDisconnectedError(ServerConnectionError):
     """Server disconnected."""
 
     def __init__(self, message: Optional[str]=None) -> None:
-        self.message = message
         if message is None:
-            self.args = ()
-        else:
-            self.args = (message,)
+            message = 'Server disconnected'
+
+        self.args = (message,)
+        self.message = message
 
 
 class ServerTimeoutError(ServerConnectionError, asyncio.TimeoutError):

--- a/tests/test_client_exceptions.py
+++ b/tests/test_client_exceptions.py
@@ -211,7 +211,7 @@ class TestClientConnectorCertificateError:
 class TestServerDisconnectedError:
     def test_ctor(self) -> None:
         err = client.ServerDisconnectedError()
-        assert err.message is None
+        assert err.message == 'Server disconnected'
 
         err = client.ServerDisconnectedError(message='No connection')
         assert err.message == 'No connection'
@@ -227,7 +227,12 @@ class TestServerDisconnectedError:
 
     def test_repr(self) -> None:
         err = client.ServerDisconnectedError()
-        assert repr(err) == "ServerDisconnectedError()"
+        if sys.version_info < (3, 7):
+            assert repr(err) == ("ServerDisconnectedError"
+                                 "('Server disconnected',)")
+        else:
+            assert repr(err) == ("ServerDisconnectedError"
+                                 "('Server disconnected')")
 
         err = client.ServerDisconnectedError(message='No connection')
         if sys.version_info < (3, 7):
@@ -237,7 +242,7 @@ class TestServerDisconnectedError:
 
     def test_str(self) -> None:
         err = client.ServerDisconnectedError()
-        assert str(err) == ''
+        assert str(err) == 'Server disconnected'
 
         err = client.ServerDisconnectedError(message='No connection')
         assert str(err) == 'No connection'

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -2682,9 +2682,11 @@ async def test_request_conn_closed(aiohttp_client) -> None:
     app.router.add_get('/', handler)
 
     client = await aiohttp_client(app)
-    with pytest.raises(aiohttp.ServerDisconnectedError):
+    with pytest.raises(aiohttp.ServerDisconnectedError) as excinfo:
         resp = await client.get('/')
         await resp.read()
+
+    assert str(excinfo.value) != ''
 
 
 async def test_dont_close_explicit_connector(aiohttp_client) -> None:


### PR DESCRIPTION
(cherry picked from commit a54956d9)

Co-authored-by: JenSte <jens.steinhauser@protonmail.com>
