### PR TITLE
Fix flaky test_when_timeout_smaller_second

### DIFF
--- a/CHANGES/5116.bugfix
+++ b/CHANGES/5116.bugfix
@@ -1,0 +1,1 @@
+Fix flaky test_when_timeout_smaller_second

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -3,7 +3,7 @@ import base64
 import gc
 import os
 import platform
-from math import modf
+from math import isclose, modf
 from unittest import mock
 
 import pytest
@@ -346,7 +346,7 @@ def test_when_timeout_smaller_second(loop) -> None:
     handle.close()
 
     assert isinstance(when, float)
-    assert f"{when:.3f}" == f"{timer:.3f}"
+    assert isclose(when, timer)
 
 
 def test_timeout_handle_cb_exc(loop) -> None:

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -346,7 +346,7 @@ def test_when_timeout_smaller_second(loop) -> None:
     handle.close()
 
     assert isinstance(when, float)
-    assert isclose(when, timer)
+    assert isclose(when - timer, 0, abs_tol=0.001)
 
 
 def test_timeout_handle_cb_exc(loop) -> None:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Fix for flaky test_when_timeout_smaller_second

## Are there changes in behavior for the user?

No

## Related issue number

#5116 

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
