### PR TITLE
Disable lockbot comments and add notes in the contribution docs

### DIFF
--- a/.github/lock.yml
+++ b/.github/lock.yml
@@ -18,15 +18,7 @@ exemptLabels: []
 lockLabel: outdated
 
 # Comment to post before locking. Set to `false` to disable
-lockComment: |
-  This thread has been automatically locked since there has not been
-  any recent activity after it was closed. Please open a [new issue] for
-  related bugs.
-
-  If you feel like there's important points made in this discussion,
-  please include those exceprts into that [new issue].
-
-  [new issue]: https://github.com/aio-libs/aiohttp/issues/new
+lockComment: false
 
 # Assign `resolved` as the reason for locking. Set to `false` to disable
 setLockReason: true

--- a/CHANGES/4504.doc
+++ b/CHANGES/4504.doc
@@ -1,0 +1,1 @@
+Updated the contribution guide to reflect the automatic thread locking policy.

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -37,6 +37,16 @@ Workflow is pretty straightforward:
    needed. The Pull Request is automatically squashed into the single commit
    once the PR is accepted.
 
+.. note::
+
+   GitHub issue threads are automatically locked when there has not been any
+   recent activity for one year.  Please open a `new issue
+   <https://github.com/aio-libs/aiohttp/issues/new>`_ for related bugs.
+
+   If you feel like there are important points in the locked discussions,
+   please include those exceprts into that new issue.
+
+
 Preconditions for running aiohttp test suite
 --------------------------------------------
 

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -39,8 +39,8 @@ Workflow is pretty straightforward:
 
 .. note::
 
-   GitHub issue threads are automatically locked when there has not been any
-   recent activity for one year.  Please open a `new issue
+   GitHub issue and pull request threads are automatically locked when there has
+   not been any recent activity for one year.  Please open a `new issue
    <https://github.com/aio-libs/aiohttp/issues/new>`_ for related bugs.
 
    If you feel like there are important points in the locked discussions,


### PR DESCRIPTION
## What do these changes do?

Disables automatic comments by the lockbot to reduce notification spams along with a new note in the contribution guideline documentation. 

## Are there changes in behavior for the user?

No code changes.

## Related issue number

#4504

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
