### PR TITLE
Fix "Usage" docstring of aiohttp.client.request

### DIFF
--- a/CHANGES/4603.doc
+++ b/CHANGES/4603.doc
@@ -1,0 +1,1 @@
+Fixed wrong "Usage" docstring of ``aiohttp.client.request``.

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -1130,10 +1130,10 @@ def request(
        total timeout by default.
     Usage::
       >>> import aiohttp
-      >>> resp = await aiohttp.request('GET', 'http://python.org/')
-      >>> resp
-      <ClientResponse(python.org/) [200]>
-      >>> data = await resp.read()
+      >>> async with aiohttp.request('GET', 'http://python.org/') as resp:
+      ...    print(resp)
+      ...    data = await resp.read()
+      <ClientResponse(https://www.python.org/) [200 OK]>
     """
     connector_owner = False
     if connector is None:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Fix wrong "Usage" of `aiohttp.client.request`'s docstring (function returns context manager).

## Are there changes in behavior for the user?

Better, reflecting docstring!

## Related issue number

#4603 

## Checklist

- [ ] I think the code is well written (N/A)
- [ ] Unit tests for the changes exist (N/A)
- [x] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
