### PR TITLE
Ensure cleanup gets run.

### DIFF
--- a/CHANGES/4999.bugfix
+++ b/CHANGES/4999.bugfix
@@ -1,0 +1,1 @@
+Ensure cleanup context is run even when an exception occurs during startup.

--- a/aiohttp/web_app.py
+++ b/aiohttp/web_app.py
@@ -302,7 +302,9 @@ class Application(MutableMapping[str, Any]):
 
         Should be called after shutdown()
         """
-        await self.on_cleanup.send(self)
+        # Avoid send() as we want to ensure cleanup is run even if not frozen.
+        for receiver in self.on_cleanup:
+            await receiver(self)
 
     def _prepare_middleware(self) -> Iterator[_Middleware]:
         yield from reversed(self._middlewares)

--- a/aiohttp/web_runner.py
+++ b/aiohttp/web_runner.py
@@ -245,10 +245,6 @@ class BaseRunner(ABC):
     async def cleanup(self) -> None:
         loop = asyncio.get_event_loop()
 
-        if self._server is None:
-            # no started yet, do nothing
-            return
-
         # The loop over sites is intentional, an exception on gather()
         # leaves self._sites in unpredictable state.
         # The loop guarantees that a site is either deleted on success or


### PR DESCRIPTION
This helps ensure that cleanup gets run, even when an exception occurs during startup. Fixes #4799 

This becomes particularly painful when the server can't be cleanly restarted without the cleanup running, especially when running locally with aiohttp-devtools, where exceptions during development are likely, and cause the runserver command to break or lock up.