### PR TITLE
Add BentoML to built-with-aiohttp list

### DIFF
--- a/docs/built_with.rst
+++ b/docs/built_with.rst
@@ -25,3 +25,4 @@ project, pointing to `<https://github.com/aio-libs/aiohttp>`_.
 * `doh-proxy <https://github.com/facebookexperimental/doh-proxy>`_ DNS Over HTTPS Proxy.
 * `Mariner <https://gitlab.com/radek-sprta/mariner>`_ Command-line torrent searcher.
 * `DEEPaaS API <https//github.com/indigo-dc/deepaas>`_ REST API for Machine learning, Deep learning and artificial intelligence applications.
+* `BentoML <https://github.com/bentoml/BentoML>`_ Machine Learning model serving framework


### PR DESCRIPTION
## What do these changes do?

Add my open source project BentoML https://github.com/bentoml/BentoML to the `Built with aiohttp` list in the docs.

BentoML is an ML model serving framework and we(mostly @hrmthw) build an adaptive micro-batching server using aiohttp, which groups prediction requests in small batches in real-time to increase model server's throughput. The algorithm is similar to Clipper https://www.usenix.org/system/files/conference/nsdi17/nsdi17-crankshaw.pdf, and we were able to achieve better performance than [the c++ implementation in Clipper](https://github.com/ucbrise/clipper) in terms of both throughput and latency(more benchmarks are coming out soon) and I thought it might be interesting to share this with this community.


## Are there changes in behavior for the user?

No

## Related issue number

N/A


## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
