### PR TITLE
[3.7] Don't write to access log twice per request.

### DIFF
--- a/aiohttp/web_protocol.py
+++ b/aiohttp/web_protocol.py
@@ -463,10 +463,6 @@ class RequestHandler(BaseProtocol):
                 # notify server about keep-alive
                 self._keepalive = bool(resp.keep_alive)
 
-                # log access
-                if self.access_log:
-                    self.log_access(request, resp, loop.time() - start)
-
                 # check payload
                 if not payload.is_eof():
                     lingering_time = self._lingering_time


### PR DESCRIPTION
Commit 29eccad84e8200b5c90856c8732da0fdbbcef904 introduced the method `RequestHandler.finish_response` that includes access logging on [line 564 of web_protocol.py](https://github.com/aio-libs/aiohttp/blob/1b72715fa1040652d0e4e8b33179801f64aa2241/aiohttp/web_protocol.py#L562). Since there's another call to `RequestHandler.log_access` on [lines 466-468](https://github.com/aio-libs/aiohttp/blob/1b72715fa1040652d0e4e8b33179801f64aa2241/aiohttp/web_protocol.py#L466-L468) this results in two access log entries per request.

This patch fixes this by removing the access logging in `RequestHandler.start`.