### PR TITLE
remove tox from requirements

### DIFF
--- a/requirements/ci-wheel.txt
+++ b/requirements/ci-wheel.txt
@@ -10,7 +10,6 @@ multidict==4.5.2
 pytest==5.2.2
 pytest-cov==2.8.1
 pytest-mock==1.11.2
-tox==3.14.1
 twine==2.0.0
 typing_extensions==3.7.4.1
 yarl==1.3.0


### PR DESCRIPTION
Saw the recent dependabot  pull

## What do these changes do?
Removes tox as requirement as the tox.ini has been removed.

## Are there changes in behavior for the user?
No

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
