### PR TITLE
Ensure cleanup contexts are completed when an exception occurs on startup

### DIFF
--- a/CHANGES/4799.bugfix
+++ b/CHANGES/4799.bugfix
@@ -1,0 +1,1 @@
+Ensure a cleanup context is cleaned up even when an exception occurs during startup.

--- a/aiohttp/web_app.py
+++ b/aiohttp/web_app.py
@@ -318,7 +318,11 @@ class Application(MutableMapping[str, Any]):
 
         Should be called after shutdown()
         """
-        await self.on_cleanup.send(self)
+        if self.on_cleanup.frozen:
+            await self.on_cleanup.send(self)
+        else:
+            # If an exception occurred in startup, ensure cleanup contexts are completed.
+            await self._cleanup_ctx._on_cleanup(self)
 
     def _prepare_middleware(self) -> Iterator[_Middleware]:
         yield from reversed(self._middlewares)

--- a/aiohttp/web_app.py
+++ b/aiohttp/web_app.py
@@ -321,7 +321,7 @@ class Application(MutableMapping[str, Any]):
         if self.on_cleanup.frozen:
             await self.on_cleanup.send(self)
         else:
-            # If an exception occurred in startup, ensure cleanup contexts are completed.
+            # If an exception occurrs in startup, ensure cleanup contexts are completed.
             await self._cleanup_ctx._on_cleanup(self)
 
     def _prepare_middleware(self) -> Iterator[_Middleware]:

--- a/aiohttp/web_app.py
+++ b/aiohttp/web_app.py
@@ -321,7 +321,7 @@ class Application(MutableMapping[str, Any]):
         if self.on_cleanup.frozen:
             await self.on_cleanup.send(self)
         else:
-            # If an exception occurrs in startup, ensure cleanup contexts are completed.
+            # If an exception occurs in startup, ensure cleanup contexts are completed.
             await self._cleanup_ctx._on_cleanup(self)
 
     def _prepare_middleware(self) -> Iterator[_Middleware]:

--- a/aiohttp/web_runner.py
+++ b/aiohttp/web_runner.py
@@ -288,10 +288,6 @@ class BaseRunner(ABC):
     async def cleanup(self) -> None:
         loop = asyncio.get_event_loop()
 
-        if self._server is None:
-            # no started yet, do nothing
-            return
-
         # The loop over sites is intentional, an exception on gather()
         # leaves self._sites in unpredictable state.
         # The loop guarantees that a site is either deleted on success or

--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -250,6 +250,32 @@ async def test_cleanup_ctx_exception_on_cleanup() -> None:
     assert out == ["pre_1", "pre_2", "pre_3", "post_3", "post_2", "post_1"]
 
 
+async def test_cleanup_ctx_cleanup_after_exception() -> None:
+    app = web.Application()
+    ctx_state = None
+
+    async def success_ctx(app):
+        nonlocal ctx_state
+        ctx_state = "START"
+        yield
+        ctx_state = "CLEAN"
+
+    async def fail_ctx(app):
+        raise Exception()
+        yield
+
+    app.cleanup_ctx.append(success_ctx)
+    app.cleanup_ctx.append(fail_ctx)
+    runner = web.AppRunner(app)
+    try:
+        with pytest.raises(Exception):
+            await runner.setup()
+    finally:
+        await runner.cleanup()
+
+    assert ctx_state == "CLEAN"
+
+
 async def test_cleanup_ctx_exception_on_cleanup_multiple() -> None:
     app = web.Application()
     out = []


### PR DESCRIPTION
Fixes #4799 

Second attempt to fix this, focusing only on cleanup_ctx this time. This will ensure any cleanup context that has been successfully started will get cleaned up, even if an exception occurs later in the startup process.

This can also be merged into 3.8.