### PR TITLE
Use md5 checksums instead of file timestamps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,4 @@ virtualenv.py
 pip-wheel-metadata
 .test-results
 coverage.xml
+*.md5

--- a/Makefile
+++ b/Makefile
@@ -100,8 +100,8 @@ clean:
 	@rm -rf .tox
 	@rm -f .develop
 	@rm -f .flake
-	@rm -f .install-deps
 	@rm -rf aiohttp.egg-info
+	@rm -f .install-deps
 	@rm -f .install-cython
 
 .PHONY: doc

--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,8 @@ all: test
 
 FORCE:
 
-# Enumerate intermediate files to don't remove them automatically
-# the target must exist, no need to execute it
+# Enumerate intermediate files to don't remove them automatically.
+# The target must exist, no need to execute it.
 .PHONY: keep-intermediate-files
 _keep-intermediate-files: $(addsuffix .md5,$(CYS))\
                          $(addsuffix .md5,$(CS))\

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ FORCE:
 # Enumerate intermediate files to don't remove them automatically
 # the target must exist, no need to execute it
 .PHONY: keep-intermediate-files
-keep-intermediate-files: $(addsuffix .md5,$(CYS))\
+_keep-intermediate-files: $(addsuffix .md5,$(CYS))\
                          $(addsuffix .md5,$(CS))\
                          $(addsuffix .md5,$(PYS))\
                          $(addsuffix .md5,$(REQS))


### PR DESCRIPTION
It allows more reliable rebuilding C extensions on jumping between aiohttp versions