### PR TITLE
Fix `body_size` comparison to `client_max_size` for web request

### DIFF
--- a/CHANGES/4558.bugfix
+++ b/CHANGES/4558.bugfix
@@ -1,0 +1,1 @@
+Fixed body_size comparision to client_max_size for web request.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -46,6 +46,7 @@ Ben Bader
 Ben Timby
 Benedikt Reinartz
 Boris Feld
+Borys Vorona
 Boyi Chen
 Brett Cannon
 Brian C. Lane

--- a/aiohttp/web_request.py
+++ b/aiohttp/web_request.py
@@ -555,7 +555,7 @@ class BaseRequest(MutableMapping[str, Any], HeadersMixin):
                 body.extend(chunk)
                 if self._client_max_size:
                     body_size = len(body)
-                    if body_size >= self._client_max_size:
+                    if body_size > self._client_max_size:
                         raise HTTPRequestEntityTooLarge(
                             max_size=self._client_max_size,
                             actual_size=body_size

--- a/tests/test_web_request.py
+++ b/tests/test_web_request.py
@@ -582,6 +582,17 @@ async def test_request_with_wrong_content_type_encoding(protocol) -> None:
     assert err.value.status_code == 415
 
 
+async def test_make_too_big_request_same_size_to_max(protocol) -> None:
+    payload = StreamReader(protocol, loop=asyncio.get_event_loop())
+    large_file = 1024 ** 2 * b'x'
+    payload.feed_data(large_file)
+    payload.feed_eof()
+    req = make_mocked_request('POST', '/', payload=payload)
+    resp_text = await req.read()
+
+    assert resp_text == large_file
+
+
 async def test_make_too_big_request_adjust_limit(protocol) -> None:
     payload = StreamReader(protocol, loop=asyncio.get_event_loop())
     large_file = 1024 ** 2 * b'x'


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do? 

Fixed body_size comparision to client_max_size for web request (#4558) 

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
