### PR TITLE
Add docs for using patch decorator in unittest prior to python 3.8

### DIFF
--- a/CHANGES/4695.doc
+++ b/CHANGES/4695.doc
@@ -1,0 +1,1 @@
+Added documentation on how to patch unittest cases with decorator for python < 3.8

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -70,6 +70,8 @@ intersphinx_mapping = {
         ('https://aiohttp-session.readthedocs.io/en/stable/', None),
     'aiohttpdemos':
         ('https://aiohttp-demos.readthedocs.io/en/latest/', None),
+    'asynctest':
+        ('https://asynctest.readthedocs.io/en/latest/', None),
 }
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -15,6 +15,7 @@ arg
 Arsenic
 async
 asyncio
+asynctest
 auth
 autocalculated
 autodetection

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -423,7 +423,7 @@ a magic mock that is async capable. It can be used with decorator as well as wit
 
         @unittest_run_loop
         async def test_ping_mocked_do_something(self):
-            with patch('test_bug.do_something') as do_something_patch:
+            with patch('tests.do_something') as do_something_patch:
                 resp = await self.client.get('/ping/')
 
                 self.assertEqual(resp.status, 200)
@@ -432,7 +432,7 @@ a magic mock that is async capable. It can be used with decorator as well as wit
                 self.assertTrue(do_something_patch.called)
 
         @unittest_run_loop
-        @patch('test_bug.do_something')
+        @patch('tests.do_something')
         async def test_ping_mocked_do_something_decorated(self, do_something_patch):
             resp = await self.client.get('/ping/')
 

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -388,12 +388,13 @@ Patching test cases is tricky, when using python older than 3.8 ``'patch'`` does
 We recommend using asynctest_ that provides a patch method that is capable of creating
 a magic mock that supports async. It can be used with decorator as well as with context manager::
 
+    from asynctest.mock import patch
+
     from aiohttp.test_utils import AioHTTPTestCase, unittest_run_loop
     from aiohttp.web_app import Application
     from aiohttp.web_request import Request
     from aiohttp.web_response import Response
     from aiohttp.web_routedef import get
-    from asynctest.mock import patch
 
 
     async def do_something():

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -386,7 +386,7 @@ Patching unittest test cases
 
 Patching test cases is tricky, when using python older than 3.8 ``'patch'`` does not behave as it has to.
 We recommend using asynctest_ that provides a patch method that is capable of creating
-a magic mock that is async capable. It can be used with decorator as well as with context manager.::
+a magic mock that supports async. It can be used with decorator as well as with context manager::
 
     from aiohttp.test_utils import AioHTTPTestCase, unittest_run_loop
     from aiohttp.web_app import Application

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -386,7 +386,10 @@ Patching unittest test cases
 
 Patching test cases is tricky, when using python older than 3.8 ``'patch'`` does not behave as it has to.
 We recommend using asynctest_ that provides a patch method that is capable of creating
-a magic mock that supports async. It can be used with decorator as well as with context manager::
+a magic mock that supports async. It can be used with a decorator as well as with a context manager:
+
+.. code-block:: python
+   :emphasize-lines: 1,37,46
 
     from asynctest.mock import patch
 

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -384,8 +384,8 @@ functionality, the AioHTTPTestCase is provided::
 Patching unittest test cases
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Patching test cases is tricky, when using python older than 3.8 ``'patch'`` does not behave as it has to.
-We recommend using asynctest_ that provides a patch method that is capable of creating
+Patching test cases is tricky, when using python older than 3.8  :py:func:`unittest.mock.patch` does not behave as it has to.
+We recommend using :py:mod:`asynctest` that provides :py:func:`asynctest.patch` that is capable of creating
 a magic mock that supports async. It can be used with a decorator as well as with a context manager:
 
 .. code-block:: python

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -885,4 +885,3 @@ Utilities
 
 .. _pytest: http://pytest.org/latest/
 .. _pytest-aiohttp: https://pypi.python.org/pypi/pytest-aiohttp
-.. _asynctest: https://pypi.org/project/asynctest/

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -384,8 +384,8 @@ functionality, the AioHTTPTestCase is provided::
 Patching unittest test cases
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Patching test cases is tricky, when using python older than 3.8  :py:func:`unittest.mock.patch` does not behave as it has to.
-We recommend using :py:mod:`asynctest` that provides :py:func:`asynctest.patch` that is capable of creating
+Patching test cases is tricky, when using python older than 3.8  :py:func:`~unittest.mock.patch` does not behave as it has to.
+We recommend using :py:mod:`asynctest` that provides :py:func:`~asynctest.patch` that is capable of creating
 a magic mock that supports async. It can be used with a decorator as well as with a context manager:
 
 .. code-block:: python

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -391,7 +391,7 @@ a magic mock that supports async. It can be used with a decorator as well as wit
 .. code-block:: python
    :emphasize-lines: 1,37,46
 
-    from asynctest.mock import patch
+    from asynctest.mock import patch as async_patch
 
     from aiohttp.test_utils import AioHTTPTestCase, unittest_run_loop
     from aiohttp.web_app import Application
@@ -427,7 +427,7 @@ a magic mock that supports async. It can be used with a decorator as well as wit
 
         @unittest_run_loop
         async def test_ping_mocked_do_something(self):
-            with patch('tests.do_something') as do_something_patch:
+            with async_patch('tests.do_something') as do_something_patch:
                 resp = await self.client.get('/ping/')
 
                 self.assertEqual(resp.status, 200)
@@ -436,7 +436,7 @@ a magic mock that supports async. It can be used with a decorator as well as wit
                 self.assertTrue(do_something_patch.called)
 
         @unittest_run_loop
-        @patch('tests.do_something')
+        @async_patch('tests.do_something')
         async def test_ping_mocked_do_something_decorated(self, do_something_patch):
             resp = await self.client.get('/ping/')
 


### PR DESCRIPTION
## What do these changes do?

As discussed in #4695 patch and make_mocked_coro do not work in a decorated unittest test case. So in the docs it is advised to use a package called `asynctest` for async method patching.

## Are there changes in behavior for the user?

It is described in the docs.

## Related issue number

#4695 

