### PR TITLE
[3.7] On exit, cancel the main task first (#3805)

### DIFF
--- a/CHANGES/3805.bugfix
+++ b/CHANGES/3805.bugfix
@@ -1,0 +1,1 @@
+Fix tasks cancellation order on exit. The run_app task needs to be cancelled first for cleanup hooks to run with all tasks intact.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -248,6 +248,7 @@ Vaibhav Sagar
 Vamsi Krishna Avula
 Vasiliy Faronov
 Vasyl Baran
+Victor Collod
 Victor Kovtun
 Vikas Kawadia
 Viktor Danyliuk


### PR DESCRIPTION
Otherwise, some tasks might be cancelled before cleanup hooks run. Fixes #3593
(cherry picked from commit c32101d)

Co-authored-by: multun <multun@users.noreply.github.com>
