### PR TITLE
Don't start heartbeat until _writer is set (#4062)

### DIFF
--- a/CHANGES/4062.bugfix
+++ b/CHANGES/4062.bugfix
@@ -1,0 +1,1 @@
+Don't start heartbeat until _writer is set

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -93,6 +93,7 @@ Emil Melnikov
 Enrique Saez
 Eric Sheng
 Erich Healy
+Erik Peterson
 Eugene Chernyshov
 Eugene Naydenov
 Eugene Nikolaiev

--- a/aiohttp/web_ws.py
+++ b/aiohttp/web_ws.py
@@ -209,8 +209,6 @@ class WebSocketResponse(StreamResponse):
         headers, protocol, compress, notakeover = self._handshake(
             request)
 
-        self._reset_heartbeat()
-
         self.set_status(101)
         self.headers.update(headers)
         self.force_close()
@@ -228,6 +226,9 @@ class WebSocketResponse(StreamResponse):
                     protocol: str, writer: WebSocketWriter) -> None:
         self._ws_protocol = protocol
         self._writer = writer
+
+        self._reset_heartbeat()
+
         loop = self._loop
         assert loop is not None
         self._reader = FlowControlDataQueue(


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

As seen in https://github.com/aio-libs/aiohttp/issues/4062 . `self._reset_heartbeat()` is being called during `_pre_start`, which is before the writer is set. The error in the issue will occur if the writer isn't set before the first heartbeat is sent.

This change waits until the writer is set, during `_post_start`, to start sending heartbeats.

## Are there changes in behavior for the user?

None

## Related issue number

#4062 

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
