### PR TITLE
Setup pre-commit hooks configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,8 @@ jobs:
       uses: py-actions/py-dependency-install@v2
       with:
         path: requirements/lint.txt
+    - name: Pre-Commit hooks
+      uses: pre-commit/action@v2.0.0
     - name: Install itself
       run: |
         python setup.py install
@@ -47,8 +49,6 @@ jobs:
         AIOHTTP_NO_EXTENSIONS: 1
     - name: Run linters
       run: |
-        make flake8
-        make isort-check
         make mypy
     - name: Install spell checker
       run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,29 @@
+repos:
+- repo: https://github.com/asottile/pyupgrade
+  rev: 'v2.7.3'
+  hooks:
+  - id: pyupgrade
+    args: ['--py36-plus']
+- repo: https://github.com/psf/black
+  rev: '20.8b1'
+  hooks:
+    - id: black
+      language_version: python3 # Should be a command that runs python3.6+
+- repo: https://github.com/pre-commit/mirrors-isort
+  rev: 'v5.6.4'
+  hooks:
+  - id: isort
+- repo: https://gitlab.com/pycqa/flake8
+  rev: '3.8.4'
+  hooks:
+  - id: flake8
+    exclude: "^docs/"
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: 'v3.3.0'
+  hooks:
+  - id: check-case-conflict
+  - id: check-json
+  - id: check-xml
+  - id: check-yaml
+  - id: debug-statements
+  - id: check-added-large-files

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -92,6 +92,12 @@ After that please install libraries required for development:
 
   For now, the development tooling depends on ``make`` and assumes an Unix OS If you wish to contribute to aiohttp from a Windows machine, the easiest way is probably to `configure the WSL <https://docs.microsoft.com/en-us/windows/wsl/install-win10>`_ so you can use the same instructions. If it's not possible for you or if it doesn't work, please contact us so we can find a solution together.
 
+Install pre-commit hooks:
+
+.. code-block:: shell
+
+   $ pre-commit install
+
 .. warning::
 
   If you plan to use temporary ``print()``, ``pdb`` or ``ipdb`` within the test suite, execute it with ``-s``:

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -1,5 +1,6 @@
 mypy==0.790; implementation_name=="cpython"
 flake8==3.8.4
-flake8-pyi==20.10.0; python_version >= "3.6"
+flake8-pyi==20.10.0
 black==20.8b1; python_version >= "3.6"
 isort==5.6.4
+pre-commit==2.7.1


### PR DESCRIPTION
I've started by applying https://github.com/asottile/pyupgrade tool but found that we can get benefits from other hooks as well.

I don't clean up the linter step on CI. For now, let's apply the PR and drop duplicated checks later.
Also, I did not apply pyupgrade converter results to the PR because I want to backport configuration to 3.7/3.8 branches first and apply fixers in separate commits.