### PR TITLE
Implement ETag support

### DIFF
--- a/CHANGES/4594.feature
+++ b/CHANGES/4594.feature
@@ -1,0 +1,1 @@
+FileResponse now supports ETag.

--- a/aiohttp/__init__.py
+++ b/aiohttp/__init__.py
@@ -38,7 +38,11 @@ from .client import (
 )
 from .cookiejar import CookieJar as CookieJar, DummyCookieJar as DummyCookieJar
 from .formdata import FormData as FormData
-from .helpers import BasicAuth as BasicAuth, ChainMapProxy as ChainMapProxy
+from .helpers import (
+    BasicAuth as BasicAuth,
+    ChainMapProxy as ChainMapProxy,
+    ETag as ETag,
+)
 from .http import (
     HttpVersion as HttpVersion,
     HttpVersion10 as HttpVersion10,
@@ -145,6 +149,7 @@ __all__: Tuple[str, ...] = (
     # helpers
     "BasicAuth",
     "ChainMapProxy",
+    "ETag",
     # http
     "HttpVersion",
     "HttpVersion10",

--- a/aiohttp/__init__.py
+++ b/aiohttp/__init__.py
@@ -38,11 +38,7 @@ from .client import (
 )
 from .cookiejar import CookieJar as CookieJar, DummyCookieJar as DummyCookieJar
 from .formdata import FormData as FormData
-from .helpers import (
-    BasicAuth as BasicAuth,
-    ChainMapProxy as ChainMapProxy,
-    ETag as ETag,
-)
+from .helpers import BasicAuth, ChainMapProxy, ETag
 from .http import (
     HttpVersion as HttpVersion,
     HttpVersion10 as HttpVersion10,

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -890,11 +890,7 @@ def populate_with_cookies(
 
 
 # https://tools.ietf.org/html/rfc7232#section-2.3
-_ETAGC = "[{}]+".format(
-    "".join(
-        chr(c) for c in (0x21,) + tuple(range(0x23, 0x7E)) + tuple(range(0x80, 0xFF))
-    )
-)
+_ETAGC = r"[!#-}\x80-\xff]+"
 _QUOTED_ETAG = fr'(W\/)?("{_ETAGC}")'
 QUOTED_ETAG_RE = re.compile(_QUOTED_ETAG)
 LIST_QUOTED_ETAG_RE = re.compile(fr"({_QUOTED_ETAG})(?:\s*,\s*|$)")

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -891,7 +891,7 @@ def populate_with_cookies(
 
 # https://tools.ietf.org/html/rfc7232#section-2.3
 _ETAGC = r"[!#-}\x80-\xff]+"
-_QUOTED_ETAG = fr'(W\/)?("{_ETAGC}")'
+_QUOTED_ETAG = fr'(W/)?("{_ETAGC}")'
 QUOTED_ETAG_RE = re.compile(_QUOTED_ETAG)
 LIST_QUOTED_ETAG_RE = re.compile(fr"({_QUOTED_ETAG})(?:\s*,\s*|$)")
 

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -890,8 +890,8 @@ def populate_with_cookies(
 
 
 # https://tools.ietf.org/html/rfc7232#section-2.3
-_ETAGC = r"[{}]+".format(
-    r"".join(
+_ETAGC = "[{}]+".format(
+    "".join(
         chr(c) for c in (0x21,) + tuple(range(0x23, 0x7E)) + tuple(range(0x80, 0xFF))
     )
 )

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -51,7 +51,7 @@ from . import hdrs
 from .log import client_logger
 from .typedefs import PathLike  # noqa
 
-__all__ = ("BasicAuth", "ChainMapProxy")
+__all__ = ("BasicAuth", "ChainMapProxy", "ETag")
 
 PY_38 = sys.version_info >= (3, 8)
 
@@ -887,3 +887,22 @@ def populate_with_cookies(
     for cookie in cookies.values():
         value = cookie.output(header="")[1:]
         headers.add(hdrs.SET_COOKIE, value)
+
+
+# https://tools.ietf.org/html/rfc7232#section-2.3
+_ETAGC = r"[{}]+".format(
+    r"".join(
+        chr(c) for c in (0x21,) + tuple(range(0x23, 0x7E)) + tuple(range(0x80, 0xFF))
+    )
+)
+_QUOTED_ETAG = fr'(W\/)?("{_ETAGC}")'
+QUOTED_ETAG_RE = re.compile(_QUOTED_ETAG)
+LIST_QUOTED_ETAG_RE = re.compile(fr"({_QUOTED_ETAG})(?:\s*,\s*|$)")
+
+ETAG_ANY = "*"
+
+
+@dataclasses.dataclass(frozen=True)
+class ETag:
+    value: str
+    is_weak: bool = False

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -891,9 +891,10 @@ def populate_with_cookies(
 
 # https://tools.ietf.org/html/rfc7232#section-2.3
 _ETAGC = r"[!#-}\x80-\xff]+"
-_QUOTED_ETAG = fr'(W/)?("{_ETAGC}")'
+_ETAGC_RE = re.compile(_ETAGC)
+_QUOTED_ETAG = fr'(W/)?"({_ETAGC})"'
 QUOTED_ETAG_RE = re.compile(_QUOTED_ETAG)
-LIST_QUOTED_ETAG_RE = re.compile(fr"({_QUOTED_ETAG})(?:\s*,\s*|$)")
+LIST_QUOTED_ETAG_RE = re.compile(fr"({_QUOTED_ETAG})(?:\s*,\s*|$)|(.)")
 
 ETAG_ANY = "*"
 
@@ -902,3 +903,10 @@ ETAG_ANY = "*"
 class ETag:
     value: str
     is_weak: bool = False
+
+
+def validate_etag_value(value: str) -> None:
+    if value != ETAG_ANY and not _ETAGC_RE.fullmatch(value):
+        raise ValueError(
+            f"Value {value!r} is not a valid etag. Maybe it contains '\"'?"
+        )

--- a/aiohttp/web_fileresponse.py
+++ b/aiohttp/web_fileresponse.py
@@ -9,8 +9,10 @@ from typing import (  # noqa
     Any,
     Awaitable,
     Callable,
+    Iterator,
     List,
     Optional,
+    Tuple,
     Union,
     cast,
 )
@@ -19,6 +21,7 @@ from typing_extensions import Final
 
 from . import hdrs
 from .abc import AbstractStreamWriter
+from .helpers import ETAG_ANY, ETag
 from .typedefs import LooseHeaders
 from .web_exceptions import (
     HTTPNotModified,
@@ -102,6 +105,31 @@ class FileResponse(StreamResponse):
         await super().write_eof()
         return writer
 
+    @staticmethod
+    def _strong_etag_match(etag_value: str, etags: Tuple[ETag, ...]) -> bool:
+        if len(etags) == 1 and etags[0].value == ETAG_ANY:
+            return True
+        else:
+            return any(etag.value == etag_value for etag in etags if not etag.is_weak)
+
+    async def _not_modified(
+        self, request: "BaseRequest", etag_value: str, last_modified: float
+    ) -> Optional[AbstractStreamWriter]:
+        self.set_status(HTTPNotModified.status_code)
+        self._length_check = False
+        self.etag = etag_value  # type: ignore
+        self.last_modified = last_modified  # type: ignore
+        # Delete any Content-Length headers provided by user. HTTP 304
+        # should always have empty response body
+        return await super().prepare(request)
+
+    async def _precondition_failed(
+        self, request: "BaseRequest"
+    ) -> Optional[AbstractStreamWriter]:
+        self.set_status(HTTPPreconditionFailed.status_code)
+        self.content_length = 0
+        return await super().prepare(request)
+
     async def prepare(self, request: "BaseRequest") -> Optional[AbstractStreamWriter]:
         filepath = self._path
 
@@ -114,20 +142,35 @@ class FileResponse(StreamResponse):
                 gzip = True
 
         loop = asyncio.get_event_loop()
-        st = await loop.run_in_executor(None, filepath.stat)
+        st: os.stat_result = await loop.run_in_executor(None, filepath.stat)
 
-        modsince = request.if_modified_since
-        if modsince is not None and st.st_mtime <= modsince.timestamp():
-            self.set_status(HTTPNotModified.status_code)
-            self._length_check = False
-            # Delete any Content-Length headers provided by user. HTTP 304
-            # should always have empty response body
-            return await super().prepare(request)
+        etag_value = f"{st.st_mtime_ns:x}-{st.st_size:x}"
+        last_modified = st.st_mtime
+
+        # https://tools.ietf.org/html/rfc7232#section-6
+        ifmatch = request.if_match
+        if ifmatch is not None and not self._strong_etag_match(etag_value, ifmatch):
+            return await self._precondition_failed(request)
 
         unmodsince = request.if_unmodified_since
-        if unmodsince is not None and st.st_mtime > unmodsince.timestamp():
-            self.set_status(HTTPPreconditionFailed.status_code)
-            return await super().prepare(request)
+        if (
+            unmodsince is not None
+            and ifmatch is None
+            and st.st_mtime > unmodsince.timestamp()
+        ):
+            return await self._precondition_failed(request)
+
+        ifnonematch = request.if_none_match
+        if ifnonematch is not None and self._strong_etag_match(etag_value, ifnonematch):
+            return await self._not_modified(request, etag_value, last_modified)
+
+        modsince = request.if_modified_since
+        if (
+            modsince is not None
+            and ifnonematch is None
+            and st.st_mtime <= modsince.timestamp()
+        ):
+            return await self._not_modified(request, etag_value, last_modified)
 
         if hdrs.CONTENT_TYPE not in self.headers:
             ct, encoding = mimetypes.guess_type(str(filepath))
@@ -218,6 +261,8 @@ class FileResponse(StreamResponse):
             self.headers[hdrs.CONTENT_ENCODING] = encoding
         if gzip:
             self.headers[hdrs.VARY] = hdrs.ACCEPT_ENCODING
+
+        self.etag = etag_value  # type: ignore[assignment]
         self.last_modified = st.st_mtime  # type: ignore[assignment]
         self.content_length = count
 

--- a/aiohttp/web_request.py
+++ b/aiohttp/web_request.py
@@ -513,10 +513,15 @@ class BaseRequest(MutableMapping[str, Any], HeadersMixin):
             )
         else:
             for match in LIST_QUOTED_ETAG_RE.finditer(etag_header):
-                is_weak, quoted_value = match.group(2), match.group(3)
+                is_weak, value, garbage = match.group(2, 3, 4)
+                # Any symbol captured by 4th group means
+                # that the following sequence is invalid.
+                if garbage:
+                    break
+
                 yield ETag(
                     is_weak=bool(is_weak),
-                    value=quoted_value[1:-1],
+                    value=value,
                 )
 
     @classmethod

--- a/aiohttp/web_request.py
+++ b/aiohttp/web_request.py
@@ -34,7 +34,10 @@ from . import hdrs
 from .abc import AbstractStreamWriter
 from .helpers import (
     _SENTINEL,
+    ETAG_ANY,
+    LIST_QUOTED_ETAG_RE,
     ChainMapProxy,
+    ETag,
     HeadersMixin,
     is_expected_content_type,
     reify,
@@ -499,6 +502,47 @@ class BaseRequest(MutableMapping[str, Any], HeadersMixin):
         This header is represented as a `datetime` object.
         """
         return self._http_date(self.headers.get(hdrs.IF_UNMODIFIED_SINCE))
+
+    @staticmethod
+    def _etag_values(etag_header: str) -> Iterator[ETag]:
+        """Extract `ETag` objects from raw header."""
+        if etag_header == ETAG_ANY:
+            yield ETag(
+                is_weak=False,
+                value=ETAG_ANY,
+            )
+        else:
+            for match in LIST_QUOTED_ETAG_RE.finditer(etag_header):
+                is_weak, quoted_value = match.group(2), match.group(3)
+                yield ETag(
+                    is_weak=bool(is_weak),
+                    value=quoted_value[1:-1],
+                )
+
+    @classmethod
+    def _if_match_or_none_impl(
+        cls, header_value: Optional[str]
+    ) -> Optional[Tuple[ETag, ...]]:
+        if not header_value:
+            return None
+
+        return tuple(cls._etag_values(header_value))
+
+    @reify
+    def if_match(self) -> Optional[Tuple[ETag, ...]]:
+        """The value of If-Match HTTP header, or None.
+
+        This header is represented as a `tuple` of `ETag` objects.
+        """
+        return self._if_match_or_none_impl(self.headers.get(hdrs.IF_MATCH))
+
+    @reify
+    def if_none_match(self) -> Optional[Tuple[ETag, ...]]:
+        """The value of If-None-Match HTTP header, or None.
+
+        This header is represented as a `tuple` of `ETag` objects.
+        """
+        return self._if_match_or_none_impl(self.headers.get(hdrs.IF_NONE_MATCH))
 
     @reify
     def if_range(self) -> Optional[datetime.datetime]:

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -1688,6 +1688,23 @@ ClientTimeout
 
    .. versionadded:: 3.3
 
+ETag
+^^^^
+
+.. class:: ETag(name, is_weak=False)
+
+   Represents `ETag` identifier.
+
+   .. attribute:: value
+
+      Value of corresponding etag without quotes.
+
+   .. attribute:: is_weak
+
+      Flag indicates that etag is weak (has `W/` prefix).
+
+   .. versionadded:: 4.0
+
 RequestInfo
 ^^^^^^^^^^^
 

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -1703,7 +1703,7 @@ ETag
 
       Flag indicates that etag is weak (has `W/` prefix).
 
-   .. versionadded:: 4.0
+   .. versionadded:: 3.8
 
 RequestInfo
 ^^^^^^^^^^^

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -29,6 +29,7 @@ Dict
 Discord
 Django
 Dup
+ETag
 Facebook
 HTTPException
 HttpProcessingError
@@ -155,6 +156,7 @@ env
 environ
 eof
 epoll
+etag
 facto
 fallback
 fallbacks

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -326,6 +326,8 @@ and :ref:`aiohttp-web-signals` handlers.
       Returns :class:`tuple` of :class:`ETag` or ``None`` if
       *If-Match* header is absent.
 
+      .. versionadded:: 3.8
+
    .. attribute:: if_none_match
 
       Read-only property that returns :class:`ETag` objects specified
@@ -334,7 +336,7 @@ and :ref:`aiohttp-web-signals` handlers.
       Returns :class:`tuple` of :class:`ETag` or ``None`` if
       *If-None-Match* header is absent.
 
-      .. versionadded:: 4.0
+      .. versionadded:: 3.8
 
    .. attribute:: if_range
 
@@ -803,6 +805,8 @@ StreamResponse
 
       **Do not** use double quotes ``"`` in the etag value,
       they will be added automatically.
+
+      .. versionadded:: 3.8
 
    .. comethod:: prepare(request)
 

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -774,6 +774,18 @@ StreamResponse
       as an :class:`int` or a :class:`float` object, and the
       value ``None`` to unset the header.
 
+   .. attribute:: etag
+
+      *ETag* header for outgoing response.
+
+      This property accepts raw :class:`str` values, :class:`ETag`
+      objects and the value ``None`` to unset the header.
+
+      In case of :class:`str` input, etag is considered as strong by default.
+
+      **Do not** use double quotes ``"`` in the etag value,
+      they will be added automatically.
+
    .. comethod:: prepare(request)
 
       :param aiohttp.web.Request request: HTTP request object, that the

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -318,6 +318,24 @@ and :ref:`aiohttp-web-signals` handlers.
 
       .. versionadded:: 3.1
 
+   .. attribute:: if_match
+
+      Read-only property that returns :class:`ETag` objects specified
+      in the *If-Match* header.
+
+      Returns :class:`tuple` of :class:`ETag` or ``None`` if
+      *If-Match* header is absent.
+
+   .. attribute:: if_none_match
+
+      Read-only property that returns :class:`ETag` objects specified
+      *If-None-Match* header.
+
+      Returns :class:`tuple` of :class:`ETag` or ``None`` if
+      *If-None-Match* header is absent.
+
+      .. versionadded:: 4.0
+
    .. attribute:: if_range
 
       Read-only property that returns the date specified in the

--- a/tests/test_web_request.py
+++ b/tests/test_web_request.py
@@ -834,16 +834,23 @@ async def test_handler_return_type(aiohttp_client: Any) -> None:
     "header_val,expected",
     [
         pytest.param(
-            '"67ab43", W/"54ed21", "7892dd"',
+            '"67ab43", W/"54ed21", "7892,dd"',
             (
                 ETag(is_weak=False, value="67ab43"),
                 ETag(is_weak=True, value="54ed21"),
-                ETag(is_weak=False, value="7892dd"),
+                ETag(is_weak=False, value="7892,dd"),
             ),
         ),
         pytest.param(
             '"bfc1ef-5b2c2730249c88ca92d82d"',
             (ETag(is_weak=False, value="bfc1ef-5b2c2730249c88ca92d82d"),),
+        ),
+        pytest.param(
+            '"valid-tag", "also-valid-tag",somegarbage"last-tag"',
+            (
+                ETag(is_weak=False, value="valid-tag"),
+                ETag(is_weak=False, value="also-valid-tag"),
+            ),
         ),
         pytest.param(
             "*",

--- a/tests/test_web_request.py
+++ b/tests/test_web_request.py
@@ -853,6 +853,10 @@ async def test_handler_return_type(aiohttp_client: Any) -> None:
             ),
         ),
         pytest.param(
+            '"ascii", "это точно не ascii", "ascii again"',
+            (ETag(is_weak=False, value="ascii"),),
+        ),
+        pytest.param(
             "*",
             (ETag(is_weak=False, value="*"),),
         ),

--- a/tests/test_web_response.py
+++ b/tests/test_web_response.py
@@ -293,12 +293,31 @@ def test_etag_any() -> None:
 
 
 @pytest.mark.parametrize(
-    "invalid", ('"invalid"', ETag(value='"invalid"', is_weak=True))
+    "invalid_value",
+    (
+        '"invalid"',
+        "повинен бути ascii",
+        ETag(value='"invalid"', is_weak=True),
+        ETag(value="bad ©®"),
+    ),
 )
-def test_etag_invalid_value(invalid) -> None:
+def test_etag_invalid_value_set(invalid_value) -> None:
     resp = StreamResponse()
     with pytest.raises(ValueError):
-        resp.etag = invalid
+        resp.etag = invalid_value
+
+
+@pytest.mark.parametrize(
+    "header",
+    (
+        "forgotten quotes",
+        '"∀ x ∉ ascii"',
+    ),
+)
+def test_etag_invalid_value_get(header) -> None:
+    resp = StreamResponse()
+    resp.headers["ETag"] = header
+    assert resp.etag is None
 
 
 @pytest.mark.parametrize("invalid", (123, ETag(value=123, is_weak=True)))

--- a/tests/test_web_response.py
+++ b/tests/test_web_response.py
@@ -14,6 +14,7 @@ from multidict import CIMultiDict, CIMultiDictProxy
 from re_assert import Matches
 
 from aiohttp import HttpVersion, HttpVersion10, HttpVersion11, hdrs
+from aiohttp.helpers import ETag
 from aiohttp.payload import BytesPayload
 from aiohttp.test_utils import make_mocked_coro, make_mocked_request
 from aiohttp.web import ContentCoding, Response, StreamResponse, json_response
@@ -25,7 +26,7 @@ def make_request(
     headers: Any = CIMultiDict(),
     version: Any = HttpVersion11,
     on_response_prepare: Optional[Any] = None,
-    **kwargs: Any
+    **kwargs: Any,
 ):
     app = kwargs.pop("app", None) or mock.Mock()
     app._debug = False
@@ -255,6 +256,48 @@ def test_last_modified_reset() -> None:
     resp.last_modified = 0
     resp.last_modified = None
     assert resp.last_modified is None
+
+
+def test_etag_initial() -> None:
+    resp = StreamResponse()
+    assert resp.etag is None
+
+
+def test_etag_string() -> None:
+    resp = StreamResponse()
+    value = "0123-kotik"
+    resp.etag = value
+    assert resp.etag == ETag(value=value)
+    assert resp.headers[hdrs.ETAG] == f'"{value}"'
+
+
+def test_etag_class() -> None:
+    resp = StreamResponse()
+    etag = ETag(value="0123-weak-kotik", is_weak=True)
+    resp.etag = etag
+    assert resp.etag == etag
+    assert resp.headers[hdrs.ETAG] == f'W/"{etag.value}"'
+
+
+def test_etag_any() -> None:
+    resp = StreamResponse()
+    resp.etag = "*"
+    assert resp.etag == ETag(value="*")
+    assert resp.headers[hdrs.ETAG] == "*"
+
+
+@pytest.mark.parametrize("wrong_value", (123, ETag(value=123, is_weak=True)))
+def test_etag_wrong_class(wrong_value) -> None:
+    resp = StreamResponse()
+    with pytest.raises(ValueError):
+        resp.etag = wrong_value
+
+
+def test_etag_reset() -> None:
+    resp = StreamResponse()
+    resp.etag = "*"
+    resp.etag = None
+    assert resp.etag is None
 
 
 async def test_start() -> None:

--- a/tests/test_web_sendfile.py
+++ b/tests/test_web_sendfile.py
@@ -15,7 +15,8 @@ def test_using_gzip_if_header_present_and_file_available(loop: Any) -> None:
     gz_filepath.open = mock.mock_open()
     gz_filepath.is_file.return_value = True
     gz_filepath.stat.return_value = mock.MagicMock()
-    gz_filepath.stat.st_size = 1024
+    gz_filepath.stat.return_value.st_size = 1024
+    gz_filepath.stat.return_value.st_mtime_ns = 1603733507222449291
 
     filepath = mock.Mock()
     filepath.name = "logo.png"
@@ -43,7 +44,8 @@ def test_gzip_if_header_not_present_and_file_available(loop: Any) -> None:
     filepath.open = mock.mock_open()
     filepath.with_name.return_value = gz_filepath
     filepath.stat.return_value = mock.MagicMock()
-    filepath.stat.st_size = 1024
+    filepath.stat.return_value.st_size = 1024
+    filepath.stat.return_value.st_mtime_ns = 1603733507222449291
 
     file_sender = FileResponse(filepath)
     file_sender._sendfile = make_mocked_coro(None)  # type: ignore[assignment]
@@ -66,7 +68,8 @@ def test_gzip_if_header_not_present_and_file_not_available(loop: Any) -> None:
     filepath.open = mock.mock_open()
     filepath.with_name.return_value = gz_filepath
     filepath.stat.return_value = mock.MagicMock()
-    filepath.stat.st_size = 1024
+    filepath.stat.return_value.st_size = 1024
+    filepath.stat.return_value.st_mtime_ns = 1603733507222449291
 
     file_sender = FileResponse(filepath)
     file_sender._sendfile = make_mocked_coro(None)  # type: ignore[assignment]
@@ -91,7 +94,8 @@ def test_gzip_if_header_present_and_file_not_available(loop: Any) -> None:
     filepath.open = mock.mock_open()
     filepath.with_name.return_value = gz_filepath
     filepath.stat.return_value = mock.MagicMock()
-    filepath.stat.st_size = 1024
+    filepath.stat.return_value.st_size = 1024
+    filepath.stat.return_value.st_mtime_ns = 1603733507222449291
 
     file_sender = FileResponse(filepath)
     file_sender._sendfile = make_mocked_coro(None)  # type: ignore[assignment]
@@ -109,7 +113,8 @@ def test_status_controlled_by_user(loop: Any) -> None:
     filepath.name = "logo.png"
     filepath.open = mock.mock_open()
     filepath.stat.return_value = mock.MagicMock()
-    filepath.stat.st_size = 1024
+    filepath.stat.return_value.st_size = 1024
+    filepath.stat.return_value.st_mtime_ns = 1603733507222449291
 
     file_sender = FileResponse(filepath, status=203)
     file_sender._sendfile = make_mocked_coro(None)  # type: ignore[assignment]

--- a/tests/test_web_sendfile_functional.py
+++ b/tests/test_web_sendfile_functional.py
@@ -3,7 +3,7 @@ import asyncio
 import pathlib
 import socket
 import zlib
-from typing import Any
+from typing import Any, Iterable
 
 import pytest
 
@@ -36,15 +36,23 @@ def sender(request: Any, loop_without_sendfile: Any):
     return maker
 
 
-async def test_static_file_ok(aiohttp_client: Any, sender: Any) -> None:
-    filepath = pathlib.Path(__file__).parent / "data.unknown_mime_type"
+@pytest.fixture
+def app_with_static_route(sender: Any) -> web.Application:
+    filename = "data.unknown_mime_type"
+    filepath = pathlib.Path(__file__).parent / filename
 
     async def handler(request):
         return sender(filepath)
 
     app = web.Application()
     app.router.add_get("/", handler)
-    client = await aiohttp_client(app)
+    return app
+
+
+async def test_static_file_ok(
+    aiohttp_client: Any, app_with_static_route: web.Application
+) -> None:
+    client = await aiohttp_client(app_with_static_route)
 
     resp = await client.get("/")
     assert resp.status == 200
@@ -74,15 +82,10 @@ async def test_zero_bytes_file_ok(aiohttp_client: Any, sender: Any) -> None:
     await resp.release()
 
 
-async def test_static_file_ok_string_path(aiohttp_client: Any, sender: Any) -> None:
-    filepath = pathlib.Path(__file__).parent / "data.unknown_mime_type"
-
-    async def handler(request):
-        return sender(str(filepath))
-
-    app = web.Application()
-    app.router.add_get("/", handler)
-    client = await aiohttp_client(app)
+async def test_static_file_ok_string_path(
+    aiohttp_client: Any, app_with_static_route: web.Application
+) -> None:
+    client = await aiohttp_client(app_with_static_route)
 
     resp = await client.get("/")
     assert resp.status == 200
@@ -215,16 +218,10 @@ async def test_static_file_with_content_encoding(
     resp.close()
 
 
-async def test_static_file_if_modified_since(aiohttp_client: Any, sender: Any) -> None:
-    filename = "data.unknown_mime_type"
-    filepath = pathlib.Path(__file__).parent / filename
-
-    async def handler(request):
-        return sender(filepath)
-
-    app = web.Application()
-    app.router.add_get("/", handler)
-    client = await aiohttp_client(app)
+async def test_static_file_if_modified_since(
+    aiohttp_client: Any, app_with_static_route: web.Application
+) -> None:
+    client = await aiohttp_client(app_with_static_route)
 
     resp = await client.get("/")
     assert 200 == resp.status
@@ -236,22 +233,15 @@ async def test_static_file_if_modified_since(aiohttp_client: Any, sender: Any) -
     body = await resp.read()
     assert 304 == resp.status
     assert resp.headers.get("Content-Length") is None
+    assert resp.headers.get("Last-Modified") == lastmod
     assert b"" == body
     resp.close()
 
 
 async def test_static_file_if_modified_since_past_date(
-    aiohttp_client: Any, sender: Any
+    aiohttp_client: Any, app_with_static_route: web.Application
 ) -> None:
-    filename = "data.unknown_mime_type"
-    filepath = pathlib.Path(__file__).parent / filename
-
-    async def handler(request):
-        return sender(filepath)
-
-    app = web.Application()
-    app.router.add_get("/", handler)
-    client = await aiohttp_client(app)
+    client = await aiohttp_client(app_with_static_route)
 
     lastmod = "Mon, 1 Jan 1990 01:01:01 GMT"
 
@@ -261,17 +251,9 @@ async def test_static_file_if_modified_since_past_date(
 
 
 async def test_static_file_if_modified_since_invalid_date(
-    aiohttp_client: Any, sender: Any
+    aiohttp_client: Any, app_with_static_route: web.Application
 ):
-    filename = "data.unknown_mime_type"
-    filepath = pathlib.Path(__file__).parent / filename
-
-    async def handler(request):
-        return sender(filepath)
-
-    app = web.Application()
-    app.router.add_get("/", handler)
-    client = await aiohttp_client(app)
+    client = await aiohttp_client(app_with_static_route)
 
     lastmod = "not a valid HTTP-date"
 
@@ -281,17 +263,9 @@ async def test_static_file_if_modified_since_invalid_date(
 
 
 async def test_static_file_if_modified_since_future_date(
-    aiohttp_client: Any, sender: Any
+    aiohttp_client: Any, app_with_static_route: web.Application
 ):
-    filename = "data.unknown_mime_type"
-    filepath = pathlib.Path(__file__).parent / filename
-
-    async def handler(request):
-        return sender(filepath)
-
-    app = web.Application()
-    app.router.add_get("/", handler)
-    client = await aiohttp_client(app)
+    client = await aiohttp_client(app_with_static_route)
 
     lastmod = "Fri, 31 Dec 9999 23:59:59 GMT"
 
@@ -299,13 +273,121 @@ async def test_static_file_if_modified_since_future_date(
     body = await resp.read()
     assert 304 == resp.status
     assert resp.headers.get("Content-Length") is None
+    assert resp.headers.get("Last-Modified")
+    assert b"" == body
+    resp.close()
+
+
+@pytest.mark.parametrize("if_unmodified_since", ("", "Fri, 31 Dec 0000 23:59:59 GMT"))
+async def test_static_file_if_match(
+    aiohttp_client: Any,
+    app_with_static_route: web.Application,
+    if_unmodified_since: str,
+) -> None:
+    client = await aiohttp_client(app_with_static_route)
+
+    resp = await client.get("/")
+    assert 200 == resp.status
+    original_etag = resp.headers.get("ETag")
+
+    assert original_etag is not None
+    resp.close()
+
+    headers = {"If-Match": original_etag, "If-Unmodified-Since": if_unmodified_since}
+    resp = await client.head("/", headers=headers)
+    body = await resp.read()
+    assert 200 == resp.status
+    assert resp.headers.get("ETag")
+    assert resp.headers.get("Last-Modified")
+    assert b"" == body
+    resp.close()
+
+
+@pytest.mark.parametrize("if_unmodified_since", ("", "Fri, 31 Dec 0000 23:59:59 GMT"))
+@pytest.mark.parametrize(
+    "etags,expected_status",
+    [
+        (("*",), 200),
+        (('"example-tag"', 'W/"weak-tag"'), 412),
+    ],
+)
+async def test_static_file_if_match_custom_tags(
+    aiohttp_client: Any,
+    app_with_static_route: web.Application,
+    if_unmodified_since: str,
+    etags: Iterable[str],
+    expected_status: Iterable[int],
+) -> None:
+    client = await aiohttp_client(app_with_static_route)
+
+    if_match = ", ".join(etags)
+    headers = {"If-Match": if_match, "If-Unmodified-Since": if_unmodified_since}
+    resp = await client.head("/", headers=headers)
+    body = await resp.read()
+    assert expected_status == resp.status
+    assert b"" == body
+    resp.close()
+
+
+@pytest.mark.parametrize("if_modified_since", ("", "Fri, 31 Dec 9999 23:59:59 GMT"))
+@pytest.mark.parametrize(
+    "additional_etags",
+    (
+        (),
+        ('"some-other-strong-etag"', 'W/"weak-tag"', "invalid-tag"),
+    ),
+)
+async def test_static_file_if_none_match(
+    aiohttp_client: Any,
+    app_with_static_route: web.Application,
+    if_modified_since: str,
+    additional_etags: Iterable[str],
+) -> None:
+    client = await aiohttp_client(app_with_static_route)
+
+    resp = await client.get("/")
+    assert 200 == resp.status
+    original_etag = resp.headers.get("ETag")
+
+    assert resp.headers.get("Last-Modified") is not None
+    assert original_etag is not None
+    resp.close()
+
+    etag = ",".join((original_etag, *additional_etags))
+
+    resp = await client.get(
+        "/", headers={"If-None-Match": etag, "If-Modified-Since": if_modified_since}
+    )
+    body = await resp.read()
+    assert 304 == resp.status
+    assert resp.headers.get("Content-Length") is None
+    assert resp.headers.get("ETag") == original_etag
+    assert b"" == body
+    resp.close()
+
+
+async def test_static_file_if_none_match_star(
+    aiohttp_client: Any,
+    app_with_static_route: web.Application,
+) -> None:
+    client = await aiohttp_client(app_with_static_route)
+
+    resp = await client.head("/", headers={"If-None-Match": "*"})
+    body = await resp.read()
+    assert 304 == resp.status
+    assert resp.headers.get("Content-Length") is None
+    assert resp.headers.get("ETag")
+    assert resp.headers.get("Last-Modified")
     assert b"" == body
     resp.close()
 
 
 @pytest.mark.skipif(not ssl, reason="ssl not supported")
 async def test_static_file_ssl(
-    aiohttp_server: Any, ssl_ctx: Any, aiohttp_client: Any, client_ssl_ctx: Any
+    aiohttp_server: Any,
+    ssl_ctx: Any,
+    aiohttp_client: Any,
+    client_ssl_ctx: Any,
 ) -> None:
     dirname = pathlib.Path(__file__).parent
     filename = "data.unknown_mime_type"
@@ -564,17 +646,9 @@ async def test_static_file_invalid_range(aiohttp_client: Any, sender: Any) -> No
 
 
 async def test_static_file_if_unmodified_since_past_with_range(
-    aiohttp_client: Any, sender: Any
+    aiohttp_client: Any, app_with_static_route: web.Application
 ):
-    filename = "data.unknown_mime_type"
-    filepath = pathlib.Path(__file__).parent / filename
-
-    async def handler(request):
-        return sender(filepath)
-
-    app = web.Application()
-    app.router.add_get("/", handler)
-    client = await aiohttp_client(app)
+    client = await aiohttp_client(app_with_static_route)
 
     lastmod = "Mon, 1 Jan 1990 01:01:01 GMT"
 
@@ -586,17 +660,9 @@ async def test_static_file_if_unmodified_since_past_with_range(
 
 
 async def test_static_file_if_unmodified_since_future_with_range(
-    aiohttp_client: Any, sender: Any
+    aiohttp_client: Any, app_with_static_route: web.Application
 ):
-    filename = "data.unknown_mime_type"
-    filepath = pathlib.Path(__file__).parent / filename
-
-    async def handler(request):
-        return sender(filepath)
-
-    app = web.Application()
-    app.router.add_get("/", handler)
-    client = await aiohttp_client(app)
+    client = await aiohttp_client(app_with_static_route)
 
     lastmod = "Fri, 31 Dec 9999 23:59:59 GMT"
 
@@ -609,16 +675,10 @@ async def test_static_file_if_unmodified_since_future_with_range(
     resp.close()
 
 
-async def test_static_file_if_range_past_with_range(aiohttp_client: Any, sender: Any):
-    filename = "data.unknown_mime_type"
-    filepath = pathlib.Path(__file__).parent / filename
-
-    async def handler(request):
-        return sender(filepath)
-
-    app = web.Application()
-    app.router.add_get("/", handler)
-    client = await aiohttp_client(app)
+async def test_static_file_if_range_past_with_range(
+    aiohttp_client: Any, app_with_static_route: web.Application
+):
+    client = await aiohttp_client(app_with_static_route)
 
     lastmod = "Mon, 1 Jan 1990 01:01:01 GMT"
 
@@ -628,16 +688,10 @@ async def test_static_file_if_range_past_with_range(aiohttp_client: Any, sender:
     resp.close()
 
 
-async def test_static_file_if_range_future_with_range(aiohttp_client: Any, sender: Any):
-    filename = "data.unknown_mime_type"
-    filepath = pathlib.Path(__file__).parent / filename
-
-    async def handler(request):
-        return sender(filepath)
-
-    app = web.Application()
-    app.router.add_get("/", handler)
-    client = await aiohttp_client(app)
+async def test_static_file_if_range_future_with_range(
+    aiohttp_client: Any, app_with_static_route: web.Application
+):
+    client = await aiohttp_client(app_with_static_route)
 
     lastmod = "Fri, 31 Dec 9999 23:59:59 GMT"
 
@@ -649,17 +703,9 @@ async def test_static_file_if_range_future_with_range(aiohttp_client: Any, sende
 
 
 async def test_static_file_if_unmodified_since_past_without_range(
-    aiohttp_client: Any, sender: Any
+    aiohttp_client: Any, app_with_static_route: web.Application
 ):
-    filename = "data.unknown_mime_type"
-    filepath = pathlib.Path(__file__).parent / filename
-
-    async def handler(request):
-        return sender(filepath)
-
-    app = web.Application()
-    app.router.add_get("/", handler)
-    client = await aiohttp_client(app)
+    client = await aiohttp_client(app_with_static_route)
 
     lastmod = "Mon, 1 Jan 1990 01:01:01 GMT"
 
@@ -669,17 +715,9 @@ async def test_static_file_if_unmodified_since_past_without_range(
 
 
 async def test_static_file_if_unmodified_since_future_without_range(
-    aiohttp_client: Any, sender: Any
+    aiohttp_client: Any, app_with_static_route: web.Application
 ):
-    filename = "data.unknown_mime_type"
-    filepath = pathlib.Path(__file__).parent / filename
-
-    async def handler(request):
-        return sender(filepath)
-
-    app = web.Application()
-    app.router.add_get("/", handler)
-    client = await aiohttp_client(app)
+    client = await aiohttp_client(app_with_static_route)
 
     lastmod = "Fri, 31 Dec 9999 23:59:59 GMT"
 
@@ -690,17 +728,9 @@ async def test_static_file_if_unmodified_since_future_without_range(
 
 
 async def test_static_file_if_range_past_without_range(
-    aiohttp_client: Any, sender: Any
+    aiohttp_client: Any, app_with_static_route: web.Application
 ):
-    filename = "data.unknown_mime_type"
-    filepath = pathlib.Path(__file__).parent / filename
-
-    async def handler(request):
-        return sender(filepath)
-
-    app = web.Application()
-    app.router.add_get("/", handler)
-    client = await aiohttp_client(app)
+    client = await aiohttp_client(app_with_static_route)
 
     lastmod = "Mon, 1 Jan 1990 01:01:01 GMT"
 
@@ -711,17 +741,9 @@ async def test_static_file_if_range_past_without_range(
 
 
 async def test_static_file_if_range_future_without_range(
-    aiohttp_client: Any, sender: Any
+    aiohttp_client: Any, app_with_static_route: web.Application
 ):
-    filename = "data.unknown_mime_type"
-    filepath = pathlib.Path(__file__).parent / filename
-
-    async def handler(request):
-        return sender(filepath)
-
-    app = web.Application()
-    app.router.add_get("/", handler)
-    client = await aiohttp_client(app)
+    client = await aiohttp_client(app_with_static_route)
 
     lastmod = "Fri, 31 Dec 9999 23:59:59 GMT"
 
@@ -732,17 +754,9 @@ async def test_static_file_if_range_future_without_range(
 
 
 async def test_static_file_if_unmodified_since_invalid_date(
-    aiohttp_client: Any, sender: Any
+    aiohttp_client: Any, app_with_static_route: web.Application
 ):
-    filename = "data.unknown_mime_type"
-    filepath = pathlib.Path(__file__).parent / filename
-
-    async def handler(request):
-        return sender(filepath)
-
-    app = web.Application()
-    app.router.add_get("/", handler)
-    client = await aiohttp_client(app)
+    client = await aiohttp_client(app_with_static_route)
 
     lastmod = "not a valid HTTP-date"
 
@@ -751,16 +765,10 @@ async def test_static_file_if_unmodified_since_invalid_date(
     resp.close()
 
 
-async def test_static_file_if_range_invalid_date(aiohttp_client: Any, sender: Any):
-    filename = "data.unknown_mime_type"
-    filepath = pathlib.Path(__file__).parent / filename
-
-    async def handler(request):
-        return sender(filepath)
-
-    app = web.Application()
-    app.router.add_get("/", handler)
-    client = await aiohttp_client(app)
+async def test_static_file_if_range_invalid_date(
+    aiohttp_client: Any, app_with_static_route: web.Application
+):
+    client = await aiohttp_client(app_with_static_route)
 
     lastmod = "not a valid HTTP-date"
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?
This PR adds `etag` property to the response object and `if_match`, `if_none_match` properties to the request object. Also it implements `ETag` support in static routes and fixes few bugs found along the way.

Despite the low priority of static files handling for `aiohttp`, I believe `ETag` and related headers has a wide application beyond this purpose.

## Are there changes in behavior for the user?

Nope, no general changes in server behaviour.

## Related issue number

Fixes #4594

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/aio-libs/aiohttp/5298)
<!-- Reviewable:end -->
