### PR TITLE
Support addition of routes when handler is wrapped by functools.partial()

### DIFF
--- a/CHANGES/4302.bugfix
+++ b/CHANGES/4302.bugfix
@@ -1,0 +1,1 @@
+Fixed the support of route handlers wrapped by functools.partial()

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -282,6 +282,7 @@ Young-Ho Cha
 Yuriy Shatrov
 Yury Selivanov
 Yusuke Tsutsumi
+Yuval Ofir
 Zlatan Sičanica
 Марк Коренберг
 Семён Марьясин

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -111,7 +111,7 @@ async def noop(*args: Any, **kwargs: Any) -> None:
 coroutines._DEBUG = old_debug  # type: ignore
 
 if not PY_38:
-    def iscoroutinefunction(handler: Any) -> bool:
+    def iscoroutinefunction(handler: Callable[..., Any]) -> bool:
         while isinstance(handler, functools.partial):
             handler = handler.func
         return asyncio.iscoroutinefunction(handler)

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -110,11 +110,13 @@ async def noop(*args: Any, **kwargs: Any) -> None:
 
 coroutines._DEBUG = old_debug  # type: ignore
 
-def iscoroutinefunction(handler: Any) -> bool:
-    if not PY_38:
+if not PY_38:
+    def iscoroutinefunction(handler: Any) -> bool:
         while isinstance(handler, functools.partial):
             handler = handler.func
     return asyncio.iscoroutinefunction(handler)
+else:
+    iscoroutinefunction = asyncio.iscoroutinefunction
 
 json_re = re.compile(r'^application/(?:[\w.+-]+?\+)?json')
 

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -110,6 +110,12 @@ async def noop(*args: Any, **kwargs: Any) -> None:
 
 coroutines._DEBUG = old_debug  # type: ignore
 
+def iscoroutinefunction(handler: Any) -> bool:
+    if not PY_38:
+        while isinstance(handler, functools.partial):
+            handler = handler.func
+    return asyncio.iscoroutinefunction(handler)
+
 json_re = re.compile(r'^application/(?:[\w.+-]+?\+)?json')
 
 

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -114,7 +114,7 @@ if not PY_38:
     def iscoroutinefunction(handler: Any) -> bool:
         while isinstance(handler, functools.partial):
             handler = handler.func
-    return asyncio.iscoroutinefunction(handler)
+        return asyncio.iscoroutinefunction(handler)
 else:
     iscoroutinefunction = asyncio.iscoroutinefunction
 

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -110,13 +110,13 @@ async def noop(*args: Any, **kwargs: Any) -> None:
 
 coroutines._DEBUG = old_debug  # type: ignore
 
-if not PY_38:
+if PY_38:
+    iscoroutinefunction = asyncio.iscoroutinefunction
+else:
     def iscoroutinefunction(handler: Callable[..., Any]) -> bool:
         while isinstance(handler, functools.partial):
             handler = handler.func
         return asyncio.iscoroutinefunction(handler)
-else:
-    iscoroutinefunction = asyncio.iscoroutinefunction
 
 json_re = re.compile(r'^application/(?:[\w.+-]+?\+)?json')
 

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -113,10 +113,10 @@ coroutines._DEBUG = old_debug  # type: ignore
 if PY_38:
     iscoroutinefunction = asyncio.iscoroutinefunction
 else:
-    def iscoroutinefunction(handler: Callable[..., Any]) -> bool:
-        while isinstance(handler, functools.partial):
-            handler = handler.func
-        return asyncio.iscoroutinefunction(handler)
+    def iscoroutinefunction(func: Callable[..., Any]) -> bool:
+        while isinstance(func, functools.partial):
+            func = func.func
+        return asyncio.iscoroutinefunction(func)
 
 json_re = re.compile(r'^application/(?:[\w.+-]+?\+)?json')
 

--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -1,5 +1,4 @@
 import abc
-import asyncio
 import base64
 import hashlib
 import keyword

--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -6,6 +6,7 @@ import keyword
 import os
 import re
 from contextlib import contextmanager
+from functools import partial
 from pathlib import Path
 from types import MappingProxyType
 from typing import (  # noqa
@@ -30,7 +31,6 @@ from typing import (  # noqa
 )
 
 from yarl import URL
-from functools import partial
 
 from . import hdrs
 from .abc import AbstractMatchInfo, AbstractRouter, AbstractView

--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -152,7 +152,7 @@ class AbstractRoute(abc.ABC):
     @staticmethod
     def iscoroutinefunction(handler):
         while isinstance(handler, partial):
-            handler = object.func
+            handler = handler.func
         return asyncio.iscoroutinefunction(handler)
 
     @property

--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -150,7 +150,7 @@ class AbstractRoute(abc.ABC):
         self._resource = resource
 
     @staticmethod
-    def iscoroutinefunction(handler):
+    def iscoroutinefunction(handler: Any) -> bool:
         while isinstance(handler, partial):
             handler = handler.func
         return asyncio.iscoroutinefunction(handler)

--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -116,6 +116,7 @@ class AbstractResource(Sized, Iterable['AbstractRoute']):
     def raw_match(self, path: str) -> bool:
         """Perform a raw match against path"""
 
+
 class AbstractRoute(abc.ABC):
 
     def __init__(self, method: str,

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -1572,8 +1572,7 @@ Router is any object that implements :class:`AbstractRouter` interface.
        *variable rule* like ``'/a/{var}'`` (see
        :ref:`handling variable paths <aiohttp-web-variable-handler>`)
 
-      Pay attention please: *handler* is converted to coroutine internally when
-      it is a regular function.
+      Pay attention please: *handler* must be a coroutine.
 
       :param str method: HTTP method for route. Should be one of
                          ``'GET'``, ``'POST'``, ``'PUT'``,

--- a/tests/test_urldispatch.py
+++ b/tests/test_urldispatch.py
@@ -1,6 +1,7 @@
 import pathlib
 import re
 from collections.abc import Container, Iterable, Mapping, MutableMapping, Sized
+from functools import partial
 from urllib.parse import unquote
 
 import pytest
@@ -32,6 +33,12 @@ def make_handler():
 
     return handler
 
+def make_partial_handler():
+
+    async def handler(a, request):
+        return Response(request)  # pragma: no cover
+
+    return partial(handler, 5)
 
 @pytest.fixture
 def app():
@@ -71,6 +78,10 @@ def test_register_uncommon_http_methods(router) -> None:
     for method in uncommon_http_methods:
         router.add_route(method, '/handler/to/path', make_handler())
 
+
+async def test_add_partial_handler(router) -> None:
+    handler = make_partial_handler()
+    router.add_get('/handler/to/path', handler)
 
 async def test_add_sync_handler(router) -> None:
     def handler(request):


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?
In aiohttp v4 a new check was added to make sure that route handlers are coroutines.
Python < v3.8 will return False for asyncio.iscoroutine(functools.partial(async_function)).
The change will iterate the wrapped function to make sure its async

## Are there changes in behavior for the user?
No

## Related issue number


## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
