### PR TITLE
Change typing of the secure argument on StreamResponse.set_cookie

### DIFF
--- a/CHANGES/4204.doc
+++ b/CHANGES/4204.doc
@@ -1,0 +1,1 @@
+Change typing of the secure argument on StreamResponse.set_cookie from Optional[str] to a Optional[bool]

--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -169,7 +169,7 @@ class StreamResponse(BaseClass, HeadersMixin):
                    domain: Optional[str]=None,
                    max_age: Optional[Union[int, str]]=None,
                    path: str='/',
-                   secure: Optional[str]=None,
+                   secure: Optional[bool]=None,
                    httponly: Optional[str]=None,
                    version: Optional[str]=None) -> None:
         """Set or update response cookie.

--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -170,7 +170,7 @@ class StreamResponse(BaseClass, HeadersMixin):
                    max_age: Optional[Union[int, str]]=None,
                    path: str='/',
                    secure: Optional[bool]=None,
-                   httponly: Optional[str]=None,
+                   httponly: Optional[bool]=None,
                    version: Optional[str]=None) -> None:
         """Set or update response cookie.
 


### PR DESCRIPTION
## What do these changes do?

This change fixes the contradiction between docs and annotation in code

## Are there changes in behavior for the user?

No

## Related issue number

This commit fixes  #4204

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
