### PR TITLE
Make web.BaseRequest and web.StreamResponse weak referenceable

### DIFF
--- a/CHANGES/4368.bugfix
+++ b/CHANGES/4368.bugfix
@@ -1,0 +1,1 @@
+Make `web.BaseRequest`, `web.Request`, `web.StreamResponse`, `web.Response` and `web.WebSocketResponse` weak referenceable again.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -95,6 +95,7 @@ Eric Sheng
 Erich Healy
 Erik Peterson
 Eugene Chernyshov
+Eugene Ershov
 Eugene Naydenov
 Eugene Nikolaiev
 Eugene Tolmachev

--- a/aiohttp/web_request.py
+++ b/aiohttp/web_request.py
@@ -113,7 +113,7 @@ class BaseRequest(MutableMapping[str, Any], HeadersMixin):
         '_method', '_version', '_rel_url', '_post', '_read_bytes',
         '_state', '_cache', '_task', '_client_max_size', '_loop',
         '_transport_sslcontext', '_transport_peername',
-        '_disconnection_waiters',
+        '_disconnection_waiters', '__weakref__'
     )
 
     def __init__(self, message: RawRequestMessage,

--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -68,7 +68,7 @@ class StreamResponse(BaseClass, HeadersMixin):
     __slots__ = ('_length_check', '_body', '_keep_alive', '_chunked',
                  '_compression', '_compression_force', '_cookies', '_req',
                  '_payload_writer', '_eof_sent', '_body_length', '_state',
-                 '_headers', '_status', '_reason')
+                 '_headers', '_status', '_reason', '__weakref__')
 
     def __init__(self, *,
                  status: int=200,

--- a/tests/test_web_request.py
+++ b/tests/test_web_request.py
@@ -1,5 +1,6 @@
 import asyncio
 import socket
+import weakref
 from collections.abc import MutableMapping
 from typing import Any
 from unittest import mock
@@ -765,3 +766,8 @@ async def test_json_invalid_content_type(aiohttp_client) -> None:
         resp_text = await resp.text()
         assert resp_text == ('Attempt to decode JSON with '
                              'unexpected mimetype: text/plain')
+
+
+def test_weakref_creation() -> None:
+    req = make_mocked_request('GET', '/')
+    weakref.ref(req)

--- a/tests/test_web_response.py
+++ b/tests/test_web_response.py
@@ -3,6 +3,7 @@ import datetime
 import gzip
 import json
 import re
+import weakref
 from concurrent.futures import ThreadPoolExecutor
 from unittest import mock
 
@@ -1089,6 +1090,11 @@ def test_response_with_immutable_headers() -> None:
                     headers=CIMultiDictProxy(CIMultiDict({'Header': 'Value'})))
     assert resp.headers == {'Header': 'Value',
                             'Content-Type': 'text/plain; charset=utf-8'}
+
+
+def test_weakref_creation() -> None:
+    resp = Response()
+    weakref.ref(resp)
 
 
 class TestJSONResponse:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
Adding `__weakref__` to `__slots__` makes `web.BaseRequest` and `web.StreamResponse` valid targets for creating weak references.

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->
Users are able to create weak references to request and response objects again after https://github.com/aio-libs/aiohttp/pull/3942.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Resolves #4368
Resolves #4370

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
