### PR TITLE
Hide warning when session is not connector owner

### DIFF
--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -267,7 +267,7 @@ class ClientSession:
 
     def __del__(self, _warnings: Any=warnings) -> None:
         try:
-            if not self.closed:
+            if not self.closed and self.connector_owner:
                 if PY_36:
                     kwargs = {'source': self}
                 else:

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -266,7 +266,7 @@ Sessions save cookies internally. If you don't need cookie processing,
 use :class:`aiohttp.DummyCookieJar`. If you need separate cookies
 for different http calls but process them in logical chains, use a single
 :class:`aiohttp.TCPConnector` with separate
-client sessions and ``own_connector=False``.
+client sessions and ``connector_owner=False``.
 
 
 How do I access database connections from a subapplication?


### PR DESCRIPTION
## What do these changes do?

I am using multiple sessions with a shared connector using the `connector_owner=False` parameter in my application. `ClientSession.close()` will not perform any work in these cases, yet aiohttp will emit an _unclosed client session_ warning when the objects are garbage collected anyways. It seems to me that this warning is unnecessary.

This change only emits this warning if a session is not closed and it is the connector owner.

Happy to work on the checklist items below if this is a welcome change.

## Are there changes in behavior for the user?

None

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
