### PR TITLE
Change  __aiter__ return type to AsyncIterator

### DIFF
--- a/CHANGES/5163.bugfix
+++ b/CHANGES/5163.bugfix
@@ -1,0 +1,1 @@
+Change return type of MultipartReader.__aiter__() and BodyPartReader.__aiter__() to AsyncIterator.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -174,6 +174,7 @@ Kimmo Parviainen-Jalanko
 Kirill Klenov
 Kirill Malovitsa
 Konstantin Valetov
+Krzysztof Blazewicz
 Kyrylo Perevozchikov
 Kyungmin Lee
 Lars P. Søndergaard

--- a/aiohttp/multipart.py
+++ b/aiohttp/multipart.py
@@ -10,6 +10,7 @@ from types import TracebackType
 from typing import (
     TYPE_CHECKING,
     Any,
+    AsyncIterator,
     Dict,
     Iterator,
     List,
@@ -271,7 +272,7 @@ class BodyPartReader:
         self._content_eof = 0
         self._cache = {}  # type: Dict[str, Any]
 
-    def __aiter__(self) -> Iterator["BodyPartReader"]:
+    def __aiter__(self) -> AsyncIterator["BodyPartReader"]:
         return self  # type: ignore
 
     async def __anext__(self) -> bytes:
@@ -583,7 +584,7 @@ class MultipartReader:
 
     def __aiter__(
         self,
-    ) -> Iterator["BodyPartReader"]:
+    ) -> AsyncIterator["BodyPartReader"]:
         return self  # type: ignore
 
     async def __anext__(


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Change return type of `MultipartReader.__aiter__()` and `BodyPartReader.__aiter__()` to `AsyncIterator`.

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

No more mypy errors should for code using multipart.

<!-- Outline any notable behaviour for the end users. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

It fixes #5163

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
