### PR TITLE
[3.7] Raising RuntimeError when trying to get empty body encoding (#4481)

### DIFF
--- a/CHANGES/4214.bugfix
+++ b/CHANGES/4214.bugfix
@@ -1,0 +1,1 @@
+Raising RuntimeError when trying to get encoding from not read body

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -260,6 +260,7 @@ Vladimir Kozlovski
 Vladimir Rutsky
 Vladimir Shulyak
 Vladimir Zakharov
+Vladyslav Bohaichuk
 Vladyslav Bondar
 W. Trevor King
 Wei Lin

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -995,6 +995,9 @@ class ClientResponse(HeadersMixin):
             if mimetype.type == 'application' and mimetype.subtype == 'json':
                 # RFC 7159 states that the default encoding is UTF-8.
                 encoding = 'utf-8'
+            elif self._body is None:
+                raise RuntimeError('Cannot guess the encoding of '
+                                   'a not yet read body')
             else:
                 encoding = chardet.detect(self._body)['encoding']
         if not encoding:

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -1432,6 +1432,9 @@ Response object
       decode a response. Some encodings detected by cchardet are not known by
       Python (e.g. VISCII).
 
+      :raise RuntimeError: if called before the body has been read,
+                           for :term:`cchardet` usage
+
       .. versionadded:: 3.0
 
 

--- a/tests/test_client_response.py
+++ b/tests/test_client_response.py
@@ -436,6 +436,33 @@ async def test_text_detect_encoding_if_invalid_charset(loop, session) -> None:
     assert response.get_encoding().lower() in ('windows-1251', 'maccyrillic')
 
 
+async def test_get_encoding_body_none(loop, session) -> None:
+    response = ClientResponse('get', URL('http://def-cl-resp.org'),
+                              request_info=mock.Mock(),
+                              writer=mock.Mock(),
+                              continue100=None,
+                              timer=TimerNoop(),
+                              traces=[],
+                              loop=loop,
+                              session=session)
+
+    def side_effect(*args, **kwargs):
+        fut = loop.create_future()
+        fut.set_result('{"encoding": "test"}')
+        return fut
+
+    response._headers = {'Content-Type': 'text/html'}
+    content = response.content = mock.Mock()
+    content.read.side_effect = side_effect
+
+    with pytest.raises(
+        RuntimeError,
+        match='^Cannot guess the encoding of a not yet read body$',
+    ):
+        response.get_encoding()
+    assert response.closed
+
+
 async def test_text_after_read(loop, session) -> None:
     response = ClientResponse('get', URL('http://def-cl-resp.org'),
                               request_info=mock.Mock(),


### PR DESCRIPTION


(cherry picked from commit 63a0d104)

Co-authored-by: Purusah <16886633+Purusah@users.noreply.github.com>
