### PR TITLE
Form data processed

### DIFF
--- a/CHANGES/4345.bugfix
+++ b/CHANGES/4345.bugfix
@@ -1,0 +1,1 @@
+Raise ClientPayloadError if FormData re-processed.

--- a/aiohttp/formdata.py
+++ b/aiohttp/formdata.py
@@ -122,7 +122,7 @@ class FormData:
     def _gen_form_data(self) -> multipart.MultipartWriter:
         """Encode a list of fields using the multipart/form-data MIME format"""
         if self._is_processed:
-            raise ClientPayloadError('Form data has been processed already')
+            raise RuntimeError('Form data has been processed already')
         for dispparams, headers, value in self._fields:
             try:
                 if hdrs.CONTENT_TYPE in headers:

--- a/aiohttp/formdata.py
+++ b/aiohttp/formdata.py
@@ -5,7 +5,6 @@ from urllib.parse import urlencode
 from multidict import MultiDict, MultiDictProxy
 
 from . import hdrs, multipart, payload
-from .client_exceptions import ClientPayloadError
 from .helpers import guess_filename
 from .payload import Payload
 

--- a/aiohttp/formdata.py
+++ b/aiohttp/formdata.py
@@ -37,10 +37,6 @@ class FormData:
     def is_multipart(self) -> bool:
         return self._is_multipart
 
-    @property
-    def is_processed(self) -> bool:
-        return self._is_processed
-
     def add_field(self, name: str, value: Any, *,
                   content_type: Optional[str]=None,
                   filename: Optional[str]=None,

--- a/tests/test_formdata.py
+++ b/tests/test_formdata.py
@@ -2,7 +2,8 @@ from unittest import mock
 
 import pytest
 
-from aiohttp.formdata import FormData
+from aiohttp import ClientSession, FormData
+from aiohttp.client_exceptions import ClientPayloadError
 
 
 @pytest.fixture
@@ -86,3 +87,16 @@ async def test_formdata_field_name_is_not_quoted(buf, writer) -> None:
     payload = form()
     await payload.write(writer)
     assert b'name="emails[]"' in buf
+
+
+async def test_mark_formdata_as_processed() -> None:
+    async with ClientSession() as session:
+        url = "http://httpbin.org/anything"
+        data = FormData()
+        data.add_field("test", "test_value", content_type="application/json")
+
+        await session.post(url, data=data)
+        assert len(data._writer._parts) == 1
+
+        with pytest.raises(ClientPayloadError):
+            await session.post(url, data=data)

--- a/tests/test_formdata.py
+++ b/tests/test_formdata.py
@@ -3,7 +3,6 @@ from unittest import mock
 import pytest
 
 from aiohttp import ClientSession, FormData
-from aiohttp.client_exceptions import ClientPayloadError
 
 
 @pytest.fixture
@@ -98,5 +97,5 @@ async def test_mark_formdata_as_processed() -> None:
         await session.post(url, data=data)
         assert len(data._writer._parts) == 1
 
-        with pytest.raises(ClientPayloadError):
+        with pytest.raises(RuntimeError):
             await session.post(url, data=data)

--- a/tests/test_web_functional.py
+++ b/tests/test_web_functional.py
@@ -40,7 +40,7 @@ def fname(here):
 def new_dummy_form():
     form = FormData()
     form.add_field('name', b'123',
-                content_transfer_encoding='base64')
+                   content_transfer_encoding='base64')
     return form
 
 

--- a/tests/test_web_functional.py
+++ b/tests/test_web_functional.py
@@ -37,6 +37,13 @@ def fname(here):
     return here / 'conftest.py'
 
 
+def new_dummy_form():
+    form = FormData()
+    form.add_field('name', b'123',
+                content_transfer_encoding='base64')
+    return form
+
+
 async def test_simple_get(aiohttp_client) -> None:
 
     async def handler(request):
@@ -513,15 +520,11 @@ async def test_100_continue_custom(aiohttp_client) -> None:
         if request.version == HttpVersion11:
             await request.writer.write(b"HTTP/1.1 100 Continue\r\n\r\n")
 
-    form = FormData()
-    form.add_field('name', b'123',
-                   content_transfer_encoding='base64')
-
     app = web.Application()
     app.router.add_post('/', handler, expect_handler=expect_handler)
     client = await aiohttp_client(app)
 
-    resp = await client.post('/', data=form, expect100=True)
+    resp = await client.post('/', data=new_dummy_form(), expect100=True)
     assert 200 == resp.status
     assert expect_received
 
@@ -540,20 +543,16 @@ async def test_100_continue_custom_response(aiohttp_client) -> None:
 
             await request.writer.write(b"HTTP/1.1 100 Continue\r\n\r\n")
 
-    form = FormData()
-    form.add_field('name', b'123',
-                   content_transfer_encoding='base64')
-
     app = web.Application()
     app.router.add_post('/', handler, expect_handler=expect_handler)
     client = await aiohttp_client(app)
 
     auth_err = False
-    resp = await client.post('/', data=form, expect100=True)
+    resp = await client.post('/', data=new_dummy_form(), expect100=True)
     assert 200 == resp.status
 
     auth_err = True
-    resp = await client.post('/', data=form, expect100=True)
+    resp = await client.post('/', data=new_dummy_form(), expect100=True)
     assert 403 == resp.status
 
 


### PR DESCRIPTION
## What do these changes do?

A FormData instance keeps track whether it has been processed already. If the instance is sent for a second time then it raises a ClientPayloadError.

## Are there changes in behavior for the user?

Will raise an exception if they try to resend a FormData instance.

## Related issue number

#4345

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
