### PR TITLE
No update-precommit on forks

### DIFF
--- a/.github/workflows/update-pre-commit.yml
+++ b/.github/workflows/update-pre-commit.yml
@@ -4,6 +4,7 @@ on:
   - cron: '0 0 * * *'
 jobs:
   auto-update:
+    if: github.repository_owner == 'aiohttp'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/CHANGES/5258.bugfix
+++ b/CHANGES/5258.bugfix
@@ -1,0 +1,3 @@
+Fixed github workflow `update-pre-commit` on forks,
+since this workflow should run only in the main repository and also because it was giving failed jobs on all the forks.
+Now it will show up as skipped workflow.


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Update-precommit workflow will no longer run on forks

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->
No

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
#5258

## Checklist

- [x] Add a new news fragment into the `CHANGES` folder