### PR TITLE
docs: fix simple typo, pipelinig -> pipelining

### DIFF
--- a/aiohttp/web_protocol.py
+++ b/aiohttp/web_protocol.py
@@ -384,7 +384,7 @@ class RequestHandler(BaseProtocol):
             self._keepalive_handle = None
 
     def close(self) -> None:
-        """Stop accepting new pipelinig messages and close
+        """Stop accepting new pipelining messages and close
         connection when handlers done processing messages"""
         self._close = True
         if self._waiter:


### PR DESCRIPTION
There is a small typo in aiohttp/web_protocol.py.

Should read `pipelining` rather than `pipelinig`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md