### PR TITLE
Prepare response headers prior to running prepare signal

### DIFF
--- a/CHANGES/1958.feature
+++ b/CHANGES/1958.feature
@@ -1,0 +1,1 @@
+Response headers are now prepared prior to running ``on_response_prepare`` hooks, directly before headers are sent to the client.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -140,6 +140,7 @@ Jon Nabozny
 Jonas Obrist
 Joongi Kim
 Josep Cugat
+Josh Junon
 Joshu Coats
 Julia Tsemusheva
 Julien Duponchelle

--- a/docs/web_advanced.rst
+++ b/docs/web_advanced.rst
@@ -537,7 +537,8 @@ For example, a middleware can only change HTTP headers for *unprepared*
 responses (see :meth:`StreamResponse.prepare`), but sometimes we
 need a hook for changing HTTP headers for streamed responses and WebSockets.
 This can be accomplished by subscribing to the
-:attr:`Application.on_response_prepare` signal::
+:attr:`Application.on_response_prepare` signal, which is called after default
+headers have been computed and directly before headers are sent::
 
     async def on_prepare(request, response):
         response.headers['My-Header'] = 'value'

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -762,7 +762,8 @@ StreamResponse
       calling this method.
 
       The coroutine calls :attr:`~aiohttp.web.Application.on_response_prepare`
-      signal handlers.
+      signal handlers after default headers have been computed and directly
+      before headers are sent.
 
    .. comethod:: write(data)
 
@@ -1316,10 +1317,11 @@ duplicated like one using :meth:`Application.copy`.
 
    .. attribute:: on_response_prepare
 
-      A :class:`~aiohttp.Signal` that is fired at the beginning
+      A :class:`~aiohttp.Signal` that is fired near the end
       of :meth:`StreamResponse.prepare` with parameters *request* and
       *response*. It can be used, for example, to add custom headers to each
-      response before sending.
+      response, or to modify the default headers computed by the application,
+      directly before sending the headers to the client.
 
       Signal handlers should have the following signature::
 

--- a/tests/test_web_response.py
+++ b/tests/test_web_response.py
@@ -1090,6 +1090,31 @@ def test_response_with_immutable_headers() -> None:
                             'Content-Type': 'text/plain; charset=utf-8'}
 
 
+async def test_response_prepared_after_header_preparation() -> None:
+    req = make_request('GET', '/')
+    resp = StreamResponse()
+    await resp.prepare(req)
+
+    assert type(resp.headers['Server']) is str
+
+    async def _strip_server(req, res):
+        assert 'Server' in res.headers
+
+        if 'Server' in res.headers:
+            del res.headers['Server']
+
+    app = mock.Mock()
+    sig = signals.Signal(app)
+    sig.append(_strip_server)
+
+    req = make_request(
+        'GET', '/', on_response_prepare=sig, app=app)
+    resp = StreamResponse()
+    await resp.prepare(req)
+
+    assert 'Server' not in resp.headers
+
+
 class TestJSONResponse:
 
     def test_content_type_is_application_json_by_default(self) -> None:


### PR DESCRIPTION
## What do these changes do?

When a response is to be sent, this prepares the headers prior to running the prepare hook instead of after.

## Are there changes in behavior for the user?

Any uses of the response prepare signal that assumed the headers are replaced after their signal handlers will now need to take this change into account.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Closes #1958.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
