### PR TITLE
Support registering OPTIONS HTTP method handlers via RouteTableDef

### DIFF
--- a/CHANGES/4663.bugfix
+++ b/CHANGES/4663.bugfix
@@ -1,1 +1,1 @@
-Allows to register Options method handlers for resources.
+Support registering OPTIONS HTTP method handlers via RouteTableDef.

--- a/CHANGES/4663.bugfix
+++ b/CHANGES/4663.bugfix
@@ -1,0 +1,1 @@
+Allows to register Options method handlers for resources.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -181,6 +181,7 @@ Mathieu Dugré
 Matt VanEseltine
 Matthieu Hauglustaine
 Matthieu Rigal
+Meet Mangukiya
 Michael Ihnatenko
 Mikhail Burshteyn
 Mikhail Kashkin

--- a/aiohttp/web_routedef.py
+++ b/aiohttp/web_routedef.py
@@ -191,6 +191,9 @@ class RouteTableDef(Sequence[AbstractRouteDef]):
     def delete(self, path: str, **kwargs: Any) -> _Deco:
         return self.route(hdrs.METH_DELETE, path, **kwargs)
 
+    def options(self, path: str, **kwargs: Any) -> _Deco:
+        return self.route(hdrs.METH_OPTIONS, path, **kwargs)
+
     def view(self, path: str, **kwargs: Any) -> _Deco:
         return self.route(hdrs.METH_ANY, path, **kwargs)
 

--- a/tests/test_route_def.py
+++ b/tests/test_route_def.py
@@ -232,6 +232,22 @@ def test_delete_deco(router) -> None:
     assert str(route.url_for()) == '/path'
 
 
+def test_options_deco(router) -> None:
+    routes = web.RouteTableDef()
+
+    @routes.options('/path')
+    async def handler(request):
+        pass
+
+    router.add_routes(routes)
+
+    assert len(router.routes()) == 1
+
+    route = list(router.routes())[0]
+    assert route.method == 'OPTIONS'
+    assert str(route.url_for()) == '/path'
+
+
 def test_route_deco(router) -> None:
     routes = web.RouteTableDef()
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Allows to register Options method handlers for resources. Currently it gives an `AttributeError: 'RouteTableDef' object has no attribute 'options'`

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Resolves #4663

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
