### PR TITLE
Use a distinct type for sentinel

### DIFF
--- a/CHANGES/5287.feature
+++ b/CHANGES/5287.feature
@@ -1,0 +1,3 @@
+Before ``sentinel`` was processed as either ``object`` or ``Any``, both variants are far from perfectness.
+
+Now ``sentinel`` has a dedicated type which is not equal to anything.

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -76,6 +76,7 @@ from .connector import (
 )
 from .cookiejar import CookieJar
 from .helpers import (
+    _SENTINEL,
     BasicAuth,
     TimeoutHandle,
     ceil_timeout,
@@ -207,7 +208,7 @@ class ClientSession:
         raise_for_status: Union[
             bool, Callable[[ClientResponse], Awaitable[None]]
         ] = False,
-        timeout: Union[object, ClientTimeout] = sentinel,
+        timeout: Union[_SENTINEL, ClientTimeout] = sentinel,
         auto_decompress: bool = True,
         trust_env: bool = False,
         requote_redirect_url: bool = True,
@@ -325,7 +326,7 @@ class ClientSession:
         read_until_eof: bool = True,
         proxy: Optional[StrOrURL] = None,
         proxy_auth: Optional[BasicAuth] = None,
-        timeout: Union[ClientTimeout, object] = sentinel,
+        timeout: Union[ClientTimeout, _SENTINEL] = sentinel,
         ssl: Optional[Union[SSLContext, bool, Fingerprint]] = None,
         proxy_headers: Optional[LooseHeaders] = None,
         trace_request_ctx: Optional[SimpleNamespace] = None,
@@ -619,7 +620,7 @@ class ClientSession:
         *,
         method: str = hdrs.METH_GET,
         protocols: Iterable[str] = (),
-        timeout: Union[ClientWSTimeout, float] = sentinel,
+        timeout: Union[ClientWSTimeout, float, _SENTINEL] = sentinel,
         receive_timeout: Optional[float] = None,
         autoclose: bool = True,
         autoping: bool = True,
@@ -663,7 +664,7 @@ class ClientSession:
         *,
         method: str = hdrs.METH_GET,
         protocols: Iterable[str] = (),
-        timeout: Union[ClientWSTimeout, float] = sentinel,
+        timeout: Union[ClientWSTimeout, float, _SENTINEL] = sentinel,
         receive_timeout: Optional[float] = None,
         autoclose: bool = True,
         autoping: bool = True,
@@ -689,7 +690,7 @@ class ClientSession:
                     DeprecationWarning,
                     stacklevel=2,
                 )
-                ws_timeout = ClientWSTimeout(ws_close=timeout)
+                ws_timeout = ClientWSTimeout(ws_close=timeout)  # type: ignore
         else:
             ws_timeout = DEFAULT_WS_CLIENT_TIMEOUT
         if receive_timeout is not None:
@@ -1147,7 +1148,7 @@ def request(
     read_until_eof: bool = True,
     proxy: Optional[StrOrURL] = None,
     proxy_auth: Optional[BasicAuth] = None,
-    timeout: Union[ClientTimeout, object] = sentinel,
+    timeout: Union[ClientTimeout, _SENTINEL] = sentinel,
     cookies: Optional[LooseCookies] = None,
     version: HttpVersion = http.HttpVersion11,
     connector: Optional[BaseConnector] = None,

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -46,7 +46,7 @@ from .client_exceptions import (
 )
 from .client_proto import ResponseHandler
 from .client_reqrep import SSL_ALLOWED_TYPES, ClientRequest, Fingerprint
-from .helpers import ceil_timeout, is_ip_address, sentinel
+from .helpers import _SENTINEL, ceil_timeout, is_ip_address, sentinel
 from .http import RESPONSES
 from .locks import EventResultOrError
 from .resolver import DefaultResolver
@@ -184,7 +184,7 @@ class BaseConnector:
     def __init__(
         self,
         *,
-        keepalive_timeout: Union[object, None, float] = sentinel,
+        keepalive_timeout: Union[_SENTINEL, None, float] = sentinel,
         force_close: bool = False,
         limit: int = 100,
         limit_per_host: int = 0,
@@ -717,7 +717,7 @@ class TCPConnector(BaseConnector):
         ssl: Union[None, bool, Fingerprint, SSLContext] = None,
         local_addr: Optional[Tuple[str, int]] = None,
         resolver: Optional[AbstractResolver] = None,
-        keepalive_timeout: Union[None, float, object] = sentinel,
+        keepalive_timeout: Union[None, float, _SENTINEL] = sentinel,
         force_close: bool = False,
         limit: int = 100,
         limit_per_host: int = 0,
@@ -1137,7 +1137,7 @@ class UnixConnector(BaseConnector):
         self,
         path: str,
         force_close: bool = False,
-        keepalive_timeout: Union[object, float, None] = sentinel,
+        keepalive_timeout: Union[_SENTINEL, float, None] = sentinel,
         limit: int = 100,
         limit_per_host: int = 0,
     ) -> None:
@@ -1187,7 +1187,7 @@ class NamedPipeConnector(BaseConnector):
         self,
         path: str,
         force_close: bool = False,
-        keepalive_timeout: Union[object, float, None] = sentinel,
+        keepalive_timeout: Union[_SENTINEL, float, None] = sentinel,
         limit: int = 100,
         limit_per_host: int = 0,
     ) -> None:

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -29,6 +29,7 @@ from typing import (
     Iterator,
     List,
     Mapping,
+    NewType,
     Optional,
     Pattern,
     Tuple,
@@ -64,8 +65,9 @@ except ImportError:
 _T = TypeVar("_T")
 _S = TypeVar("_S")
 
+_SENTINEL = NewType("_SENTINEL", object)
 
-sentinel = object()  # type: Any
+sentinel: _SENTINEL = _SENTINEL(object())
 NO_EXTENSIONS = bool(os.environ.get("AIOHTTP_NO_EXTENSIONS"))  # type: bool
 
 # N.B. sys.flags.dev_mode is available on Python 3.7+, use getattr
@@ -657,7 +659,7 @@ class HeadersMixin:
         super().__init__()
         self._content_type = None  # type: Optional[str]
         self._content_dict = None  # type: Optional[Dict[str, str]]
-        self._stored_content_type = sentinel
+        self._stored_content_type: Union[str, _SENTINEL] = sentinel
 
     def _parse_content_type(self, raw: str) -> None:
         self._stored_content_type = raw

--- a/aiohttp/payload.py
+++ b/aiohttp/payload.py
@@ -27,6 +27,7 @@ from multidict import CIMultiDict
 from . import hdrs
 from .abc import AbstractStreamWriter
 from .helpers import (
+    _SENTINEL,
     content_disposition_header,
     guess_filename,
     parse_mimetype,
@@ -134,7 +135,7 @@ class Payload(ABC):
         headers: Optional[
             Union[_CIMultiDict, Dict[str, str], Iterable[Tuple[str, str]]]
         ] = None,
-        content_type: Optional[str] = sentinel,
+        content_type: Union[None, str, _SENTINEL] = sentinel,
         filename: Optional[str] = None,
         encoding: Optional[str] = None,
         **kwargs: Any,
@@ -144,6 +145,7 @@ class Payload(ABC):
         self._headers = CIMultiDict()  # type: _CIMultiDict
         self._value = value
         if content_type is not sentinel and content_type is not None:
+            assert isinstance(content_type, str)
             self._headers[hdrs.CONTENT_TYPE] = content_type
         elif self._filename is not None:
             content_type = mimetypes.guess_type(self._filename)[0]

--- a/aiohttp/test_utils.py
+++ b/aiohttp/test_utils.py
@@ -24,7 +24,7 @@ from . import ClientSession, hdrs
 from .abc import AbstractCookieJar
 from .client_reqrep import ClientResponse
 from .client_ws import ClientWebSocketResponse
-from .helpers import PY_38, sentinel
+from .helpers import _SENTINEL, PY_38, sentinel
 from .http import HttpVersion, RawRequestMessage
 from .signals import Signal
 from .web import (
@@ -84,7 +84,7 @@ class BaseTestServer(ABC):
     def __init__(
         self,
         *,
-        scheme: Union[str, object] = sentinel,
+        scheme: Union[str, _SENTINEL] = sentinel,
         host: str = "127.0.0.1",
         port: Optional[int] = None,
         skip_url_asserts: bool = False,
@@ -198,7 +198,7 @@ class TestServer(BaseTestServer):
         self,
         app: Application,
         *,
-        scheme: Union[str, object] = sentinel,
+        scheme: Union[str, _SENTINEL] = sentinel,
         host: str = "127.0.0.1",
         port: Optional[int] = None,
         **kwargs: Any,
@@ -215,7 +215,7 @@ class RawTestServer(BaseTestServer):
         self,
         handler: _RequestHandler,
         *,
-        scheme: Union[str, object] = sentinel,
+        scheme: Union[str, _SENTINEL] = sentinel,
         host: str = "127.0.0.1",
         port: Optional[int] = None,
         **kwargs: Any,

--- a/aiohttp/web_request.py
+++ b/aiohttp/web_request.py
@@ -31,6 +31,7 @@ from yarl import URL
 from . import hdrs
 from .abc import AbstractStreamWriter
 from .helpers import (
+    _SENTINEL,
     ChainMapProxy,
     HeadersMixin,
     is_expected_content_type,
@@ -191,12 +192,12 @@ class BaseRequest(MutableMapping[str, Any], HeadersMixin):
     def clone(
         self,
         *,
-        method: str = sentinel,
-        rel_url: StrOrURL = sentinel,
-        headers: LooseHeaders = sentinel,
-        scheme: str = sentinel,
-        host: str = sentinel,
-        remote: str = sentinel,
+        method: Union[str, _SENTINEL] = sentinel,
+        rel_url: Union[StrOrURL, _SENTINEL] = sentinel,
+        headers: Union[LooseHeaders, _SENTINEL] = sentinel,
+        scheme: Union[str, _SENTINEL] = sentinel,
+        host: Union[str, _SENTINEL] = sentinel,
+        remote: Union[str, _SENTINEL] = sentinel,
     ) -> "BaseRequest":
         """Clone itself with replacement some attributes.
 
@@ -213,25 +214,26 @@ class BaseRequest(MutableMapping[str, Any], HeadersMixin):
         if method is not sentinel:
             dct["method"] = method
         if rel_url is not sentinel:
-            new_url = URL(rel_url)
+            new_url: URL = URL(rel_url)  # type: ignore
             dct["url"] = new_url
             dct["path"] = str(new_url)
         if headers is not sentinel:
             # a copy semantic
-            dct["headers"] = CIMultiDictProxy(CIMultiDict(headers))
+            new_headers = CIMultiDictProxy(CIMultiDict(headers))  # type: ignore
+            dct["headers"] = new_headers
             dct["raw_headers"] = tuple(
-                (k.encode("utf-8"), v.encode("utf-8")) for k, v in headers.items()
+                (k.encode("utf-8"), v.encode("utf-8")) for k, v in new_headers.items()
             )
 
         message = self._message._replace(**dct)
 
-        kwargs = {}
+        kwargs: Dict[str, str] = {}
         if scheme is not sentinel:
-            kwargs["scheme"] = scheme
+            kwargs["scheme"] = scheme  # type: ignore
         if host is not sentinel:
-            kwargs["host"] = host
+            kwargs["host"] = host  # type: ignore
         if remote is not sentinel:
-            kwargs["remote"] = remote
+            kwargs["remote"] = remote  # type: ignore
 
         return self.__class__(
             message,
@@ -787,12 +789,12 @@ class Request(BaseRequest):
     def clone(
         self,
         *,
-        method: str = sentinel,
-        rel_url: StrOrURL = sentinel,
-        headers: LooseHeaders = sentinel,
-        scheme: str = sentinel,
-        host: str = sentinel,
-        remote: str = sentinel,
+        method: Union[str, _SENTINEL] = sentinel,
+        rel_url: Union[StrOrURL, _SENTINEL] = sentinel,
+        headers: Union[LooseHeaders, _SENTINEL] = sentinel,
+        scheme: Union[str, _SENTINEL] = sentinel,
+        host: Union[str, _SENTINEL] = sentinel,
+        remote: Union[str, _SENTINEL] = sentinel,
     ) -> "Request":
         ret = super().clone(
             method=method,


### PR DESCRIPTION
Before `sentinel` was processed as either `object` or `Any`, both variants are far from perfectness.

Now `sentinel` has a dedicated type which is not equal to anything.