### PR TITLE
Fix (#4850): Timeouts checked once a second.

### DIFF
--- a/CHANGES/4850.bugfix
+++ b/CHANGES/4850.bugfix
@@ -1,0 +1,1 @@
+Timeouts checked once a second.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -73,6 +73,7 @@ Danny Song
 David Bibb
 David Michael Brown
 Denilson Amorim
+Denis Belavin
 Denis Matiychuk
 Dennis Kliban
 Dima Veselov

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -16,7 +16,7 @@ import time
 import weakref
 from collections import namedtuple
 from contextlib import suppress
-from math import ceil, trunc
+from math import ceil
 from pathlib import Path
 from types import TracebackType
 from typing import (  # noqa

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -539,7 +539,7 @@ class TimeoutHandle:
 
     def start(self) -> Optional[asyncio.Handle]:
         if self._timeout is not None and self._timeout > 0:
-            at = round(self._loop.time() + self._timeout, 3)
+            at = self._loop.time() + self._timeout
             return self._loop.call_at(at, self.__call__)
         else:
             return None

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -16,7 +16,7 @@ import time
 import weakref
 from collections import namedtuple
 from contextlib import suppress
-from math import ceil
+from math import ceil, trunc
 from pathlib import Path
 from types import TracebackType
 from typing import (  # noqa
@@ -539,7 +539,7 @@ class TimeoutHandle:
 
     def start(self) -> Optional[asyncio.Handle]:
         if self._timeout is not None and self._timeout > 0:
-            at = ceil(self._loop.time() + self._timeout)
+            at = round(self._loop.time() + self._timeout, 3)
             return self._loop.call_at(at, self.__call__)
         else:
             return None

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -308,14 +308,14 @@ def test_timeout_handle(loop) -> None:
 
 def test_when_timeout_smaller_second(loop) -> None:
     timeout = 0.1
-    timer = round(loop.time() + timeout, 3)
+    timer = loop.time() + timeout
 
     handle = helpers.TimeoutHandle(loop, timeout)
-    when = handle.start().when()
+    when = handle.start()._when
     handle.close()
 
     assert isinstance(when, float)
-    assert when == timer
+    assert f"{when:.3f}" == f"{timer:.3f}"
 
 
 def test_timeout_handle_cb_exc(loop) -> None:

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -306,6 +306,18 @@ def test_timeout_handle(loop) -> None:
     assert not handle._callbacks
 
 
+def test_when_timeout_smaller_second(loop) -> None:
+    timeout = 0.1
+    timer = round(loop.time() + timeout, 3)
+
+    handle = helpers.TimeoutHandle(loop, timeout)
+    when = handle.start().when()
+    handle.close()
+
+    assert isinstance(when, float)
+    assert when == timer
+
+
 def test_timeout_handle_cb_exc(loop) -> None:
     handle = helpers.TimeoutHandle(loop, 10.2)
     cb = mock.Mock()


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?
Bug fix.

<!-- Please give a short brief about these changes. -->
Replaced the `ceil` method with the `round` method with rounding to 3 decimal places. This will allow to get a `timeout` of less than a second.

## Are there changes in behavior for the user?
Yes. Now the user can set a `timeout` of less than a second.

<!-- Outline any notable behaviour for the end users. -->

## Related issue number
#4850
<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
