### PR TITLE
Added properties of default ClientSession params to ClientSession class

### DIFF
--- a/CHANGES/3882.feature
+++ b/CHANGES/3882.feature
@@ -1,0 +1,1 @@
+Added properties of default ClientSession params to ClientSession class so it is available for introspection

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -920,7 +920,7 @@ class ClientSession:
         return self._timeout
 
     @property
-    def default_headers(self) -> 'CIMultiDict[str]':
+    def headers(self) -> 'CIMultiDict[str]':
         """The default headers of the client session."""
         return self._default_headers
 
@@ -956,7 +956,7 @@ class ClientSession:
 
     @property
     def auto_decompress(self) -> bool:
-        """Should automatically decompress response body"""
+        """Should the body response be automatically decompressed"""
         return self._auto_decompress
 
     @property

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -918,6 +918,58 @@ class ClientSession:
         """Timeout for the session."""
         return self._timeout
 
+    @property
+    def headers(self) -> CIMultiDict[str]:
+        """The headers of the client session."""
+        return self._default_headers
+
+    @property
+    def skip_auto_headers(self) -> frozenset:
+        """Headers for which autogeneration should be skipped"""
+        return self._skip_auto_headers
+
+    @property
+    def auth(self) -> Optional[BasicAuth]:
+        """An object that represents HTTP Basic Authorization"""
+        return self._default_auth
+
+    @property
+    def json_serialize(self) -> JSONEncoder:
+        """Json serializer callable"""
+        return self._json_serialize
+
+    @property
+    def connector_owner(self) -> bool:
+        """Should connector be closed on session closing"""
+        return self._connector_owner
+
+    @property
+    def raise_for_status(self) -> bool:
+        """
+        Should `ClientResponse.raise_for_status()`
+        be called for each response
+        """
+        return self._raise_for_status
+
+    @property
+    def auto_decompress(self) -> bool:
+        """Should automatically decompress response body"""
+        return self._auto_decompress
+
+    @property
+    def trust_env(self) -> bool:
+        """
+        Should get proxies information
+        from HTTP_PROXY / HTTPS_PROXY environment variables
+        or ~/.netrc file if present
+        """
+        return self._trust_env
+
+    @property
+    def trace_configs(self) -> List[TraceConfig]:
+        """A list of TraceConfig instances used for client tracing"""
+        return self._trace_configs
+
     def detach(self) -> None:
         """Detach connector from session without closing the former.
 

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -14,6 +14,7 @@ from typing import (  # noqa
     Awaitable,
     Callable,
     Coroutine,
+    FrozenSet,
     Generator,
     Generic,
     Iterable,
@@ -919,12 +920,12 @@ class ClientSession:
         return self._timeout
 
     @property
-    def headers(self) -> CIMultiDict[str]:
-        """The headers of the client session."""
+    def default_headers(self) -> 'CIMultiDict[str]':
+        """The default headers of the client session."""
         return self._default_headers
 
     @property
-    def skip_auto_headers(self) -> frozenset:
+    def skip_auto_headers(self) -> FrozenSet[istr]:
         """Headers for which autogeneration should be skipped"""
         return self._skip_auto_headers
 
@@ -944,7 +945,9 @@ class ClientSession:
         return self._connector_owner
 
     @property
-    def raise_for_status(self) -> bool:
+    def raise_for_status(
+        self
+    ) -> Union[bool, Callable[[ClientResponse], Awaitable[None]]]:
         """
         Should `ClientResponse.raise_for_status()`
         be called for each response

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -215,6 +215,82 @@ The client session supports the context manager protocol for self closing.
 
       .. versionadded:: 3.7
 
+   .. attribute:: headers
+
+      HTTP Headers that sent with every request
+
+      May be either *iterable of key-value pairs* or
+      :class:`~collections.abc.Mapping`
+      (e.g. :class:`dict`,
+      :class:`~multidict.CIMultiDict`).
+
+      .. versionadded:: 3.7
+
+   .. attribute:: skip_auto_headers
+
+      Set of headers for which autogeneration skipped.
+
+      :class:`frozenset` of :class:`str` or :class:`~aiohttp.istr` (optional)
+
+      .. versionadded:: 3.7
+
+   .. attribute:: auth
+
+      An object that represents HTTP Basic Authorization.
+
+      :class:`~aiohttp.BasicAuth` (optional)
+
+      .. versionadded:: 3.7
+
+   .. attribute:: json_serialize
+
+      Json serializer callable.
+
+      By default :func:`json.dumps` function.
+
+      .. versionadded:: 3.7
+
+   .. attribute:: connector_owner
+
+      Should connector be closed on session closing
+
+      :class:`bool` (optional)
+
+      .. versionadded:: 3.7
+
+   .. attribute:: raise_for_status
+
+      Should :meth:`ClientResponse.raise_for_status()` be called for each response
+
+      Either :class:`bool` or :class:`callable`
+
+      .. versionadded:: 3.7
+
+   .. attribute:: auto_decompress
+
+      Should the body response be automatically decompressed
+
+      :class:`bool` default is ``True``
+
+      .. versionadded:: 3.7
+
+   .. attribute:: trust_env
+
+      Should get proxies information from HTTP_PROXY / HTTPS_PROXY environment
+      variables or ~/.netrc file if present
+
+      :class:`bool` default is ``False``
+
+      .. versionadded:: 3.7
+
+   .. attribute:: trace_config
+
+      A list of :class:`TraceConfig` instances used for client
+      tracing.  ``None`` (default) is used for request tracing
+      disabling.  See :ref:`aiohttp-client-tracing-reference` for more information.
+
+      .. versionadded:: 3.7
+
    .. comethod:: request(method, url, *, params=None, data=None, json=None,\
                          cookies=None, headers=None, skip_auto_headers=None, \
                          auth=None, allow_redirects=True,\

--- a/tests/test_client_session.py
+++ b/tests/test_client_session.py
@@ -70,7 +70,7 @@ async def test_close_coro(create_session) -> None:
 async def test_init_headers_simple_dict(create_session) -> None:
     session = await create_session(headers={"h1": "header1",
                                             "h2": "header2"})
-    assert (sorted(session._default_headers.items()) ==
+    assert (sorted(session.default_headers.items()) ==
             ([("h1", "header1"), ("h2", "header2")]))
 
 
@@ -78,7 +78,7 @@ async def test_init_headers_list_of_tuples(create_session) -> None:
     session = await create_session(headers=[("h1", "header1"),
                                             ("h2", "header2"),
                                             ("h3", "header3")])
-    assert (session._default_headers ==
+    assert (session.default_headers ==
             CIMultiDict([("h1", "header1"),
                          ("h2", "header2"),
                          ("h3", "header3")]))
@@ -88,7 +88,7 @@ async def test_init_headers_MultiDict(create_session) -> None:
     session = await create_session(headers=MultiDict([("h1", "header1"),
                                                       ("h2", "header2"),
                                                       ("h3", "header3")]))
-    assert (session._default_headers ==
+    assert (session.default_headers ==
             CIMultiDict([("H1", "header1"),
                          ("H2", "header2"),
                          ("H3", "header3")]))
@@ -99,7 +99,7 @@ async def test_init_headers_list_of_tuples_with_duplicates(
     session = await create_session(headers=[("h1", "header11"),
                                             ("h2", "header21"),
                                             ("h1", "header12")])
-    assert (session._default_headers ==
+    assert (session.default_headers ==
             CIMultiDict([("H1", "header11"),
                          ("H2", "header21"),
                          ("H1", "header12")]))

--- a/tests/test_client_session.py
+++ b/tests/test_client_session.py
@@ -70,7 +70,7 @@ async def test_close_coro(create_session) -> None:
 async def test_init_headers_simple_dict(create_session) -> None:
     session = await create_session(headers={"h1": "header1",
                                             "h2": "header2"})
-    assert (sorted(session.default_headers.items()) ==
+    assert (sorted(session.headers.items()) ==
             ([("h1", "header1"), ("h2", "header2")]))
 
 
@@ -78,7 +78,7 @@ async def test_init_headers_list_of_tuples(create_session) -> None:
     session = await create_session(headers=[("h1", "header1"),
                                             ("h2", "header2"),
                                             ("h3", "header3")])
-    assert (session.default_headers ==
+    assert (session.headers ==
             CIMultiDict([("h1", "header1"),
                          ("h2", "header2"),
                          ("h3", "header3")]))
@@ -88,7 +88,7 @@ async def test_init_headers_MultiDict(create_session) -> None:
     session = await create_session(headers=MultiDict([("h1", "header1"),
                                                       ("h2", "header2"),
                                                       ("h3", "header3")]))
-    assert (session.default_headers ==
+    assert (session.headers ==
             CIMultiDict([("H1", "header1"),
                          ("H2", "header2"),
                          ("H3", "header3")]))
@@ -99,7 +99,7 @@ async def test_init_headers_list_of_tuples_with_duplicates(
     session = await create_session(headers=[("h1", "header11"),
                                             ("h2", "header21"),
                                             ("h1", "header12")])
-    assert (session.default_headers ==
+    assert (session.headers ==
             CIMultiDict([("H1", "header11"),
                          ("H2", "header21"),
                          ("H1", "header12")]))


### PR DESCRIPTION
## What do these changes do?

Added properties of default ClientSession params to ClientSession class so it is available for introspection now

## Are there changes in behavior for the user?

Users can now see which default parameters were initialized with ClientSession

## Related issue number

This commit fixes  #3882

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
