### PR TITLE
Link the Truth value of a ClientResponse to the underlying status

### DIFF
--- a/CHANGES/4377.feature
+++ b/CHANGES/4377.feature
@@ -1,0 +1,1 @@
+Link the Truth value of a ClientResponse to the underlying status.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -61,6 +61,7 @@ Chris Laws
 Chris Moore
 Christopher Schmitt
 Claudiu Popa
+Colin Bounouar
 Colin Dunklau
 Cong Xu
 Damien Nadé

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -729,6 +729,16 @@ class ClientResponse(HeadersMixin):
         print(self.headers, file=out)
         return out.getvalue()
 
+    def __bool__(self) -> bool:
+        """Returns True if :attr:`status` is less than 400.
+
+        Checks if the status code of the response is superior or equal to 400
+        to see if there was a client error or a server error. If
+        the status code, is inferior to 400, this will return True. This
+        is **not** a check to see if the response code is ``200 OK``.
+        """
+        return 400 > self.status
+
     @property
     def connection(self) -> Optional['Connection']:
         return self._connection

--- a/tests/test_client_response.py
+++ b/tests/test_client_response.py
@@ -638,6 +638,20 @@ def test_raise_for_status_2xx() -> None:
     response.raise_for_status()  # should not raise
 
 
+def test_bool_ok_with_status_2xx() -> None:
+    response = ClientResponse('get', URL('http://def-cl-resp.org'),
+                              request_info=mock.Mock(),
+                              writer=mock.Mock(),
+                              continue100=None,
+                              timer=TimerNoop(),
+                              traces=[],
+                              loop=mock.Mock(),
+                              session=mock.Mock())
+    response.status = 200
+    response.reason = 'OK'
+    assert bool(response) is True
+
+
 def test_raise_for_status_4xx() -> None:
     response = ClientResponse('get', URL('http://def-cl-resp.org'),
                               request_info=mock.Mock(),
@@ -654,6 +668,20 @@ def test_raise_for_status_4xx() -> None:
     assert str(cm.value.status) == '409'
     assert str(cm.value.message) == "CONFLICT"
     assert response.closed
+
+
+def test_bool_not_ok_with_status_4xx() -> None:
+    response = ClientResponse('get', URL('http://def-cl-resp.org'),
+                              request_info=mock.Mock(),
+                              writer=mock.Mock(),
+                              continue100=None,
+                              timer=TimerNoop(),
+                              traces=[],
+                              loop=mock.Mock(),
+                              session=mock.Mock())
+    response.status = 409
+    response.reason = 'CONFLICT'
+    assert bool(response) is False
 
 
 def test_raise_for_status_4xx_without_reason() -> None:


### PR DESCRIPTION
## What do these changes do?

Provides the ability to use the Truth value of a response, the same we can when using [requests](https://github.com/psf/requests/blob/master/requests/models.py#L673).

## Are there changes in behavior for the user?

In case users where relying on the Truth value instead of checking to None explicitly, this might change the behavior in case of an HTTP error.

But was it ever a proper usage ?

## Related issue number

None to my knowledge

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
