### PR TITLE
body_exists for requests without body should be False

### DIFF
--- a/CHANGES/4528.bugfix
+++ b/CHANGES/4528.bugfix
@@ -1,0 +1,1 @@
+Fixed request.body_exists returns wrong value for methods without body.

--- a/aiohttp/_http_parser.pyx
+++ b/aiohttp/_http_parser.pyx
@@ -5,6 +5,7 @@
 from __future__ import absolute_import, print_function
 from cpython.mem cimport PyMem_Malloc, PyMem_Free
 from libc.string cimport memcpy
+from libc.limits cimport ULLONG_MAX
 from cpython cimport (PyObject_GetBuffer, PyBuffer_Release, PyBUF_SIMPLE,
                       Py_buffer, PyBytes_AsString, PyBytes_AsStringAndSize)
 
@@ -270,6 +271,7 @@ cdef class HttpParser:
         size_t _max_field_size
         size_t _max_headers
         bint _response_with_body
+        bint _read_until_eof
 
         bint    _started
         object  _url
@@ -309,7 +311,8 @@ cdef class HttpParser:
                    object protocol, object loop, object timer=None,
                    size_t max_line_size=8190, size_t max_headers=32768,
                    size_t max_field_size=8190, payload_exception=None,
-                   bint response_with_body=True, bint auto_decompress=True):
+                   bint response_with_body=True, bint read_until_eof=False,
+                   bint auto_decompress=True):
         cparser.http_parser_init(self._cparser, mode)
         self._cparser.data = <void*>self
         self._cparser.content_length = 0
@@ -334,6 +337,7 @@ cdef class HttpParser:
         self._max_headers = max_headers
         self._max_field_size = max_field_size
         self._response_with_body = response_with_body
+        self._read_until_eof = read_until_eof
         self._upgraded = False
         self._auto_decompress = auto_decompress
         self._content_encoding = None
@@ -427,8 +431,12 @@ cdef class HttpParser:
                 headers, raw_headers, should_close, encoding,
                 upgrade, chunked)
 
-        if (self._cparser.content_length > 0 or chunked or
-                self._cparser.method == 5):  # CONNECT: 5
+        if (ULLONG_MAX > self._cparser.content_length > 0 or chunked or
+                self._cparser.method == 5 or  # CONNECT: 5
+                (self._cparser.status_code >= 199 and
+                 self._cparser.content_length == ULLONG_MAX and
+                 self._read_until_eof)
+        ):
             payload = StreamReader(
                 self._protocol, timer=self._timer, loop=self._loop)
         else:
@@ -545,7 +553,7 @@ cdef class HttpRequestParser(HttpParser):
                  bint response_with_body=True, bint read_until_eof=False):
          self._init(cparser.HTTP_REQUEST, protocol, loop, timer,
                     max_line_size, max_headers, max_field_size,
-                    payload_exception, response_with_body)
+                    payload_exception, response_with_body, read_until_eof)
 
     cdef object _on_status_complete(self):
          cdef Py_buffer py_buf
@@ -573,7 +581,8 @@ cdef class HttpResponseParser(HttpParser):
                  bint auto_decompress=True):
         self._init(cparser.HTTP_RESPONSE, protocol, loop, timer,
                    max_line_size, max_headers, max_field_size,
-                   payload_exception, response_with_body, auto_decompress)
+                   payload_exception, response_with_body, read_until_eof,
+                   auto_decompress)
 
     cdef object _on_status_complete(self):
         if self._buf:

--- a/tests/test_web_functional.py
+++ b/tests/test_web_functional.py
@@ -685,7 +685,11 @@ async def test_upload_file_object(aiohttp_client) -> None:
         assert 200 == resp.status
 
 
-async def test_empty_content_for_query_without_body(aiohttp_client) -> None:
+@pytest.mark.parametrize("method", [
+    "get", "post", "options", "post", "put", "patch", "delete"
+])
+async def test_empty_content_for_query_without_body(
+        method, aiohttp_client) -> None:
 
     async def handler(request):
         assert not request.body_exists
@@ -693,10 +697,10 @@ async def test_empty_content_for_query_without_body(aiohttp_client) -> None:
         return web.Response()
 
     app = web.Application()
-    app.router.add_post('/', handler)
+    app.router.add_route(method, '/', handler)
     client = await aiohttp_client(app)
 
-    resp = await client.post('/')
+    resp = await client.request(method, '/')
     assert 200 == resp.status
 
 


### PR DESCRIPTION
## What do these changes do?

This PR tries to implement [this logic](https://github.com/aio-libs/aiohttp/blob/4d03dbb32338cfda1234a3ba8628cf4b10e201d5/aiohttp/http_parser.py#L310) for `_http_parser` 

## Are there changes in behavior for the user?

No

## Related issue number

#4528 

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
