### PR TITLE
Support websocket proxies configured via environment variables

### DIFF
--- a/CHANGES/4648.bugfix
+++ b/CHANGES/4648.bugfix
@@ -1,0 +1,1 @@
+Fix issue with proxy configured by environment variables for websockets.

--- a/CHANGES/4648.bugfix
+++ b/CHANGES/4648.bugfix
@@ -1,1 +1,1 @@
-Fix issue with proxy configured by environment variables for websockets.
+Fix supporting WebSockets proxies configured via environment variables.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -175,6 +175,7 @@ Manuel Miranda
 Marat Sharafutdinov
 Marco Paolini
 Mariano Anaya
+Mariusz Masztalerczuk
 Martijn Pieters
 Martin Melka
 Martin Richard

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -229,15 +229,16 @@ class ProxyInfo:
 
 def proxies_from_env() -> Dict[str, ProxyInfo]:
     proxy_urls = {k: URL(v) for k, v in getproxies().items()
-                  if k in ('http', 'https')}
+                  if k in ('http', 'https', 'ws', 'wss')}
     netrc_obj = netrc_from_env()
     stripped = {k: strip_auth_from_url(v) for k, v in proxy_urls.items()}
     ret = {}
     for proto, val in stripped.items():
         proxy, auth = val
-        if proxy.scheme == 'https':
+        if proxy.scheme in ('https', 'ws', 'wss'):
             client_logger.warning(
-                "HTTPS proxies %s are not supported, ignoring", proxy)
+                "%s proxies %s are not supported, ignoring",
+                proxy.scheme.upper(), proxy)
             continue
         if netrc_obj and auth is None:
             auth_from_netrc = None

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -235,7 +235,7 @@ def proxies_from_env() -> Dict[str, ProxyInfo]:
     ret = {}
     for proto, val in stripped.items():
         proxy, auth = val
-        if proxy.scheme in ('https', 'ws', 'wss'):
+        if proxy.scheme in ('https', 'wss'):
             client_logger.warning(
                 "%s proxies %s are not supported, ignoring",
                 proxy.scheme.upper(), proxy)

--- a/docs/client_advanced.rst
+++ b/docs/client_advanced.rst
@@ -527,8 +527,8 @@ Contrary to the ``requests`` library, it won't read environment
 variables by default. But you can do so by passing
 ``trust_env=True`` into :class:`aiohttp.ClientSession`
 constructor for extracting proxy configuration from
-*HTTP_PROXY* or *HTTPS_PROXY* *environment variables* (both are case
-insensitive)::
+*HTTP_PROXY*, *HTTPS_PROXY*, *WS_PROXY* or *WSS_PROXY* *environment 
+variables* (both are case insensitive)::
 
    async with aiohttp.ClientSession(trust_env=True) as session:
        async with session.get("http://python.org") as resp:

--- a/docs/client_advanced.rst
+++ b/docs/client_advanced.rst
@@ -528,7 +528,7 @@ variables by default. But you can do so by passing
 ``trust_env=True`` into :class:`aiohttp.ClientSession`
 constructor for extracting proxy configuration from
 *HTTP_PROXY*, *HTTPS_PROXY*, *WS_PROXY* or *WSS_PROXY* *environment 
-variables* (both are case insensitive)::
+variables* (all are case insensitive)::
 
    async with aiohttp.ClientSession(trust_env=True) as session:
        async with session.get("http://python.org") as resp:

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -423,6 +423,15 @@ def test_proxies_from_env_http(mocker) -> None:
     assert ret['http'].proxy_auth is None
 
 
+def test_proxies_from_env_http_proxy_for_ws_proto(mocker) -> None:
+    url = URL('http://aiohttp.io/path')
+    mocker.patch.dict(os.environ, {'ws_proxy': str(url)})
+    ret = helpers.proxies_from_env()
+    assert ret.keys() == {'ws'}
+    assert ret['ws'].proxy == url
+    assert ret['ws'].proxy_auth is None
+
+
 def test_proxies_from_env_http_proxy_for_https_proto(mocker) -> None:
     url = URL('http://aiohttp.io/path')
     mocker.patch.dict(os.environ, {'https_proxy': str(url)})
@@ -431,14 +440,38 @@ def test_proxies_from_env_http_proxy_for_https_proto(mocker) -> None:
     assert ret['https'].proxy == url
     assert ret['https'].proxy_auth is None
 
+def test_proxies_from_env_http_proxy_for_wss_proto(mocker) -> None:
+    url = URL('http://aiohttp.io/path')
+    mocker.patch.dict(os.environ, {'wss_proxy': str(url)})
+    ret = helpers.proxies_from_env()
+    assert ret.keys() == {'wss'}
+    assert ret['wss'].proxy == url
+    assert ret['wss'].proxy_auth is None
+
 
 def test_proxies_from_env_https_proxy_skipped(mocker) -> None:
     url = URL('https://aiohttp.io/path')
     mocker.patch.dict(os.environ, {'https_proxy': str(url)})
     log = mocker.patch('aiohttp.log.client_logger.warning')
     assert helpers.proxies_from_env() == {}
-    log.assert_called_with('HTTPS proxies %s are not supported, ignoring',
-                           URL('https://aiohttp.io/path'))
+    log.assert_called_with('%s proxies %s are not supported, ignoring',
+                           'HTTPS', URL('https://aiohttp.io/path'))
+
+def test_proxies_from_env_ws_proxy_skipped(mocker) -> None:
+    url = URL('ws://aiohttp.io/path')
+    mocker.patch.dict(os.environ, {'wss_proxy': str(url)})
+    log = mocker.patch('aiohttp.log.client_logger.warning')
+    assert helpers.proxies_from_env() == {}
+    log.assert_called_with('%s proxies %s are not supported, ignoring',
+                           'WS', URL('ws://aiohttp.io/path'))
+
+def test_proxies_from_env_wss_proxy_skipped(mocker) -> None:
+    url = URL('wss://aiohttp.io/path')
+    mocker.patch.dict(os.environ, {'wss_proxy': str(url)})
+    log = mocker.patch('aiohttp.log.client_logger.warning')
+    assert helpers.proxies_from_env() == {}
+    log.assert_called_with('%s proxies %s are not supported, ignoring',
+                           'WSS', URL('wss://aiohttp.io/path'))
 
 
 def test_proxies_from_env_http_with_auth(mocker) -> None:

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -440,9 +440,9 @@ def test_proxies_from_env_http_proxy_for_https_proto(mocker) -> None:
     assert ret['https'].proxy == url
     assert ret['https'].proxy_auth is None
 
-def test_proxies_from_env_http_proxy_for_wss_proto(mocker) -> None:
+def test_proxies_from_env_http_proxy_for_wss_proto(monkeypatch) -> None:
     url = URL('http://aiohttp.io/path')
-    mocker.patch.dict(os.environ, {'wss_proxy': str(url)})
+    monkeypatch.setenv('wss_proxy', str(url))
     ret = helpers.proxies_from_env()
     assert ret.keys() == {'wss'}
     assert ret['wss'].proxy == url

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -430,8 +430,10 @@ def test_proxies_from_env_skipped(monkeypatch, caplog, protocol) -> None:
     monkeypatch.setenv(protocol + '_proxy', str(url))
     assert helpers.proxies_from_env() == {}
     assert len(caplog.records) == 1
-    log_message = '{proto!s} proxies {url!s} are not supported, ' \
-                  'ignoring'.format(proto=protocol.upper(), url=url)
+    log_message = (
+        '{proto!s} proxies {url!s} are not supported, ignoring'.
+        format(proto=protocol.upper(), url=url)
+    )
     assert caplog.record_tuples == [('aiohttp.client', 30, log_message)]
 
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -415,9 +415,9 @@ def test_set_content_disposition_bad_param() -> None:
 # --------------------- proxies_from_env ------------------------------
 
 @pytest.mark.parametrize('protocol', ['http', 'https', 'ws', 'wss'])
-def test_proxies_from_env(mocker, protocol) -> None:
+def test_proxies_from_env(monkeypatch, protocol) -> None:
     url = URL('http://aiohttp.io/path')
-    mocker.patch.dict(os.environ, {protocol + '_proxy': str(url)})
+    monkeypatch.setenv(protocol + '_proxy', str(url))
     ret = helpers.proxies_from_env()
     assert ret.keys() == {protocol}
     assert ret[protocol].proxy == url
@@ -425,15 +425,13 @@ def test_proxies_from_env(mocker, protocol) -> None:
 
 
 @pytest.mark.parametrize('protocol', ['https', 'wss'])
-def test_proxies_from_env_skipped(mocker, caplog, protocol) -> None:
+def test_proxies_from_env_skipped(monkeypatch, caplog, protocol) -> None:
     url = URL(protocol + '://aiohttp.io/path')
-    mocker.patch.dict(os.environ, {protocol + '_proxy': str(url)})
-
+    monkeypatch.setenv(protocol + '_proxy', str(url))
     assert helpers.proxies_from_env() == {}
     assert len(caplog.records) == 1
-
-    log_message = '{proto!s} proxies {url!s} are not supported, ignoring'.format(
-        proto=protocol.upper(), url=url)
+    log_message = '{proto!s} proxies {url!s} are not supported, ' \
+                  'ignoring'.format(proto=protocol.upper(), url=url)
     assert caplog.record_tuples == [('aiohttp.client', 30, log_message)]
 
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -432,8 +432,8 @@ def test_proxies_from_env_skipped(mocker, caplog, protocol) -> None:
     assert helpers.proxies_from_env() == {}
     assert len(caplog.records) == 1
 
-    log_message = '{} proxies {} are not supported, ignoring'.format(
-        protocol.upper(), str(url))
+    log_message = '{proto!s} proxies {url!s} are not supported, ignoring'.format(
+        proto=protocol.upper(), url=url)
     assert caplog.record_tuples == [('aiohttp.client', 30, log_message)]
 
 


### PR DESCRIPTION
## What do these changes do?

Fixes a problem with the non-working configuration of the proxy
for wss (when a proxy URL was set via env var).

## Are there changes in behavior for the user?

Working proxy

## Related issue number

Resolves #4648

## Checklist

- [ ] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
