### PR TITLE
Added support of tempfile as payload

### DIFF
--- a/aiohttp/payload.py
+++ b/aiohttp/payload.py
@@ -1,4 +1,3 @@
-import abc
 import asyncio
 import enum
 import io
@@ -6,7 +5,7 @@ import json
 import mimetypes
 import os
 import warnings
-from abc import ABC, abstractmethod
+from abc import ABC, ABCMeta, abstractmethod
 from itertools import chain
 from typing import (
     IO,
@@ -441,7 +440,7 @@ class StreamReaderPayload(AsyncIterablePayload):
         super().__init__(value.iter_any(), *args, **kwargs)
 
 
-class TempFileMetaclass(abc.ABCMeta):
+class TempFileMetaclass(ABCMeta):
     def __instancecheck__(self, instance: Any) -> bool:
         return hasattr(instance, 'read') and hasattr(instance, 'close')
 

--- a/aiohttp/payload.py
+++ b/aiohttp/payload.py
@@ -1,3 +1,4 @@
+import abc
 import asyncio
 import enum
 import io
@@ -440,6 +441,15 @@ class StreamReaderPayload(AsyncIterablePayload):
         super().__init__(value.iter_any(), *args, **kwargs)
 
 
+class TempFileMetaclass(abc.ABCMeta):
+    def __instancecheck__(self, instance: Any) -> bool:
+        return hasattr(instance, 'read') and hasattr(instance, 'close')
+
+
+class TempFilePayload(IOBasePayload, metaclass=TempFileMetaclass):
+    pass
+
+
 PAYLOAD_REGISTRY = PayloadRegistry()
 PAYLOAD_REGISTRY.register(BytesPayload, (bytes, bytearray, memoryview))
 PAYLOAD_REGISTRY.register(StringPayload, str)
@@ -448,7 +458,7 @@ PAYLOAD_REGISTRY.register(TextIOPayload, io.TextIOBase)
 PAYLOAD_REGISTRY.register(BytesIOPayload, io.BytesIO)
 PAYLOAD_REGISTRY.register(
     BufferedReaderPayload, (io.BufferedReader, io.BufferedRandom))
-PAYLOAD_REGISTRY.register(IOBasePayload, io.IOBase)
+PAYLOAD_REGISTRY.register(IOBasePayload, (io.IOBase, TempFilePayload))
 PAYLOAD_REGISTRY.register(StreamReaderPayload, StreamReader)
 # try_last for giving a chance to more specialized async interables like
 # multidict.BodyPartReaderPayload override the default


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

tempfile can be used as a payload

## Are there changes in behavior for the user?

tempfile can be used as a payload

## Related issue number

#4432 

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
