### PR TITLE
fix typo in ServerDisconnectedError docs

### DIFF
--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -2146,7 +2146,7 @@ Connection errors
 
    Server disconnected.
 
-   Derived from :exc:`ServerDisconnectionError`
+   Derived from :exc:`ServerConnectionError`
 
    .. attribute:: message
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Small doc fix. `ServerDisconnectedError` was previously documented as being derived from a non-existent class.

## Are there changes in behavior for the user?

No.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
