### PR TITLE
[3.8] StreamResponse use Transfer-Encoding: chunked for 204 responses (#5135)

### DIFF
--- a/CHANGES/5106.bugfix
+++ b/CHANGES/5106.bugfix
@@ -1,0 +1,1 @@
+Remove Transfer-Encoding and Content-Type headers for 204 in StreamResponse

--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -420,7 +420,7 @@ class StreamResponse(BaseClass, HeadersMixin):
         elif self._length_check:
             writer.length = self.content_length
             if writer.length is None:
-                if version >= HttpVersion11:
+                if version >= HttpVersion11 and self.status != 204:
                     writer.enable_chunking()
                     headers[hdrs.TRANSFER_ENCODING] = "chunked"
                     if hdrs.CONTENT_LENGTH in headers:
@@ -432,7 +432,8 @@ class StreamResponse(BaseClass, HeadersMixin):
             elif version >= HttpVersion11 and self.status in (100, 101, 102, 103, 204):
                 del headers[hdrs.CONTENT_LENGTH]
 
-        headers.setdefault(hdrs.CONTENT_TYPE, "application/octet-stream")
+        if self.status != 204:
+            headers.setdefault(hdrs.CONTENT_TYPE, "application/octet-stream")
         headers.setdefault(hdrs.DATE, rfc822_formatted_time())
         headers.setdefault(hdrs.SERVER, SERVER_SOFTWARE)
 

--- a/tests/test_web_functional.py
+++ b/tests/test_web_functional.py
@@ -13,7 +13,7 @@ from yarl import URL
 
 import aiohttp
 from aiohttp import FormData, HttpVersion10, HttpVersion11, TraceConfig, multipart, web
-from aiohttp.hdrs import CONTENT_LENGTH, TRANSFER_ENCODING
+from aiohttp.hdrs import CONTENT_LENGTH, CONTENT_TYPE, TRANSFER_ENCODING
 from aiohttp.test_utils import make_mocked_coro
 
 try:
@@ -1966,4 +1966,16 @@ async def test_response_101_204_no_content_length_http11(
     client = await aiohttp_client(app, version="1.1")
     resp = await client.get("/")
     assert CONTENT_LENGTH not in resp.headers
+    assert TRANSFER_ENCODING not in resp.headers
+
+
+async def test_stream_response_headers_204(aiohttp_client):
+    async def handler(_):
+        return web.StreamResponse(status=204)
+
+    app = web.Application()
+    app.router.add_get("/", handler)
+    client = await aiohttp_client(app)
+    resp = await client.get("/")
+    assert CONTENT_TYPE not in resp.headers
     assert TRANSFER_ENCODING not in resp.headers


### PR DESCRIPTION
Co-authored-by: Andrew Svetlov <andrew.svetlov@gmail.com>
(cherry picked from commit 12a7e85)

Co-authored-by: Dmitry Erlikh <derlih@gmail.com>
