### PR TITLE
[3.6] Don't cancel web handler on disconnection (#4080)

### DIFF
--- a/CHANGES/4080.feature
+++ b/CHANGES/4080.feature
@@ -1,0 +1,1 @@
+Don't cancel web handler on peer disconnection, raise `OSError` on reading/writing instead.

--- a/aiohttp/http_websocket.py
+++ b/aiohttp/http_websocket.py
@@ -13,7 +13,6 @@ from typing import Any, Callable, List, Optional, Tuple, Union
 
 from .base_protocol import BaseProtocol
 from .helpers import NO_EXTENSIONS
-from .log import ws_logger
 from .streams import DataQueue
 
 __all__ = ('WS_CLOSED_MESSAGE', 'WS_CLOSING_MESSAGE', 'WS_KEY',
@@ -567,8 +566,8 @@ class WebSocketWriter:
     async def _send_frame(self, message: bytes, opcode: int,
                           compress: Optional[int]=None) -> None:
         """Send a frame over the websocket with message as its payload."""
-        if self._closing:
-            ws_logger.warning('websocket connection is closing.')
+        if self._closing and not (opcode & WSMsgType.CLOSE):
+            raise ConnectionResetError('Cannot write to closing transport')
 
         rsv = 0
 
@@ -610,20 +609,25 @@ class WebSocketWriter:
             mask = mask.to_bytes(4, 'big')
             message = bytearray(message)
             _websocket_mask(mask, message)
-            self.transport.write(header + mask + message)
+            self._write(header + mask + message)
             self._output_size += len(header) + len(mask) + len(message)
         else:
             if len(message) > MSG_SIZE:
-                self.transport.write(header)
-                self.transport.write(message)
+                self._write(header)
+                self._write(message)
             else:
-                self.transport.write(header + message)
+                self._write(header + message)
 
             self._output_size += len(header) + len(message)
 
         if self._output_size > self._limit:
             self._output_size = 0
             await self.protocol._drain_helper()
+
+    def _write(self, data: bytes) -> None:
+        if self.transport is None or self.transport.is_closing():
+            raise ConnectionResetError('Cannot write to closing transport')
+        self.transport.write(data)
 
     async def pong(self, message: bytes=b'') -> None:
         """Send pong message."""

--- a/aiohttp/web_protocol.py
+++ b/aiohttp/web_protocol.py
@@ -247,7 +247,7 @@ class RequestHandler(BaseProtocol):
 
         if self._current_request is not None:
             if exc is None:
-                exc = ConnectionResetError("Connetion lost")
+                exc = ConnectionResetError("Connection lost")
             self._current_request._cancel(exc)
 
         if self._error_handler is not None:

--- a/aiohttp/web_request.py
+++ b/aiohttp/web_request.py
@@ -696,6 +696,9 @@ class BaseRequest(MutableMapping[str, Any], HeadersMixin):
     async def _prepare_hook(self, response: StreamResponse) -> None:
         return
 
+    def _cancel(self, exc: BaseException) -> None:
+        self._payload.set_exception(exc)
+
 
 class Request(BaseRequest):
 

--- a/aiohttp/web_ws.py
+++ b/aiohttp/web_ws.py
@@ -454,3 +454,7 @@ class WebSocketResponse(StreamResponse):
                         WSMsgType.CLOSED):
             raise StopAsyncIteration  # NOQA
         return msg
+
+    def _cancel(self, exc: BaseException) -> None:
+        if self._reader is not None:
+            self._reader.set_exception(exc)

--- a/docs/web_advanced.rst
+++ b/docs/web_advanced.rst
@@ -20,103 +20,22 @@ But in case of custom regular expressions for
 *percent encoded*: if you pass Unicode patterns they don't match to
 *requoted* path.
 
+Peer disconnection
+------------------
 
-Web Handler Cancellation
-------------------------
+When a client peer is gone a subsequent reading or writing raises :exc:`OSError`
+or more specific exception like :exc:`ConnectionResetError`.
 
-.. warning::
+The reason for disconnection is vary; it can be a network issue or explicit
+socket closing on the peer side without reading the whole server response.
 
-   :term:`web-handler` execution could be canceled on every ``await``
-   if client drops connection without reading entire response's BODY.
-
-   The behavior is very different from classic WSGI frameworks like
-   Flask and Django.
-
-Sometimes it is a desirable behavior: on processing ``GET`` request the
-code might fetch data from database or other web resource, the
-fetching is potentially slow.
-
-Canceling this fetch is very good: the peer dropped connection
-already, there is no reason to waste time and resources (memory etc) by
-getting data from DB without any chance to send it back to peer.
-
-But sometimes the cancellation is bad: on ``POST`` request very often
-is needed to save data to DB regardless to peer closing.
-
-Cancellation prevention could be implemented in several ways:
-
-* Applying :func:`asyncio.shield` to coroutine that saves data into DB.
-* Spawning a new task for DB saving
-* Using aiojobs_ or other third party library.
-
-:func:`asyncio.shield` works pretty good. The only disadvantage is you
-need to split web handler into exactly two async functions: one
-for handler itself and other for protected code.
-
-For example the following snippet is not safe::
+*aiohttp* handles disconnection properly but you can handle it explicitly, e.g.::
 
    async def handler(request):
-       await asyncio.shield(write_to_redis(request))
-       await asyncio.shield(write_to_postgres(request))
-       return web.Response(text='OK')
-
-Cancellation might be occurred just after saving data in REDIS,
-``write_to_postgres`` will be not called.
-
-Spawning a new task is much worse: there is no place to ``await``
-spawned tasks::
-
-   async def handler(request):
-       request.loop.create_task(write_to_redis(request))
-       return web.Response(text='OK')
-
-In this case errors from ``write_to_redis`` are not awaited, it leads
-to many asyncio log messages *Future exception was never retrieved*
-and *Task was destroyed but it is pending!*.
-
-Moreover on :ref:`aiohttp-web-graceful-shutdown` phase *aiohttp* don't
-wait for these tasks, you have a great chance to loose very important
-data.
-
-On other hand aiojobs_ provides an API for spawning new jobs and
-awaiting their results etc. It stores all scheduled activity in
-internal data structures and could terminate them gracefully::
-
-   from aiojobs.aiohttp import setup, spawn
-
-   async def coro(timeout):
-       await asyncio.sleep(timeout)  # do something in background
-
-   async def handler(request):
-       await spawn(request, coro())
-       return web.Response()
-
-   app = web.Application()
-   setup(app)
-   app.router.add_get('/', handler)
-
-All not finished jobs will be terminated on
-:attr:`Application.on_cleanup` signal.
-
-To prevent cancellation of the whole :term:`web-handler` use
-``@atomic`` decorator::
-
-   from aiojobs.aiohttp import atomic
-
-   @atomic
-   async def handler(request):
-       await write_to_db()
-       return web.Response()
-
-   app = web.Application()
-   setup(app)
-   app.router.add_post('/', handler)
-
-It prevents all ``handler`` async function from cancellation,
-``write_to_db`` will be never interrupted.
-
-.. _aiojobs: http://aiojobs.readthedocs.io/en/latest/
-
+       try:
+           text = await request.text()
+       except OSError:
+           # disconnected
 
 Passing a coroutine into run_app and Gunicorn
 ---------------------------------------------

--- a/tests/test_client_ws.py
+++ b/tests/test_client_ws.py
@@ -9,7 +9,6 @@ import pytest
 import aiohttp
 from aiohttp import client, hdrs
 from aiohttp.http import WS_KEY
-from aiohttp.log import ws_logger
 from aiohttp.streams import EofStream
 from aiohttp.test_utils import make_mocked_coro
 
@@ -363,7 +362,7 @@ async def test_close_exc2(loop, ws_key, key_data) -> None:
                     await resp.close()
 
 
-async def test_send_data_after_close(ws_key, key_data, loop, mocker) -> None:
+async def test_send_data_after_close(ws_key, key_data, loop) -> None:
     resp = mock.Mock()
     resp.status = 101
     resp.headers = {
@@ -381,16 +380,13 @@ async def test_send_data_after_close(ws_key, key_data, loop, mocker) -> None:
                 'http://test.org')
             resp._writer._closing = True
 
-            mocker.spy(ws_logger, 'warning')
-
             for meth, args in ((resp.ping, ()),
                                (resp.pong, ()),
                                (resp.send_str, ('s',)),
                                (resp.send_bytes, (b'b',)),
                                (resp.send_json, ({},))):
-                await meth(*args)
-                assert ws_logger.warning.called
-                ws_logger.warning.reset_mock()
+                with pytest.raises(ConnectionResetError):
+                    await meth(*args)
 
 
 async def test_send_data_type_errors(ws_key, key_data, loop) -> None:

--- a/tests/test_web_websocket.py
+++ b/tests/test_web_websocket.py
@@ -5,7 +5,6 @@ import pytest
 from multidict import CIMultiDict
 
 from aiohttp import WSMessage, WSMsgType, signals
-from aiohttp.log import ws_logger
 from aiohttp.streams import EofStream
 from aiohttp.test_utils import make_mocked_coro, make_mocked_request
 from aiohttp.web import HTTPBadRequest, WebSocketResponse
@@ -226,52 +225,48 @@ def test_closed_after_ctor() -> None:
     assert ws.close_code is None
 
 
-async def test_send_str_closed(make_request, mocker) -> None:
+async def test_send_str_closed(make_request) -> None:
     req = make_request('GET', '/')
     ws = WebSocketResponse()
     await ws.prepare(req)
     ws._reader.feed_data(WS_CLOSED_MESSAGE, 0)
     await ws.close()
 
-    mocker.spy(ws_logger, 'warning')
-    await ws.send_str('string')
-    assert ws_logger.warning.called
+    with pytest.raises(ConnectionError):
+        await ws.send_str('string')
 
 
-async def test_send_bytes_closed(make_request, mocker) -> None:
+async def test_send_bytes_closed(make_request) -> None:
     req = make_request('GET', '/')
     ws = WebSocketResponse()
     await ws.prepare(req)
     ws._reader.feed_data(WS_CLOSED_MESSAGE, 0)
     await ws.close()
 
-    mocker.spy(ws_logger, 'warning')
-    await ws.send_bytes(b'bytes')
-    assert ws_logger.warning.called
+    with pytest.raises(ConnectionError):
+        await ws.send_bytes(b'bytes')
 
 
-async def test_send_json_closed(make_request, mocker) -> None:
+async def test_send_json_closed(make_request) -> None:
     req = make_request('GET', '/')
     ws = WebSocketResponse()
     await ws.prepare(req)
     ws._reader.feed_data(WS_CLOSED_MESSAGE, 0)
     await ws.close()
 
-    mocker.spy(ws_logger, 'warning')
-    await ws.send_json({'type': 'json'})
-    assert ws_logger.warning.called
+    with pytest.raises(ConnectionError):
+        await ws.send_json({'type': 'json'})
 
 
-async def test_ping_closed(make_request, mocker) -> None:
+async def test_ping_closed(make_request) -> None:
     req = make_request('GET', '/')
     ws = WebSocketResponse()
     await ws.prepare(req)
     ws._reader.feed_data(WS_CLOSED_MESSAGE, 0)
     await ws.close()
 
-    mocker.spy(ws_logger, 'warning')
-    await ws.ping()
-    assert ws_logger.warning.called
+    with pytest.raises(ConnectionError):
+        await ws.ping()
 
 
 async def test_pong_closed(make_request, mocker) -> None:
@@ -281,9 +276,8 @@ async def test_pong_closed(make_request, mocker) -> None:
     ws._reader.feed_data(WS_CLOSED_MESSAGE, 0)
     await ws.close()
 
-    mocker.spy(ws_logger, 'warning')
-    await ws.pong()
-    assert ws_logger.warning.called
+    with pytest.raises(ConnectionError):
+        await ws.pong()
 
 
 async def test_close_idempotent(make_request) -> None:
@@ -354,40 +348,6 @@ async def test_receive_eofstream_in_reader(make_request, loop) -> None:
     assert ws.closed
 
 
-async def test_receive_exc_in_reader(make_request, loop) -> None:
-    req = make_request('GET', '/')
-    ws = WebSocketResponse()
-    await ws.prepare(req)
-
-    ws._reader = mock.Mock()
-    exc = ValueError()
-    res = loop.create_future()
-    res.set_exception(exc)
-    ws._reader.read = make_mocked_coro(res)
-    ws._payload_writer.drain = mock.Mock()
-    ws._payload_writer.drain.return_value = loop.create_future()
-    ws._payload_writer.drain.return_value.set_result(True)
-
-    msg = await ws.receive()
-    assert msg.type == WSMsgType.ERROR
-    assert msg.data is exc
-    assert ws.exception() is exc
-
-
-async def test_receive_cancelled(make_request, loop) -> None:
-    req = make_request('GET', '/')
-    ws = WebSocketResponse()
-    await ws.prepare(req)
-
-    ws._reader = mock.Mock()
-    res = loop.create_future()
-    res.set_exception(asyncio.CancelledError())
-    ws._reader.read = make_mocked_coro(res)
-
-    with pytest.raises(asyncio.CancelledError):
-        await ws.receive()
-
-
 async def test_receive_timeouterror(make_request, loop) -> None:
     req = make_request('GET', '/')
     ws = WebSocketResponse()
@@ -428,33 +388,7 @@ async def test_concurrent_receive(make_request) -> None:
         await ws.receive()
 
 
-async def test_close_exc(make_request, loop, mocker) -> None:
-    req = make_request('GET', '/')
-
-    ws = WebSocketResponse()
-    await ws.prepare(req)
-
-    ws._reader = mock.Mock()
-    exc = ValueError()
-    ws._reader.read.return_value = loop.create_future()
-    ws._reader.read.return_value.set_exception(exc)
-    ws._payload_writer.drain = mock.Mock()
-    ws._payload_writer.drain.return_value = loop.create_future()
-    ws._payload_writer.drain.return_value.set_result(True)
-
-    await ws.close()
-    assert ws.closed
-    assert ws.exception() is exc
-
-    ws._closed = False
-    ws._reader.read.return_value = loop.create_future()
-    ws._reader.read.return_value.set_exception(asyncio.CancelledError())
-    with pytest.raises(asyncio.CancelledError):
-        await ws.close()
-    assert ws.close_code == 1006
-
-
-async def test_close_exc2(make_request) -> None:
+async def test_close_exc(make_request) -> None:
 
     req = make_request('GET', '/')
     ws = WebSocketResponse()

--- a/tests/test_web_websocket_functional.py
+++ b/tests/test_web_websocket_functional.py
@@ -276,19 +276,6 @@ async def test_close_timeout(loop, aiohttp_client) -> None:
     await asyncio.sleep(0.08, loop=loop)
     msg = await ws._reader.read()
     assert msg.type == WSMsgType.CLOSE
-    await ws.send_str('hang')
-
-    # i am not sure what do we test here
-    # under uvloop this code raises RuntimeError
-    try:
-        await asyncio.sleep(0.08, loop=loop)
-        await ws.send_str('hang')
-        await asyncio.sleep(0.08, loop=loop)
-        await ws.send_str('hang')
-        await asyncio.sleep(0.08, loop=loop)
-        await ws.send_str('hang')
-    except RuntimeError:
-        pass
 
     await asyncio.sleep(0.08, loop=loop)
     assert (await aborted)
@@ -668,19 +655,12 @@ async def test_heartbeat(loop, aiohttp_client, ceil) -> None:
 
 
 async def test_heartbeat_no_pong(loop, aiohttp_client, ceil) -> None:
-    cancelled = False
 
     async def handler(request):
-        nonlocal cancelled
-
         ws = web.WebSocketResponse(heartbeat=0.05)
         await ws.prepare(request)
 
-        try:
-            await ws.receive()
-        except asyncio.CancelledError:
-            cancelled = True
-
+        await ws.receive()
         return ws
 
     app = web.Application()
@@ -690,9 +670,7 @@ async def test_heartbeat_no_pong(loop, aiohttp_client, ceil) -> None:
     ws = await client.ws_connect('/', autoping=False)
     msg = await ws.receive()
     assert msg.type == aiohttp.WSMsgType.ping
-    await ws.receive()
-
-    assert cancelled
+    await ws.close()
 
 
 async def test_server_ws_async_for(loop, aiohttp_server) -> None:

--- a/tests/test_websocket_writer.py
+++ b/tests/test_websocket_writer.py
@@ -16,7 +16,9 @@ def protocol():
 
 @pytest.fixture
 def transport():
-    return mock.Mock()
+    ret = mock.Mock()
+    ret.is_closing.return_value = False
+    return ret
 
 
 @pytest.fixture


### PR DESCRIPTION
## What do these changes do?

Backport #4080 to aiohttp 3.6.  I'm not sure whether there's gonna be another 3.6 release or if 3.7 is still planned but this allows to handle connections issues properly so would be good to have.

#3804 wasn't backported to 3.6 so I had to put the `try`-`finally` block in the `start()` as `_handle_request` method doesn't exist here, I'm not entirely sure if I've done it properly. I could alternatively also backport #3804, either in this or seperate PR that this would depend on.

## Are there changes in behavior for the user?

`ConnectionResetError` is raised on writing to closing transport instead of a warning.

## Related issue number

#4080

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
