### PR TITLE
Fix bug in route name validation (#4691)

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,29 +1,12 @@
 # Ref: https://help.github.com/en/github/building-a-strong-community/configuring-issue-templates-for-your-repository#configuring-the-template-chooser
 blank_issues_enabled: false  # default: true
 contact_links:
-- name: 🔐 Security bug report 🔥
-  url: https://github.com/aio-libs/.github/security/policy
-  about: |
-    Please learn how to report security vulnerabilities here.
-
-    For all security related bugs, send an email
-    instead of using this issue tracker and you
-    will receive a prompt response.
-
-    For more information, see
-    https://github.com/aio-libs/.github/security/policy
 - name: 🤷💻🤦 StackOverflow
   url: https://stackoverflow.com/questions/tagged/aiohttp
   about: Please ask typical Q&A here
-- name: 💬 Gitter Chat
-  url: https://gitter.im/aio-libs/Lobby
-  about: Chat with devs and community
 - name: 💬 Discourse
   url: https://aio-libs.discourse.group/
   about: Please start usage discussions here
-- name: 💬 Mailing list
-  url: https://groups.google.com/forum/#!forum/aio-libs
-  about: Usage Q&A
-- name: 📝 Code of Conduct
-  url: https://github.com/aio-libs/.github/blob/master/CODE_OF_CONDUCT.md
-  about: ❤ Be nice to other members of the community. ☮ Behave.
+- name: 💬 Gitter Chat
+  url: https://gitter.im/aio-libs/Lobby
+  about: Chat with devs and community

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,12 +1,29 @@
 # Ref: https://help.github.com/en/github/building-a-strong-community/configuring-issue-templates-for-your-repository#configuring-the-template-chooser
 blank_issues_enabled: false  # default: true
 contact_links:
+- name: 🔐 Security bug report 🔥
+  url: https://github.com/aio-libs/.github/security/policy
+  about: |
+    Please learn how to report security vulnerabilities here.
+
+    For all security related bugs, send an email
+    instead of using this issue tracker and you
+    will receive a prompt response.
+
+    For more information, see
+    https://github.com/aio-libs/.github/security/policy
 - name: 🤷💻🤦 StackOverflow
   url: https://stackoverflow.com/questions/tagged/aiohttp
   about: Please ask typical Q&A here
-- name: 💬 Discourse
-  url: https://aio-libs.discourse.group/
-  about: Please start usage discussions here
 - name: 💬 Gitter Chat
   url: https://gitter.im/aio-libs/Lobby
   about: Chat with devs and community
+- name: 💬 Discourse
+  url: https://aio-libs.discourse.group/
+  about: Please start usage discussions here
+- name: 💬 Mailing list
+  url: https://groups.google.com/forum/#!forum/aio-libs
+  about: Usage Q&A
+- name: 📝 Code of Conduct
+  url: https://github.com/aio-libs/.github/blob/master/CODE_OF_CONDUCT.md
+  about: ❤ Be nice to other members of the community. ☮ Behave.

--- a/CHANGES/4691.bugfix
+++ b/CHANGES/4691.bugfix
@@ -1,0 +1,1 @@
+Fix the register_resource function to validate route name before splitting it so that route name can include python keywords.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -254,6 +254,7 @@ Thomas Forbes
 Thomas Grainger
 Tolga Tezel
 Tomasz Trebski
+Toshiaki Tanaka
 Trinh Hoang Nhu
 Vadim Suharnikov
 Vaibhav Sagar

--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -977,9 +977,13 @@ class UrlDispatcher(AbstractRouter, Mapping[str, AbstractResource]):
         name = resource.name
 
         if name is not None:
+            if keyword.iskeyword(name):
+                raise ValueError('Incorrect route name {!r}, '
+                                 'python keywords cannot be used '
+                                 'for route name'.format(name))
             parts = self.NAME_SPLIT_RE.split(name)
             for part in parts:
-                if not part.isidentifier() or keyword.iskeyword(part):
+                if not part.isidentifier():
                     raise ValueError('Incorrect route name {!r}, '
                                      'the name should be a sequence of '
                                      'python identifiers separated '

--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -977,10 +977,10 @@ class UrlDispatcher(AbstractRouter, Mapping[str, AbstractResource]):
         name = resource.name
 
         if name is not None:
-            if keyword.iskeyword(name):
-                raise ValueError('Incorrect route name {!r}, '
+            if keyword.iskeyword(name.strip()):
+                raise ValueError(f'Incorrect route name {name!r}, '
                                  'python keywords cannot be used '
-                                 'for route name'.format(name))
+                                 'for route name')
             parts = self.NAME_SPLIT_RE.split(name)
             for part in parts:
                 if not part.isidentifier():

--- a/tools/check_changes.py
+++ b/tools/check_changes.py
@@ -3,6 +3,7 @@
 import sys
 from pathlib import Path
 
+
 ALLOWED_SUFFIXES = ['.feature',
                     '.bugfix',
                     '.doc',

--- a/tools/check_changes.py
+++ b/tools/check_changes.py
@@ -3,7 +3,6 @@
 import sys
 from pathlib import Path
 
-
 ALLOWED_SUFFIXES = ['.feature',
                     '.bugfix',
                     '.doc',

--- a/tools/gen.py
+++ b/tools/gen.py
@@ -1,13 +1,11 @@
 #!/usr/bin/env python3
 
-import io
-import pathlib
-from collections import defaultdict
-
-import multidict
-
 import aiohttp
+import pathlib
 import aiohttp.hdrs
+import multidict
+from collections import defaultdict
+import io
 
 headers = [getattr(aiohttp.hdrs, name)
            for name in dir(aiohttp.hdrs)

--- a/tools/gen.py
+++ b/tools/gen.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python3
 
-import aiohttp
-import pathlib
-import aiohttp.hdrs
-import multidict
-from collections import defaultdict
 import io
+import pathlib
+from collections import defaultdict
+
+import multidict
+
+import aiohttp
+import aiohttp.hdrs
 
 headers = [getattr(aiohttp.hdrs, name)
            for name in dir(aiohttp.hdrs)


### PR DESCRIPTION
fix #4691 

The register_resource function in aiohttp/web_urldispatcher.py had a bug in route name validation.
It validated each part of the splitted route name whether it's a python keyword.
I fixed the function to validate route name before splitting it and added a new error message.