### PR TITLE
Add missing slots to `_RequestContextManager` and `_WSRequestContextManager`

### DIFF
--- a/CHANGES/5329.bugfix
+++ b/CHANGES/5329.bugfix
@@ -1,0 +1,1 @@
+Add missing slots to ```_RequestContextManager`` and ``_WSRequestContextManager``

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -319,6 +319,7 @@ Ye Cao
 Yegor Roganov
 Yifei Kong
 Young-Ho Cha
+Yury Pliner
 Yuriy Shatrov
 Yury Selivanov
 Yusuke Tsutsumi

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -319,8 +319,8 @@ Ye Cao
 Yegor Roganov
 Yifei Kong
 Young-Ho Cha
-Yury Pliner
 Yuriy Shatrov
+Yury Pliner
 Yury Selivanov
 Yusuke Tsutsumi
 Yuval Ofir

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -1072,6 +1072,8 @@ class _BaseRequestContextManager(Coroutine[Any, Any, _RetType], Generic[_RetType
 
 
 class _RequestContextManager(_BaseRequestContextManager[ClientResponse]):
+    __slots__ = ()
+
     async def __aexit__(
         self,
         exc_type: Optional[Type[BaseException]],
@@ -1087,6 +1089,8 @@ class _RequestContextManager(_BaseRequestContextManager[ClientResponse]):
 
 
 class _WSRequestContextManager(_BaseRequestContextManager[ClientWebSocketResponse]):
+    __slots__ = ()
+
     async def __aexit__(
         self,
         exc_type: Optional[Type[BaseException]],


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

It seems that slots were forgotten in children of `_BaseRequestContextManager`

<!-- Please give a short brief about these changes. -->

PR adds slots to `_RequestContextManager` and `_WSRequestContextManager`

Here is a very short sample to show the diff:
```
import sys


class ASlot:
    __slots__ = ("a", "b")

    def __init__(self):
        self.a = 42
        self.b = 24


class BNoSlot(ASlot):
    pass


class BSlot(ASlot):
    __slots__ = ()

print(sys.getsizeof(ASlot())) # 48
print(sys.getsizeof(BNoSlot())) # 64
print(sys.getsizeof(BSlot())) # 48
```

- [X] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [X] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [X] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
