### PR TITLE
Replace attrs with dataclasses

### DIFF
--- a/CHANGES/5284.feature
+++ b/CHANGES/5284.feature
@@ -1,0 +1,1 @@
+Use ``dataclasses`` instead of ``attrs`` for ``ClientTimeout``, client signals, and other few internal structures.

--- a/CHANGES/5284.removal
+++ b/CHANGES/5284.removal
@@ -1,0 +1,1 @@
+``attrs`` library was replaced with ``dataclasses``.  Replace ``attr.evolve()`` with ``dataclasses.replace()`` if needed.

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import base64
+import dataclasses
 import hashlib
 import json
 import os
@@ -28,7 +29,6 @@ from typing import (
     Union,
 )
 
-import attr
 from multidict import CIMultiDict, MultiDict, MultiDictProxy, istr
 from typing_extensions import final
 from yarl import URL
@@ -135,7 +135,7 @@ except ImportError:  # pragma: no cover
     SSLContext = object  # type: ignore
 
 
-@attr.s(auto_attribs=True, frozen=True, slots=True)
+@dataclasses.dataclass(frozen=True)
 class ClientTimeout:
     total: Optional[float] = None
     connect: Optional[float] = None
@@ -700,7 +700,7 @@ class ClientSession:
                 DeprecationWarning,
                 stacklevel=2,
             )
-            ws_timeout = attr.evolve(ws_timeout, ws_receive=receive_timeout)
+            ws_timeout = dataclasses.replace(ws_timeout, ws_receive=receive_timeout)
 
         if headers is None:
             real_headers = CIMultiDict()  # type: CIMultiDict[str]

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -1,5 +1,6 @@
 import asyncio
 import codecs
+import dataclasses
 import functools
 import io
 import re
@@ -23,7 +24,6 @@ from typing import (
     cast,
 )
 
-import attr
 from multidict import CIMultiDict, CIMultiDictProxy, MultiDict, MultiDictProxy
 from yarl import URL
 
@@ -86,23 +86,19 @@ def _gen_default_accept_encoding() -> str:
     return "gzip, deflate, br" if HAS_BROTLI else "gzip, deflate"
 
 
-@attr.s(auto_attribs=True, frozen=True, slots=True)
+@dataclasses.dataclass(frozen=True)
 class ContentDisposition:
     type: Optional[str]
     parameters: "MappingProxyType[str, str]"
     filename: Optional[str]
 
 
-@attr.s(auto_attribs=True, frozen=True, slots=True)
+@dataclasses.dataclass(frozen=True)
 class RequestInfo:
     url: URL
     method: str
     headers: "CIMultiDictProxy[str]"
-    real_url: URL = attr.ib()
-
-    @real_url.default
-    def real_url_default(self) -> URL:
-        return self.url
+    real_url: URL
 
 
 class Fingerprint:
@@ -145,7 +141,7 @@ else:  # pragma: no cover
     SSL_ALLOWED_TYPES = type(None)
 
 
-@attr.s(auto_attribs=True, slots=True, frozen=True)
+@dataclasses.dataclass(frozen=True)
 class ConnectionKey:
     # the key should contain an information about used proxy / TLS
     # to prevent reusing wrong connections from a pool

--- a/aiohttp/client_ws.py
+++ b/aiohttp/client_ws.py
@@ -1,10 +1,10 @@
 """WebSocket client for asyncio."""
 
 import asyncio
+import dataclasses
 from typing import Any, Optional
 
 import async_timeout
-import attr
 
 from .client_exceptions import ClientError
 from .client_reqrep import ClientResponse
@@ -27,7 +27,7 @@ from .typedefs import (
 )
 
 
-@attr.s(auto_attribs=True, frozen=True, slots=True)
+@dataclasses.dataclass(frozen=True)
 class ClientWSTimeout:
     ws_receive: Optional[float] = None
     ws_close: Optional[float] = None

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -1,4 +1,5 @@
 import asyncio
+import dataclasses
 import functools
 import logging
 import random
@@ -27,8 +28,6 @@ from typing import (  # noqa
     Union,
     cast,
 )
-
-import attr
 
 from . import hdrs, helpers
 from .abc import AbstractResolver
@@ -1070,7 +1069,7 @@ class TCPConnector(BaseConnector):
             # asyncio handles this perfectly
             proxy_req.method = hdrs.METH_CONNECT
             proxy_req.url = req.url
-            key = attr.evolve(
+            key = dataclasses.replace(
                 req.connection_key, proxy=None, proxy_auth=None, proxy_headers_hash=None
             )
             conn = Connection(self, key, proto, self._loop)

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -4,6 +4,7 @@ import asyncio
 import base64
 import binascii
 import cgi
+import dataclasses
 import datetime
 import functools
 import netrc
@@ -41,7 +42,6 @@ from urllib.parse import quote
 from urllib.request import getproxies
 
 import async_timeout
-import attr
 from multidict import CIMultiDict, MultiDict, MultiDictProxy
 from typing_extensions import Protocol, final
 from yarl import URL
@@ -230,7 +230,7 @@ def netrc_from_env() -> Optional[netrc.netrc]:
     return None
 
 
-@attr.s(auto_attribs=True, frozen=True, slots=True)
+@dataclasses.dataclass(frozen=True)
 class ProxyInfo:
     proxy: URL
     proxy_auth: Optional[BasicAuth]
@@ -267,7 +267,7 @@ def proxies_from_env() -> Dict[str, ProxyInfo]:
     return ret
 
 
-@attr.s(auto_attribs=True, frozen=True, slots=True)
+@dataclasses.dataclass(frozen=True)
 class MimeType:
     type: str
     subtype: str

--- a/aiohttp/tracing.py
+++ b/aiohttp/tracing.py
@@ -1,7 +1,7 @@
+import dataclasses
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, Awaitable, Optional, Type, TypeVar
 
-import attr
 from multidict import CIMultiDict
 from yarl import URL
 
@@ -217,7 +217,7 @@ class TraceConfig:
         return self._on_request_headers_sent
 
 
-@attr.s(auto_attribs=True, frozen=True, slots=True)
+@dataclasses.dataclass(frozen=True)
 class TraceRequestStartParams:
     """ Parameters sent by the `on_request_start` signal"""
 
@@ -226,7 +226,7 @@ class TraceRequestStartParams:
     headers: "CIMultiDict[str]"
 
 
-@attr.s(auto_attribs=True, frozen=True, slots=True)
+@dataclasses.dataclass(frozen=True)
 class TraceRequestChunkSentParams:
     """ Parameters sent by the `on_request_chunk_sent` signal"""
 
@@ -235,7 +235,7 @@ class TraceRequestChunkSentParams:
     chunk: bytes
 
 
-@attr.s(auto_attribs=True, frozen=True, slots=True)
+@dataclasses.dataclass(frozen=True)
 class TraceResponseChunkReceivedParams:
     """ Parameters sent by the `on_response_chunk_received` signal"""
 
@@ -244,7 +244,7 @@ class TraceResponseChunkReceivedParams:
     chunk: bytes
 
 
-@attr.s(auto_attribs=True, frozen=True, slots=True)
+@dataclasses.dataclass(frozen=True)
 class TraceRequestEndParams:
     """ Parameters sent by the `on_request_end` signal"""
 
@@ -254,7 +254,7 @@ class TraceRequestEndParams:
     response: ClientResponse
 
 
-@attr.s(auto_attribs=True, frozen=True, slots=True)
+@dataclasses.dataclass(frozen=True)
 class TraceRequestExceptionParams:
     """ Parameters sent by the `on_request_exception` signal"""
 
@@ -264,7 +264,7 @@ class TraceRequestExceptionParams:
     exception: BaseException
 
 
-@attr.s(auto_attribs=True, frozen=True, slots=True)
+@dataclasses.dataclass(frozen=True)
 class TraceRequestRedirectParams:
     """ Parameters sent by the `on_request_redirect` signal"""
 
@@ -274,60 +274,60 @@ class TraceRequestRedirectParams:
     response: ClientResponse
 
 
-@attr.s(auto_attribs=True, frozen=True, slots=True)
+@dataclasses.dataclass(frozen=True)
 class TraceConnectionQueuedStartParams:
     """ Parameters sent by the `on_connection_queued_start` signal"""
 
 
-@attr.s(auto_attribs=True, frozen=True, slots=True)
+@dataclasses.dataclass(frozen=True)
 class TraceConnectionQueuedEndParams:
     """ Parameters sent by the `on_connection_queued_end` signal"""
 
 
-@attr.s(auto_attribs=True, frozen=True, slots=True)
+@dataclasses.dataclass(frozen=True)
 class TraceConnectionCreateStartParams:
     """ Parameters sent by the `on_connection_create_start` signal"""
 
 
-@attr.s(auto_attribs=True, frozen=True, slots=True)
+@dataclasses.dataclass(frozen=True)
 class TraceConnectionCreateEndParams:
     """ Parameters sent by the `on_connection_create_end` signal"""
 
 
-@attr.s(auto_attribs=True, frozen=True, slots=True)
+@dataclasses.dataclass(frozen=True)
 class TraceConnectionReuseconnParams:
     """ Parameters sent by the `on_connection_reuseconn` signal"""
 
 
-@attr.s(auto_attribs=True, frozen=True, slots=True)
+@dataclasses.dataclass(frozen=True)
 class TraceDnsResolveHostStartParams:
     """ Parameters sent by the `on_dns_resolvehost_start` signal"""
 
     host: str
 
 
-@attr.s(auto_attribs=True, frozen=True, slots=True)
+@dataclasses.dataclass(frozen=True)
 class TraceDnsResolveHostEndParams:
     """ Parameters sent by the `on_dns_resolvehost_end` signal"""
 
     host: str
 
 
-@attr.s(auto_attribs=True, frozen=True, slots=True)
+@dataclasses.dataclass(frozen=True)
 class TraceDnsCacheHitParams:
     """ Parameters sent by the `on_dns_cache_hit` signal"""
 
     host: str
 
 
-@attr.s(auto_attribs=True, frozen=True, slots=True)
+@dataclasses.dataclass(frozen=True)
 class TraceDnsCacheMissParams:
     """ Parameters sent by the `on_dns_cache_miss` signal"""
 
     host: str
 
 
-@attr.s(auto_attribs=True, frozen=True, slots=True)
+@dataclasses.dataclass(frozen=True)
 class TraceRequestHeadersSentParams:
     """ Parameters sent by the `on_request_headers_sent` signal"""
 

--- a/aiohttp/web_request.py
+++ b/aiohttp/web_request.py
@@ -1,4 +1,5 @@
 import asyncio
+import dataclasses
 import datetime
 import io
 import re
@@ -24,7 +25,6 @@ from typing import (
 )
 from urllib.parse import parse_qsl
 
-import attr
 from multidict import CIMultiDict, CIMultiDictProxy, MultiDict, MultiDictProxy
 from yarl import URL
 
@@ -65,7 +65,7 @@ if TYPE_CHECKING:  # pragma: no cover
     from .web_urldispatcher import UrlMappingMatchInfo
 
 
-@attr.s(auto_attribs=True, frozen=True, slots=True)
+@dataclasses.dataclass(frozen=True)
 class FileField:
     name: str
     filename: str

--- a/aiohttp/web_routedef.py
+++ b/aiohttp/web_routedef.py
@@ -1,4 +1,5 @@
 import abc
+import dataclasses
 import os  # noqa
 from typing import (
     TYPE_CHECKING,
@@ -14,8 +15,6 @@ from typing import (
     Union,
     overload,
 )
-
-import attr
 
 from . import hdrs
 from .abc import AbstractView
@@ -57,7 +56,7 @@ _SimpleHandler = Callable[[Request], Awaitable[StreamResponse]]
 _HandlerType = Union[Type[AbstractView], _SimpleHandler]
 
 
-@attr.s(auto_attribs=True, frozen=True, repr=False, slots=True)
+@dataclasses.dataclass(frozen=True, repr=False)
 class RouteDef(AbstractRouteDef):
     method: str
     path: str
@@ -82,7 +81,7 @@ class RouteDef(AbstractRouteDef):
             ]
 
 
-@attr.s(auto_attribs=True, frozen=True, repr=False, slots=True)
+@dataclasses.dataclass(frozen=True, repr=False)
 class StaticDef(AbstractRouteDef):
     prefix: str
     path: PathLike

--- a/aiohttp/web_ws.py
+++ b/aiohttp/web_ws.py
@@ -1,12 +1,12 @@
 import asyncio
 import base64
 import binascii
+import dataclasses
 import hashlib
 import json
 from typing import Any, Iterable, Optional, Tuple
 
 import async_timeout
-import attr
 from multidict import CIMultiDict
 
 from . import hdrs
@@ -41,7 +41,7 @@ __all__ = (
 THRESHOLD_CONNLOST_ACCESS = 5
 
 
-@attr.s(auto_attribs=True, frozen=True, slots=True)
+@dataclasses.dataclass(frozen=True)
 class WebSocketReady:
     ok: bool
     protocol: Optional[str]

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -3,7 +3,6 @@
 aiodns==2.0.0; sys_platform=="linux" or sys_platform=="darwin" and python_version>="3.7"
 async-timeout==4.0.0a3
 asynctest==0.13.0; python_version<"3.8"
-attrs==20.3.0
 Brotli==1.0.9
 cchardet==2.1.7
 chardet==3.0.4

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,6 @@ except IndexError:
     raise RuntimeError("Unable to determine version.")
 
 install_requires = [
-    "attrs>=17.3.0",
     "chardet>=2.0,<4.0",
     "multidict>=4.5,<7.0",
     "async_timeout>=4.0a2,<5.0",

--- a/tests/test_client_request.py
+++ b/tests/test_client_request.py
@@ -98,9 +98,8 @@ def test_version_default(make_request) -> None:
 
 def test_request_info(make_request) -> None:
     req = make_request("get", "http://python.org/")
-    assert req.request_info == aiohttp.RequestInfo(
-        URL("http://python.org/"), "GET", req.headers
-    )
+    url = URL("http://python.org/")
+    assert req.request_info == aiohttp.RequestInfo(url, "GET", req.headers, url)
 
 
 def test_request_info_with_fragment(make_request) -> None:

--- a/tests/test_client_response.py
+++ b/tests/test_client_response.py
@@ -955,7 +955,7 @@ def test_response_request_info() -> None:
     response = ClientResponse(
         "get",
         URL(url),
-        request_info=RequestInfo(url, "get", headers),
+        request_info=RequestInfo(url, "get", headers, url),
         writer=mock.Mock(),
         continue100=None,
         timer=TimerNoop(),
@@ -974,7 +974,7 @@ def test_request_info_in_exception() -> None:
     response = ClientResponse(
         "get",
         URL(url),
-        request_info=RequestInfo(url, "get", headers),
+        request_info=RequestInfo(url, "get", headers, url),
         writer=mock.Mock(),
         continue100=None,
         timer=TimerNoop(),
@@ -995,7 +995,7 @@ def test_no_redirect_history_in_exception() -> None:
     response = ClientResponse(
         "get",
         URL(url),
-        request_info=RequestInfo(url, "get", headers),
+        request_info=RequestInfo(url, "get", headers, url),
         writer=mock.Mock(),
         continue100=None,
         timer=TimerNoop(),
@@ -1018,7 +1018,7 @@ def test_redirect_history_in_exception() -> None:
     response = ClientResponse(
         "get",
         URL(url),
-        request_info=RequestInfo(url, "get", headers),
+        request_info=RequestInfo(url, "get", headers, url),
         writer=mock.Mock(),
         continue100=None,
         timer=TimerNoop(),
@@ -1032,7 +1032,7 @@ def test_redirect_history_in_exception() -> None:
     hist_response = ClientResponse(
         "get",
         URL(hist_url),
-        request_info=RequestInfo(url, "get", headers),
+        request_info=RequestInfo(url, "get", headers, url),
         writer=mock.Mock(),
         continue100=None,
         timer=TimerNoop(),


### PR DESCRIPTION
aiohttp 4.0 supports Python 3.7+.
There is no need to use `attrs` but better to switch to the standard `dataclasses` module.
`attrs` is great but the standard is even better.

The only downside is: for `attrs` you should use `dataclasses.replace(ds, name=val)` instead of `attr.evolve(ds, name=val)`.
I think it is a good compromise.