### PR TITLE
Allow to send a bytestring by WebSocketResponse.send_str

### DIFF
--- a/CHANGES/4828.feature
+++ b/CHANGES/4828.feature
@@ -1,1 +1,1 @@
-Allow to send JSON as bytestring by WebSocketResponse.send_json
+Allow to send a bytestring by WebSocketResponse.send_str

--- a/CHANGES/4828.feature
+++ b/CHANGES/4828.feature
@@ -1,0 +1,1 @@
+Allow to send JSON as bytestring by WebSocketResponse.send_json

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -69,6 +69,7 @@ Dan Xu
 Daniel García
 Daniel Grossmann-Kavanagh
 Daniel Nelson
+Daniil Kozhanov
 Danny Song
 David Bibb
 David Michael Brown

--- a/aiohttp/web_ws.py
+++ b/aiohttp/web_ws.py
@@ -3,7 +3,7 @@ import base64
 import binascii
 import hashlib
 import json
-from typing import Any, Iterable, Optional, Tuple, Union
+from typing import Any, Iterable, Optional, Tuple
 
 import async_timeout
 import attr
@@ -294,8 +294,8 @@ class WebSocketResponse(StreamResponse):
                             type(data))
         await self._writer.send(data, binary=True, compress=compress)
 
-    async def send_json(self, data: Any, compress: Optional[bool] = None, *,
-                        dumps: JSONEncoder = json.dumps) -> None:
+    async def send_json(self, data: Any, compress: Optional[bool]=None, *,
+                        dumps: JSONEncoder=json.dumps) -> None:
         await self.send_str(dumps(data), compress=compress)
 
     async def write_eof(self) -> None:  # type: ignore


### PR DESCRIPTION
## What do these changes do?

WebSocketWriter from `http_websocket.py` can actually send only the binary data and the UTF-8 string must be encoded anyway:
```python
class WebSocketWriter:
    async def send(self, message: Union[str, bytes],
                   binary: bool=False,
                   compress: Optional[int]=None) -> None:
        """Send a frame over the websocket with message as its payload."""
        if isinstance(message, str):
            message = message.encode('utf-8')
        if binary:
            await self._send_frame(message, WSMsgType.BINARY, compress)
        else:
            await self._send_frame(message, WSMsgType.TEXT, compress)
```
Sometimes we need to send a bytestring and the client must understand that this is a text data. For example:
```python
await ws.send_json({'foo': 'bar'}, dumps=orjson.dump)
```
which is equivalent to
```python
await ws.send_str(b'{"foo":"bar"}')
```
Decoding `b'{"foo":"bar"}'.decode('utf-8') ` is useless because then the WebSocketWriter encodes it back.
Using `send_bytes` instead of `send_str` is incorrect because client must understand which type of data received.

## Are there changes in behavior for the user?

The change only adds additional functionality.

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
