### PR TITLE
Add types to loose cookies3

### DIFF
--- a/CHANGES/4250.misc
+++ b/CHANGES/4250.misc
@@ -1,1 +1,1 @@
-Add two more types to LooseCookies with tests for the allowed types.
+Fixed annotations of the cookies parameter of CookieJar.update_cookies() and ClientRequest.update_cookies().

--- a/CHANGES/4250.misc
+++ b/CHANGES/4250.misc
@@ -1,0 +1,1 @@
+Add two more types to LooseCookies with tests for the allowed types.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -1,6 +1,7 @@
 - Contributors -
 ----------------
 A. Jesse Jiryu Davis
+Adam Bannister
 Adam Cooper
 Adam Mills
 Adrián Chaves

--- a/aiohttp/typedefs.py
+++ b/aiohttp/typedefs.py
@@ -51,8 +51,10 @@ StrToMorselMapping = Mapping[str, 'Morsel[Any]']
 LooseCookies = Union[
     StrBaseCookieTuples,
     StrMorselTuples,
+    Iterable[Tuple[str, str]],
     StrToBaseCookieMapping,
     StrToMorselMapping,
+    Mapping[str, str],
     'BaseCookie[str]',
 ]
 

--- a/aiohttp/typedefs.py
+++ b/aiohttp/typedefs.py
@@ -44,17 +44,15 @@ LooseHeaders = Union[Mapping[Union[str, istr], str], _CIMultiDict,
 RawHeaders = Tuple[Tuple[bytes, bytes], ...]
 StrOrURL = Union[str, URL]
 
-StrBaseCookieTuples = Iterable[Tuple[str, 'BaseCookie[str]']]
-StrMorselTuples = Iterable[Tuple[str, 'Morsel[str]']]
-StrToBaseCookieMapping = Mapping[str, 'BaseCookie[str]']
-StrToMorselMapping = Mapping[str, 'Morsel[Any]']
+LooseCookiesMappings = Mapping[
+    str, Union[str, 'BaseCookie[str]', 'Morsel[Any]']
+]
+LooseCookiesIterables = Iterable[
+    Tuple[str, Union[str, 'BaseCookie[str]', 'Morsel[Any]']]
+]
 LooseCookies = Union[
-    StrBaseCookieTuples,
-    StrMorselTuples,
-    Iterable[Tuple[str, str]],
-    StrToBaseCookieMapping,
-    StrToMorselMapping,
-    Mapping[str, str],
+    LooseCookiesMappings,
+    LooseCookiesIterables,
     'BaseCookie[str]',
 ]
 

--- a/tests/test_client_request.py
+++ b/tests/test_client_request.py
@@ -5,7 +5,7 @@ import hashlib
 import io
 import pathlib
 import zlib
-from http.cookies import SimpleCookie
+from http.cookies import BaseCookie, Morsel, SimpleCookie
 from unittest import mock
 
 import pytest
@@ -1121,3 +1121,22 @@ def test_insecure_fingerprint_md5(loop) -> None:
 def test_insecure_fingerprint_sha1(loop) -> None:
     with pytest.raises(ValueError):
         Fingerprint(hashlib.sha1(b"foo").digest())
+
+
+def test_loose_cookies_types(loop) -> None:
+    req = ClientRequest('get', URL('http://python.org'), loop=loop)
+    morsel = Morsel()
+    morsel.set(key='string', val='Another string', coded_val='really')
+
+    accepted_types = [
+        [('str', BaseCookie())],
+        [('str', morsel)],
+        [('str', 'str'), ],
+        {'str': BaseCookie()},
+        {'str': morsel},
+        {'str': 'str'},
+        SimpleCookie(),
+    ]
+
+    for loose_cookies_type in accepted_types:
+        req.update_cookies(cookies=loose_cookies_type)

--- a/tests/test_cookiejar.py
+++ b/tests/test_cookiejar.py
@@ -3,7 +3,7 @@ import datetime
 import itertools
 import pathlib
 import unittest
-from http.cookies import SimpleCookie
+from http.cookies import SimpleCookie, BaseCookie, Morsel
 from unittest import mock
 
 import pytest
@@ -662,3 +662,20 @@ async def test_dummy_cookie_jar() -> None:
         next(iter(dummy_jar))
     assert not dummy_jar.filter_cookies(URL("http://example.com/"))
     dummy_jar.clear()
+
+
+async def test_loose_cookies_types() -> None:
+    jar = CookieJar()
+
+    accepted_types = {
+        'StrBaseCookieTuples': [('str', BaseCookie())],
+        'StrMorselTuples': [('str', Morsel())],
+        'StrStrTuples': [('str', 'str'), ],
+        'StrToBaseCookieMapping': {'str': BaseCookie()},
+        'StrToMorselMapping': {'str': Morsel()},
+        'StrToStrMapping': {'str': 'str'},
+        'BaseCookie[str]': SimpleCookie(),
+    }
+
+    for name, loose_cookies_type in accepted_types.items():
+        jar.update_cookies(cookies=loose_cookies_type)

--- a/tests/test_cookiejar.py
+++ b/tests/test_cookiejar.py
@@ -3,7 +3,8 @@ import datetime
 import itertools
 import pathlib
 import unittest
-from http.cookies import SimpleCookie, BaseCookie, Morsel
+from http.cookies import BaseCookie, Morsel, SimpleCookie
+
 from unittest import mock
 
 import pytest

--- a/tests/test_cookiejar.py
+++ b/tests/test_cookiejar.py
@@ -667,15 +667,15 @@ async def test_dummy_cookie_jar() -> None:
 async def test_loose_cookies_types() -> None:
     jar = CookieJar()
 
-    accepted_types = {
-        'StrBaseCookieTuples': [('str', BaseCookie())],
-        'StrMorselTuples': [('str', Morsel())],
-        'StrStrTuples': [('str', 'str'), ],
-        'StrToBaseCookieMapping': {'str': BaseCookie()},
-        'StrToMorselMapping': {'str': Morsel()},
-        'StrToStrMapping': {'str': 'str'},
-        'BaseCookie[str]': SimpleCookie(),
-    }
+    accepted_types = [
+        [('str', BaseCookie())],
+        [('str', Morsel())],
+        [('str', 'str'), ],
+        {'str': BaseCookie()},
+        {'str': Morsel()},
+        {'str': 'str'},
+        SimpleCookie(),
+    ]
 
-    for name, loose_cookies_type in accepted_types.items():
+    for loose_cookies_type in accepted_types:
         jar.update_cookies(cookies=loose_cookies_type)

--- a/tests/test_cookiejar.py
+++ b/tests/test_cookiejar.py
@@ -4,7 +4,6 @@ import itertools
 import pathlib
 import unittest
 from http.cookies import BaseCookie, Morsel, SimpleCookie
-
 from unittest import mock
 
 import pytest


### PR DESCRIPTION
## What do these changes do?

Add tests as requested for types that update cookies accept. Adds two more accepted types to LooseCookies.

## Are there changes in behavior for the user?

Nope.

## Related issue number

#4205

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
