### PR TITLE
Implemented readuntil in StreamResponse 

### DIFF
--- a/CHANGES/4054.feature
+++ b/CHANGES/4054.feature
@@ -1,0 +1,1 @@
+Implemented readuntil in StreamResponse

--- a/aiohttp/streams.py
+++ b/aiohttp/streams.py
@@ -312,15 +312,15 @@ class StreamReader(AsyncStreamReaderMixin):
     async def readline(self) -> bytes:
         return await self.readuntil()
 
-    async def readuntil(self, separator: bytes=b'\n') -> bytes:
+    async def readuntil(self, separator: bytes = b"\n") -> bytes:
         seplen = len(separator)
         if seplen == 0:
-            raise ValueError('Separator should be at least one-byte string')
+            raise ValueError("Separator should be at least one-byte string")
 
         if self._exception is not None:
             raise self._exception
 
-        chunk = b''
+        chunk = b""
         chunk_size = 0
         not_enough = True
 
@@ -336,13 +336,13 @@ class StreamReader(AsyncStreamReaderMixin):
                     not_enough = False
 
                 if chunk_size > self._high_water:
-                    raise ValueError('Chunk too big')
+                    raise ValueError("Chunk too big")
 
             if self._eof:
                 break
 
             if not_enough:
-                await self._wait('readuntil')
+                await self._wait("readuntil")
 
         return chunk
 

--- a/aiohttp/streams.py
+++ b/aiohttp/streams.py
@@ -310,34 +310,41 @@ class StreamReader(AsyncStreamReaderMixin):
             self._waiter = None
 
     async def readline(self) -> bytes:
+        return await self.readuntil()
+
+    async def readuntil(self, separator: bytes=b'\n') -> bytes:
+        seplen = len(separator)
+        if seplen == 0:
+            raise ValueError('Separator should be at least one-byte string')
+
         if self._exception is not None:
             raise self._exception
 
-        line = []
-        line_size = 0
+        chunk = b''
+        chunk_size = 0
         not_enough = True
 
         while not_enough:
             while self._buffer and not_enough:
                 offset = self._buffer_offset
-                ichar = self._buffer[0].find(b"\n", offset) + 1
-                # Read from current offset to found b'\n' or to the end.
+                ichar = self._buffer[0].find(separator, offset) + 1
+                # Read from current offset to found separator or to the end.
                 data = self._read_nowait_chunk(ichar - offset if ichar else -1)
-                line.append(data)
-                line_size += len(data)
+                chunk += data
+                chunk_size += len(data)
                 if ichar:
                     not_enough = False
 
-                if line_size > self._high_water:
-                    raise ValueError("Line is too long")
+                if chunk_size > self._high_water:
+                    raise ValueError('Chunk too big')
 
             if self._eof:
                 break
 
             if not_enough:
-                await self._wait("readline")
+                await self._wait('readuntil')
 
-        return b"".join(line)
+        return chunk
 
     async def read(self, n: int = -1) -> bytes:
         if self._exception is not None:
@@ -516,6 +523,8 @@ class EmptyStreamReader(AsyncStreamReaderMixin):
 
     async def read(self, n: int = -1) -> bytes:
         return b""
+
+    # TODO add async def readuntil
 
     async def readany(self) -> bytes:
         return b""

--- a/docs/streams.rst
+++ b/docs/streams.rst
@@ -70,6 +70,17 @@ Reading Methods
 
    :return bytes: the given line
 
+.. comethod:: StreamReader.readuntil(separator="\n")
+
+   Read until separator, where `separator` is a sequence of bytes.
+
+   If EOF is received, and `separator` was not found, the method will
+   return the partial read bytes.
+
+   If the EOF was received and the internal buffer is empty, return an
+   empty bytes object.
+
+   :return bytes: the given data
 
 .. comethod:: StreamReader.readchunk()
 

--- a/docs/streams.rst
+++ b/docs/streams.rst
@@ -80,6 +80,8 @@ Reading Methods
    If the EOF was received and the internal buffer is empty, return an
    empty bytes object.
 
+   .. versionadded:: 3.8 
+
    :return bytes: the given data
 
 .. comethod:: StreamReader.readchunk()

--- a/docs/streams.rst
+++ b/docs/streams.rst
@@ -80,7 +80,7 @@ Reading Methods
    If the EOF was received and the internal buffer is empty, return an
    empty bytes object.
 
-   .. versionadded:: 3.8 
+   .. versionadded:: 3.8
 
    :return bytes: the given data
 

--- a/tests/test_streams.py
+++ b/tests/test_streams.py
@@ -381,36 +381,37 @@ class TestStreamReader:
         # Read one chunk. 'readuntil' will need to wait for the data
         # to come from 'cb'
         stream = self._make_one()
-        stream.feed_data(b'chunk1 ')
-        read_task = loop.create_task(stream.readuntil(b'*'))
+        stream.feed_data(b"chunk1 ")
+        read_task = loop.create_task(stream.readuntil(b"*"))
 
         def cb():
-            stream.feed_data(b'chunk2 ')
-            stream.feed_data(b'chunk3 ')
-            stream.feed_data(b'* chunk4')
+            stream.feed_data(b"chunk2 ")
+            stream.feed_data(b"chunk3 ")
+            stream.feed_data(b"* chunk4")
+
         loop.call_soon(cb)
 
         line = await read_task
-        assert b'chunk1 chunk2 chunk3 *' == line
+        assert b"chunk1 chunk2 chunk3 *" == line
 
         stream.feed_eof()
         data = await stream.read()
-        assert b' chunk4' == data
+        assert b" chunk4" == data
 
     async def test_readuntil_limit_with_existing_data(self) -> None:
         # Read one chunk. The data is in StreamReader's buffer
         # before the event loop is run.
 
         stream = self._make_one(limit=2)
-        stream.feed_data(b'li')
-        stream.feed_data(b'ne1&line2&')
+        stream.feed_data(b"li")
+        stream.feed_data(b"ne1&line2&")
 
         with pytest.raises(ValueError):
-            await stream.readuntil(b'&')
+            await stream.readuntil(b"&")
         # The buffer should contain the remaining data after exception
         stream.feed_eof()
         data = await stream.read()
-        assert b'line2&' == data
+        assert b"line2&" == data
 
     async def test_readuntil_limit(self) -> None:
         loop = asyncio.get_event_loop()
@@ -419,71 +420,72 @@ class TestStreamReader:
         stream = self._make_one(limit=4)
 
         def cb():
-            stream.feed_data(b'chunk1')
-            stream.feed_data(b'chunk2$')
-            stream.feed_data(b'chunk3#')
+            stream.feed_data(b"chunk1")
+            stream.feed_data(b"chunk2$")
+            stream.feed_data(b"chunk3#")
             stream.feed_eof()
+
         loop.call_soon(cb)
 
         with pytest.raises(ValueError):
-            await stream.readuntil(b'$')
+            await stream.readuntil(b"$")
         data = await stream.read()
-        assert b'chunk3#' == data
+        assert b"chunk3#" == data
 
     async def test_readuntil_nolimit_nowait(self) -> None:
         # All needed data for the first 'readuntil' call will be
         # in the buffer.
         stream = self._make_one()
-        data = b'line1!line2!line3!'
+        data = b"line1!line2!line3!"
         stream.feed_data(data[:6])
         stream.feed_data(data[6:])
 
-        line = await stream.readuntil(b'!')
-        assert b'line1!' == line
+        line = await stream.readuntil(b"!")
+        assert b"line1!" == line
 
         stream.feed_eof()
         data = await stream.read()
-        assert b'line2!line3!' == data
+        assert b"line2!line3!" == data
 
     async def test_readuntil_eof(self) -> None:
         stream = self._make_one()
-        stream.feed_data(b'some data')
+        stream.feed_data(b"some data")
         stream.feed_eof()
 
-        line = await stream.readuntil(b'@')
-        assert b'some data' == line
+        line = await stream.readuntil(b"@")
+        assert b"some data" == line
 
     async def test_readuntil_empty_eof(self) -> None:
         stream = self._make_one()
         stream.feed_eof()
 
-        line = await stream.readuntil(b'@')
-        assert b'' == line
+        line = await stream.readuntil(b"@")
+        assert b"" == line
 
     async def test_readuntil_read_byte_count(self) -> None:
         stream = self._make_one()
-        data = b'line1!line2!line3!'
+        data = b"line1!line2!line3!"
         stream.feed_data(data)
 
-        await stream.readuntil(b'!')
+        await stream.readuntil(b"!")
 
         data = await stream.read(7)
-        assert b'line2!l' == data
+        assert b"line2!l" == data
 
         stream.feed_eof()
         data = await stream.read()
-        assert b'ine3!' == data
+        assert b"ine3!" == data
 
     async def test_readuntil_exception(self) -> None:
         stream = self._make_one()
-        stream.feed_data(b'line#')
+        stream.feed_data(b"line#")
 
-        data = await stream.readuntil(b'#')
-        assert b'line#' == data
+        data = await stream.readuntil(b"#")
+        assert b"line#" == data
 
         stream.set_exception(ValueError())
         with pytest.raises(ValueError):
-            await stream.readuntil(b'#')
+            await stream.readuntil(b"#")
 
     async def test_readexactly_zero_or_less(self) -> None:
         # Read exact number of bytes (zero or less).

--- a/tests/test_streams.py
+++ b/tests/test_streams.py
@@ -376,6 +376,115 @@ class TestStreamReader:
         with pytest.raises(ValueError):
             await stream.readline()
 
+    async def test_readuntil(self) -> None:
+        loop = asyncio.get_event_loop()
+        # Read one chunk. 'readuntil' will need to wait for the data
+        # to come from 'cb'
+        stream = self._make_one()
+        stream.feed_data(b'chunk1 ')
+        read_task = loop.create_task(stream.readuntil(b'*'))
+
+        def cb():
+            stream.feed_data(b'chunk2 ')
+            stream.feed_data(b'chunk3 ')
+            stream.feed_data(b'* chunk4')
+        loop.call_soon(cb)
+
+        line = await read_task
+        assert b'chunk1 chunk2 chunk3 *' == line
+
+        stream.feed_eof()
+        data = await stream.read()
+        assert b' chunk4' == data
+
+    async def test_readuntil_limit_with_existing_data(self) -> None:
+        # Read one chunk. The data is in StreamReader's buffer
+        # before the event loop is run.
+
+        stream = self._make_one(limit=2)
+        stream.feed_data(b'li')
+        stream.feed_data(b'ne1&line2&')
+
+        with pytest.raises(ValueError):
+            await stream.readuntil(b'&')
+        # The buffer should contain the remaining data after exception
+        stream.feed_eof()
+        data = await stream.read()
+        assert b'line2&' == data
+
+    async def test_readuntil_limit(self) -> None:
+        loop = asyncio.get_event_loop()
+        # Read one chunk. StreamReaders are fed with data after
+        # their 'readuntil' methods are called.
+        stream = self._make_one(limit=4)
+
+        def cb():
+            stream.feed_data(b'chunk1')
+            stream.feed_data(b'chunk2$')
+            stream.feed_data(b'chunk3#')
+            stream.feed_eof()
+        loop.call_soon(cb)
+
+        with pytest.raises(ValueError):
+            await stream.readuntil(b'$')
+        data = await stream.read()
+        assert b'chunk3#' == data
+
+    async def test_readuntil_nolimit_nowait(self) -> None:
+        # All needed data for the first 'readuntil' call will be
+        # in the buffer.
+        stream = self._make_one()
+        data = b'line1!line2!line3!'
+        stream.feed_data(data[:6])
+        stream.feed_data(data[6:])
+
+        line = await stream.readuntil(b'!')
+        assert b'line1!' == line
+
+        stream.feed_eof()
+        data = await stream.read()
+        assert b'line2!line3!' == data
+
+    async def test_readuntil_eof(self) -> None:
+        stream = self._make_one()
+        stream.feed_data(b'some data')
+        stream.feed_eof()
+
+        line = await stream.readuntil(b'@')
+        assert b'some data' == line
+
+    async def test_readuntil_empty_eof(self) -> None:
+        stream = self._make_one()
+        stream.feed_eof()
+
+        line = await stream.readuntil(b'@')
+        assert b'' == line
+
+    async def test_readuntil_read_byte_count(self) -> None:
+        stream = self._make_one()
+        data = b'line1!line2!line3!'
+        stream.feed_data(data)
+
+        await stream.readuntil(b'!')
+
+        data = await stream.read(7)
+        assert b'line2!l' == data
+
+        stream.feed_eof()
+        data = await stream.read()
+        assert b'ine3!' == data
+
+    async def test_readuntil_exception(self) -> None:
+        stream = self._make_one()
+        stream.feed_data(b'line#')
+
+        data = await stream.readuntil(b'#')
+        assert b'line#' == data
+
+        stream.set_exception(ValueError())
+        with pytest.raises(ValueError):
+            await stream.readuntil(b'#')
+
     async def test_readexactly_zero_or_less(self) -> None:
         # Read exact number of bytes (zero or less).
         stream = self._make_one()


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Added `readuntil` method, heavily mimicking `asyncio.streams` and recycling the code of readline in current `StreamResponse` class. With this change `readline` uses `readuntil` with `\n` as a separator
Same for the tests that just use different separators.

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

New way to wait for new data

<!-- Outline any notable behaviour for the end users. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

#4054 

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt` This change is inside another PR I submitted #4732 
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
