### PR TITLE
Ensure zero byte files can be sent

### DIFF
--- a/CHANGES/5124.bugfix
+++ b/CHANGES/5124.bugfix
@@ -1,0 +1,1 @@
+Ensure sending a zero byte file does not throw an exception

--- a/aiohttp/web_fileresponse.py
+++ b/aiohttp/web_fileresponse.py
@@ -98,7 +98,13 @@ class SendfileStreamWriter(StreamWriter):
         if hasattr(loop, "sendfile"):
             # Python 3.7+
             self.transport.write(data)
-            await loop.sendfile(self.transport, self._fobj, self._offset, self._count)
+            if self._count != 0:
+                await loop.sendfile(
+                    self.transport,
+                    self._fobj,
+                    self._offset,
+                    self._count
+                )
             await super().write_eof()
             return
 

--- a/tests/test_web_sendfile_functional.py
+++ b/tests/test_web_sendfile_functional.py
@@ -44,6 +44,25 @@ async def test_static_file_ok(aiohttp_client, sender) -> None:
     await resp.release()
 
 
+async def test_zero_bytes_file_ok(aiohttp_client, sender) -> None:
+    filepath = pathlib.Path(__file__).parent / "data.zero_bytes"
+
+    async def handler(request):
+        return sender(filepath)
+
+    app = web.Application()
+    app.router.add_get("/", handler)
+    client = await aiohttp_client(app)
+
+    resp = await client.get("/")
+    assert resp.status == 200
+    txt = await resp.text()
+    assert "" == txt.rstrip()
+    assert "application/octet-stream" == resp.headers["Content-Type"]
+    assert resp.headers.get("Content-Encoding") is None
+    await resp.release()
+
+
 async def test_static_file_ok_string_path(aiohttp_client, sender) -> None:
     filepath = pathlib.Path(__file__).parent / "data.unknown_mime_type"
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Restores previous behavior of not throwing an exception when sending a zero byte file.

## Are there changes in behavior for the user?

Regression fix

## Related issue number

Fixes #5124

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
