### PR TITLE
Fix str method of ClientResponseError to hide password

### DIFF
--- a/CHANGES/5399.bugfix
+++ b/CHANGES/5399.bugfix
@@ -1,0 +1,1 @@
+Fixed str method for ``ClientResponseError`` so the password is not logged as clear text.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -76,6 +76,7 @@ Daniel Grossmann-Kavanagh
 Daniel Nelson
 Danny Song
 David Bibb
+David Davis
 David Michael Brown
 Denilson Amorim
 Denis Matiychuk

--- a/aiohttp/client_exceptions.py
+++ b/aiohttp/client_exceptions.py
@@ -71,10 +71,15 @@ class ClientResponseError(ClientError):
         self.args = (request_info, history)
 
     def __str__(self) -> str:
+        if self.request_info.real_url.password:
+            url = self.request_info.real_url.with_password("*hidden*")
+        else:
+            url = self.request_info.real_url
+
         return "{}, message={!r}, url={!r}".format(
             self.status,
             self.message,
-            self.request_info.real_url,
+            url,
         )
 
     def __repr__(self) -> str:

--- a/tests/test_client_exceptions.py
+++ b/tests/test_client_exceptions.py
@@ -6,15 +6,17 @@ import pickle
 import sys
 from typing import Any
 
+from yarl import URL
+
 from aiohttp import client, client_reqrep
 
 
 class TestClientResponseError:
     request_info: Any = client.RequestInfo(
-        url="http://example.com",
+        url=URL("http://example.com"),
         method="GET",
         headers={},
-        real_url="http://example.com",
+        real_url=URL("http://example.com"),
     )
 
     def test_default_status(self) -> None:
@@ -81,7 +83,27 @@ class TestClientResponseError:
             headers={},
         )
         assert str(err) == (
-            "400, message='Something wrong', " "url='http://example.com'"
+            "400, message='Something wrong', " "url=URL('http://example.com')"
+        )
+
+    def test_str_with_password(self) -> None:
+        request_info: Any = client.RequestInfo(
+            url=URL("http://user:pass@example.com"),
+            method="GET",
+            headers={},
+            real_url=URL("http://user:pass@example.com"),
+        )
+
+        err = client.ClientResponseError(
+            request_info=request_info,
+            history=(),
+            status=400,
+            message="Something wrong",
+            headers={},
+        )
+        assert str(err) == (
+            "400, message='Something wrong', "
+            "url=URL('http://user:*hidden*@example.com')"
         )
 
 


### PR DESCRIPTION
fixes #5399

<!-- Thank you for your contribution! -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
