### PR TITLE
Updated the docs so there is no contradiction in ttl_dns_cache default value

### DIFF
--- a/CHANGES/3512.doc
+++ b/CHANGES/3512.doc
@@ -1,0 +1,1 @@
+Updated the docs so there is no contradiction in ttl_dns_cache default value

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -847,10 +847,9 @@ TCPConnector
    :param int ttl_dns_cache: expire after some seconds the DNS entries, ``None``
       means cached forever. By default 10 seconds.
 
-      By default DNS entries are cached forever, in some environments the IP
-      addresses related to a specific HOST can change after a specific time. Use
-      this option to keep the DNS cache updated refreshing each entry after N
-      seconds.
+      In some environments the IP addresses related to a specific HOST can
+      change after a specific time. Use this option to keep the DNS cache
+      updated refreshing each entry after N seconds.
 
    :param int limit: total number simultaneous connections. If *limit* is
                      ``None`` the connector has no limit (default: 100).


### PR DESCRIPTION
## What do these changes do?

Updated the docs so there is no contradiction in `TCPConnector.ttl_dns_cache` default value

## Are there changes in behavior for the user?

No.

## Related issue number

This commit fixes  #3512

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
