### PR TITLE
Fix MacOS CI

### DIFF
--- a/requirements/ci-wheel.txt
+++ b/requirements/ci-wheel.txt
@@ -16,7 +16,9 @@ typing_extensions==3.7.4
 yarl==1.3.0
 
 # Using PEP 508 env markers to control dependency on runtimes:
-aiodns==2.0.0; platform_system!="Windows"  # required c-ares will not build on windows
+
+# required c-ares will not build on windows and has build problems on Macos Python<3.7
+aiodns==2.0.0; sys_platform=="linux" or sys_platform=="darvin" and python_version>="3.7"
 cryptography==2.8; platform_machine!="i686" # no 32-bit wheels
 trustme==0.5.2; platform_machine!="i686"    # no 32-bit wheels
 codecov==2.0.15


### PR DESCRIPTION
CARES C Extension build fails on macOS for Python<3.7