### PR TITLE
Fix AttributeError: object has no attribute 'decode' for PAYLOAD_REGISTRY class

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -48,7 +48,8 @@ Bugfixes
   `#5163 <https://github.com/aio-libs/aiohttp/issues/5163>`_
 - Provide x86 Windows wheels.
   `#5230 <https://github.com/aio-libs/aiohttp/issues/5230>`_
-
+- Fix AttributeError: object has no attribute 'decode' for PAYLOAD_REGISTRY.
+  `#5281 <https://github.com/aio-libs/aiohttp/issues/5281>`_
 
 Improved Documentation
 ----------------------

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -9,8 +9,8 @@ Adrián Chaves
 Alan Tse
 Alec Hanefeld
 Alejandro Gómez
-Aleksandr Vaskevich
 Aleksandr Danshyn
+Aleksandr Vaskevich
 Aleksey Kutepov
 Alex Hayes
 Alex Key

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -9,6 +9,7 @@ Adrián Chaves
 Alan Tse
 Alec Hanefeld
 Alejandro Gómez
+Aleksandr Vaskevich
 Aleksandr Danshyn
 Aleksey Kutepov
 Alex Hayes

--- a/aiohttp/payload.py
+++ b/aiohttp/payload.py
@@ -386,6 +386,9 @@ class JsonPayload(BytesPayload):
             **kwargs,
         )
 
+    def decode(self, encoding: str) -> str:
+        return self._value.decode(encoding)
+
 
 if TYPE_CHECKING:  # pragma: no cover
     from typing import AsyncIterable, AsyncIterator

--- a/tests/test_payload.py
+++ b/tests/test_payload.py
@@ -1,11 +1,11 @@
 import array
 import json
 from io import StringIO
-from typing import Any, AsyncIterator, Iterator
+from typing import Any, AsyncIterator, Iterator, Mapping
 
 import pytest
 
-from aiohttp import payload
+from aiohttp import payload, web
 
 
 @pytest.fixture
@@ -123,3 +123,21 @@ def test_decode_json_payload(registry: Any) -> None:
     j = {"foo": 42}
     p = payload.JsonPayload(j)
     assert json.dumps(j) == p.decode("utf-8")
+
+
+async def test_json_payload(registry: Any, aiohttp_client: Any) -> None:
+    async def handler(request):
+        return web.Response(body={"foo": 42})
+
+    app = web.Application()
+    payload.register_payload(
+        payload.JsonPayload, Mapping, order=payload.Order.try_first
+    )
+    app.router.add_route("GET", "/", handler)
+    client = await aiohttp_client(app)
+    resp = await client.get("/")
+    body = json.loads(await resp.text())
+    assert "application/json" == resp.content_type
+    assert resp.status == 200
+    assert "foo" in body
+    assert body["foo"] == 42

--- a/tests/test_payload.py
+++ b/tests/test_payload.py
@@ -1,4 +1,5 @@
 import array
+import json
 from io import StringIO
 from typing import Any, AsyncIterator, Iterator
 
@@ -116,3 +117,9 @@ def test_async_iterable_payload_not_async_iterable() -> None:
 
     with pytest.raises(TypeError):
         payload.AsyncIterablePayload(object())  # type: ignore
+
+
+def test_decode_json_payload(registry: Any) -> None:
+    j = {"foo": 42}
+    p = payload.JsonPayload(j)
+    assert json.dumps(j) == p.decode("utf-8")

--- a/tests/test_payload.py
+++ b/tests/test_payload.py
@@ -125,14 +125,12 @@ def test_decode_json_payload(registry: Any) -> None:
     assert json.dumps(j) == p.decode("utf-8")
 
 
-async def test_json_payload(registry: Any, aiohttp_client: Any) -> None:
-    async def handler(request):
+async def test_json_payload(aiohttp_client: Any) -> None:
+    async def handler(request: web.Request) -> web.Response:
         return web.Response(body={"foo": 42})
 
     app = web.Application()
-    payload.register_payload(
-        payload.JsonPayload, Mapping, order=payload.Order.try_first
-    )
+    payload.register_payload(payload.JsonPayload, Mapping)
     app.router.add_route("GET", "/", handler)
     client = await aiohttp_client(app)
     resp = await client.get("/")

--- a/tests/test_payload.py
+++ b/tests/test_payload.py
@@ -125,7 +125,7 @@ def test_decode_json_payload(registry: Any) -> None:
     assert json.dumps(j) == p.decode("utf-8")
 
 
-async def test_json_payload(aiohttp_client: Any) -> None:
+async def test_json_payload(registry: Any, aiohttp_client: Any) -> None:
     async def handler(request: web.Request) -> web.Response:
         return web.Response(body={"foo": 42})
 

--- a/tests/test_web_response.py
+++ b/tests/test_web_response.py
@@ -5,8 +5,7 @@ import gzip
 import json
 import weakref
 from concurrent.futures import ThreadPoolExecutor
-from typing import Any, Mapping, Optional
-from types import MappingProxyType
+from typing import Any, Optional
 from unittest import mock
 
 import aiosignal
@@ -15,7 +14,7 @@ from multidict import CIMultiDict, CIMultiDictProxy
 from re_assert import Matches
 
 from aiohttp import HttpVersion, HttpVersion10, HttpVersion11, hdrs
-from aiohttp.payload import BytesPayload, JsonPayload, PAYLOAD_REGISTRY
+from aiohttp.payload import BytesPayload
 from aiohttp.test_utils import make_mocked_coro, make_mocked_request
 from aiohttp.web import ContentCoding, Response, StreamResponse, json_response
 
@@ -1095,11 +1094,3 @@ class TestJSONResponse:
     def test_content_type_is_overrideable(self) -> None:
         resp = json_response({"foo": 42}, content_type="application/vnd.json+api")
         assert "application/vnd.json+api" == resp.content_type
-
-
-class TestPayloadRegistryResponse:
-    def test_json_payload_text(self) -> None:
-        PAYLOAD_REGISTRY.register(JsonPayload, (Mapping, MappingProxyType))
-        data = {"foo": 42}
-        resp = json_response(data)
-        assert json.dumps(data) == resp.text

--- a/tests/test_web_response.py
+++ b/tests/test_web_response.py
@@ -5,7 +5,8 @@ import gzip
 import json
 import weakref
 from concurrent.futures import ThreadPoolExecutor
-from typing import Any, Optional
+from typing import Any, Mapping, Optional
+from types import MappingProxyType
 from unittest import mock
 
 import aiosignal
@@ -14,7 +15,7 @@ from multidict import CIMultiDict, CIMultiDictProxy
 from re_assert import Matches
 
 from aiohttp import HttpVersion, HttpVersion10, HttpVersion11, hdrs
-from aiohttp.payload import BytesPayload
+from aiohttp.payload import BytesPayload, JsonPayload, PAYLOAD_REGISTRY
 from aiohttp.test_utils import make_mocked_coro, make_mocked_request
 from aiohttp.web import ContentCoding, Response, StreamResponse, json_response
 
@@ -1094,3 +1095,11 @@ class TestJSONResponse:
     def test_content_type_is_overrideable(self) -> None:
         resp = json_response({"foo": 42}, content_type="application/vnd.json+api")
         assert "application/vnd.json+api" == resp.content_type
+
+
+class TestPayloadRegistryResponse:
+    def test_json_payload_text(self) -> None:
+        PAYLOAD_REGISTRY.register(JsonPayload, (Mapping, MappingProxyType))
+        data = {"foo": 42}
+        resp = json_response(data)
+        assert json.dumps(data) == resp.text


### PR DESCRIPTION
Implement the decode method in the JsonPayload class #5281
Added test for JsonPayload

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
- [x] Add a new news fragment into the `CHANGES` folder