### PR TITLE
Abort the transport for all connections if enable_cleanup_closed is true

### DIFF
--- a/CHANGES/5406.bugfix
+++ b/CHANGES/5406.bugfix
@@ -1,0 +1,1 @@
+Ensure all SSL connections abort the transport when closing the connector.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -316,6 +316,7 @@ Willem de Groot
 William Grzybowski
 William S.
 Wilson Ong
+Yang Qian
 Yang Zhou
 Yannick Koechlin
 Yannick Péroux

--- a/tests/test_client_session.py
+++ b/tests/test_client_session.py
@@ -17,7 +17,7 @@ from yarl import URL
 import aiohttp
 from aiohttp import client, hdrs, web
 from aiohttp.client import ClientSession
-from aiohttp.client_reqrep import ClientRequest
+from aiohttp.client_reqrep import ClientRequest, ConnectionKey
 from aiohttp.connector import BaseConnector, TCPConnector
 from aiohttp.test_utils import make_mocked_coro
 
@@ -29,7 +29,8 @@ def connector(loop: Any, create_mocked_conn: Any):
 
     conn = loop.run_until_complete(make_conn())
     proto = create_mocked_conn()
-    conn._conns["a"] = [(proto, 123)]
+    key = ConnectionKey("localhost", 80, True, None, None, None, None)
+    conn._conns[key] = [(proto, 123)]
     yield conn
     loop.run_until_complete(conn.close())
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

When closing the connector, only the connections which are closed abort the
transport.
The connections which are available or acquired do not abort the transport.

This commit fixes the issue.


<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->
Nope

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
