### PR TITLE
Fix missing default value in the doc

### DIFF
--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -1504,7 +1504,7 @@ ClientTimeout
 ^^^^^^^^^^^^^
 
 .. class:: ClientTimeout(*, total=None, connect=None, \
-                         sock_connect, sock_read=None)
+                         sock_connect=None, sock_read=None)
 
    A data class for client timeout settings.
 


### PR DESCRIPTION
Fix the missing default value in the document function signature.
According to source code [client.py](https://github.com/aio-libs/aiohttp/blob/master/aiohttp/client.py) line 151, the defalut value should be `None`.

    class ClientTimeout:
        total = attr.ib(type=Optional[float], default=None)
        connect = attr.ib(type=Optional[float], default=None)
        sock_read = attr.ib(type=Optional[float], default=None)
        sock_connect = attr.ib(type=Optional[float], default=None)

<!-- Thank you for your contribution! -->

## What do these changes do?
Just add a simple default value in the document function signature.
<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?
NO
<!-- Outline any notable behaviour for the end users. -->

## Related issue number
Because it's just a samll bug, I think there's no need to open a new issue.
<!-- Are there any issues opened that will be resolved by merging this change? -->

