### PR TITLE
Better checksum calculation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,27 +115,16 @@ jobs:
         path: ${{ steps.pip-cache.outputs.dir }}
         restore-keys: |
             pip-ci-${{ runner.os }}-${{ matrix.pyver }}-{{ matrix.no-extensions }}-
-    - name: Install cython
-      if: ${{ matrix.no-extensions == '' }}
-      uses: py-actions/py-dependency-install@v2
-      with:
-        path: requirements/cython.txt
     - name: Cythonize
       if: ${{ matrix.no-extensions == '' }}
       run: |
         make cythonize
-    - name: Install dependencies
-      uses: py-actions/py-dependency-install@v2
-      with:
-        path: requirements/test.txt
-      env:
-        AIOHTTP_NO_EXTENSIONS: ${{ matrix.no-extensions }}
     - name: Run unittests
       env:
         COLOR: 'yes'
         AIOHTTP_NO_EXTENSIONS: ${{ matrix.no-extensions }}
       run: |
-        python -m pytest tests -vv
+        make vvtest
         python -m coverage xml
     - name: Upload coverage
       uses: codecov/codecov-action@v1
@@ -168,10 +157,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: 3.8
-    - name: Install cython
-      uses: py-actions/py-dependency-install@v2
-      with:
-        path: requirements/cython.txt
     - name: Cythonize
       run: |
         make cythonize
@@ -210,11 +195,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: 3.8
-    - name: Install cython
-      if: ${{ matrix.no-extensions == '' }}
-      uses: py-actions/py-dependency-install@v2
-      with:
-        path: requirements/cython.txt
     - name: Cythonize
       if: ${{ matrix.no-extensions == '' }}
       run: |
@@ -255,11 +235,6 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.pyver }}
-    - name: Install cython
-      if: ${{ matrix.no-extensions == '' }}
-      uses: py-actions/py-dependency-install@v2
-      with:
-        path: requirements/cython.txt
     - name: Cythonize
       if: ${{ matrix.no-extensions == '' }}
       run: |

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@
 .envrc
 .flake
 .gitconfig
+.hash
 .idea
 .install-cython
 .install-deps

--- a/Makefile
+++ b/Makefile
@@ -26,10 +26,9 @@ FORCE:
 	$(eval $@_ABS := $(abspath $@))
 	$(eval $@_NAME := $($@_ABS))
 	$(eval $@_HASHDIR := $(dir $($@_ABS)))
-	$(eval $@_PDIR := $($@_HASHDIR)../)
-	$(eval $@_TMP := $($@_PDIR)$(notdir $($@_ABS)))
-	$(eval $@_ORIG := $(basename $($@_TMP)))
-	@#echo ==== $($@_ABS) $($@_HASHDIR) $($@_NAME) $($@_PDIR) $($@_TMP) $($@_ORIG)
+	$(eval $@_TMP := $($@_HASHDIR)../$(notdir $($@_ABS)))
+	$(eval $@_ORIG := $(subst /.hash/../,/,$(basename $($@_TMP))))
+	@#echo ==== $($@_ABS) $($@_HASHDIR) $($@_NAME) $($@_TMP) $($@_ORIG)
 	@if ! (sha256sum --check $($@_ABS) 1>/dev/null 2>/dev/null); then \
 	  mkdir -p $($@_HASHDIR); \
 	  echo re-hash $($@_ORIG); \

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ FORCE:
 	@# (perhaps even several times for each file).
 	@# That is why much less readable but faster solution exists
 	@./tools/check_sum.py $@ # --debug
+	endif
 
 # Enumerate intermediate files to don't remove them automatically.
 # The target must exist, no need to execute it.

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,6 @@ CS := $(wildcard aiohttp/*.c)
 PYS := $(wildcard aiohttp/*.py)
 REQS := $(wildcard requirements/*.txt)
 ALLS := $(sort $(CYS) $(CS) $(PYS) $(REQS))
-SRC := aiohttp examples tests setup.py
 
 .PHONY: all
 all: test

--- a/Makefile
+++ b/Makefile
@@ -89,6 +89,10 @@ test: .develop
 vtest: .develop
 	@pytest -s -v
 
+.PHONY: vvtest
+vtest: .develop
+	@pytest -vv
+
 .PHONY: clean
 clean:
 	@rm -rf `find . -name __pycache__`

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ tst:
 FORCE:
 
 %.hash: FORCE
+	ifeq (, $(shell which sha256sum))
 	$(eval $@_ABS := $(abspath $@))
 	$(eval $@_NAME := $($@_ABS))
 	$(eval $@_HASHDIR := $(dir $($@_ABS)))
@@ -34,11 +35,11 @@ FORCE:
 	  echo re-hash $($@_ORIG); \
 	  sha256sum $($@_ORIG) > $($@_ABS); \
 	fi
-
-# check_sum.py works perfectly fine but slow when called for every file from $(ALLS)
-# (perhaps even several times for each file).
-# That's why much less readable but faster solution exists
-#	@./tools/check_sum.py $@ # --debug
+	else
+	@# check_sum.py works perfectly fine but slow when called for every file from $(ALLS)
+	@# (perhaps even several times for each file).
+	@# That is why much less readable but faster solution exists
+	@./tools/check_sum.py $@ # --debug
 
 # Enumerate intermediate files to don't remove them automatically.
 # The target must exist, no need to execute it.

--- a/Makefile
+++ b/Makefile
@@ -44,23 +44,8 @@ else
 endif
 
 # Enumerate intermediate files to don't remove them automatically.
-# The target must exist, no need to execute it.
 .SECONDARY: $(call to-hash,$(ALLS))
 
-
-# Exists for debug purposes
-.PHONY: KEEP-INTERMEDIATE-FILES
-KEEP-INTERMEDIATE-FILES: $(call to-hash,$(ALLS))
-	@echo ====================
-	@echo CYS $(CYS)
-	@echo CS $(CS)
-	@echo PYS $(PYS)
-	@echo REQS $(REQS)
-	@echo ALLS $(ALLS)
-	@echo --------------------
-	@echo TO-HASH $(call to-hash,$(ALLS))
-	@echo ++++++++++++++++++++
-	@echo $^
 
 .install-cython: $(call to-hash,requirements/cython.txt)
 	pip install -r requirements/cython.txt

--- a/Makefile
+++ b/Makefile
@@ -21,10 +21,7 @@ FORCE:
 # Enumerate intermediate files to don't remove them automatically.
 # The target must exist, no need to execute it.
 .PHONY: _keep-intermediate-files
-_keep-intermediate-files: $(addsuffix .md5,$(CYS))\
-                         $(addsuffix .md5,$(CS))\
-                         $(addsuffix .md5,$(PYS))\
-                         $(addsuffix .md5,$(REQS))
+_keep-intermediate-files: $(call to-md5,$(CYS) $(CS) $(PYS) $(REQS))
 
 .install-cython: $(call to-md5,requirements/cython.txt)
 	pip install -r requirements/cython.txt
@@ -78,6 +75,7 @@ clean:
 	@rm -f `find . -type f -name '#*#' `
 	@rm -f `find . -type f -name '*.orig' `
 	@rm -f `find . -type f -name '*.rej' `
+	@rm -f `find . -type f -name '*.md5' `
 	@rm -f .coverage
 	@rm -rf htmlcov
 	@rm -rf build

--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ vtest: .develop
 	@pytest -s -v
 
 .PHONY: vvtest
-vtest: .develop
+vvtest: .develop
 	@pytest -vv
 
 .PHONY: clean

--- a/requirements/cython.txt
+++ b/requirements/cython.txt
@@ -1,9 +1,2 @@
 -r multidict.txt
-
-
-
-
-
-
-
 cython==0.29.21

--- a/requirements/cython.txt
+++ b/requirements/cython.txt
@@ -1,2 +1,9 @@
 -r multidict.txt
+
+
+
+
+
+
+
 cython==0.29.21

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -1,4 +1,4 @@
-black==20.8b1; python_version >= "3.6"
+black==20.8b1; implementation_name=="cpython"
 flake8==3.8.4
 flake8-pyi==20.10.0
 isort==5.6.4

--- a/tools/check_sum.py
+++ b/tools/check_sum.py
@@ -19,7 +19,7 @@ def main(argv):
     dirname = dst.parent
     if dirname.name != ".hash":
         if args.debug:
-            print(f"Invalid name {dst} -> dirname {dirname}")
+            print(f"Invalid name {dst} -> dirname {dirname}", file=sys.stderr)
         return 0
     dirname.mkdir(exist_ok=True)
     src_dir = dirname.parent
@@ -30,7 +30,7 @@ def main(argv):
         hasher.update(full_src.read_bytes())
     except OSError:
         if args.debug:
-            print(f"Cannot open {full_src}")
+            print(f"Cannot open {full_src}", file=sys.stderr)
         return 0
     src_hash = hasher.hexdigest()
     if dst.exists():
@@ -39,8 +39,7 @@ def main(argv):
         dst_hash = ""
     if src_hash != dst_hash:
         dst.write_text(src_hash)
-        if args.debug:
-            print(f"Update {src_hash} checksum")
+        print(f"re-hash {src_hash}")
     else:
         if args.debug:
             print(f"Skip {src_hash} checksum, up-to-date")

--- a/tools/check_sum.py
+++ b/tools/check_sum.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python
+
+import argparse
+import hashlib
+import pathlib
+import sys
+
+PARSER = argparse.ArgumentParser(
+    description="Helper for check file hashes in Makefile instead of bare timestamps"
+)
+PARSER.add_argument("dst", metavar="DST", type=pathlib.Path)
+PARSER.add_argument("-d", "--debug", action="store_true", default=False)
+
+
+def main(argv):
+    args = PARSER.parse_args(argv)
+    dst = args.dst
+    assert dst.suffix == ".hash"
+    dirname = dst.parent
+    if dirname.name != ".hash":
+        if args.debug:
+            print(f"Invalid name {dst} -> dirname {dirname}")
+        return 0
+    dirname.mkdir(exist_ok=True)
+    src_dir = dirname.parent
+    src_name = dst.stem  # drop .hash
+    full_src = src_dir / src_name
+    hasher = hashlib.sha256()
+    try:
+        hasher.update(full_src.read_bytes())
+    except OSError:
+        if args.debug:
+            print(f"Cannot open {full_src}")
+        return 0
+    src_hash = hasher.hexdigest()
+    if dst.exists():
+        dst_hash = dst.read_text()
+    else:
+        dst_hash = ""
+    if src_hash != dst_hash:
+        dst.write_text(src_hash)
+        if args.debug:
+            print(f"Update {src_hash} checksum")
+    else:
+        if args.debug:
+            print(f"Skip {src_hash} checksum, up-to-date")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
1. Use sha256 instead of md5
2. Put hashes into `.hash` directory to avoid working directory pollution.