### PR TITLE
Fix lock bot markdown link

### DIFF
--- a/.github/lock.yml
+++ b/.github/lock.yml
@@ -20,13 +20,13 @@ lockLabel: outdated
 # Comment to post before locking. Set to `false` to disable
 lockComment: |
   This thread has been automatically locked since there has not been
-  any recent activity after it was closed. Please open a [new issue] for
+  any recent activity after it was closed. Please open a [new issue][newissue] for
   related bugs.
 
   If you feel like there's important points made in this discussion,
-  please include those exceprts into that [new issue].
+  please include those exceprts in that [new issue][newissue].
 
-  [new issue]: https://github.com/aio-libs/aiohttp/issues/new
+  [newissue]: https://github.com/aio-libs/aiohttp/issues/new
 
 # Assign `resolved` as the reason for locking. Set to `false` to disable
 setLockReason: true


### PR DESCRIPTION
Fix markdown link

<!-- Thank you for your contribution! -->

## What do these changes do?

Fixes markdown link in the lock bot posts.

Malformed link example: https://github.com/aio-libs/aiohttp/issues/3252#issuecomment-546749077

![image](https://user-images.githubusercontent.com/5297556/68228701-85c8b000-ffbb-11e9-919c-459f4e002eed.png)


## Are there changes in behavior for the user?

GitHub integration only.

## Related issue number

None

## Checklist

N/A, GH bot/integration.