### PR TITLE
Implement binding to IPv6 addresses in the pytest server fixture.

### DIFF
--- a/CHANGES/4650.bugfix
+++ b/CHANGES/4650.bugfix
@@ -1,0 +1,1 @@
+Modify test_utils.BaseTestServer to allow IPv6 hostnames.

--- a/CHANGES/4650.bugfix
+++ b/CHANGES/4650.bugfix
@@ -1,1 +1,1 @@
-Modify test_utils.BaseTestServer to allow IPv6 hostnames.
+Implement binding to IPv6 addresses in the pytest server fixture.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -144,6 +144,7 @@ Jinkyu Yi
 Joel Watts
 Jon Nabozny
 Jonas Obrist
+Jonny Tan
 Joongi Kim
 Josep Cugat
 Joshu Coats

--- a/aiohttp/test_utils.py
+++ b/aiohttp/test_utils.py
@@ -119,10 +119,10 @@ class BaseTestServer(ABC):
         absolute_host = self.host
         try:
             version = ipaddress.ip_address(self.host).version
-            if version == 6:
-                absolute_host = f"[{self.host}]"
         except ValueError:
             version = 4
+        if version == 6:
+            absolute_host = f"[{self.host}]"
         family = socket.AF_INET6 if version == 6 else socket.AF_INET
         _sock = get_port_socket(self.host, self.port, family=family)
         self.host, self.port = _sock.getsockname()[:2]

--- a/aiohttp/test_utils.py
+++ b/aiohttp/test_utils.py
@@ -62,8 +62,10 @@ else:
 REUSE_ADDRESS = os.name == 'posix' and sys.platform != 'cygwin'
 
 
-def get_unused_port_socket(host: str) -> socket.socket:
-    return get_port_socket(host, 0)
+def get_unused_port_socket(
+        host: str,
+        family: socket.AddressFamily = socket.AF_INET) -> socket.socket:
+    return get_port_socket(host, 0, family)
 
 
 def get_port_socket(

--- a/aiohttp/test_utils.py
+++ b/aiohttp/test_utils.py
@@ -5,6 +5,7 @@ import contextlib
 import functools
 import gc
 import inspect
+import ipaddress
 import os
 import socket
 import sys
@@ -65,8 +66,11 @@ def get_unused_port_socket(host: str) -> socket.socket:
     return get_port_socket(host, 0)
 
 
-def get_port_socket(host: str, port: int) -> socket.socket:
-    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+def get_port_socket(
+        host: str,
+        port: int,
+        family: socket.AddressFamily = socket.AF_INET) -> socket.socket:
+    s = socket.socket(family, socket.SOCK_STREAM)
     if REUSE_ADDRESS:
         # Windows has different semantics for SO_REUSEADDR,
         # so don't set it. Ref:
@@ -110,7 +114,15 @@ class BaseTestServer(ABC):
         await self.runner.setup()
         if not self.port:
             self.port = 0
-        _sock = get_port_socket(self.host, self.port)
+        absolute_host = self.host
+        try:
+            version = ipaddress.ip_address(self.host).version
+            if version == 6:
+                absolute_host = f"[{self.host}]"
+        except ValueError:
+            version = 4
+        family = socket.AF_INET6 if version == 6 else socket.AF_INET
+        _sock = get_port_socket(self.host, self.port, family=family)
         self.host, self.port = _sock.getsockname()[:2]
         site = SockSite(self.runner, sock=_sock, ssl_context=self._ssl)
         await site.start()
@@ -126,7 +138,7 @@ class BaseTestServer(ABC):
                 scheme = 'http'
             self.scheme = scheme
         self._root = URL('{}://{}:{}'.format(self.scheme,
-                                             self.host,
+                                             absolute_host,
                                              self.port))
 
     @abstractmethod  # pragma: no cover

--- a/tests/test_test_utils.py
+++ b/tests/test_test_utils.py
@@ -305,3 +305,15 @@ async def test_custom_port(loop, app, aiohttp_unused_port) -> None:
     assert _hello_world_str == text
 
     await client.close()
+
+
+@pytest.mark.parametrize("hostname,expected_host",
+                         [("127.0.0.1", "127.0.0.1"),
+                          ("localhost", "127.0.0.1"),
+                          ("::1", "::1")])
+async def test_test_server_hostnames(hostname, expected_host, loop) -> None:
+    app = _create_example_app()
+    server = _TestServer(app, host=hostname, loop=loop)
+    async with server:
+        pass
+    assert server.host == expected_host

--- a/tests/test_test_utils.py
+++ b/tests/test_test_utils.py
@@ -307,7 +307,7 @@ async def test_custom_port(loop, app, aiohttp_unused_port) -> None:
     await client.close()
 
 
-@pytest.mark.parametrize("hostname,expected_host",
+@pytest.mark.parametrize(("hostname", "expected_host"),
                          [("127.0.0.1", "127.0.0.1"),
                           ("localhost", "127.0.0.1"),
                           ("::1", "::1")])


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?
This change allows TestServer to be instantiated with IPv6 hostnames.
Previously, the TestServer would open an IPv4 family socket regardless
of hostname, causing an error to be raised upon starting the server.
The BaseTestServer now parses the hostname and create an IPv4 or
IPv6 socket based on the hostname.

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?
Creating a TestServer from test_utils.py with an IPv6 hostname ('::1') no longer throws
```
 socket.gaierror: [Errno -9] Address family for hostname not supported
```


<!-- Outline any notable behaviour for the end users. -->

## Related issue number
None
<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
