### PR TITLE
Eliminate side-effects from the `ClientResponse.ok` property

### DIFF
--- a/CHANGES/5403.bugfix
+++ b/CHANGES/5403.bugfix
@@ -1,1 +1,1 @@
-Don't release the ```ClientResponse``` object during call to ```ok``` property for failed requests.
+Stop automatically releasing the ``ClientResponse`` object on calls to the ``ok`` property for the failed requests.

--- a/CHANGES/5403.bugfix
+++ b/CHANGES/5403.bugfix
@@ -1,0 +1,1 @@
+Don't release the ```ClientResponse``` object during call to ```ok``` property for failed requests.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -3,6 +3,7 @@
 A. Jesse Jiryu Davis
 Adam Bannister
 Adam Cooper
+Adam Horacek
 Adam Mills
 Adrian Krupa
 Adrián Chaves

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -923,14 +923,10 @@ class ClientResponse(HeadersMixin):
         This is **not** a check for ``200 OK`` but a check that the response
         status is under 400.
         """
-        try:
-            self.raise_for_status()
-        except ClientResponseError:
-            return False
-        return True
+        return 400 > self.status
 
     def raise_for_status(self) -> None:
-        if 400 <= self.status:
+        if not self.ok:
             # reason should always be not None for a started response
             assert self.reason is not None
             self.release()

--- a/tests/test_client_response.py
+++ b/tests/test_client_response.py
@@ -1243,3 +1243,22 @@ def test_response_links_empty(loop: Any, session: Any) -> None:
     )
     response._headers = CIMultiDict()
     assert response.links == {}
+
+
+def test_response_not_closed_after_get_ok() -> None:
+    response = ClientResponse(
+        "get",
+        URL("http://del-cl-resp.org"),
+        request_info=mock.Mock(),
+        writer=mock.Mock(),
+        continue100=None,
+        timer=TimerNoop(),
+        traces=[],
+        loop=mock.Mock(),
+        session=mock.Mock(),
+    )
+    response.status = 400
+    response.reason = "Bad Request"
+    response._closed = False
+    assert not response.ok
+    assert not response.closed

--- a/tests/test_client_response.py
+++ b/tests/test_client_response.py
@@ -1245,7 +1245,7 @@ def test_response_links_empty(loop: Any, session: Any) -> None:
     assert response.links == {}
 
 
-def test_response_not_closed_after_get_ok() -> None:
+def test_response_not_closed_after_get_ok(mocker) -> None:
     response = ClientResponse(
         "get",
         URL("http://del-cl-resp.org"),
@@ -1260,5 +1260,7 @@ def test_response_not_closed_after_get_ok() -> None:
     response.status = 400
     response.reason = "Bad Request"
     response._closed = False
+    spy = mocker.spy(response, "raise_for_status")
     assert not response.ok
     assert not response.closed
+    assert spy.call_count == 0


### PR DESCRIPTION
Make `ClientResponse.ok` property only check the `self.status` for 400+ status codes and reuse it in `raise_for_status` method

## Are there changes in behavior for the user?

Yes. User will be allowed to use code 
```python
res = await session.get('url-returning-400-status')
if not res.ok:
    body = await res.text()
```

## Related issue number

fixes #5403

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
