### PR TITLE
[3.7] Use .raw_host instead of slower .host in client API (#4402)

### DIFF
--- a/CHANGES/4402.feature
+++ b/CHANGES/4402.feature
@@ -1,0 +1,1 @@
+Use .raw_host instead of slower .host in client API

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -318,7 +318,7 @@ class ClientRequest:
 
     @property
     def host(self) -> str:
-        ret = self.url.host
+        ret = self.url.raw_host
         assert ret is not None
         return ret
 
@@ -335,7 +335,7 @@ class ClientRequest:
     def update_host(self, url: URL) -> None:
         """Update destination host, port and connection type (ssl)."""
         # get host/port
-        if not url.host:
+        if not url.raw_host:
             raise InvalidURL(url)
 
         # basic auth info


### PR DESCRIPTION
(cherry picked from commit 95e548c3)

Co-authored-by: Andrew Svetlov <andrew.svetlov@gmail.com>
