### PR TITLE
[3.7] Fix docs of WebSocketResponse.close and ClientWebSocketResponse.close (#4540)

### DIFF
--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -1564,7 +1564,7 @@ manually.
 
       :param int code: closing code
 
-      :param message: optional payload of *pong* message,
+      :param message: optional payload of *close* message,
          :class:`str` (converted to *UTF-8* encoded bytes) or :class:`bytes`.
 
    .. comethod:: receive()

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -1106,7 +1106,7 @@ WebSocketResponse
 
       :param int code: closing code
 
-      :param message: optional payload of *pong* message,
+      :param message: optional payload of *close* message,
                       :class:`str` (converted to *UTF-8* encoded bytes)
                       or :class:`bytes`.
 


### PR DESCRIPTION


(cherry picked from commit 7e8a94ed)

Co-authored-by: Marat Sharafutdinov <decaz89@gmail.com>
