### PR TITLE
Fix race condition on connect when tracing is active (#5259)

### DIFF
--- a/CHANGES/5259.bugfix
+++ b/CHANGES/5259.bugfix
@@ -1,0 +1,1 @@
+Acquire the connection before running traces to prevent race condition.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -48,6 +48,7 @@ Arthur Darcet
 Ben Bader
 Ben Timby
 Benedikt Reinartz
+Bob Haddleton
 Boris Feld
 Borys Vorona
 Boyi Chen

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -525,8 +525,14 @@ class BaseConnector:
                     await trace.send_connection_create_end()
         else:
             if traces:
+                # Acquire the connection to prevent race conditions with limits
+                placeholder = cast(ResponseHandler, _TransportPlaceholder(self._loop))
+                self._acquired.add(placeholder)
+                self._acquired_per_host[key].add(placeholder)
                 for trace in traces:
                     await trace.send_connection_reuseconn()
+                self._acquired.remove(placeholder)
+                self._drop_acquired_per_host(key, placeholder)
 
         self._acquired.add(proto)
         self._acquired_per_host[key].add(proto)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

Acquire the connection before running traces, to prevent race condition.

<!-- Please give a short brief about these changes. -->

This change will ensure that the limit and limit_per_host functionality in BaseConnector works when traces are configured.

NOTE: Unit tests are TBD as this is an async race condition which is extremely difficult to unit test.  Suggestions are welcome.

<!-- Outline any notable behaviour for the end users. -->

## Related issue number

Fixes #5259 

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [X ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [X] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [X] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
