### PR TITLE
AioHTTPTestCase more async friendly

### DIFF
--- a/CHANGES/4700.feature
+++ b/CHANGES/4700.feature
@@ -1,1 +1,6 @@
 AioHTTPTestCase more async friendly
+
+for the people who use unittest and are used to use unittest.TestCase
+it will be easier to write new test cases like the sync version of the TestCase class,
+without using the decorator `@unittest_run_loop`, just `async def test_*`.
+The only difference is that for the people using python3.7 and below a new dependency is needed, it is `asynctestcase`.

--- a/CHANGES/4700.feature
+++ b/CHANGES/4700.feature
@@ -1,6 +1,6 @@
 AioHTTPTestCase is more async friendly now.
 
-for the people who use unittest and are used to use unittest.TestCase
+For people who use unittest and are used to use unittest.TestCase
 it will be easier to write new test cases like the sync version of the TestCase class,
 without using the decorator `@unittest_run_loop`, just `async def test_*`.
 The only difference is that for the people using python3.7 and below a new dependency is needed, it is `asynctestcase`.

--- a/CHANGES/4700.feature
+++ b/CHANGES/4700.feature
@@ -1,4 +1,4 @@
-AioHTTPTestCase more async friendly
+AioHTTPTestCase is more async friendly now.
 
 for the people who use unittest and are used to use unittest.TestCase
 it will be easier to write new test cases like the sync version of the TestCase class,

--- a/CHANGES/4700.feature
+++ b/CHANGES/4700.feature
@@ -1,0 +1,1 @@
+AioHTTPTestCase more async friendly

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -30,6 +30,7 @@ Alexey Stepanov
 Amin Etesamian
 Amit Tulshyan
 Amy Boyle
+Anas El Amraoui
 Anders Melchiorsen
 Andrei Ursulenko
 Andrej Antonov

--- a/aiohttp/test_utils.py
+++ b/aiohttp/test_utils.py
@@ -45,9 +45,9 @@ else:
     SSLContext = None
 
 if PY_38:
-    from unittest import IsolatedAsyncioTestCase as TestCase
+    from unittest import IsolatedAsyncioTestCase as TestCase  # type: ignore
 else:
-    from asynctest import TestCase  # type: ignore
+    from asynctest import TestCase
 
 REUSE_ADDRESS = os.name == "posix" and sys.platform != "cygwin"
 

--- a/aiohttp/test_utils.py
+++ b/aiohttp/test_utils.py
@@ -45,9 +45,9 @@ else:
     SSLContext = None
 
 if PY_38:
-    from unittest import IsolatedAsyncioTestCase as TestCase  # type: ignore
+    from unittest import IsolatedAsyncioTestCase as TestCase
 else:
-    from asynctest import TestCase
+    from asynctest import TestCase  # type: ignore
 
 REUSE_ADDRESS = os.name == "posix" and sys.platform != "cygwin"
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -2,6 +2,7 @@
 # required c-ares will not build on windows and has build problems on Macos Python<3.7
 aiodns==2.0.0; sys_platform=="linux" or sys_platform=="darwin" and python_version>="3.7"
 async-timeout==4.0.0a3
+asynctest==0.13.0; python_version<"3.8"
 attrs==20.3.0
 Brotli==1.0.9
 cchardet==2.1.7

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,5 +1,5 @@
 -r lint.txt
 -r test.txt
 -r doc.txt
-cherry_picker==1.3.2; python_version>="3.6"
 asynctest==0.13.0; python_version<"3.8"
+cherry_picker==1.3.2; python_version>="3.6"

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -2,3 +2,4 @@
 -r test.txt
 -r doc.txt
 cherry_picker==1.3.2; python_version>="3.6"
+asynctest==0.13.0; python_version<"3.8"

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,5 +1,4 @@
 -r lint.txt
 -r test.txt
 -r doc.txt
-asynctest==0.13.0; python_version<"3.8"
 cherry_picker==1.3.2; python_version>="3.6"

--- a/setup.cfg
+++ b/setup.cfg
@@ -97,3 +97,7 @@ ignore_missing_imports = true
 
 [mypy-idna_ssl]
 ignore_missing_imports = true
+
+
+[mypy-asynctest]
+ignore_missing_imports = true

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,7 @@ install_requires = [
     "chardet>=2.0,<4.0",
     "multidict>=4.5,<7.0",
     "async_timeout>=4.0a2,<5.0",
+    'asynctest==0.13.0; python_version<"3.8"',
     "yarl>=1.0,<2.0",
     'idna-ssl>=1.0; python_version<"3.7"',
     "typing_extensions>=3.6.5",

--- a/tests/test_test_utils.py
+++ b/tests/test_test_utils.py
@@ -95,7 +95,7 @@ class TestAioHTTPTestCase(AioHTTPTestCase):
         text = await request.text()
         assert _hello_world_str == text
 
-    def test_example(self) -> None:
+    def test_inner_example(self) -> None:
         async def test_get_route() -> None:
             resp = await self.client.request("GET", "/")
             assert resp.status == 200
@@ -103,6 +103,21 @@ class TestAioHTTPTestCase(AioHTTPTestCase):
             assert _hello_world_str == text
 
         self.loop.run_until_complete(test_get_route())
+
+    async def test_example_without_explicit_loop(self) -> None:
+        request = await self.client.request("GET", "/")
+        assert request.status == 200
+        text = await request.text()
+        assert _hello_world_str == text
+
+    async def test_inner_example_without_explicit_loop(self) -> None:
+        async def test_get_route() -> None:
+            resp = await self.client.request("GET", "/")
+            assert resp.status == 200
+            text = await resp.text()
+            assert _hello_world_str == text
+
+        await test_get_route()
 
 
 def test_get_route(loop, test_client) -> None:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Make AioHTTPTestCase more async friendly, making a user able to run a test case with async methods without needing to use `@unittest_run_loop` decorator, adding a dependency for testing for python3.7 and below as mentioned in #4700 and #4695 while using built in asyncio test case available from python 3.8

This change is backward compatible, I did not change any name of classes or methods.

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

Yes, test can be written with async functions without `@unittest_run_loop`.
For python3.7 and below `asynctest` dependency must be installed.

Testing becomes more straight forward like the following
```python
from aiohttp.test_utils import AioHTTPTestCase
from aiohttp.web_app import Application
from aiohttp.web_request import Request
from aiohttp.web_response import Response
from aiohttp.web_routedef import get

async def ping(request: Request) -> Response:
    return Response(text='pong')


class TestApplication(AioHTTPTestCase):
    def get_app(self) -> Application:
        app = Application()
        app.router.add_routes([
            get('/ping/', ping)
        ])

        return app

    async def test_ping(self):
        resp = await self.client.get('/ping/')

        self.assertEqual(resp.status, 200)
        self.assertEqual(await resp.text(), 'pong')

```

<!-- Outline any notable behaviour for the end users. -->

## Related issue number

#4700 and #4695

<!-- Are there any issues opened that will be resolved by merging this change? -->

#4700 will be resolved after this merge

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."

I did not add any new tests, it seems to me that the old tests are passing, I would be glad to know if this kind of change is welcome so that I can proceed with the docs and more testing maybe on the patching side like I pointed out in this PR #4697

