### PR TITLE
Fix resolver task is not awaited when connector is cancelled

### DIFF
--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -738,6 +738,50 @@ async def test_tcp_connector_dns_throttle_requests_cancelled_when_close(
             await f
 
 
+@pytest.fixture
+def dns_response_error(loop):
+    async def coro():
+        # simulates a network operation
+        await asyncio.sleep(0)
+        raise socket.gaierror(-3, 'Temporary failure in name resolution')
+    return coro
+
+
+async def test_tcp_connector_cancel_dns_error_captured(
+        loop,
+        dns_response_error) -> None:
+
+    exception_handler_called = False
+
+    def exception_handler(loop, context):
+        nonlocal exception_handler_called
+        exception_handler_called = True
+
+    loop.set_exception_handler(mock.Mock(side_effect=exception_handler))
+
+    with mock.patch('aiohttp.connector.DefaultResolver') as m_resolver:
+        req = ClientRequest(
+            method='GET',
+            url=URL('http://temporary-failure:80'),
+            loop=loop
+        )
+        conn = aiohttp.TCPConnector(
+            use_dns_cache=False,
+        )
+        m_resolver().resolve.return_value = dns_response_error()
+        f = loop.create_task(
+            conn._create_direct_connection(req, [], ClientTimeout(0))
+        )
+
+        await asyncio.sleep(0)
+        f.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await f
+
+        gc.collect()
+        assert exception_handler_called is False
+
+
 async def test_tcp_connector_dns_tracing(loop, dns_response) -> None:
     session = mock.Mock()
     trace_config_ctx = mock.Mock()


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

Fixes #4330

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

No

## Related issue number

#4330

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
