### PR TITLE
Import `Protocol` from typing_extensions

### DIFF
--- a/CHANGES/5111.bugfix
+++ b/CHANGES/5111.bugfix
@@ -1,0 +1,2 @@
+Fixed a type error with reified properties caused by the
+conditional import of `Protocol`.

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -45,7 +45,7 @@ from urllib.request import getproxies
 import async_timeout
 import attr
 from multidict import MultiDict, MultiDictProxy
-from typing_extensions import final
+from typing_extensions import Protocol, final
 from yarl import URL
 
 from . import hdrs
@@ -66,11 +66,6 @@ try:
     from typing import ContextManager
 except ImportError:
     from typing_extensions import ContextManager
-
-if PY_38:
-    from typing import Protocol
-else:
-    from typing_extensions import Protocol  # type: ignore
 
 
 def all_tasks(


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Conditional imports must reference `sys.version_info` directly
for type checkers to be able to narrow them.  If a type checker
cannot tell whether `PY_38` is true, it will combine the imports
from both clauses in a `Union`.
However, `typing.Protocol` and `typing_extensions.Protocol` are
incompatible with each other - they do not inherit from the same class.
This produces a type error which is reported to users of aiohttp
depending on their type checking configuration.

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

No.

<!-- Outline any notable behaviour for the end users. -->

## Related issue number

—

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
