### PR TITLE
fix incorrect case: Host -> host

### DIFF
--- a/docs/tracing_reference.rst
+++ b/docs/tracing_reference.rst
@@ -304,10 +304,10 @@ TraceRequestChunkSentParams
        Bytes of chunk sent
 
 
-TraceResponseChunkSentParams
+TraceResponseChunkReceivedParams
 ----------------------------
 
-.. class:: TraceResponseChunkSentParams
+.. class:: TraceResponseChunkReceivedParams
 
    .. versionadded:: 3.1
 

--- a/docs/tracing_reference.rst
+++ b/docs/tracing_reference.rst
@@ -440,7 +440,7 @@ TraceDnsResolveHostStartParams
 
    See :attr:`TraceConfig.on_dns_resolvehost_start` for details.
 
-   .. attribute:: Host
+   .. attribute:: host
 
        Host that will be resolved.
 
@@ -451,7 +451,7 @@ TraceDnsResolveHostEndParams
 
    See :attr:`TraceConfig.on_dns_resolvehost_end` for details.
 
-   .. attribute:: Host
+   .. attribute:: host
 
        Host that has been resolved.
 
@@ -462,7 +462,7 @@ TraceDnsCacheHitParams
 
    See :attr:`TraceConfig.on_dns_cache_hit` for details.
 
-   .. attribute:: Host
+   .. attribute:: host
 
        Host found in the cache.
 
@@ -473,6 +473,6 @@ TraceDnsCacheMissParams
 
    See :attr:`TraceConfig.on_dns_cache_miss` for details.
 
-   .. attribute:: Host
+   .. attribute:: host
 
        Host didn't find the cache.


### PR DESCRIPTION
🐞 **Describe the bug**
Incorrect case in document `docs/tracing_reference.rst`.
Attribute **Host** should be **host**.
```
TraceDnsResolveHostStartParams
------------------------------

.. class:: TraceDnsResolveHostStartParams

   See :attr:`TraceConfig.on_dns_resolvehost_start` for details.

   .. attribute:: Host

       Host that will be resolved.

TraceDnsResolveHostEndParams
----------------------------

.. class:: TraceDnsResolveHostEndParams

   See :attr:`TraceConfig.on_dns_resolvehost_end` for details.

   .. attribute:: Host

       Host that has been resolved.

TraceDnsCacheHitParams
----------------------

.. class:: TraceDnsCacheHitParams

   See :attr:`TraceConfig.on_dns_cache_hit` for details.

   .. attribute:: Host

       Host found in the cache.

TraceDnsCacheMissParams
-----------------------

.. class:: TraceDnsCacheMissParams

   See :attr:`TraceConfig.on_dns_cache_miss` for details.

   .. attribute:: Host

       Host didn't find the cache.
```

💡 **Source code**
source code file: `aiohttp/aiohttp/tracing.py`
line: 233-254
```python
@attr.s(frozen=True, slots=True)
class TraceDnsResolveHostStartParams:
    """ Parameters sent by the `on_dns_resolvehost_start` signal"""
    host = attr.ib(type=str)


@attr.s(frozen=True, slots=True)
class TraceDnsResolveHostEndParams:
    """ Parameters sent by the `on_dns_resolvehost_end` signal"""
    host = attr.ib(type=str)


@attr.s(frozen=True, slots=True)
class TraceDnsCacheHitParams:
    """ Parameters sent by the `on_dns_cache_hit` signal"""
    host = attr.ib(type=str)


@attr.s(frozen=True, slots=True)
class TraceDnsCacheMissParams:
    """ Parameters sent by the `on_dns_cache_miss` signal"""
    host = attr.ib(type=str)
```
