### PR TITLE
TCPConnector ttl_dns_cache type hint.

### DIFF
--- a/CHANGES/4270.doc
+++ b/CHANGES/4270.doc
@@ -1,0 +1,1 @@
+Changes doc and ttl_dns_cache type from int to Optional[int].

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -98,6 +98,7 @@ Eugene Nikolaiev
 Eugene Tolmachev
 Evert Lammerts
 Felix Yan
+Fernanda Guimarães
 FichteFoll
 Florian Scheffler
 Frederik Gladhorn

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -695,7 +695,7 @@ class TCPConnector(BaseConnector):
     """
 
     def __init__(self, *,
-                 use_dns_cache: bool=True, ttl_dns_cache: int=10,
+                 use_dns_cache: bool=True, ttl_dns_cache: Optional[int]=10,
                  family: int=0,
                  ssl: Union[None, bool, Fingerprint, SSLContext]=None,
                  local_addr: Optional[Tuple[str, int]]=None,

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -921,7 +921,7 @@ TCPConnector
       *side effects* also.
 
    :param int ttl_dns_cache: expire after some seconds the DNS entries, ``None``
-      means cached forever. By default 10 seconds.
+      means cached forever. By default 10 seconds (optional).
 
       In some environments the IP addresses related to a specific HOST can
       change after a specific time. Use this option to keep the DNS cache


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?
<!-- Please give a short brief about these changes. -->
These change make `ttl_dns_cache` type `Optional[int]` instead of `int`.

## Are there changes in behavior for the user?
<!-- Outline any notable behaviour for the end users. -->
No.

## Related issue number
<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #4270

## Checklist

- [X] I think the code is well written
- [ ] Unit tests for the changes exist
- [X] Documentation reflects the changes
- [X] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [X] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
