### PR TITLE
Add runner.serve_forever()

### DIFF
--- a/CHANGES/2746.feature
+++ b/CHANGES/2746.feature
@@ -1,0 +1,1 @@
+Add method `BaseRunner.serve_forever()` that waits forever until being cancelled.

--- a/docs/web_advanced.rst
+++ b/docs/web_advanced.rst
@@ -768,9 +768,7 @@ The simple startup code for serving HTTP site on ``'localhost'``, port
     await runner.setup()
     site = web.TCPSite(runner, 'localhost', 8080)
     await site.start()
-
-    while True:
-        await asyncio.sleep(3600)  # sleep forever
+    await runner.serve_forever()
 
 To stop serving call :meth:`AppRunner.cleanup`::
 

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -2458,6 +2458,7 @@ application on specific TCP or Unix socket, e.g.::
     await runner.setup()
     site = web.TCPSite(runner, 'localhost', 8080)
     await site.start()
+    # wait for finish signal
     await runner.serve_forever()
 
 

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -2458,8 +2458,7 @@ application on specific TCP or Unix socket, e.g.::
     await runner.setup()
     site = web.TCPSite(runner, 'localhost', 8080)
     await site.start()
-    # wait for finish signal
-    await runner.cleanup()
+    await runner.serve_forever()
 
 
 .. versionadded:: 3.0
@@ -2495,6 +2494,13 @@ application on specific TCP or Unix socket, e.g.::
    .. comethod:: setup()
 
       Initialize the server. Should be called before adding sites.
+
+
+   .. comethod:: serve_forever()
+
+      Wait forever. Cancellation of serve_forever task causes the runner to be closed.
+      This method can be called only if the runner is already initialized.
+      Only one serve_forever task can exist per one runner object.
 
    .. comethod:: cleanup()
 

--- a/tests/test_web_runner.py
+++ b/tests/test_web_runner.py
@@ -1,6 +1,7 @@
 import asyncio
 import platform
 import signal
+from typing import Optional
 
 import pytest
 
@@ -19,8 +20,8 @@ def make_runner(loop, app):
     asyncio.set_event_loop(loop)
     runners = []
 
-    def go(**kwargs):
-        runner = web.AppRunner(app, **kwargs)
+    def go(app_param: Optional[web.AppRunner] = None, **kwargs):
+        runner = web.AppRunner(app_param or app, **kwargs)
         runners.append(runner)
         return runner
     yield go
@@ -186,3 +187,55 @@ async def test_named_pipe_runner_proactor_loop(
     pipe = web.NamedPipeSite(runner, pipe_name)
     await pipe.start()
     await runner.cleanup()
+
+
+async def test_app_runner_serve_forever_uninitialized(
+        make_runner, loop) -> None:
+    runner = make_runner()
+    with pytest.raises(RuntimeError):
+        await runner.serve_forever()
+
+
+async def test_app_runner_serve_forever_concurrent_call(
+        make_runner, loop) -> None:
+    runner = make_runner()
+    task = loop.create_task(runner.serve_forever())
+    await asyncio.sleep(0.01)
+    with pytest.raises(RuntimeError):
+        await runner.serve_forever()
+    task.cancel()
+
+
+async def test_app_runner_serve_forever_multiple_times(
+        make_runner, loop) -> None:
+    runner = make_runner()
+    for i in range(3):
+        await runner.setup()
+        task = loop.create_task(runner.serve_forever())
+        await asyncio.sleep(0.01)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+async def test_app_runner_serve_forever_cleanup_called(
+        make_runner, app, loop) -> None:
+
+    called = False
+
+    async def on_cleanup(app_param):
+        nonlocal called
+        assert app is app_param
+        called = True
+
+    app.on_cleanup.append(on_cleanup)
+    app.freeze()
+    runner = make_runner(app)
+    await runner.setup()
+
+    task = loop.create_task(runner.serve_forever())
+    await asyncio.sleep(0.01)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert called


### PR DESCRIPTION
## What do these changes do?
This PR adds a handy method `runner.serve_forever()` similar to [`asyncio.Server.serve_forever()`](https://docs.python.org/3.7/library/asyncio-eventloop.html#asyncio.Server.serve_forever)
<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?
Yes! see changes in documentation

## Related issue number

Closes https://github.com/aio-libs/aiohttp/issues/2746
<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
