### PR TITLE
Enable strict xfail mode in pytest by default

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -43,6 +43,7 @@ norecursedirs = dist docs build .tox .eggs
 minversion = 3.8.2
 testpaths = tests/
 junit_family=xunit2
+xfail_strict = true
 
 [mypy]
 follow_imports = silent

--- a/tests/test_web_protocol.py
+++ b/tests/test_web_protocol.py
@@ -1,7 +1,6 @@
 # Tests for aiohttp/server.py
 
 import asyncio
-import platform
 import socket
 from functools import partial
 from unittest import mock
@@ -9,8 +8,6 @@ from unittest import mock
 import pytest
 
 from aiohttp import helpers, http, streams, web
-
-IS_MACOS = platform.system() == 'Darwin'
 
 
 @pytest.fixture
@@ -329,11 +326,6 @@ async def test_handle_uncompleted(
         "Error handling request", exc_info=mock.ANY)
 
 
-@pytest.mark.xfail(
-    IS_MACOS,
-    raises=TypeError,
-    reason='Intermittently fails on macOS',
-)
 async def test_handle_uncompleted_pipe(
         make_srv, transport, request_handler, handle_with_error):
     closed = False


### PR DESCRIPTION
## What do these changes do?

This makes pytest treat XPASS as failures.

As per https://pganssle-talks.github.io/xfail-lightning

## Are there changes in behavior for the user?

N/A

## Related issue number

N/A

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
