### PR TITLE
Backport fix of noop in least invasive way

### DIFF
--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -103,14 +103,10 @@ old_debug = coroutines._DEBUG  # type: ignore
 coroutines._DEBUG = False  # type: ignore
 
 
-@asyncio.coroutine
-def noop(*args, **kwargs):  # type: ignore
-    return  # type: ignore
-
-
-async def noop2(*args: Any, **kwargs: Any) -> None:
+async def noop(*args: Any, **kwargs: Any) -> None:
     return
 
+noop2 = noop
 
 coroutines._DEBUG = old_debug  # type: ignore
 


### PR DESCRIPTION
The coroutine-style definition of noop causes a warning on Python 3.8.

On master, it has been fixed and noop2 removed. This is the least invasive way to get rid of the warning in aiohttp 3.6.x that shouldn't break anything.

I don't think this needs a changelog entry?