### PR TITLE
Bump async-timeout version for aiohttp 3.8

### DIFF
--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -74,8 +74,8 @@ from .helpers import (
     DEBUG,
     PY_36,
     BasicAuth,
-    CeilTimeout,
     TimeoutHandle,
+    ceil_timeout,
     get_running_loop,
     proxies_from_env,
     sentinel,
@@ -515,7 +515,7 @@ class ClientSession:
 
                     # connection timeout
                     try:
-                        with CeilTimeout(real_timeout.connect, loop=self._loop):
+                        async with ceil_timeout(real_timeout.connect):
                             assert self._connector is not None
                             conn = await self._connector.connect(
                                 req, traces=traces, timeout=real_timeout

--- a/aiohttp/client_ws.py
+++ b/aiohttp/client_ws.py
@@ -192,7 +192,7 @@ class ClientWebSocketResponse:
 
             while True:
                 try:
-                    with async_timeout.timeout(self._timeout, loop=self._loop):
+                    async with async_timeout.timeout(self._timeout):
                         msg = await self._reader.read()
                 except asyncio.CancelledError:
                     self._close_code = WSCloseCode.ABNORMAL_CLOSURE
@@ -225,9 +225,7 @@ class ClientWebSocketResponse:
             try:
                 self._waiting = self._loop.create_future()
                 try:
-                    with async_timeout.timeout(
-                        timeout or self._receive_timeout, loop=self._loop
-                    ):
+                    async with async_timeout.timeout(timeout or self._receive_timeout):
                         msg = await self._reader.read()
                     self._reset_heartbeat()
                 finally:

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -45,7 +45,14 @@ from .client_exceptions import (
 )
 from .client_proto import ResponseHandler
 from .client_reqrep import ClientRequest, Fingerprint, _merge_ssl_params
-from .helpers import PY_36, CeilTimeout, get_running_loop, is_ip_address, noop, sentinel
+from .helpers import (
+    PY_36,
+    ceil_timeout,
+    get_running_loop,
+    is_ip_address,
+    noop,
+    sentinel,
+)
 from .http import RESPONSES
 from .locks import EventResultOrError
 from .resolver import DefaultResolver
@@ -972,7 +979,7 @@ class TCPConnector(BaseConnector):
         **kwargs: Any,
     ) -> Tuple[asyncio.Transport, ResponseHandler]:
         try:
-            with CeilTimeout(timeout.sock_connect):
+            async with ceil_timeout(timeout.sock_connect):
                 return await self._loop.create_connection(*args, **kwargs)  # type: ignore  # noqa
         except cert_errors as exc:
             raise ClientConnectorCertificateError(req.connection_key, exc) from exc
@@ -1196,7 +1203,7 @@ class UnixConnector(BaseConnector):
         self, req: "ClientRequest", traces: List["Trace"], timeout: "ClientTimeout"
     ) -> ResponseHandler:
         try:
-            with CeilTimeout(timeout.sock_connect):
+            async with ceil_timeout(timeout.sock_connect):
                 _, proto = await self._loop.create_unix_connection(
                     self._factory, self._path
                 )
@@ -1252,7 +1259,7 @@ class NamedPipeConnector(BaseConnector):
         self, req: "ClientRequest", traces: List["Trace"], timeout: "ClientTimeout"
     ) -> ResponseHandler:
         try:
-            with CeilTimeout(timeout.sock_connect):
+            async with ceil_timeout(timeout.sock_connect):
                 _, proto = await self._loop.create_pipe_connection(  # type: ignore
                     self._factory, self._path
                 )

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -671,7 +671,7 @@ def ceil_timeout(delay: Optional[float]) -> async_timeout.Timeout:
         loop = get_running_loop()
         now = loop.time()
         when = now + delay
-        if delay <= 5:
+        if delay > 5:
             when = ceil(when)
         return async_timeout.timeout_at(when)
 

--- a/aiohttp/web_protocol.py
+++ b/aiohttp/web_protocol.py
@@ -26,7 +26,7 @@ import yarl
 
 from .abc import AbstractAccessLogger, AbstractStreamWriter
 from .base_protocol import BaseProtocol
-from .helpers import CeilTimeout
+from .helpers import ceil_timeout
 from .http import (
     HttpProcessingError,
     HttpRequestParser,
@@ -239,7 +239,7 @@ class RequestHandler(BaseProtocol):
 
         # wait for handlers
         with suppress(asyncio.CancelledError, asyncio.TimeoutError):
-            with CeilTimeout(timeout, loop=self._loop):
+            async with ceil_timeout(timeout):
                 if self._current_request is not None:
                     self._current_request._cancel(asyncio.CancelledError())
 
@@ -523,7 +523,7 @@ class RequestHandler(BaseProtocol):
 
                         with suppress(asyncio.TimeoutError, asyncio.CancelledError):
                             while not payload.is_eof() and now < end_t:
-                                with CeilTimeout(end_t - now, loop=loop):
+                                async with ceil_timeout(end_t - now):
                                     # read and ignore
                                     await payload.readany()
                                 now = loop.time()

--- a/aiohttp/web_ws.py
+++ b/aiohttp/web_ws.py
@@ -360,7 +360,7 @@ class WebSocketResponse(StreamResponse):
             reader = self._reader
             assert reader is not None
             try:
-                with async_timeout.timeout(self._timeout, loop=self._loop):
+                async with async_timeout.timeout(self._timeout):
                     msg = await reader.read()
             except asyncio.CancelledError:
                 self._close_code = WSCloseCode.ABNORMAL_CLOSURE
@@ -401,9 +401,7 @@ class WebSocketResponse(StreamResponse):
             try:
                 self._waiting = loop.create_future()
                 try:
-                    with async_timeout.timeout(
-                        timeout or self._receive_timeout, loop=self._loop
-                    ):
+                    async with async_timeout.timeout(timeout or self._receive_timeout):
                         msg = await self._reader.read()
                     self._reset_heartbeat()
                 finally:

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -3,7 +3,7 @@
 aiodns==2.0.0; sys_platform=="linux" or sys_platform=="darwin" and python_version>="3.7"
 aiosignal==1.1.2
 async-generator==1.10
-async-timeout==3.0.1
+async-timeout==4.0.0a3
 asynctest==0.13.0; python_version<"3.8"
 attrs==20.3.0
 brotlipy==0.7.0

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ install_requires = [
     "attrs>=17.3.0",
     "chardet>=2.0,<4.0",
     "multidict>=4.5,<7.0",
-    "async_timeout>=3.0,<4.0",
+    "async_timeout>=4.0.0a3,<5.0",
     'asynctest==0.13.0; python_version<"3.8"',
     "yarl>=1.0,<2.0",
     'idna-ssl>=1.0; python_version<"3.7"',

--- a/tests/test_client_ws_functional.py
+++ b/tests/test_client_ws_functional.py
@@ -461,7 +461,7 @@ async def test_recv_timeout(aiohttp_client) -> None:
     await resp.send_str("ask")
 
     with pytest.raises(asyncio.TimeoutError):
-        with async_timeout.timeout(0.01):
+        async with async_timeout.timeout(0.01):
             await resp.receive()
 
     await resp.close()


### PR DESCRIPTION
This change allows keeping more or less the same code that uses timeouts for both master and 3.8 branches.

The master has backward-incompatible changes and it is not complete yet; aiohttp 4.0 cannot be published anytime soon.
