### PR TITLE
Avoid circular references between response handler and parser

### DIFF
--- a/CHANGES/4369.bugfix
+++ b/CHANGES/4369.bugfix
@@ -1,0 +1,1 @@
+Avoid circular references between response handler and parser

--- a/aiohttp/client_proto.py
+++ b/aiohttp/client_proto.py
@@ -64,6 +64,13 @@ class ResponseHandler(BaseProtocol,
             self._payload = None
             self._drop_timeout()
 
+        # The parser can have a reference back to this instance
+        # via parser.protocol set it to None to avoid leaking objects
+        self._parser = None
+
+        # And same most likely goes for _payload_parser as well
+        self._payload_parser = None
+
     def is_connected(self) -> bool:
         return self.transport is not None
 


### PR DESCRIPTION
ResponseHandler kept a reference via `_parser` to HttpResponseParser
which in turn kept a reference in `protocol` to ResponseHandler.

This breaks that reference on `close()` by setting `_parser` to
None.

---

I'm not entirely sure this is correct, I assumed that `ResponseHandler` methods `data_received` and `connection_lost` are never called after `close()`

Also I think there is a deeper issue in asyncio that I haven't been able to pin-point yet as the `ResponseHandler` is still kept around by references from `_SelectorSocketTransport` via `SSLProtocol`.


## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
