### PR TITLE
Annotate all attrs members

### DIFF
--- a/CHANGES/5115.bugfix
+++ b/CHANGES/5115.bugfix
@@ -1,0 +1,1 @@
+Added annotations to all attrs members.

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -141,20 +141,20 @@ except ImportError:  # pragma: no cover
     SSLContext = object  # type: ignore
 
 
-@attr.s(frozen=True, slots=True)
+@attr.s(auto_attribs=True, frozen=True, slots=True)
 class ClientTimeout:
-    total = attr.ib(type=Optional[float], default=None)
-    connect = attr.ib(type=Optional[float], default=None)
-    sock_read = attr.ib(type=Optional[float], default=None)
-    sock_connect = attr.ib(type=Optional[float], default=None)
+    total: Optional[float] = None
+    connect: Optional[float] = None
+    sock_read: Optional[float] = None
+    sock_connect: Optional[float] = None
 
-    # pool_queue_timeout = attr.ib(type=float, default=None)
-    # dns_resolution_timeout = attr.ib(type=float, default=None)
-    # socket_connect_timeout = attr.ib(type=float, default=None)
-    # connection_acquiring_timeout = attr.ib(type=float, default=None)
-    # new_connection_timeout = attr.ib(type=float, default=None)
-    # http_header_timeout = attr.ib(type=float, default=None)
-    # response_body_timeout = attr.ib(type=float, default=None)
+    # pool_queue_timeout: Optional[float] = None
+    # dns_resolution_timeout: Optional[float] = None
+    # socket_connect_timeout: Optional[float] = None
+    # connection_acquiring_timeout: Optional[float] = None
+    # new_connection_timeout: Optional[float] = None
+    # http_header_timeout: Optional[float] = None
+    # response_body_timeout: Optional[float] = None
 
     # to create a timeout specific for a single request, either
     # - create a completely new one to overwrite the default

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -81,21 +81,19 @@ if TYPE_CHECKING:  # pragma: no cover
     from .tracing import Trace  # noqa
 
 
-@attr.s(frozen=True, slots=True)
+@attr.s(auto_attribs=True, frozen=True, slots=True)
 class ContentDisposition:
-    type = attr.ib(type=str)  # type: Optional[str]
-    parameters = attr.ib(
-        type=MappingProxyType
-    )  # type: MappingProxyType[str, str]  # noqa
-    filename = attr.ib(type=str)  # type: Optional[str]
+    type: Optional[str]
+    parameters: MappingProxyType[str, str]
+    filename: Optional[str]
 
 
-@attr.s(frozen=True, slots=True)
+@attr.s(auto_attribs=True, frozen=True, slots=True)
 class RequestInfo:
-    url = attr.ib(type=URL)
-    method = attr.ib(type=str)
-    headers = attr.ib(type=CIMultiDictProxy)  # type: CIMultiDictProxy[str]
-    real_url = attr.ib(type=URL)
+    url: URL
+    method: str
+    headers: CIMultiDictProxy[str]
+    real_url: URL = attr.ib()
 
     @real_url.default
     def real_url_default(self) -> URL:
@@ -142,19 +140,17 @@ else:  # pragma: no cover
     SSL_ALLOWED_TYPES = type(None)
 
 
-@attr.s(slots=True, frozen=True)
+@attr.s(auto_attribs=True, slots=True, frozen=True)
 class ConnectionKey:
     # the key should contain an information about used proxy / TLS
     # to prevent reusing wrong connections from a pool
-    host = attr.ib(type=str)
-    port = attr.ib(type=int)  # type: Optional[int]
-    is_ssl = attr.ib(type=bool)
-    ssl = attr.ib()  # type: Union[SSLContext, None, bool, Fingerprint]
-    proxy = attr.ib()  # type: Optional[URL]
-    proxy_auth = attr.ib()  # type: Optional[BasicAuth]
-    proxy_headers_hash = attr.ib(
-        type=int
-    )  # type: Optional[int] # noqa # hash(CIMultiDict)
+    host: str
+    port: Optional[int]
+    is_ssl: bool
+    ssl: Union[SSLContext, None, bool, Fingerprint]
+    proxy: Optional[URL]
+    proxy_auth: Optional[BasicAuth]
+    proxy_headers_hash: Optional[int]  # hash(CIMultiDict)
 
 
 class ClientRequest:

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -84,7 +84,7 @@ if TYPE_CHECKING:  # pragma: no cover
 @attr.s(auto_attribs=True, frozen=True, slots=True)
 class ContentDisposition:
     type: Optional[str]
-    parameters: MappingProxyType[str, str]
+    parameters: "MappingProxyType[str, str]"
     filename: Optional[str]
 
 

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -92,7 +92,7 @@ class ContentDisposition:
 class RequestInfo:
     url: URL
     method: str
-    headers: CIMultiDictProxy[str]
+    headers: "CIMultiDictProxy[str]"
     real_url: URL = attr.ib()
 
     @real_url.default

--- a/aiohttp/client_ws.py
+++ b/aiohttp/client_ws.py
@@ -26,10 +26,10 @@ from .typedefs import (
 )
 
 
-@attr.s(frozen=True, slots=True)
+@attr.s(auto_attribs=True, frozen=True, slots=True)
 class ClientWSTimeout:
-    ws_receive = attr.ib(type=Optional[float], default=None)
-    ws_close = attr.ib(type=Optional[float], default=None)
+    ws_receive: Optional[float] = None
+    ws_close: Optional[float] = None
 
 
 DEFAULT_WS_CLIENT_TIMEOUT = ClientWSTimeout(ws_receive=None, ws_close=10.0)

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -248,10 +248,10 @@ def netrc_from_env() -> Optional[netrc.netrc]:
     return None
 
 
-@attr.s(frozen=True, slots=True)
+@attr.s(auto_attribs=True, frozen=True, slots=True)
 class ProxyInfo:
-    proxy = attr.ib(type=URL)
-    proxy_auth = attr.ib(type=Optional[BasicAuth])
+    proxy: URL
+    proxy_auth: Optional[BasicAuth]
 
 
 def proxies_from_env() -> Dict[str, ProxyInfo]:
@@ -318,12 +318,12 @@ def isasyncgenfunction(obj: Any) -> bool:
         return False
 
 
-@attr.s(frozen=True, slots=True)
+@attr.s(auto_attribs=True, frozen=True, slots=True)
 class MimeType:
-    type = attr.ib(type=str)
-    subtype = attr.ib(type=str)
-    suffix = attr.ib(type=str)
-    parameters = attr.ib(type=MultiDictProxy)  # type: MultiDictProxy[str]
+    type: str
+    subtype: str
+    suffix: str
+    parameters: MultiDictProxy[str]
 
 
 @functools.lru_cache(maxsize=56)

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -323,7 +323,7 @@ class MimeType:
     type: str
     subtype: str
     suffix: str
-    parameters: MultiDictProxy[str]
+    parameters: "MultiDictProxy[str]"
 
 
 @functools.lru_cache(maxsize=56)

--- a/aiohttp/tracing.py
+++ b/aiohttp/tracing.py
@@ -206,114 +206,114 @@ class TraceConfig:
         return self._on_dns_cache_miss
 
 
-@attr.s(frozen=True, slots=True)
+@attr.s(auto_attribs=True, frozen=True, slots=True)
 class TraceRequestStartParams:
     """ Parameters sent by the `on_request_start` signal"""
 
-    method = attr.ib(type=str)
-    url = attr.ib(type=URL)
-    headers = attr.ib(type="CIMultiDict[str]")
+    method: str
+    url: URL
+    headers: "CIMultiDict[str]"
 
 
-@attr.s(frozen=True, slots=True)
+@attr.s(auto_attribs=True, frozen=True, slots=True)
 class TraceRequestChunkSentParams:
     """ Parameters sent by the `on_request_chunk_sent` signal"""
 
-    method = attr.ib(type=str)
-    url = attr.ib(type=URL)
-    chunk = attr.ib(type=bytes)
+    method: str
+    url: URL
+    chunk: bytes
 
 
-@attr.s(frozen=True, slots=True)
+@attr.s(auto_attribs=True, frozen=True, slots=True)
 class TraceResponseChunkReceivedParams:
     """ Parameters sent by the `on_response_chunk_received` signal"""
 
-    method = attr.ib(type=str)
-    url = attr.ib(type=URL)
-    chunk = attr.ib(type=bytes)
+    method: str
+    url: URL
+    chunk: bytes
 
 
-@attr.s(frozen=True, slots=True)
+@attr.s(auto_attribs=True, frozen=True, slots=True)
 class TraceRequestEndParams:
     """ Parameters sent by the `on_request_end` signal"""
 
-    method = attr.ib(type=str)
-    url = attr.ib(type=URL)
-    headers = attr.ib(type="CIMultiDict[str]")
-    response = attr.ib(type=ClientResponse)
+    method: str
+    url: URL
+    headers: "CIMultiDict[str]"
+    response: ClientResponse
 
 
-@attr.s(frozen=True, slots=True)
+@attr.s(auto_attribs=True, frozen=True, slots=True)
 class TraceRequestExceptionParams:
     """ Parameters sent by the `on_request_exception` signal"""
 
-    method = attr.ib(type=str)
-    url = attr.ib(type=URL)
-    headers = attr.ib(type="CIMultiDict[str]")
-    exception = attr.ib(type=BaseException)
+    method: str
+    url: URL
+    headers: "CIMultiDict[str]"
+    exception: BaseException
 
 
-@attr.s(frozen=True, slots=True)
+@attr.s(auto_attribs=True, frozen=True, slots=True)
 class TraceRequestRedirectParams:
     """ Parameters sent by the `on_request_redirect` signal"""
 
-    method = attr.ib(type=str)
-    url = attr.ib(type=URL)
-    headers = attr.ib(type="CIMultiDict[str]")
-    response = attr.ib(type=ClientResponse)
+    method: str
+    url: URL
+    headers: "CIMultiDict[str]"
+    response: ClientResponse
 
 
-@attr.s(frozen=True, slots=True)
+@attr.s(auto_attribs=True, frozen=True, slots=True)
 class TraceConnectionQueuedStartParams:
     """ Parameters sent by the `on_connection_queued_start` signal"""
 
 
-@attr.s(frozen=True, slots=True)
+@attr.s(auto_attribs=True, frozen=True, slots=True)
 class TraceConnectionQueuedEndParams:
     """ Parameters sent by the `on_connection_queued_end` signal"""
 
 
-@attr.s(frozen=True, slots=True)
+@attr.s(auto_attribs=True, frozen=True, slots=True)
 class TraceConnectionCreateStartParams:
     """ Parameters sent by the `on_connection_create_start` signal"""
 
 
-@attr.s(frozen=True, slots=True)
+@attr.s(auto_attribs=True, frozen=True, slots=True)
 class TraceConnectionCreateEndParams:
     """ Parameters sent by the `on_connection_create_end` signal"""
 
 
-@attr.s(frozen=True, slots=True)
+@attr.s(auto_attribs=True, frozen=True, slots=True)
 class TraceConnectionReuseconnParams:
     """ Parameters sent by the `on_connection_reuseconn` signal"""
 
 
-@attr.s(frozen=True, slots=True)
+@attr.s(auto_attribs=True, frozen=True, slots=True)
 class TraceDnsResolveHostStartParams:
     """ Parameters sent by the `on_dns_resolvehost_start` signal"""
 
-    host = attr.ib(type=str)
+    host: str
 
 
-@attr.s(frozen=True, slots=True)
+@attr.s(auto_attribs=True, frozen=True, slots=True)
 class TraceDnsResolveHostEndParams:
     """ Parameters sent by the `on_dns_resolvehost_end` signal"""
 
-    host = attr.ib(type=str)
+    host: str
 
 
-@attr.s(frozen=True, slots=True)
+@attr.s(auto_attribs=True, frozen=True, slots=True)
 class TraceDnsCacheHitParams:
     """ Parameters sent by the `on_dns_cache_hit` signal"""
 
-    host = attr.ib(type=str)
+    host: str
 
 
-@attr.s(frozen=True, slots=True)
+@attr.s(auto_attribs=True, frozen=True, slots=True)
 class TraceDnsCacheMissParams:
     """ Parameters sent by the `on_dns_cache_miss` signal"""
 
-    host = attr.ib(type=str)
+    host: str
 
 
 class Trace:

--- a/aiohttp/web_request.py
+++ b/aiohttp/web_request.py
@@ -71,7 +71,7 @@ class FileField:
     filename: str
     file: io.BufferedReader
     content_type: str
-    headers: CIMultiDictProxy[str]
+    headers: "CIMultiDictProxy[str]"
 
 
 _TCHAR = string.digits + string.ascii_letters + r"!#$%&'*+.^_`|~-"

--- a/aiohttp/web_request.py
+++ b/aiohttp/web_request.py
@@ -65,13 +65,13 @@ if TYPE_CHECKING:  # pragma: no cover
     from .web_urldispatcher import UrlMappingMatchInfo  # noqa
 
 
-@attr.s(frozen=True, slots=True)
+@attr.s(auto_attribs=True, frozen=True, slots=True)
 class FileField:
-    name = attr.ib(type=str)
-    filename = attr.ib(type=str)
-    file = attr.ib(type=io.BufferedReader)
-    content_type = attr.ib(type=str)
-    headers = attr.ib(type=CIMultiDictProxy)  # type: CIMultiDictProxy[str]
+    name: str
+    filename: str
+    file: io.BufferedReader
+    content_type: str
+    headers: CIMultiDictProxy[str]
 
 
 _TCHAR = string.digits + string.ascii_letters + r"!#$%&'*+.^_`|~-"

--- a/aiohttp/web_routedef.py
+++ b/aiohttp/web_routedef.py
@@ -57,12 +57,12 @@ _SimpleHandler = Callable[[Request], Awaitable[StreamResponse]]
 _HandlerType = Union[Type[AbstractView], _SimpleHandler]
 
 
-@attr.s(frozen=True, repr=False, slots=True)
+@attr.s(auto_attribs=True, frozen=True, repr=False, slots=True)
 class RouteDef(AbstractRouteDef):
-    method = attr.ib(type=str)
-    path = attr.ib(type=str)
-    handler = attr.ib()  # type: _HandlerType
-    kwargs = attr.ib(type=Dict[str, Any])
+    method: str
+    path: str
+    handler: _HandlerType
+    kwargs: Dict[str, Any]
 
     def __repr__(self) -> str:
         info = []
@@ -82,11 +82,11 @@ class RouteDef(AbstractRouteDef):
             ]
 
 
-@attr.s(frozen=True, repr=False, slots=True)
+@attr.s(auto_attribs=True, frozen=True, repr=False, slots=True)
 class StaticDef(AbstractRouteDef):
-    prefix = attr.ib(type=str)
-    path = attr.ib()  # type: PathLike
-    kwargs = attr.ib(type=Dict[str, Any])
+    prefix: str
+    path: PathLike
+    kwargs: Dict[str, Any]
 
     def __repr__(self) -> str:
         info = []

--- a/aiohttp/web_ws.py
+++ b/aiohttp/web_ws.py
@@ -40,10 +40,10 @@ __all__ = (
 THRESHOLD_CONNLOST_ACCESS = 5
 
 
-@attr.s(frozen=True, slots=True)
+@attr.s(auto_attribs=True, frozen=True, slots=True)
 class WebSocketReady:
-    ok = attr.ib(type=bool)
-    protocol = attr.ib(type=Optional[str])
+    ok: bool
+    protocol: Optional[str]
 
     def __bool__(self) -> bool:
         return self.ok


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

In py.typed packages, public attributes must be explicitly typed.
This is not an issue for mypy because the attrs mypy plug-in is able
to infer the types of attrs dynamically.  However, in other
static type checkers, like Pyright and pytype, the type of
unannotated attrs is not known statically.

Since aiohttp no longer supports Python versions older than 3.6
I've taken the liberty of converting the annotations to the native
format.

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

No.

<!-- Outline any notable behaviour for the end users. -->

## Related issue number

—

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
