### PR TITLE
Fixed proxy_headers not being added on client_reqrep.py

### DIFF
--- a/CHANGES/4422.feature
+++ b/CHANGES/4422.feature
@@ -1,0 +1,1 @@
+proxy_headers not passed to proxy

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -232,6 +232,7 @@ class ClientRequest:
         self.update_version(version)
         self.update_host(url)
         self.update_headers(headers)
+        self.update_proxy_headers(proxy_headers)
         self.update_auto_headers(skip_auto_headers)
         self.update_cookies(cookies)
         self.update_content_encoding(data)
@@ -328,6 +329,15 @@ class ClientRequest:
                     self.headers[key] = value
                 else:
                     self.headers.add(key, value)
+
+    def update_proxy_headers(self, proxy_headers: Optional[LooseHeaders]) -> None:
+        """Update proxy headers."""
+        if proxy_headers:
+            if isinstance(proxy_headers, (dict, MultiDictProxy, MultiDict)):
+                proxy_headers = proxy_headers.items()  # type: ignore
+
+            for key, value in proxy_headers:
+                self.headers.add(key, value)
 
     def update_auto_headers(self, skip_auto_headers: Iterable[str]) -> None:
         self.skip_auto_headers = CIMultiDict(


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?
proxy_headers are actually sent to proxy

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?
No

<!-- Outline any notable behaviour for the end users. -->

## Related issue number
https://github.com/aio-libs/aiohttp/issues/4422

## Checklist

- [ x] I think the code is well written
- [ x] Documentation reflects the changes

