### PR TITLE
Correct a spelling mistake in quickstart: "canonize"->"canonicalize"

### DIFF
--- a/CHANGES/4986.doc
+++ b/CHANGES/4986.doc
@@ -1,0 +1,1 @@
+Spelling: Change "canonize" to "canonicalize".

--- a/docs/client_quickstart.rst
+++ b/docs/client_quickstart.rst
@@ -115,18 +115,18 @@ is not encoded by library. Note that ``+`` is not encoded::
 
 .. note::
 
-   *aiohttp* internally performs URL canonization before sending request.
+   *aiohttp* internally performs URL canonicalization before sending request.
 
-   Canonization encodes *host* part by :term:`IDNA` codec and applies
+   Canonicalization encodes *host* part by :term:`IDNA` codec and applies
    :term:`requoting` to *path* and *query* parts.
 
    For example ``URL('http://example.com/путь/%30?a=%31')`` is converted to
    ``URL('http://example.com/%D0%BF%D1%83%D1%82%D1%8C/0?a=1')``.
 
-   Sometimes canonization is not desirable if server accepts exact
+   Sometimes canonicalization is not desirable if server accepts exact
    representation and does not requote URL itself.
 
-   To disable canonization use ``encoded=True`` parameter for URL construction::
+   To disable canonicalization use ``encoded=True`` parameter for URL construction::
 
       await session.get(
           URL('http://example.com/%30', encoded=True))


### PR DESCRIPTION
## What do these changes do?

Fix spelling in the client-quickstart file.

"canonize" means to declare a person to be a saint - https://en.wikipedia.org/wiki/Canonization

You mean "canonicalize" - https://en.wikipedia.org/wiki/Canonicalization

## Are there changes in behavior for the user?

no
