### PR TITLE
Add aiohttp_retry to third-party docs

### DIFF
--- a/docs/third_party.rst
+++ b/docs/third_party.rst
@@ -278,3 +278,6 @@ period ask to raise the status.
 
 - `aiohttp-sse-client <https://github.com/rtfol/aiohttp-sse-client>`_
   A Server-Sent Event python client base on aiohttp. Python 3.6+ required.
+
+- `aiohttp-retry <https://github.com/inyutin/aiohttp_retry>`_
+  Wrapper for aiohttp client for retrying requests. Python 3.6+ required.


### PR DESCRIPTION
This PR adds [aiohttp_retry](https://github.com/inyutin/aiohttp_retry) library to docs-page.
aiohttp_retry just a simple wrapper for aiohttp to make requests retryable. 
I suppose that it fits well third-party page :)

Example of usage:
```python
from aiohttp_retry import RetryClient, RetryOptions

async def main():
    retry_options = RetryOptions(attempts=1)
    retry_client = RetryClient(raise_for_status=False, retry_options=retry_options)
    async with retry_client.get('https://ya.ru') as response:
        print(response.status)
        
    await retry_client.close()
```