### PR TITLE
chore(docs): fix brackets in quickstart example

### DIFF
--- a/docs/web_quickstart.rst
+++ b/docs/web_quickstart.rst
@@ -274,7 +274,7 @@ application developers can organize handlers in classes if they so wish::
 
    handler = Handler()
    app.add_routes([web.get('/intro', handler.handle_intro),
-                   web.get('/greet/{name}', handler.handle_greeting)]
+                   web.get('/greet/{name}', handler.handle_greeting)])
 
 
 .. _aiohttp-web-class-based-views:


### PR DESCRIPTION
## What do these changes do?

fixes missing closing bracket in quickstart example 
