### PR TITLE
[3.7] Import `Protocol` from typing_extensions (#5111)

### DIFF
--- a/CHANGES/5111.bugfix
+++ b/CHANGES/5111.bugfix
@@ -1,0 +1,2 @@
+Fixed a type error with reified properties caused by the
+conditional import of `Protocol`.

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -45,6 +45,7 @@ from urllib.request import getproxies
 import async_timeout
 import attr
 from multidict import MultiDict, MultiDictProxy
+from typing_extensions import Protocol
 from yarl import URL
 
 from . import hdrs
@@ -66,11 +67,6 @@ try:
     from typing import ContextManager
 except ImportError:
     from typing_extensions import ContextManager
-
-if PY_38:
-    from typing import Protocol
-else:
-    from typing_extensions import Protocol  # type: ignore
 
 
 def all_tasks(


### PR DESCRIPTION
Conditional imports must reference `sys.version_info` directly
for type checkers to be able to narrow them.  If a type checker
cannot tell whether `PY_38` is true, it will combine the imports
from both clauses in a `Union`.
However, `typing.Protocol` and `typing_extensions.Protocol` are
incompatible with each other - they do not inherit from the same class.
This produces a type error which is reported to users of aiohttp
depending on their type checking configuration..
(cherry picked from commit fb8037ab89587377c402d134dcf1a3e4a89b4918)

Co-authored-by: layday <31134424+layday@users.noreply.github.com>
