### PR TITLE
[3.7] Apply SO_REUSEADDR to test server's socket (#4393)

### DIFF
--- a/CHANGES/4393.feature
+++ b/CHANGES/4393.feature
@@ -1,0 +1,1 @@
+Apply SO_REUSEADDR to test server's socket.

--- a/aiohttp/test_utils.py
+++ b/aiohttp/test_utils.py
@@ -5,6 +5,7 @@ import contextlib
 import functools
 import gc
 import inspect
+import os
 import socket
 import sys
 import unittest
@@ -57,12 +58,20 @@ else:
     SSLContext = None
 
 
+REUSE_ADDRESS = os.name == 'posix' and sys.platform != 'cygwin'
+
+
 def get_unused_port_socket(host: str) -> socket.socket:
     return get_port_socket(host, 0)
 
 
 def get_port_socket(host: str, port: int) -> socket.socket:
     s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    if REUSE_ADDRESS:
+        # Windows has different semantics for SO_REUSEADDR,
+        # so don't set it. Ref:
+        # https://docs.microsoft.com/en-us/windows/win32/winsock/using-so-reuseaddr-and-so-exclusiveaddruse
+        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
     s.bind((host, port))
     return s
 


### PR DESCRIPTION
(cherry picked from commit b38e65af)

Co-authored-by: Andrew Svetlov <andrew.svetlov@gmail.com>
