### PR TITLE
[3.7] Change typing of the secure argument on StreamResponse.set_cookie (#4238)

### DIFF
--- a/CHANGES/4204.doc
+++ b/CHANGES/4204.doc
@@ -1,0 +1,1 @@
+Change typing of the secure argument on StreamResponse.set_cookie from Optional[str] to a Optional[bool]

--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -181,8 +181,8 @@ class StreamResponse(BaseClass, HeadersMixin):
                    domain: Optional[str]=None,
                    max_age: Optional[Union[int, str]]=None,
                    path: str='/',
-                   secure: Optional[str]=None,
-                   httponly: Optional[str]=None,
+                   secure: Optional[bool]=None,
+                   httponly: Optional[bool]=None,
                    version: Optional[str]=None) -> None:
         """Set or update response cookie.
 


### PR DESCRIPTION


(cherry picked from commit e4573f8c)

Co-authored-by: Pavel Filatov <triksrimer@gmail.com>
