### PR TITLE
Return hostnames from ThreadedResolver

### DIFF
--- a/CHANGES/5110.bugfix
+++ b/CHANGES/5110.bugfix
@@ -1,0 +1,3 @@
+Fix a variable-shadowing bug causing `ThreadedResolver.resolve` to
+return the resolved IP as the "hostname" in each record, which prevented
+validation of HTTPS connections.

--- a/aiohttp/resolver.py
+++ b/aiohttp/resolver.py
@@ -25,10 +25,10 @@ class ThreadedResolver(AbstractResolver):
         self._loop = get_running_loop()
 
     async def resolve(
-        self, host: str, port: int = 0, family: int = socket.AF_INET
+        self, hostname: str, port: int = 0, family: int = socket.AF_INET
     ) -> List[Dict[str, Any]]:
         infos = await self._loop.getaddrinfo(
-            host, port, type=socket.SOCK_STREAM, family=family
+            hostname, port, type=socket.SOCK_STREAM, family=family
         )
 
         hosts = []
@@ -45,7 +45,7 @@ class ThreadedResolver(AbstractResolver):
                 host, port = address[:2]
             hosts.append(
                 {
-                    "hostname": host,
+                    "hostname": hostname,
                     "host": host,
                     "port": port,
                     "family": family,

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -663,10 +663,10 @@ async def test_tcp_connector_resolve_host(loop) -> None:
     for rec in res:
         if rec["family"] == socket.AF_INET:
             assert rec["host"] == "127.0.0.1"
-            assert rec["hostname"] == "127.0.0.1"
+            assert rec["hostname"] == "localhost"
             assert rec["port"] == 8080
         elif rec["family"] == socket.AF_INET6:
-            assert rec["hostname"] == "::1"
+            assert rec["hostname"] == "localhost"
             assert rec["port"] == 8080
             if platform.system() == "Darwin":
                 assert rec["host"] in ("::1", "fe80::1", "fe80::1%lo0")

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -89,6 +89,7 @@ async def test_threaded_resolver_positive_lookup() -> None:
     resolver = ThreadedResolver()
     resolver._loop = loop
     real = await resolver.resolve("www.python.org")
+    assert real[0]["hostname"] == "www.python.org"
     ipaddress.ip_address(real[0]["host"])
 
 


### PR DESCRIPTION
## What do these changes do?

Fix a variable-shadowing bug causing `ThreadedResolver.resolve` to
return the resolved IP as the "hostname" in each record, which prevented
validation of HTTPS connections.  Fixes #5110.

## Are there changes in behavior for the user?

Failed HTTPS connections will work again.

## Related issue number

Fixes #5110.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes (N/A: bugfix)
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt` (N/A: no new content)
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
