### PR TITLE
Expose the response's content buffering limit for lines longer than 128KB

### DIFF
--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -94,7 +94,7 @@ from .http_websocket import (  # noqa
     ws_ext_gen,
     ws_ext_parse,
 )
-from .streams import FlowControlDataQueue
+from .streams import DEFAULT_LIMIT, FlowControlDataQueue
 from .tracing import Trace, TraceConfig
 from .typedefs import JSONEncoder, LooseCookies, LooseHeaders, StrOrURL
 
@@ -310,6 +310,7 @@ class ClientSession:
             expect100: bool=False,
             raise_for_status: Union[None, bool, Callable[[ClientResponse], Awaitable[None]]]=None,  # noqa
             read_until_eof: bool=True,
+            limit: int=DEFAULT_LIMIT,
             proxy: Optional[StrOrURL]=None,
             proxy_auth: Optional[BasicAuth]=None,
             timeout: Union[ClientTimeout, object]=sentinel,
@@ -457,7 +458,7 @@ class ClientSession:
 
                     assert conn.protocol is not None
                     conn.protocol.set_response_params(
-                        timer=timer,
+                        limit=limit, timer=timer,
                         skip_payload=method.upper() == 'HEAD',
                         read_until_eof=read_until_eof,
                         auto_decompress=self._auto_decompress,
@@ -1094,6 +1095,7 @@ def request(
         expect100: bool=False,
         raise_for_status: Optional[bool]=None,
         read_until_eof: bool=True,
+        limit: int=DEFAULT_LIMIT,
         proxy: Optional[StrOrURL]=None,
         proxy_auth: Optional[BasicAuth]=None,
         timeout: Union[ClientTimeout, object]=sentinel,
@@ -1159,6 +1161,7 @@ def request(
                          expect100=expect100,
                          raise_for_status=raise_for_status,
                          read_until_eof=read_until_eof,
+                         limit=limit,
                          proxy=proxy,
                          proxy_auth=proxy_auth,),
         session)

--- a/aiohttp/client_proto.py
+++ b/aiohttp/client_proto.py
@@ -11,7 +11,7 @@ from .client_exceptions import (
 )
 from .helpers import BaseTimerContext, set_exception, set_result
 from .http import HttpResponseParser, RawResponseMessage
-from .streams import EMPTY_PAYLOAD, DataQueue, StreamReader
+from .streams import DEFAULT_LIMIT, EMPTY_PAYLOAD, DataQueue, StreamReader
 
 
 class ResponseHandler(BaseProtocol,
@@ -140,7 +140,9 @@ class ResponseHandler(BaseProtocol,
             data, self._tail = self._tail, b''
             self.data_received(data)
 
-    def set_response_params(self, *, timer: BaseTimerContext=None,
+    def set_response_params(self, *,
+                            timer: BaseTimerContext=None,
+                            limit: int=DEFAULT_LIMIT,
                             skip_payload: bool=False,
                             read_until_eof: bool=False,
                             auto_decompress: bool=True,
@@ -151,7 +153,7 @@ class ResponseHandler(BaseProtocol,
         self._reschedule_timeout()
 
         self._parser = HttpResponseParser(
-            self, self._loop, timer=timer,
+            self, self._loop, timer=timer, limit=limit,
             payload_exception=ClientPayloadError,
             read_until_eof=read_until_eof,
             auto_decompress=auto_decompress)


### PR DESCRIPTION
## What do these changes do?

Solve the problem with "Line is too long" for JSON-lines streaming responses (Kubernetes API and similar), as described in #4453.

## Are there changes in behavior for the user?

An extra optional kwarg is exposed for the requests, which affects the response's content buffering:

```python
        response = await session.get('http://xyz/path', limit=1*1024*1024)
```

The value of `0` means no limit — which can affect the memory footprint:

```python
        response = await session.get('http://xyz/path', limit=0)
```

The default is `2**16`, as it was before, which leads to the buffer size limit of 128 KB (the high-watermark is 2x of the limit itself).

## PR notes

I have doubts on the following topics — it would be nice to clarify them:

* Cython & `.pyx` files — I have no experience with this, just changed like the surrounding code.
* Should it be named `limit=` for the users? Or maybe `response_buffer_limit=`?
* What's the purpose of the low-watermark, of the actual memory consumed got up to 2x of that limit, not as would be expected by the users?
* Monkey-patching of `DEFAULT_LIMIT` (if it was used by anyone) will break now, as the imports are done by-value into multiple modules. I usually use the Google-style imports (`from pkg import mod; mod.VAL`), which work with any monkey-patching quite well. I didn't find such cases in aiohttp, so I'm not sure if this will match the code style.

The code is developed and manually tested against v3.6.2. The master-based version is just a rebase, in the assumption that it works. I could not test the master/v4.0.0a1 code, as it break `aresponses` completely, and the example uses `aresponses` to have a minimalistic web server locally.

The tests (`make test`) on v3.6.2 & v4.0.0a1 fail with `ValueError: option names {'--aiohttp-fast'} already added` — some help would be needed to make them run.

## Related issue number

#4453 

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
