### PR TITLE
[3.7] TCPConnector ttl_dns_cache type hint. (#4279).

### DIFF
--- a/CHANGES/4270.doc
+++ b/CHANGES/4270.doc
@@ -1,0 +1,1 @@
+Changes doc and ttl_dns_cache type from int to Optional[int].

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -94,6 +94,8 @@ Eugene Naydenov
 Eugene Nikolaiev
 Eugene Tolmachev
 Evert Lammerts
+Felix Yan
+Fernanda Guimarães
 FichteFoll
 Florian Scheffler
 Frederik Gladhorn

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -713,7 +713,7 @@ class TCPConnector(BaseConnector):
 
     def __init__(self, *, verify_ssl: bool=True,
                  fingerprint: Optional[bytes]=None,
-                 use_dns_cache: bool=True, ttl_dns_cache: int=10,
+                 use_dns_cache: bool=True, ttl_dns_cache: Optional[int]=10,
                  family: int=0,
                  ssl_context: Optional[SSLContext]=None,
                  ssl: Union[None, bool, Fingerprint, SSLContext]=None,

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -1038,7 +1038,7 @@ TCPConnector
       *side effects* also.
 
    :param int ttl_dns_cache: expire after some seconds the DNS entries, ``None``
-      means cached forever. By default 10 seconds.
+      means cached forever. By default 10 seconds (optional).
 
       In some environments the IP addresses related to a specific HOST can
       change after a specific time. Use this option to keep the DNS cache


### PR DESCRIPTION
(cherry picked from commit 18b9274a199e437279b9213ab0256d064736a0ff)

Co-authored-by: Fernanda Guimarães <31302805+haneybarg@users.noreply.github.com>
