### PR TITLE
[3.7] Preserve view handler function attributes across middlewares (#4195).

### DIFF
--- a/CHANGES/4174.bugfix
+++ b/CHANGES/4174.bugfix
@@ -1,0 +1,1 @@
+Preserve view handler function attributes across middlewares

--- a/aiohttp/web_app.py
+++ b/aiohttp/web_app.py
@@ -1,7 +1,7 @@
 import asyncio
 import logging
 import warnings
-from functools import partial
+from functools import partial, update_wrapper
 from typing import (  # noqa
     TYPE_CHECKING,
     Any,
@@ -453,7 +453,9 @@ class Application(MutableMapping[str, Any]):
                 for app in match_info.apps[::-1]:
                     for m, new_style in app._middlewares_handlers:  # type: ignore  # noqa
                         if new_style:
-                            handler = partial(m, handler=handler)
+                            handler = update_wrapper(
+                                partial(m, handler=handler), handler
+                            )
                         else:
                             handler = await m(app, handler)  # type: ignore
 


### PR DESCRIPTION


(cherry picked from commit 2c70eb806032b1608dad301238f0a952585c5e0a)

Co-authored-by: Gustavo J. A. M. Carneiro <gjcarneiro@gmail.com>
