### PR TITLE
Header prep before hook

### DIFF
--- a/CHANGES/1958.feature
+++ b/CHANGES/1958.feature
@@ -1,0 +1,1 @@
+Response headers are now prepared prior to running ``on_response_prepare`` hooks, directly before headers are sent to the client.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -155,6 +155,7 @@ Jonathan Wright
 Jonny Tan
 Joongi Kim
 Josep Cugat
+Josh Junon
 Joshu Coats
 Julia Tsemusheva
 Julien Duponchelle

--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -352,15 +352,17 @@ class StreamResponse(BaseClass, HeadersMixin):
         self._req = request
         writer = self._payload_writer = request._payload_writer
 
-        await self._prepare_headers(request, writer)
+        await self._prepare_headers()
         await request._prepare_hook(self)
-        await self._write_headers(request, writer)
+        await self._write_headers()
 
         return writer
 
-    async def _prepare_headers(
-        self, request: 'BaseRequest', writer: AbstractStreamWriter
-    ) -> None:
+    async def _prepare_headers(self) -> None:
+        request = self._req
+        assert request is not None
+        writer = self._payload_writer
+        assert writer is not None
         keep_alive = self._keep_alive
         if keep_alive is None:
             keep_alive = request.keep_alive
@@ -409,9 +411,11 @@ class StreamResponse(BaseClass, HeadersMixin):
                 if version == HttpVersion11:
                     headers[hdrs.CONNECTION] = 'close'
 
-    async def _write_headers(
-        self, request: 'BaseRequest', writer: AbstractStreamWriter
-    ) -> None:
+    async def _write_headers(self) -> None:
+        request = self._req
+        assert request is not None
+        writer = self._payload_writer
+        assert writer is not None
         # status line
         version = request.version
         status_line = 'HTTP/{}.{} {} {}'.format(

--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -346,19 +346,27 @@ class StreamResponse(BaseClass, HeadersMixin):
         if self._payload_writer is not None:
             return self._payload_writer
 
-        await request._prepare_hook(self)
         return await self._start(request)
 
     async def _start(self, request: 'BaseRequest') -> AbstractStreamWriter:
         self._req = request
+        writer = self._payload_writer = request._payload_writer
 
+        await self._prepare_headers(request, writer)
+        await request._prepare_hook(self)
+        await self._write_headers(request, writer)
+
+        return writer
+
+    async def _prepare_headers(
+        self, request: 'BaseRequest', writer: AbstractStreamWriter
+    ) -> None:
         keep_alive = self._keep_alive
         if keep_alive is None:
             keep_alive = request.keep_alive
         self._keep_alive = keep_alive
 
         version = request.version
-        writer = self._payload_writer = request._payload_writer
 
         headers = self._headers
         for cookie in self._cookies.values():
@@ -401,12 +409,14 @@ class StreamResponse(BaseClass, HeadersMixin):
                 if version == HttpVersion11:
                     headers[hdrs.CONNECTION] = 'close'
 
+    async def _write_headers(
+        self, request: 'BaseRequest', writer: AbstractStreamWriter
+    ) -> None:
         # status line
+        version = request.version
         status_line = 'HTTP/{}.{} {} {}'.format(
             version[0], version[1], self._status, self._reason)
-        await writer.write_headers(status_line, headers)
-
-        return writer
+        await writer.write_headers(status_line, self._headers)
 
     async def write(self, data: bytes) -> None:
         assert isinstance(data, (bytes, bytearray, memoryview)), \

--- a/docs/web_advanced.rst
+++ b/docs/web_advanced.rst
@@ -537,7 +537,8 @@ For example, a middleware can only change HTTP headers for *unprepared*
 responses (see :meth:`StreamResponse.prepare`), but sometimes we
 need a hook for changing HTTP headers for streamed responses and WebSockets.
 This can be accomplished by subscribing to the
-:attr:`Application.on_response_prepare` signal::
+:attr:`Application.on_response_prepare` signal, which is called after default
+headers have been computed and directly before headers are sent::
 
     async def on_prepare(request, response):
         response.headers['My-Header'] = 'value'

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -783,7 +783,8 @@ StreamResponse
       calling this method.
 
       The coroutine calls :attr:`~aiohttp.web.Application.on_response_prepare`
-      signal handlers.
+      signal handlers after default headers have been computed and directly
+      before headers are sent.
 
    .. comethod:: write(data)
 
@@ -1337,10 +1338,11 @@ duplicated like one using :meth:`Application.copy`.
 
    .. attribute:: on_response_prepare
 
-      A :class:`~aiohttp.Signal` that is fired at the beginning
+      A :class:`~aiohttp.Signal` that is fired near the end
       of :meth:`StreamResponse.prepare` with parameters *request* and
       *response*. It can be used, for example, to add custom headers to each
-      response before sending.
+      response, or to modify the default headers computed by the application,
+      directly before sending the headers to the client.
 
       Signal handlers should have the following signature::
 

--- a/tests/test_web_response.py
+++ b/tests/test_web_response.py
@@ -1092,6 +1092,31 @@ def test_response_with_immutable_headers() -> None:
                             'Content-Type': 'text/plain; charset=utf-8'}
 
 
+async def test_response_prepared_after_header_preparation() -> None:
+    req = make_request('GET', '/')
+    resp = StreamResponse()
+    await resp.prepare(req)
+
+    assert type(resp.headers['Server']) is str
+
+    async def _strip_server(req, res):
+        assert 'Server' in res.headers
+
+        if 'Server' in res.headers:
+            del res.headers['Server']
+
+    app = mock.Mock()
+    sig = signals.Signal(app)
+    sig.append(_strip_server)
+
+    req = make_request(
+        'GET', '/', on_response_prepare=sig, app=app)
+    resp = StreamResponse()
+    await resp.prepare(req)
+
+    assert 'Server' not in resp.headers
+
+
 def test_weakref_creation() -> None:
     resp = Response()
     weakref.ref(resp)


### PR DESCRIPTION
Pick up of #4263

Closes #1958

-----
[View rendered .github/ISSUE_TEMPLATE/bug_report.md](https://github.com/aio-libs/aiohttp/blob/header-prep-before-hook/.github/ISSUE_TEMPLATE/bug_report.md)
[View rendered .github/ISSUE_TEMPLATE/feature_request.md](https://github.com/aio-libs/aiohttp/blob/header-prep-before-hook/.github/ISSUE_TEMPLATE/feature_request.md)