### PR TITLE
Fix the tracing module's type hints

### DIFF
--- a/CHANGES/4912.bugfix
+++ b/CHANGES/4912.bugfix
@@ -1,0 +1,1 @@
+Fixed the type annotations in the ``tracing`` module.

--- a/aiohttp/tracing.py
+++ b/aiohttp/tracing.py
@@ -13,13 +13,13 @@ if TYPE_CHECKING:  # pragma: no cover
 
     from .client import ClientSession  # noqa
 
-    _ParamT = TypeVar('_ParamT')
+    _ParamT_contra = TypeVar('_ParamT_contra', contravariant=True)
 
-    class _SignalCallback(Protocol[_ParamT]):
+    class _SignalCallback(Protocol[_ParamT_contra]):
         def __call__(self,
                      __client_session: ClientSession,
                      __trace_config_ctx: SimpleNamespace,
-                     __params: _ParamT) -> Awaitable[None]: ...
+                     __params: _ParamT_contra) -> Awaitable[None]: ...
 
 
 __all__ = (

--- a/aiohttp/tracing.py
+++ b/aiohttp/tracing.py
@@ -1,5 +1,5 @@
 from types import SimpleNamespace
-from typing import TYPE_CHECKING, Awaitable, Callable, Type, Union
+from typing import TYPE_CHECKING, Awaitable, Type, TypeVar
 
 import attr
 from multidict import CIMultiDict  # noqa
@@ -9,29 +9,17 @@ from .client_reqrep import ClientResponse
 from .signals import Signal
 
 if TYPE_CHECKING:  # pragma: no cover
+    from typing_extensions import Protocol
+
     from .client import ClientSession  # noqa
 
-    _SignalArgs = Union[
-        'TraceRequestStartParams',
-        'TraceRequestEndParams',
-        'TraceRequestExceptionParams',
-        'TraceConnectionQueuedStartParams',
-        'TraceConnectionQueuedEndParams',
-        'TraceConnectionCreateStartParams',
-        'TraceConnectionCreateEndParams',
-        'TraceConnectionReuseconnParams',
-        'TraceDnsResolveHostStartParams',
-        'TraceDnsResolveHostEndParams',
-        'TraceDnsCacheHitParams',
-        'TraceDnsCacheMissParams',
-        'TraceRequestRedirectParams',
-        'TraceRequestChunkSentParams',
-        'TraceResponseChunkReceivedParams',
-    ]
-    _Signal = Signal[Callable[[ClientSession, SimpleNamespace, _SignalArgs],
-                              Awaitable[None]]]
-else:
-    _Signal = Signal
+    _ParamT = TypeVar('_ParamT')
+
+    class _SignalCallback(Protocol[_ParamT]):
+        def __call__(self,
+                     __client_session: ClientSession,
+                     __trace_config_ctx: SimpleNamespace,
+                     __params: _ParamT) -> Awaitable[None]: ...
 
 
 __all__ = (
@@ -54,23 +42,53 @@ class TraceConfig:
         self,
         trace_config_ctx_factory: Type[SimpleNamespace]=SimpleNamespace
     ) -> None:
-        self._on_request_start = Signal(self)  # type: _Signal
-        self._on_request_chunk_sent = Signal(self)  # type: _Signal
-        self._on_response_chunk_received = Signal(self)  # type: _Signal
-        self._on_request_end = Signal(self)  # type: _Signal
-        self._on_request_exception = Signal(self)  # type: _Signal
-        self._on_request_redirect = Signal(self)  # type: _Signal
-        self._on_connection_queued_start = Signal(self)  # type: _Signal
-        self._on_connection_queued_end = Signal(self)  # type: _Signal
-        self._on_connection_create_start = Signal(self)  # type: _Signal
-        self._on_connection_create_end = Signal(self)  # type: _Signal
-        self._on_connection_reuseconn = Signal(self)  # type: _Signal
-        self._on_dns_resolvehost_start = Signal(self)  # type: _Signal
-        self._on_dns_resolvehost_end = Signal(self)  # type: _Signal
-        self._on_dns_cache_hit = Signal(self)  # type: _Signal
-        self._on_dns_cache_miss = Signal(self)  # type: _Signal
+        self._on_request_start = Signal(
+            self
+        )  # type: Signal[_SignalCallback[TraceRequestStartParams]]
+        self._on_request_chunk_sent = Signal(
+            self
+        )  # type: Signal[_SignalCallback[TraceRequestChunkSentParams]]
+        self._on_response_chunk_received = Signal(
+            self
+        )  # type: Signal[_SignalCallback[TraceResponseChunkReceivedParams]]
+        self._on_request_end = Signal(
+            self
+        )  # type: Signal[_SignalCallback[TraceRequestEndParams]]
+        self._on_request_exception = Signal(
+            self
+        )  # type: Signal[_SignalCallback[TraceRequestExceptionParams]]
+        self._on_request_redirect = Signal(
+            self
+        )  # type: Signal[_SignalCallback[TraceRequestRedirectParams]]
+        self._on_connection_queued_start = Signal(
+            self
+        )  # type: Signal[_SignalCallback[TraceConnectionQueuedStartParams]]
+        self._on_connection_queued_end = Signal(
+            self
+        )  # type: Signal[_SignalCallback[TraceConnectionQueuedEndParams]]
+        self._on_connection_create_start = Signal(
+            self
+        )  # type: Signal[_SignalCallback[TraceConnectionCreateStartParams]]
+        self._on_connection_create_end = Signal(
+            self
+        )  # type: Signal[_SignalCallback[TraceConnectionCreateEndParams]]
+        self._on_connection_reuseconn = Signal(
+            self
+        )  # type: Signal[_SignalCallback[TraceConnectionReuseconnParams]]
+        self._on_dns_resolvehost_start = Signal(
+            self
+        )  # type: Signal[_SignalCallback[TraceDnsResolveHostStartParams]]
+        self._on_dns_resolvehost_end = Signal(
+            self
+        )  # type: Signal[_SignalCallback[TraceDnsResolveHostEndParams]]
+        self._on_dns_cache_hit = Signal(
+            self
+        )  # type: Signal[_SignalCallback[TraceDnsCacheHitParams]]
+        self._on_dns_cache_miss = Signal(
+            self
+        )  # type: Signal[_SignalCallback[TraceDnsCacheMissParams]]
 
-        self._trace_config_ctx_factory = trace_config_ctx_factory  # type: Type[SimpleNamespace] # noqa
+        self._trace_config_ctx_factory = trace_config_ctx_factory
 
     def trace_config_ctx(
         self,
@@ -98,63 +116,93 @@ class TraceConfig:
         self._on_dns_cache_miss.freeze()
 
     @property
-    def on_request_start(self) -> _Signal:
+    def on_request_start(
+        self
+    ) -> 'Signal[_SignalCallback[TraceRequestStartParams]]':
         return self._on_request_start
 
     @property
-    def on_request_chunk_sent(self) -> _Signal:
+    def on_request_chunk_sent(
+        self
+    ) -> 'Signal[_SignalCallback[TraceRequestChunkSentParams]]':
         return self._on_request_chunk_sent
 
     @property
-    def on_response_chunk_received(self) -> _Signal:
+    def on_response_chunk_received(
+        self
+    ) -> 'Signal[_SignalCallback[TraceResponseChunkReceivedParams]]':
         return self._on_response_chunk_received
 
     @property
-    def on_request_end(self) -> _Signal:
+    def on_request_end(
+        self
+    ) -> 'Signal[_SignalCallback[TraceRequestEndParams]]':
         return self._on_request_end
 
     @property
-    def on_request_exception(self) -> _Signal:
+    def on_request_exception(
+        self
+    ) -> 'Signal[_SignalCallback[TraceRequestExceptionParams]]':
         return self._on_request_exception
 
     @property
-    def on_request_redirect(self) -> _Signal:
+    def on_request_redirect(
+        self
+    ) -> 'Signal[_SignalCallback[TraceRequestRedirectParams]]':
         return self._on_request_redirect
 
     @property
-    def on_connection_queued_start(self) -> _Signal:
+    def on_connection_queued_start(
+        self
+    ) -> 'Signal[_SignalCallback[TraceConnectionQueuedStartParams]]':
         return self._on_connection_queued_start
 
     @property
-    def on_connection_queued_end(self) -> _Signal:
+    def on_connection_queued_end(
+        self
+    ) -> 'Signal[_SignalCallback[TraceConnectionQueuedEndParams]]':
         return self._on_connection_queued_end
 
     @property
-    def on_connection_create_start(self) -> _Signal:
+    def on_connection_create_start(
+        self
+    ) -> 'Signal[_SignalCallback[TraceConnectionCreateStartParams]]':
         return self._on_connection_create_start
 
     @property
-    def on_connection_create_end(self) -> _Signal:
+    def on_connection_create_end(
+        self
+    ) -> 'Signal[_SignalCallback[TraceConnectionCreateEndParams]]':
         return self._on_connection_create_end
 
     @property
-    def on_connection_reuseconn(self) -> _Signal:
+    def on_connection_reuseconn(
+        self
+    ) -> 'Signal[_SignalCallback[TraceConnectionReuseconnParams]]':
         return self._on_connection_reuseconn
 
     @property
-    def on_dns_resolvehost_start(self) -> _Signal:
+    def on_dns_resolvehost_start(
+        self
+    ) -> 'Signal[_SignalCallback[TraceDnsResolveHostStartParams]]':
         return self._on_dns_resolvehost_start
 
     @property
-    def on_dns_resolvehost_end(self) -> _Signal:
+    def on_dns_resolvehost_end(
+        self
+    ) -> 'Signal[_SignalCallback[TraceDnsResolveHostEndParams]]':
         return self._on_dns_resolvehost_end
 
     @property
-    def on_dns_cache_hit(self) -> _Signal:
+    def on_dns_cache_hit(
+        self
+    ) -> 'Signal[_SignalCallback[TraceDnsCacheHitParams]]':
         return self._on_dns_cache_hit
 
     @property
-    def on_dns_cache_miss(self) -> _Signal:
+    def on_dns_cache_miss(
+        self
+    ) -> 'Signal[_SignalCallback[TraceDnsCacheMissParams]]':
         return self._on_dns_cache_miss
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

`_SignalArgs` is (was) a supertype of its
arguments and with `Callable ` being _contravariant_
in its arguments, the only way this would've
passed a type check is if the callback were to
(purport to) accept every single one of the
parameter types in a union,
exactly as specified - or `object`.
Either way, the parameter types were not
associated with their corresponding signals
so it would have been possible to append
a callback with a `TraceDnsCacheMissParams`
parameter to an `on_request_start` signal.

## Are there changes in behavior for the user?

No.

## Related issue number

—

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
