### PR TITLE
[3.8] Enforce strict mypy checks

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -1,0 +1,24 @@
+[mypy]
+warn_unused_configs = True
+strict = True
+
+[mypy-aiodns]
+ignore_missing_imports = True
+
+[mypy-brotli]
+ignore_missing_imports = True
+
+[mypy-gunicorn.*]
+ignore_missing_imports = True
+
+[mypy-uvloop]
+ignore_missing_imports = True
+
+[mypy-cchardet]
+ignore_missing_imports = True
+
+[mypy-tokio]
+ignore_missing_imports = True
+
+[mypy-asynctest]
+ignore_missing_imports = True

--- a/CHANGES/3927.misc
+++ b/CHANGES/3927.misc
@@ -1,0 +1,1 @@
+Use ``mypy --strict``

--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ fmt format:
 
 .PHONY: mypy
 mypy:
-	mypy aiohttp
+	mypy --show-error-codes aiohttp
 
 .develop: .install-deps $(call to-hash,$(PYS) $(CYS) $(CS))
 	pip install -e .

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -131,7 +131,7 @@ __all__ = (
 try:
     from ssl import SSLContext
 except ImportError:  # pragma: no cover
-    SSLContext = object  # type: ignore
+    SSLContext = object  # type: ignore[misc,assignment]
 
 
 @attr.s(auto_attribs=True, frozen=True, slots=True)
@@ -265,7 +265,7 @@ class ClientSession:
                     stacklevel=2,
                 )
         else:
-            self._timeout = timeout  # type: ignore
+            self._timeout = timeout  # type: ignore[assignment]
             if read_timeout is not sentinel:
                 raise ValueError(
                     "read_timeout and timeout parameters "
@@ -421,7 +421,7 @@ class ClientSession:
             real_timeout = self._timeout  # type: ClientTimeout
         else:
             if not isinstance(timeout, ClientTimeout):
-                real_timeout = ClientTimeout(total=timeout)  # type: ignore
+                real_timeout = ClientTimeout(total=timeout)  # type: ignore[arg-type]
             else:
                 real_timeout = timeout
         # timeout is cumulative for all request operations
@@ -1101,7 +1101,7 @@ class _BaseRequestContextManager(Coroutine[Any, Any, _RetType], Generic[_RetType
     def send(self, arg: None) -> "asyncio.Future[Any]":
         return self._coro.send(arg)
 
-    def throw(self, arg: BaseException) -> None:  # type: ignore
+    def throw(self, arg: BaseException) -> None:  # type: ignore[arg-type,override]
         self._coro.throw(arg)
 
     def close(self) -> None:

--- a/aiohttp/client_exceptions.py
+++ b/aiohttp/client_exceptions.py
@@ -12,7 +12,7 @@ try:
 
     SSLContext = ssl.SSLContext
 except ImportError:  # pragma: no cover
-    ssl = SSLContext = None  # type: ignore
+    ssl = SSLContext = None  # type: ignore[assignment]
 
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -303,11 +303,11 @@ else:  # pragma: no cover
     ssl_error_bases = (ClientSSLError,)
 
 
-class ClientConnectorSSLError(*ssl_error_bases):  # type: ignore
+class ClientConnectorSSLError(*ssl_error_bases):  # type: ignore[misc]
     """Response ssl error."""
 
 
-class ClientConnectorCertificateError(*cert_errors_bases):  # type: ignore
+class ClientConnectorCertificateError(*cert_errors_bases):  # type: ignore[misc]
     """Response certificate error."""
 
     def __init__(

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -63,13 +63,13 @@ try:
     import ssl
     from ssl import SSLContext
 except ImportError:  # pragma: no cover
-    ssl = None  # type: ignore
-    SSLContext = object  # type: ignore
+    ssl = None  # type: ignore[assignment]
+    SSLContext = object  # type: ignore[misc,assignment]
 
 try:
     import cchardet as chardet
 except ImportError:  # pragma: no cover
-    import chardet  # type: ignore
+    import chardet  # type: ignore[no-redef]
 
 
 __all__ = ("ClientRequest", "ClientResponse", "RequestInfo", "Fingerprint")
@@ -399,9 +399,9 @@ class ClientRequest:
 
         if headers:
             if isinstance(headers, (dict, MultiDictProxy, MultiDict)):
-                headers = headers.items()  # type: ignore
+                headers = headers.items()  # type: ignore[assignment]
 
-            for key, value in headers:  # type: ignore
+            for key, value in headers:  # type: ignore[misc]
                 # A special case for Host header
                 if key.lower() == "host":
                     self.headers[key] = value
@@ -413,7 +413,7 @@ class ClientRequest:
             (hdr, None) for hdr in sorted(skip_auto_headers)
         )
         used_headers = self.headers.copy()
-        used_headers.extend(self.skip_auto_headers)  # type: ignore
+        used_headers.extend(self.skip_auto_headers)  # type: ignore[arg-type]
 
         for hdr, val in self.DEFAULT_HEADERS.items():
             if hdr not in used_headers:
@@ -435,7 +435,7 @@ class ClientRequest:
         if isinstance(cookies, Mapping):
             iter_cookies = cookies.items()
         else:
-            iter_cookies = cookies  # type: ignore
+            iter_cookies = cookies  # type: ignore[assignment]
         for name, value in iter_cookies:
             if isinstance(value, Morsel):
                 # Preserve coded_value
@@ -443,7 +443,7 @@ class ClientRequest:
                 mrsl_val.set(value.key, value.value, value.coded_value)
                 c[name] = mrsl_val
             else:
-                c[name] = value  # type: ignore
+                c[name] = value  # type: ignore[assignment]
 
         self.headers[hdrs.COOKIE] = c.output(header="", sep=";").strip()
 
@@ -585,10 +585,10 @@ class ClientRequest:
                 await self.body.write(writer)
             else:
                 if isinstance(self.body, (bytes, bytearray)):
-                    self.body = (self.body,)  # type: ignore
+                    self.body = (self.body,)  # type: ignore[assignment]
 
                 for chunk in self.body:
-                    await writer.write(chunk)  # type: ignore
+                    await writer.write(chunk)  # type: ignore[arg-type]
 
             await writer.write_eof()
         except OSError as exc:
@@ -878,7 +878,7 @@ class ClientResponse(HeadersMixin):
 
                 link.add(key, value)
 
-            key = link.get("rel", url)  # type: ignore
+            key = link.get("rel", url)  # type: ignore[assignment]
 
             link.add("url", self.url.join(URL(url)))
 
@@ -896,7 +896,8 @@ class ClientResponse(HeadersMixin):
             while True:
                 # read response
                 try:
-                    message, payload = await self._protocol.read()  # type: ignore
+                    protocol = self._protocol
+                    message, payload = await protocol.read()  # type: ignore[union-attr]
                 except http.HttpProcessingError as exc:
                     raise ClientResponseError(
                         self.request_info,
@@ -1049,7 +1050,7 @@ class ClientResponse(HeadersMixin):
         elif self._released:
             raise ClientConnectionError("Connection closed")
 
-        return self._body
+        return self._body  # type: ignore[no-any-return]
 
     def get_encoding(self) -> str:
         ctype = self.headers.get(hdrs.CONTENT_TYPE, "").lower()
@@ -1087,7 +1088,9 @@ class ClientResponse(HeadersMixin):
         if encoding is None:
             encoding = self.get_encoding()
 
-        return self._body.decode(encoding, errors=errors)  # type: ignore
+        return self._body.decode(  # type: ignore[no-any-return,union-attr]
+            encoding, errors=errors
+        )
 
     async def json(
         self,
@@ -1112,7 +1115,7 @@ class ClientResponse(HeadersMixin):
                     headers=self.headers,
                 )
 
-        stripped = self._body.strip()  # type: ignore
+        stripped = self._body.strip()  # type: ignore[union-attr]
         if not stripped:
             return None
 

--- a/aiohttp/client_ws.py
+++ b/aiohttp/client_ws.py
@@ -1,7 +1,7 @@
 """WebSocket client for asyncio."""
 
 import asyncio
-from typing import Any, Optional
+from typing import Any, Optional, cast
 
 import async_timeout
 
@@ -57,10 +57,10 @@ class ClientWebSocketResponse:
         self._autoclose = autoclose
         self._autoping = autoping
         self._heartbeat = heartbeat
-        self._heartbeat_cb = None
+        self._heartbeat_cb: Optional[asyncio.TimerHandle] = None
         if heartbeat is not None:
             self._pong_heartbeat = heartbeat / 2.0
-        self._pong_response_cb = None
+        self._pong_response_cb: Optional[asyncio.TimerHandle] = None
         self._loop = loop
         self._waiting = None  # type: Optional[asyncio.Future[bool]]
         self._exception = None  # type: Optional[BaseException]
@@ -273,13 +273,13 @@ class ClientWebSocketResponse:
         msg = await self.receive(timeout)
         if msg.type != WSMsgType.TEXT:
             raise TypeError(f"Received message {msg.type}:{msg.data!r} is not str")
-        return msg.data
+        return cast(str, msg.data)
 
     async def receive_bytes(self, *, timeout: Optional[float] = None) -> bytes:
         msg = await self.receive(timeout)
         if msg.type != WSMsgType.BINARY:
             raise TypeError(f"Received message {msg.type}:{msg.data!r} is not bytes")
-        return msg.data
+        return cast(bytes, msg.data)
 
     async def receive_json(
         self,

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -62,8 +62,8 @@ try:
 
     SSLContext = ssl.SSLContext
 except ImportError:  # pragma: no cover
-    ssl = None  # type: ignore
-    SSLContext = object  # type: ignore
+    ssl = None  # type: ignore[assignment]
+    SSLContext = object  # type: ignore[misc,assignment]
 
 
 __all__ = ("BaseConnector", "TCPConnector", "UnixConnector", "NamedPipeConnector")
@@ -250,7 +250,7 @@ class BaseConnector:
         self._force_close = force_close
 
         # {host_key: FIFO list of waiters}
-        self._waiters = defaultdict(deque)  # type: ignore
+        self._waiters = defaultdict(deque)  # type: ignore[var-annotated]
 
         self._loop = loop
         self._factory = functools.partial(ResponseHandler, loop=loop)
@@ -258,10 +258,10 @@ class BaseConnector:
         self.cookies = SimpleCookie()  # type: SimpleCookie[str]
 
         # start keep-alive connection cleanup task
-        self._cleanup_handle = None
+        self._cleanup_handle: Optional[asyncio.TimerHandle] = None
 
         # start cleanup closed transports task
-        self._cleanup_closed_handle = None
+        self._cleanup_closed_handle: Optional[asyncio.TimerHandle] = None
         self._cleanup_closed_disabled = not enable_cleanup_closed
         self._cleanup_closed_transports = []  # type: List[Optional[asyncio.Transport]]
         self._cleanup_closed()
@@ -844,7 +844,7 @@ class TCPConnector(BaseConnector):
                 for trace in traces:
                     await trace.send_dns_resolvehost_end(host)
 
-            return res
+            return res  # type: ignore[no-any-return]
 
         key = (host, port)
 
@@ -980,7 +980,7 @@ class TCPConnector(BaseConnector):
     ) -> Tuple[asyncio.Transport, ResponseHandler]:
         try:
             async with ceil_timeout(timeout.sock_connect):
-                return await self._loop.create_connection(*args, **kwargs)  # type: ignore  # noqa
+                return await self._loop.create_connection(*args, **kwargs)  # type: ignore[return-value]  # noqa
         except cert_errors as exc:
             raise ClientConnectorCertificateError(req.connection_key, exc) from exc
         except ssl_errors as exc:
@@ -1069,7 +1069,7 @@ class TCPConnector(BaseConnector):
     ) -> Tuple[asyncio.Transport, ResponseHandler]:
         headers = {}  # type: Dict[str, str]
         if req.proxy_headers is not None:
-            headers = req.proxy_headers  # type: ignore
+            headers = req.proxy_headers  # type: ignore[assignment]
         headers[hdrs.HOST] = req.headers[hdrs.HOST]
 
         url = req.proxy
@@ -1244,7 +1244,9 @@ class NamedPipeConnector(BaseConnector):
             limit_per_host=limit_per_host,
             loop=loop,
         )
-        if not isinstance(self._loop, asyncio.ProactorEventLoop):  # type: ignore
+        if not isinstance(
+            self._loop, asyncio.ProactorEventLoop  # type: ignore[attr-defined]
+        ):
             raise RuntimeError(
                 "Named Pipes only available in proactor " "loop under windows"
             )
@@ -1260,7 +1262,7 @@ class NamedPipeConnector(BaseConnector):
     ) -> ResponseHandler:
         try:
             async with ceil_timeout(timeout.sock_connect):
-                _, proto = await self._loop.create_pipe_connection(  # type: ignore
+                _, proto = await self._loop.create_pipe_connection(  # type: ignore[attr-defined] # noqa: E501
                     self._factory, self._path
                 )
                 # the drain is required so that the connection_made is called

--- a/aiohttp/cookiejar.py
+++ b/aiohttp/cookiejar.py
@@ -152,7 +152,7 @@ class CookieJar(AbstractCookieJar):
         for name, cookie in cookies:
             if not isinstance(cookie, Morsel):
                 tmp = SimpleCookie()  # type: SimpleCookie[str]
-                tmp[name] = cookie  # type: ignore
+                tmp[name] = cookie  # type: ignore[assignment]
                 cookie = tmp[name]
 
             domain = cookie["domain"]

--- a/aiohttp/formdata.py
+++ b/aiohttp/formdata.py
@@ -92,14 +92,14 @@ class FormData:
 
             if isinstance(rec, io.IOBase):
                 k = guess_filename(rec, "unknown")
-                self.add_field(k, rec)  # type: ignore
+                self.add_field(k, rec)  # type: ignore[arg-type]
 
             elif isinstance(rec, (MultiDictProxy, MultiDict)):
                 to_add.extend(rec.items())
 
             elif isinstance(rec, (list, tuple)) and len(rec) == 2:
                 k, fp = rec
-                self.add_field(k, fp)  # type: ignore
+                self.add_field(k, fp)  # type: ignore[arg-type]
 
             else:
                 raise TypeError(

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -59,7 +59,7 @@ PY_37 = sys.version_info >= (3, 7)
 PY_38 = sys.version_info >= (3, 8)
 
 if not PY_37:
-    import idna_ssl
+    import idna_ssl  # type: ignore[import]
 
     idna_ssl.patch_match_hostname()
 
@@ -297,7 +297,7 @@ def get_running_loop(
 def isasyncgenfunction(obj: Any) -> bool:
     func = getattr(inspect, "isasyncgenfunction", None)
     if func is not None:
-        return func(obj)
+        return func(obj)  # type: ignore[no-any-return]
     else:
         return False
 
@@ -395,8 +395,8 @@ def content_disposition_header(
     return value
 
 
-class _TSelf(Protocol):
-    _cache: Dict[str, Any]
+class _TSelf(Protocol, Generic[_T]):
+    _cache: Dict[str, _T]
 
 
 class reify(Generic[_T]):
@@ -413,7 +413,7 @@ class reify(Generic[_T]):
         self.__doc__ = wrapped.__doc__
         self.name = wrapped.__name__
 
-    def __get__(self, inst: _TSelf, owner: Optional[Type[Any]] = None) -> _T:
+    def __get__(self, inst: _TSelf[_T], owner: Optional[Type[Any]] = None) -> _T:
         try:
             try:
                 return inst._cache[self.name]
@@ -426,7 +426,7 @@ class reify(Generic[_T]):
                 return self
             raise
 
-    def __set__(self, inst: _TSelf, value: _T) -> None:
+    def __set__(self, inst: _TSelf[_T], value: _T) -> None:
         raise AttributeError("reified property is read-only")
 
 
@@ -436,7 +436,7 @@ try:
     from ._helpers import reify as reify_c
 
     if not NO_EXTENSIONS:
-        reify = reify_c  # type: ignore
+        reify = reify_c  # type: ignore[misc,assignment]
 except ImportError:
     pass
 
@@ -532,7 +532,7 @@ def rfc822_formatted_time() -> str:
     return _cached_formatted_datetime
 
 
-def _weakref_handle(info):  # type: ignore
+def _weakref_handle(info: "Tuple[weakref.ref[object], str]") -> None:
     ref, name = info
     ob = ref()
     if ob is not None:
@@ -540,21 +540,27 @@ def _weakref_handle(info):  # type: ignore
             getattr(ob, name)()
 
 
-def weakref_handle(ob, name, timeout, loop):  # type: ignore
+def weakref_handle(
+    ob: object, name: str, timeout: float, loop: asyncio.AbstractEventLoop
+) -> Optional[asyncio.TimerHandle]:
     if timeout is not None and timeout > 0:
         when = loop.time() + timeout
         if timeout >= 5:
             when = ceil(when)
 
         return loop.call_at(when, _weakref_handle, (weakref.ref(ob), name))
+    return None
 
 
-def call_later(cb, timeout, loop):  # type: ignore
+def call_later(
+    cb: Callable[[], Any], timeout: float, loop: asyncio.AbstractEventLoop
+) -> Optional[asyncio.TimerHandle]:
     if timeout is not None and timeout > 0:
         when = loop.time() + timeout
         if timeout > 5:
             when = ceil(when)
         return loop.call_at(when, cb)
+    return None
 
 
 class TimeoutHandle:
@@ -696,23 +702,25 @@ class HeadersMixin:
     @property
     def content_type(self) -> str:
         """The value of content part for Content-Type HTTP header."""
-        raw = self._headers.get(hdrs.CONTENT_TYPE)  # type: ignore
+        raw = self._headers.get(hdrs.CONTENT_TYPE)  # type: ignore[attr-defined]
         if self._stored_content_type != raw:
             self._parse_content_type(raw)
-        return self._content_type  # type: ignore
+        return self._content_type  # type: ignore[return-value]
 
     @property
     def charset(self) -> Optional[str]:
         """The value of charset part for Content-Type HTTP header."""
-        raw = self._headers.get(hdrs.CONTENT_TYPE)  # type: ignore
+        raw = self._headers.get(hdrs.CONTENT_TYPE)  # type: ignore[attr-defined]
         if self._stored_content_type != raw:
             self._parse_content_type(raw)
-        return self._content_dict.get("charset")  # type: ignore
+        return self._content_dict.get("charset")  # type: ignore[union-attr]
 
     @property
     def content_length(self) -> Optional[int]:
         """The value of Content-Length HTTP header."""
-        content_length = self._headers.get(hdrs.CONTENT_LENGTH)  # type: ignore
+        content_length = self._headers.get(  # type: ignore[attr-defined]
+            hdrs.CONTENT_LENGTH
+        )
 
         if content_length is not None:
             return int(content_length)
@@ -755,7 +763,7 @@ class ChainMapProxy(Mapping[str, Any]):
 
     def __len__(self) -> int:
         # reuses stored hash values if possible
-        return len(set().union(*self._maps))  # type: ignore
+        return len(set().union(*self._maps))  # type: ignore[arg-type]
 
     def __iter__(self) -> Iterator[str]:
         d = {}  # type: Dict[str, Any]

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -10,6 +10,7 @@ from typing import (
     Any,
     Generic,
     List,
+    NamedTuple,
     Optional,
     Pattern,
     Set,
@@ -17,6 +18,7 @@ from typing import (
     Type,
     TypeVar,
     Union,
+    cast,
 )
 
 from multidict import CIMultiDict, CIMultiDictProxy, istr
@@ -69,21 +71,19 @@ METHRE: Final[Pattern[str]] = re.compile(r"[!#$%&'*+\-.^_`|~0-9A-Za-z]+")
 VERSRE: Final[Pattern[str]] = re.compile(r"HTTP/(\d+).(\d+)")
 HDRRE: Final[Pattern[bytes]] = re.compile(rb"[\x00-\x1F\x7F()<>@,;:\[\]={} \t\\\\\"]")
 
-RawRequestMessage = collections.namedtuple(
-    "RawRequestMessage",
-    [
-        "method",
-        "path",
-        "version",
-        "headers",
-        "raw_headers",
-        "should_close",
-        "compression",
-        "upgrade",
-        "chunked",
-        "url",
-    ],
-)
+
+class RawRequestMessage(NamedTuple):
+    method: str
+    path: str
+    version: HttpVersion
+    headers: CIMultiDictProxy[str]
+    raw_headers: RawHeaders
+    should_close: bool
+    compression: Optional[str]
+    upgrade: bool
+    chunked: bool
+    url: URL
+
 
 RawResponseMessage = collections.namedtuple(
     "RawResponseMessage",
@@ -312,20 +312,27 @@ class HttpParser(abc.ABC, Generic[_MsgT]):
                     # \r\n\r\n found
                     if self._lines[-1] == EMPTY:
                         try:
-                            msg = self.parse_message(self._lines)
+                            msg: _MsgT = self.parse_message(self._lines)
                         finally:
                             self._lines.clear()
 
-                        # payload length
-                        length = msg.headers.get(CONTENT_LENGTH)
-                        if length is not None:
+                        def get_content_lenght() -> Optional[int]:
+                            # payload length
+                            length_hdr = msg.headers.get(CONTENT_LENGTH)
+                            if length_hdr is None:
+                                return None
+
                             try:
-                                length = int(length)
+                                length = int(length_hdr)
                             except ValueError:
                                 raise InvalidHeader(CONTENT_LENGTH)
+
                             if length < 0:
                                 raise InvalidHeader(CONTENT_LENGTH)
 
+                            return length
+
+                        length = get_content_lenght()
                         # do not support old websocket spec
                         if SEC_WEBSOCKET_KEY1 in msg.headers:
                             raise InvalidHeader(SEC_WEBSOCKET_KEY1)
@@ -840,12 +847,12 @@ class DeflateBuffer:
 
                 def decompress(self, data: bytes) -> bytes:
                     if hasattr(self._obj, "decompress"):
-                        return self._obj.decompress(data)
-                    return self._obj.process(data)
+                        return cast(bytes, self._obj.decompress(data))
+                    return cast(bytes, self._obj.process(data))
 
                 def flush(self) -> bytes:
                     if hasattr(self._obj, "flush"):
-                        return self._obj.flush()
+                        return cast(bytes, self._obj.flush())
                     return b""
 
             self.decompressor = BrotliDecoder()
@@ -910,7 +917,7 @@ RawResponseMessagePy = RawResponseMessage
 
 try:
     if not NO_EXTENSIONS:
-        from ._http_parser import (  # type: ignore
+        from ._http_parser import (  # type: ignore[import,no-redef]
             HttpRequestParser,
             HttpResponseParser,
             RawRequestMessage,

--- a/aiohttp/http_websocket.py
+++ b/aiohttp/http_websocket.py
@@ -9,7 +9,7 @@ import sys
 import zlib
 from enum import IntEnum
 from struct import Struct
-from typing import Any, Callable, List, Optional, Pattern, Set, Tuple, Union
+from typing import Any, Callable, List, Optional, Pattern, Set, Tuple, Union, cast
 
 from typing_extensions import Final
 
@@ -111,7 +111,7 @@ class WebSocketError(Exception):
         super().__init__(code, message)
 
     def __str__(self) -> str:
-        return self.args[1]
+        return cast(str, self.args[1])
 
 
 class WSHandshakeError(Exception):
@@ -153,7 +153,7 @@ if NO_EXTENSIONS:  # pragma: no cover
     _websocket_mask = _websocket_mask_python
 else:
     try:
-        from ._websocket import _websocket_mask_cython  # type: ignore
+        from ._websocket import _websocket_mask_cython  # type: ignore[import]
 
         _websocket_mask = _websocket_mask_cython
     except ImportError:  # pragma: no cover

--- a/aiohttp/http_writer.py
+++ b/aiohttp/http_writer.py
@@ -183,7 +183,7 @@ def _py_serialize_headers(status_line: str, headers: "CIMultiDict[str]") -> byte
 _serialize_headers = _py_serialize_headers
 
 try:
-    import aiohttp._http_writer as _http_writer  # type: ignore
+    import aiohttp._http_writer as _http_writer  # type: ignore[import]
 
     _c_serialize_headers = _http_writer._serialize_headers
     if not NO_EXTENSIONS:

--- a/aiohttp/multipart.py
+++ b/aiohttp/multipart.py
@@ -11,6 +11,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     AsyncIterator,
+    Deque,
     Dict,
     Iterator,
     List,
@@ -20,6 +21,7 @@ from typing import (
     Tuple,
     Type,
     Union,
+    cast,
 )
 from urllib.parse import parse_qsl, unquote, urlencode
 
@@ -261,13 +263,13 @@ class BodyPartReader:
         self._length = int(length) if length is not None else None
         self._read_bytes = 0
         # TODO: typeing.Deque is not supported by Python 3.5
-        self._unread = deque()  # type: Any
+        self._unread: Deque[bytes] = deque()
         self._prev_chunk = None  # type: Optional[bytes]
         self._content_eof = 0
         self._cache = {}  # type: Dict[str, Any]
 
     def __aiter__(self) -> AsyncIterator["BodyPartReader"]:
-        return self  # type: ignore
+        return self  # type: ignore[return-value]
 
     async def __anext__(self) -> bytes:
         part = await self.next()
@@ -411,7 +413,7 @@ class BodyPartReader:
         if not data:
             return None
         encoding = encoding or self.get_charset(default="utf-8")
-        return json.loads(data.decode(encoding))
+        return cast(Dict[str, Any], json.loads(data.decode(encoding)))
 
     async def form(self, *, encoding: Optional[str] = None) -> List[Tuple[str, str]]:
         """Like read(), but assumes that body parts contains form
@@ -541,7 +543,7 @@ class MultipartReader:
     def __aiter__(
         self,
     ) -> AsyncIterator["BodyPartReader"]:
-        return self  # type: ignore
+        return self  # type: ignore[return-value]
 
     async def __anext__(
         self,
@@ -828,7 +830,7 @@ class MultipartWriter(Payload):
         if size is not None and not (encoding or te_encoding):
             payload.headers[CONTENT_LENGTH] = str(size)
 
-        self._parts.append((payload, encoding, te_encoding))  # type: ignore
+        self._parts.append((payload, encoding, te_encoding))  # type: ignore[arg-type]
         return payload
 
     def append_json(
@@ -893,7 +895,7 @@ class MultipartWriter(Payload):
                     w.enable_compression(encoding)
                 if te_encoding:
                     w.enable_encoding(te_encoding)
-                await part.write(w)  # type: ignore
+                await part.write(w)  # type: ignore[arg-type]
                 await w.write_eof()
             else:
                 await part.write(writer)

--- a/aiohttp/payload.py
+++ b/aiohttp/payload.py
@@ -55,7 +55,6 @@ __all__ = (
 
 TOO_LARGE_BYTES_BODY: Final[int] = 2 ** 20  # 1 MB
 
-
 if TYPE_CHECKING:  # pragma: no cover
     from typing import List
 
@@ -90,6 +89,10 @@ class payload_type:
         return factory
 
 
+PayloadType = Type["Payload"]
+_PayloadRegistryItem = Tuple[PayloadType, Any]
+
+
 class PayloadRegistry:
     """Payload registry.
 
@@ -97,12 +100,16 @@ class PayloadRegistry:
     """
 
     def __init__(self) -> None:
-        self._first = []  # type: List[Tuple[Type[Payload], Any]]
-        self._normal = []  # type: List[Tuple[Type[Payload], Any]]
-        self._last = []  # type: List[Tuple[Type[Payload], Any]]
+        self._first = []  # type: List[_PayloadRegistryItem]
+        self._normal = []  # type: List[_PayloadRegistryItem]
+        self._last = []  # type: List[_PayloadRegistryItem]
 
     def get(
-        self, data: Any, *args: Any, _CHAIN: Any = chain, **kwargs: Any
+        self,
+        data: Any,
+        *args: Any,
+        _CHAIN: "Type[chain[_PayloadRegistryItem]]" = chain,
+        **kwargs: Any,
     ) -> "Payload":
         if isinstance(data, Payload):
             return data
@@ -113,7 +120,7 @@ class PayloadRegistry:
         raise LookupError()
 
     def register(
-        self, factory: Type["Payload"], type: Any, *, order: Order = Order.normal
+        self, factory: PayloadType, type: Any, *, order: Order = Order.normal
     ) -> None:
         if order is Order.try_first:
             self._first.append((factory, type))
@@ -277,6 +284,8 @@ class StringIOPayload(StringPayload):
 
 
 class IOBasePayload(Payload):
+    _value: IO[Any]
+
     def __init__(
         self, value: IO[Any], disposition: str = "attachment", *args: Any, **kwargs: Any
     ) -> None:
@@ -301,6 +310,8 @@ class IOBasePayload(Payload):
 
 
 class TextIOPayload(IOBasePayload):
+    _value: TextIO
+
     def __init__(
         self,
         value: TextIO,
@@ -341,7 +352,12 @@ class TextIOPayload(IOBasePayload):
         try:
             chunk = await loop.run_in_executor(None, self._value.read, 2 ** 16)
             while chunk:
-                await writer.write(chunk.encode(self._encoding))
+                data = (
+                    chunk.encode(encoding=self._encoding)
+                    if self._encoding
+                    else chunk.encode()
+                )
+                await writer.write(data)
                 chunk = await loop.run_in_executor(None, self._value.read, 2 ** 16)
         finally:
             await loop.run_in_executor(None, self._value.close)

--- a/aiohttp/payload_streamer.py
+++ b/aiohttp/payload_streamer.py
@@ -43,7 +43,7 @@ class _stream_wrapper:
         self.kwargs = kwargs
 
     async def __call__(self, writer: AbstractStreamWriter) -> None:
-        await self.coro(writer, *self.args, **self.kwargs)  # type: ignore
+        await self.coro(writer, *self.args, **self.kwargs)  # type: ignore[operator]
 
 
 class streamer:

--- a/aiohttp/pytest_plugin.py
+++ b/aiohttp/pytest_plugin.py
@@ -30,7 +30,7 @@ except ImportError:  # pragma: no cover
     tokio = None
 
 
-def pytest_addoption(parser):  # type: ignore
+def pytest_addoption(parser):  # type: ignore[no-untyped-def]
     parser.addoption(
         "--aiohttp-fast",
         action="store_true",
@@ -51,7 +51,7 @@ def pytest_addoption(parser):  # type: ignore
     )
 
 
-def pytest_fixture_setup(fixturedef):  # type: ignore
+def pytest_fixture_setup(fixturedef):  # type: ignore[no-untyped-def]
     """
     Allow fixtures to be coroutines. Run coroutine fixtures in an event loop.
     """
@@ -72,7 +72,7 @@ def pytest_fixture_setup(fixturedef):  # type: ignore
         fixturedef.argnames += ("request",)
         strip_request = True
 
-    def wrapper(*args, **kwargs):  # type: ignore
+    def wrapper(*args, **kwargs):  # type: ignore[no-untyped-def]
         request = kwargs["request"]
         if strip_request:
             del kwargs["request"]
@@ -93,7 +93,7 @@ def pytest_fixture_setup(fixturedef):  # type: ignore
             # then advance it again in a finalizer
             gen = func(*args, **kwargs)
 
-            def finalizer():  # type: ignore
+            def finalizer():  # type: ignore[no-untyped-def]
                 try:
                     return _loop.run_until_complete(gen.__anext__())
                 except StopAsyncIteration:
@@ -108,19 +108,19 @@ def pytest_fixture_setup(fixturedef):  # type: ignore
 
 
 @pytest.fixture
-def fast(request):  # type: ignore
+def fast(request):  # type: ignore[no-untyped-def]
     """--fast config option"""
     return request.config.getoption("--aiohttp-fast")
 
 
 @pytest.fixture
-def loop_debug(request):  # type: ignore
+def loop_debug(request):  # type: ignore[no-untyped-def]
     """--enable-loop-debug config option"""
     return request.config.getoption("--aiohttp-enable-loop-debug")
 
 
 @contextlib.contextmanager
-def _runtime_warning_context():  # type: ignore
+def _runtime_warning_context():  # type: ignore[no-untyped-def]
     """
     Context manager which checks for RuntimeWarnings, specifically to
     avoid "coroutine 'X' was never awaited" warnings being missed.
@@ -143,7 +143,7 @@ def _runtime_warning_context():  # type: ignore
 
 
 @contextlib.contextmanager
-def _passthrough_loop_context(loop, fast=False):  # type: ignore
+def _passthrough_loop_context(loop, fast=False):  # type: ignore[no-untyped-def]
     """
     setups and tears down a loop unless one is passed in via the loop
     argument when it's passed straight through.
@@ -158,7 +158,7 @@ def _passthrough_loop_context(loop, fast=False):  # type: ignore
         teardown_test_loop(loop, fast=fast)
 
 
-def pytest_pycollect_makeitem(collector, name, obj):  # type: ignore
+def pytest_pycollect_makeitem(collector, name, obj):  # type: ignore[no-untyped-def]
     """
     Fix pytest collecting for coroutines.
     """
@@ -166,7 +166,7 @@ def pytest_pycollect_makeitem(collector, name, obj):  # type: ignore
         return list(collector._genfunctions(name, obj))
 
 
-def pytest_pyfunc_call(pyfuncitem):  # type: ignore
+def pytest_pyfunc_call(pyfuncitem):  # type: ignore[no-untyped-def]
     """
     Run coroutines in an event loop instead of a normal function call.
     """
@@ -186,7 +186,7 @@ def pytest_pyfunc_call(pyfuncitem):  # type: ignore
         return True
 
 
-def pytest_generate_tests(metafunc):  # type: ignore
+def pytest_generate_tests(metafunc):  # type: ignore[no-untyped-def]
     if "loop_factory" not in metafunc.fixturenames:
         return
 
@@ -202,7 +202,7 @@ def pytest_generate_tests(metafunc):  # type: ignore
     if loops == "all":
         loops = "pyloop,uvloop?,tokio?"
 
-    factories = {}  # type: ignore
+    factories = {}  # type: ignore[var-annotated]
     for name in loops.split(","):
         required = not name.endswith("?")
         name = name.strip(" ?")
@@ -221,7 +221,7 @@ def pytest_generate_tests(metafunc):  # type: ignore
 
 
 @pytest.fixture
-def loop(loop_factory, fast, loop_debug):  # type: ignore
+def loop(loop_factory, fast, loop_debug):  # type: ignore[no-untyped-def]
     """Return an instance of the event loop."""
     policy = loop_factory()
     asyncio.set_event_loop_policy(policy)
@@ -233,12 +233,12 @@ def loop(loop_factory, fast, loop_debug):  # type: ignore
 
 
 @pytest.fixture
-def proactor_loop():  # type: ignore
+def proactor_loop():  # type: ignore[no-untyped-def]
     if not PY_37:
         policy = asyncio.get_event_loop_policy()
-        policy._loop_factory = asyncio.ProactorEventLoop  # type: ignore
+        policy._loop_factory = asyncio.ProactorEventLoop  # type: ignore[attr-defined]
     else:
-        policy = asyncio.WindowsProactorEventLoopPolicy()  # type: ignore
+        policy = asyncio.WindowsProactorEventLoopPolicy()  # type: ignore[attr-defined]
         asyncio.set_event_loop_policy(policy)
 
     with loop_context(policy.new_event_loop) as _loop:
@@ -247,7 +247,7 @@ def proactor_loop():  # type: ignore
 
 
 @pytest.fixture
-def unused_port(aiohttp_unused_port):  # type: ignore # pragma: no cover
+def unused_port(aiohttp_unused_port):  # type: ignore[no-untyped-def] # pragma: no cover
     warnings.warn(
         "Deprecated, use aiohttp_unused_port fixture instead",
         DeprecationWarning,
@@ -257,20 +257,20 @@ def unused_port(aiohttp_unused_port):  # type: ignore # pragma: no cover
 
 
 @pytest.fixture
-def aiohttp_unused_port():  # type: ignore
+def aiohttp_unused_port():  # type: ignore[no-untyped-def]
     """Return a port that is unused on the current host."""
     return _unused_port
 
 
 @pytest.fixture
-def aiohttp_server(loop):  # type: ignore
+def aiohttp_server(loop):  # type: ignore[no-untyped-def]
     """Factory to create a TestServer instance, given an app.
 
     aiohttp_server(app, **kwargs)
     """
     servers = []
 
-    async def go(app, *, port=None, **kwargs):  # type: ignore
+    async def go(app, *, port=None, **kwargs):  # type: ignore[no-untyped-def]
         server = TestServer(app, port=port)
         await server.start_server(loop=loop, **kwargs)
         servers.append(server)
@@ -278,7 +278,7 @@ def aiohttp_server(loop):  # type: ignore
 
     yield go
 
-    async def finalize():  # type: ignore
+    async def finalize() -> None:
         while servers:
             await servers.pop().close()
 
@@ -286,7 +286,7 @@ def aiohttp_server(loop):  # type: ignore
 
 
 @pytest.fixture
-def test_server(aiohttp_server):  # type: ignore  # pragma: no cover
+def test_server(aiohttp_server):  # type: ignore[no-untyped-def]  # pragma: no cover
     warnings.warn(
         "Deprecated, use aiohttp_server fixture instead",
         DeprecationWarning,
@@ -296,14 +296,14 @@ def test_server(aiohttp_server):  # type: ignore  # pragma: no cover
 
 
 @pytest.fixture
-def aiohttp_raw_server(loop):  # type: ignore
+def aiohttp_raw_server(loop):  # type: ignore[no-untyped-def]
     """Factory to create a RawTestServer instance, given a web handler.
 
     aiohttp_raw_server(handler, **kwargs)
     """
     servers = []
 
-    async def go(handler, *, port=None, **kwargs):  # type: ignore
+    async def go(handler, *, port=None, **kwargs):  # type: ignore[no-untyped-def]
         server = RawTestServer(handler, port=port)
         await server.start_server(loop=loop, **kwargs)
         servers.append(server)
@@ -311,7 +311,7 @@ def aiohttp_raw_server(loop):  # type: ignore
 
     yield go
 
-    async def finalize():  # type: ignore
+    async def finalize() -> None:
         while servers:
             await servers.pop().close()
 
@@ -319,7 +319,9 @@ def aiohttp_raw_server(loop):  # type: ignore
 
 
 @pytest.fixture
-def raw_test_server(aiohttp_raw_server):  # type: ignore  # pragma: no cover
+def raw_test_server(  # type: ignore[no-untyped-def]  # pragma: no cover
+    aiohttp_raw_server,
+):
     warnings.warn(
         "Deprecated, use aiohttp_raw_server fixture instead",
         DeprecationWarning,
@@ -329,7 +331,7 @@ def raw_test_server(aiohttp_raw_server):  # type: ignore  # pragma: no cover
 
 
 @pytest.fixture
-def aiohttp_client(loop):  # type: ignore
+def aiohttp_client(loop):  # type: ignore[no-untyped-def]
     """Factory to create a TestClient instance.
 
     aiohttp_client(app, **kwargs)
@@ -338,9 +340,11 @@ def aiohttp_client(loop):  # type: ignore
     """
     clients = []
 
-    async def go(__param, *args, server_kwargs=None, **kwargs):  # type: ignore
+    async def go(  # type: ignore[no-untyped-def]
+        __param, *args, server_kwargs=None, **kwargs
+    ):
 
-        if isinstance(__param, Callable) and not isinstance(  # type: ignore
+        if isinstance(__param, Callable) and not isinstance(  # type: ignore[arg-type]
             __param, (Application, BaseTestServer)
         ):
             __param = __param(loop, *args, **kwargs)
@@ -363,7 +367,7 @@ def aiohttp_client(loop):  # type: ignore
 
     yield go
 
-    async def finalize():  # type: ignore
+    async def finalize() -> None:
         while clients:
             await clients.pop().close()
 
@@ -371,7 +375,7 @@ def aiohttp_client(loop):  # type: ignore
 
 
 @pytest.fixture
-def test_client(aiohttp_client):  # type: ignore  # pragma: no cover
+def test_client(aiohttp_client):  # type: ignore[no-untyped-def]  # pragma: no cover
     warnings.warn(
         "Deprecated, use aiohttp_client fixture instead",
         DeprecationWarning,

--- a/aiohttp/resolver.py
+++ b/aiohttp/resolver.py
@@ -38,7 +38,7 @@ class ThreadedResolver(AbstractResolver):
 
         hosts = []
         for family, _, proto, _, address in infos:
-            if family == socket.AF_INET6 and address[3]:  # type: ignore
+            if family == socket.AF_INET6 and address[3]:  # type: ignore[misc]
                 # This is essential for link-local IPv6 addresses.
                 # LL IPv6 is a VERY rare case. Strictly speaking, we should use
                 # getnameinfo() unconditionally, but performance makes sense.
@@ -143,7 +143,7 @@ class AsyncResolver(AbstractResolver):
         return hosts
 
     async def close(self) -> None:
-        return self._resolver.cancel()
+        self._resolver.cancel()
 
 
 DefaultResolver = AsyncResolver if aiodns_default else ThreadedResolver

--- a/aiohttp/streams.py
+++ b/aiohttp/streams.py
@@ -62,14 +62,16 @@ class ChunkTupleAsyncStreamIterator:
 
 class AsyncStreamReaderMixin:
     def __aiter__(self) -> AsyncStreamIterator[bytes]:
-        return AsyncStreamIterator(self.readline)  # type: ignore
+        return AsyncStreamIterator(self.readline)  # type: ignore[attr-defined]
 
     def iter_chunked(self, n: int) -> AsyncStreamIterator[bytes]:
         """Returns an asynchronous iterator that yields chunks of size n.
 
         Python-3.5 available for Python 3.5+ only
         """
-        return AsyncStreamIterator(lambda: self.read(n))  # type: ignore
+        return AsyncStreamIterator(
+            lambda: self.read(n)  # type: ignore[attr-defined,no-any-return]
+        )
 
     def iter_any(self) -> AsyncStreamIterator[bytes]:
         """Returns an asynchronous iterator that yields all the available
@@ -77,7 +79,7 @@ class AsyncStreamReaderMixin:
 
         Python-3.5 available for Python 3.5+ only
         """
-        return AsyncStreamIterator(self.readany)  # type: ignore
+        return AsyncStreamIterator(self.readany)  # type: ignore[attr-defined]
 
     def iter_chunks(self) -> ChunkTupleAsyncStreamIterator:
         """Returns an asynchronous iterator that yields chunks of data
@@ -86,7 +88,7 @@ class AsyncStreamReaderMixin:
 
         Python-3.5 available for Python 3.5+ only
         """
-        return ChunkTupleAsyncStreamIterator(self)  # type: ignore
+        return ChunkTupleAsyncStreamIterator(self)  # type: ignore[arg-type]
 
 
 class StreamReader(AsyncStreamReaderMixin):

--- a/aiohttp/test_utils.py
+++ b/aiohttp/test_utils.py
@@ -10,7 +10,17 @@ import socket
 import sys
 from abc import ABC, abstractmethod
 from types import TracebackType
-from typing import TYPE_CHECKING, Any, Callable, Iterator, List, Optional, Type, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Iterator,
+    List,
+    Optional,
+    Type,
+    Union,
+    cast,
+)
 from unittest import mock
 
 from aiosignal import Signal
@@ -46,7 +56,7 @@ else:
 if PY_38:
     from unittest import IsolatedAsyncioTestCase as TestCase
 else:
-    from asynctest import TestCase  # type: ignore
+    from asynctest import TestCase  # type: ignore[no-redef]
 
 REUSE_ADDRESS = os.name == "posix" and sys.platform != "cygwin"
 
@@ -70,7 +80,7 @@ def unused_port() -> int:
     """Return a port that is unused on the current host."""
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
         s.bind(("127.0.0.1", 0))
-        return s.getsockname()[1]
+        return cast(int, s.getsockname()[1])
 
 
 class BaseTestServer(ABC):
@@ -279,8 +289,8 @@ class TestClient:
         return self._server
 
     @property
-    def app(self) -> Application:
-        return getattr(self._server, "app", None)
+    def app(self) -> Optional[Application]:
+        return cast(Optional[Application], getattr(self._server, "app", None))
 
     @property
     def session(self) -> ClientSession:
@@ -615,7 +625,7 @@ def make_mocked_request(
         headers,
         raw_hdrs,
         closing,
-        False,
+        None,
         False,
         chunked,
         URL(path),

--- a/aiohttp/web.py
+++ b/aiohttp/web.py
@@ -279,7 +279,7 @@ __all__ = (
 try:
     from ssl import SSLContext
 except ImportError:  # pragma: no cover
-    SSLContext = Any  # type: ignore
+    SSLContext = Any  # type: ignore[misc,assignment]
 
 HostSequence = TypingIterable[str]
 
@@ -305,7 +305,7 @@ async def _run_app(
 ) -> None:
     # A internal functio to actually do all dirty job for application running
     if asyncio.iscoroutine(app):
-        app = await app  # type: ignore
+        app = await app  # type: ignore[misc]
 
     app = cast(Application, app)
 

--- a/aiohttp/web_app.py
+++ b/aiohttp/web_app.py
@@ -279,7 +279,7 @@ class Application(MutableMapping[str, Any]):
     @property
     def debug(self) -> bool:
         warnings.warn("debug property is deprecated", DeprecationWarning, stacklevel=2)
-        return self._debug
+        return self._debug  # type: ignore[no-any-return]
 
     def _reg_subapp_signals(self, subapp: "Application") -> None:
         def reg_handler(signame: str) -> None:
@@ -385,7 +385,7 @@ class Application(MutableMapping[str, Any]):
                 kwargs[k] = v
 
         return Server(
-            self._handle,  # type: ignore
+            self._handle,  # type: ignore[arg-type]
             request_factory=self._make_request,
             loop=self._loop,
             **kwargs,
@@ -482,7 +482,7 @@ class Application(MutableMapping[str, Any]):
         match_info.freeze()
 
         resp = None
-        request._match_info = match_info  # type: ignore
+        request._match_info = match_info  # type: ignore[assignment]
         expect = request.headers.get(hdrs.EXPECT)
         if expect:
             resp = await match_info.expect_handler(request)
@@ -493,13 +493,13 @@ class Application(MutableMapping[str, Any]):
 
             if self._run_middlewares:
                 for app in match_info.apps[::-1]:
-                    for m, new_style in app._middlewares_handlers:  # type: ignore
+                    for m, new_style in app._middlewares_handlers:  # type: ignore[union-attr] # noqa
                         if new_style:
                             handler = update_wrapper(
                                 partial(m, handler=handler), handler
                             )
                         else:
-                            handler = await m(app, handler)  # type: ignore
+                            handler = await m(app, handler)  # type: ignore[arg-type]
 
             resp = await handler(request)
 
@@ -519,7 +519,7 @@ class Application(MutableMapping[str, Any]):
 class CleanupError(RuntimeError):
     @property
     def exceptions(self) -> List[BaseException]:
-        return self.args[1]
+        return cast(List[BaseException], self.args[1])
 
 
 if TYPE_CHECKING:  # pragma: no cover

--- a/aiohttp/web_fileresponse.py
+++ b/aiohttp/web_fileresponse.py
@@ -213,12 +213,12 @@ class FileResponse(StreamResponse):
                 self.set_status(status)
 
         if should_set_ct:
-            self.content_type = ct  # type: ignore
+            self.content_type = ct  # type: ignore[assignment]
         if encoding:
             self.headers[hdrs.CONTENT_ENCODING] = encoding
         if gzip:
             self.headers[hdrs.VARY] = hdrs.ACCEPT_ENCODING
-        self.last_modified = st.st_mtime  # type: ignore
+        self.last_modified = st.st_mtime  # type: ignore[assignment]
         self.content_length = count
 
         self.headers[hdrs.ACCEPT_RANGES] = "bytes"

--- a/aiohttp/web_log.py
+++ b/aiohttp/web_log.py
@@ -198,10 +198,10 @@ class AccessLogger(AbstractAccessLogger):
                 if key.__class__ is str:
                     extra[key] = value
                 else:
-                    k1, k2 = key  # type: ignore
-                    dct = extra.get(k1, {})  # type: ignore
-                    dct[k2] = value  # type: ignore
-                    extra[k1] = dct  # type: ignore
+                    k1, k2 = key  # type: ignore[misc]
+                    dct = extra.get(k1, {})  # type: ignore[var-annotated,has-type]
+                    dct[k2] = value  # type: ignore[index,has-type]
+                    extra[k1] = dct  # type: ignore[has-type,assignment]
 
             self.logger.info(self._log_format % tuple(values), extra=extra)
         except Exception:

--- a/aiohttp/web_middlewares.py
+++ b/aiohttp/web_middlewares.py
@@ -21,7 +21,7 @@ async def _check_request_resolves(request: Request, path: str) -> Tuple[bool, Re
     alt_request = request.clone(rel_url=path)
 
     match_info = await request.app.router.resolve(alt_request)
-    alt_request._match_info = match_info  # type: ignore
+    alt_request._match_info = match_info  # type: ignore[assignment]
 
     if match_info.http_exception is None:
         return True, alt_request
@@ -30,7 +30,7 @@ async def _check_request_resolves(request: Request, path: str) -> Tuple[bool, Re
 
 
 def middleware(f: _Func) -> _Func:
-    f.__middleware_version__ = 1  # type: ignore
+    f.__middleware_version__ = 1  # type: ignore[attr-defined]
     return f
 
 

--- a/aiohttp/web_protocol.py
+++ b/aiohttp/web_protocol.py
@@ -62,7 +62,16 @@ _RequestFactory = Callable[
 _RequestHandler = Callable[[BaseRequest], Awaitable[StreamResponse]]
 
 ERROR = RawRequestMessage(
-    "UNKNOWN", "/", HttpVersion10, {}, {}, True, False, False, False, yarl.URL("/")
+    "UNKNOWN",
+    "/",
+    HttpVersion10,
+    {},  # type: ignore[arg-type]
+    {},  # type: ignore[arg-type]
+    True,
+    None,
+    False,
+    False,
+    yarl.URL("/"),
 )
 
 

--- a/aiohttp/web_request.py
+++ b/aiohttp/web_request.py
@@ -400,8 +400,7 @@ class BaseRequest(MutableMapping[str, Any], HeadersMixin):
         host = self._message.headers.get(hdrs.HOST)
         if host is not None:
             return host
-        else:
-            return socket.getfqdn()
+        return socket.getfqdn()
 
     @reify
     def remote(self) -> Optional[str]:
@@ -412,10 +411,11 @@ class BaseRequest(MutableMapping[str, Any], HeadersMixin):
         - overridden value by .clone(remote=new_remote) call.
         - peername of opened socket
         """
+        if self._transport_peername is None:
+            return None
         if isinstance(self._transport_peername, (list, tuple)):
-            return self._transport_peername[0]
-        else:
-            return self._transport_peername
+            return str(self._transport_peername[0])
+        return str(self._transport_peername)
 
     @reify
     def url(self) -> URL:
@@ -448,9 +448,9 @@ class BaseRequest(MutableMapping[str, Any], HeadersMixin):
         return self._message.path
 
     @reify
-    def query(self) -> "MultiDictProxy[str]":
+    def query(self) -> MultiDictProxy[str]:
         """A multidict with all the variables in the query string."""
-        return self._rel_url.query
+        return MultiDictProxy(self._rel_url.query)
 
     @reify
     def query_string(self) -> str:

--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -46,7 +46,7 @@ else:
 if not PY_38:
     # allow samesite to be used in python < 3.8
     # already permitted in python 3.8, see https://bugs.python.org/issue29613
-    Morsel._reserved["samesite"] = "SameSite"  # type: ignore
+    Morsel._reserved["samesite"] = "SameSite"  # type: ignore[attr-defined]
 
 
 class ContentCoding(enum.Enum):
@@ -100,8 +100,11 @@ class StreamResponse(BaseClass, HeadersMixin):
         return self._payload_writer is not None
 
     @property
-    def task(self) -> "asyncio.Task[None]":
-        return getattr(self._req, "task", None)
+    def task(self) -> "Optional[asyncio.Task[None]]":
+        if self._req:
+            return self._req.task
+        else:
+            return None
 
     @property
     def status(self) -> int:

--- a/aiohttp/web_routedef.py
+++ b/aiohttp/web_routedef.py
@@ -171,7 +171,7 @@ class RouteTableDef(Sequence[AbstractRouteDef]):
     def __getitem__(self, index: slice) -> List[AbstractRouteDef]:
         ...
 
-    def __getitem__(self, index):  # type: ignore
+    def __getitem__(self, index):  # type: ignore[no-untyped-def]
         return self._items[index]
 
     def __iter__(self) -> Iterator[AbstractRouteDef]:

--- a/aiohttp/web_runner.py
+++ b/aiohttp/web_runner.py
@@ -12,7 +12,7 @@ from .web_server import Server
 try:
     from ssl import SSLContext
 except ImportError:
-    SSLContext = object  # type: ignore
+    SSLContext = object  # type: ignore[misc,assignment]
 
 
 __all__ = (
@@ -171,7 +171,9 @@ class NamedPipeSite(BaseSite):
         self, runner: "BaseRunner", path: str, *, shutdown_timeout: float = 60.0
     ) -> None:
         loop = asyncio.get_event_loop()
-        if not isinstance(loop, asyncio.ProactorEventLoop):  # type: ignore
+        if not isinstance(
+            loop, asyncio.ProactorEventLoop  # type: ignore[attr-defined]
+        ):
             raise RuntimeError(
                 "Named Pipes only available in proactor" "loop under windows"
             )
@@ -187,7 +189,9 @@ class NamedPipeSite(BaseSite):
         loop = asyncio.get_event_loop()
         server = self._runner.server
         assert server is not None
-        _server = await loop.start_serving_pipe(server, self._path)  # type: ignore
+        _server = await loop.start_serving_pipe(  # type: ignore[attr-defined]
+            server, self._path
+        )
         self._server = _server[0]
 
 

--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -34,7 +34,7 @@ from typing import (
 )
 
 from typing_extensions import Final, TypedDict
-from yarl import URL, __version__ as yarl_version  # type: ignore
+from yarl import URL, __version__ as yarl_version  # type: ignore[attr-defined]
 
 from . import hdrs
 from .abc import AbstractMatchInfo, AbstractRouter, AbstractView
@@ -197,7 +197,7 @@ class AbstractRoute(abc.ABC):
                 result = old_handler(request)
                 if asyncio.iscoroutine(result):
                     return await result
-                return result  # type: ignore
+                return result  # type: ignore[return-value]
 
             old_handler = handler
             handler = handler_wrapper
@@ -260,7 +260,7 @@ class UrlMappingMatchInfo(BaseDict, AbstractMatchInfo):
     def http_exception(self) -> Optional[HTTPException]:
         return None
 
-    def get_info(self) -> _InfoDict:  # type: ignore
+    def get_info(self) -> _InfoDict:  # type: ignore[override]
         return self._route.get_info()
 
     @property
@@ -425,7 +425,7 @@ class PlainResource(Resource):
     def get_info(self) -> _InfoDict:
         return {"path": self._path}
 
-    def url_for(self) -> URL:  # type: ignore
+    def url_for(self) -> URL:  # type: ignore[override]
         return URL.build(path=self._path, encoded=True)
 
     def __repr__(self) -> str:
@@ -573,7 +573,7 @@ class StaticResource(PrefixResource):
             ),
         }
 
-    def url_for(  # type: ignore
+    def url_for(  # type: ignore[override]
         self,
         *,
         filename: Union[str, Path],
@@ -946,7 +946,9 @@ class View(AbstractView):
     async def _iter(self) -> StreamResponse:
         if self.request.method not in hdrs.METH_ALL:
             self._raise_allowed_methods()
-        method = getattr(self, self.request.method.lower(), None)
+        method: Callable[[], Awaitable[StreamResponse]] = getattr(
+            self, self.request.method.lower(), None
+        )
         if method is None:
             self._raise_allowed_methods()
         resp = await method()

--- a/aiohttp/web_ws.py
+++ b/aiohttp/web_ws.py
@@ -3,7 +3,7 @@ import base64
 import binascii
 import hashlib
 import json
-from typing import Any, Iterable, Optional, Tuple
+from typing import Any, Iterable, Optional, Tuple, cast
 
 import async_timeout
 import attr
@@ -84,10 +84,10 @@ class WebSocketResponse(StreamResponse):
         self._autoclose = autoclose
         self._autoping = autoping
         self._heartbeat = heartbeat
-        self._heartbeat_cb = None
+        self._heartbeat_cb: Optional[asyncio.TimerHandle] = None
         if heartbeat is not None:
             self._pong_heartbeat = heartbeat / 2.0
-        self._pong_response_cb = None
+        self._pong_response_cb: Optional[asyncio.TimerHandle] = None
         self._compress = compress
         self._max_msg_size = max_msg_size
 
@@ -104,16 +104,18 @@ class WebSocketResponse(StreamResponse):
         self._cancel_heartbeat()
 
         if self._heartbeat is not None:
+            assert self._loop is not None
             self._heartbeat_cb = call_later(
                 self._send_heartbeat, self._heartbeat, self._loop
             )
 
     def _send_heartbeat(self) -> None:
         if self._heartbeat is not None and not self._closed:
+            assert self._loop is not None
             # fire-and-forget a task is not perfect but maybe ok for
             # sending ping. Otherwise we need a long-living heartbeat
             # task in the class.
-            self._loop.create_task(self._writer.ping())  # type: ignore
+            self._loop.create_task(self._writer.ping())  # type: ignore[union-attr]
 
             if self._pong_response_cb is not None:
                 self._pong_response_cb.cancel()
@@ -195,9 +197,9 @@ class WebSocketResponse(StreamResponse):
         accept_val = base64.b64encode(
             hashlib.sha1(key.encode() + WS_KEY).digest()
         ).decode()
-        response_headers = CIMultiDict(  # type: ignore
+        response_headers = CIMultiDict(  # type: ignore[var-annotated]
             {
-                hdrs.UPGRADE: "websocket",  # type: ignore
+                hdrs.UPGRADE: "websocket",  # type: ignore[arg-type]
                 hdrs.CONNECTION: "upgrade",
                 hdrs.SEC_WEBSOCKET_ACCEPT: accept_val,
             }
@@ -218,7 +220,12 @@ class WebSocketResponse(StreamResponse):
 
         if protocol:
             response_headers[hdrs.SEC_WEBSOCKET_PROTOCOL] = protocol
-        return (response_headers, protocol, compress, notakeover)  # type: ignore
+        return (
+            response_headers,
+            protocol,
+            compress,
+            notakeover,
+        )  # type: ignore[return-value]
 
     def _pre_start(self, request: BaseRequest) -> Tuple[str, WebSocketWriter]:
         self._loop = request._loop
@@ -317,7 +324,7 @@ class WebSocketResponse(StreamResponse):
     ) -> None:
         await self.send_str(dumps(data), compress=compress)
 
-    async def write_eof(self) -> None:  # type: ignore
+    async def write_eof(self) -> None:  # type: ignore[override]
         if self._eof_sent:
             return
         if self._payload_writer is None:
@@ -450,13 +457,13 @@ class WebSocketResponse(StreamResponse):
                     msg.type, msg.data
                 )
             )
-        return msg.data
+        return cast(str, msg.data)
 
     async def receive_bytes(self, *, timeout: Optional[float] = None) -> bytes:
         msg = await self.receive(timeout)
         if msg.type != WSMsgType.BINARY:
             raise TypeError(f"Received message {msg.type}:{msg.data!r} is not bytes")
-        return msg.data
+        return cast(bytes, msg.data)
 
     async def receive_json(
         self, *, loads: JSONDecoder = json.loads, timeout: Optional[float] = None

--- a/aiohttp/worker.py
+++ b/aiohttp/worker.py
@@ -22,14 +22,14 @@ try:
 
     SSLContext = ssl.SSLContext
 except ImportError:  # pragma: no cover
-    ssl = None  # type: ignore
-    SSLContext = object  # type: ignore
+    ssl = None  # type: ignore[assignment]
+    SSLContext = object  # type: ignore[misc,assignment]
 
 
 __all__ = ("GunicornWebWorker", "GunicornUVLoopWebWorker", "GunicornTokioWebWorker")
 
 
-class GunicornWebWorker(base.Worker):
+class GunicornWebWorker(base.Worker):  # type: ignore[misc]
 
     DEFAULT_AIOHTTP_LOG_FORMAT = AccessLogger.LOG_FORMAT
     DEFAULT_GUNICORN_LOG_FORMAT = GunicornAccessLogFormat.default
@@ -101,7 +101,7 @@ class GunicornWebWorker(base.Worker):
         # If our parent changed then we shut down.
         pid = os.getpid()
         try:
-            while self.alive:  # type: ignore
+            while self.alive:  # type: ignore[has-type]
                 self.notify()
 
                 cnt = server.requests_count

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -4,3 +4,4 @@ flake8-pyi==20.10.0
 isort==5.6.4
 mypy==0.790; implementation_name=="cpython"
 pre-commit==2.9.3
+pytest==6.1.2

--- a/tests/test_payload.py
+++ b/tests/test_payload.py
@@ -36,7 +36,9 @@ def test_register_unsupported_order(registry) -> None:
         pass
 
     with pytest.raises(ValueError):
-        payload.register_payload(Payload, TestProvider, order=object())
+        payload.register_payload(
+            Payload, TestProvider, order=object()  # type: ignore[arg-type]
+        )
 
 
 def test_payload_ctor() -> None:
@@ -65,7 +67,7 @@ def test_bytes_payload_explicit_content_type() -> None:
 
 def test_bytes_payload_bad_type() -> None:
     with pytest.raises(TypeError):
-        payload.BytesPayload(object())
+        payload.BytesPayload(object())  # type: ignore[arg-type]
 
 
 def test_bytes_payload_memoryview_correct_size() -> None:

--- a/tests/test_web_sendfile.py
+++ b/tests/test_web_sendfile.py
@@ -22,7 +22,7 @@ def test_using_gzip_if_header_present_and_file_available(loop) -> None:
     filepath.with_name.return_value = gz_filepath
 
     file_sender = FileResponse(filepath)
-    file_sender._sendfile = make_mocked_coro(None)
+    file_sender._sendfile = make_mocked_coro(None)  # type: ignore[assignment]
 
     loop.run_until_complete(file_sender.prepare(request))
 
@@ -45,7 +45,7 @@ def test_gzip_if_header_not_present_and_file_available(loop) -> None:
     filepath.stat.st_size = 1024
 
     file_sender = FileResponse(filepath)
-    file_sender._sendfile = make_mocked_coro(None)
+    file_sender._sendfile = make_mocked_coro(None)  # type: ignore[assignment]
 
     loop.run_until_complete(file_sender.prepare(request))
 
@@ -68,7 +68,7 @@ def test_gzip_if_header_not_present_and_file_not_available(loop) -> None:
     filepath.stat.st_size = 1024
 
     file_sender = FileResponse(filepath)
-    file_sender._sendfile = make_mocked_coro(None)
+    file_sender._sendfile = make_mocked_coro(None)  # type: ignore[assignment]
 
     loop.run_until_complete(file_sender.prepare(request))
 
@@ -93,7 +93,7 @@ def test_gzip_if_header_present_and_file_not_available(loop) -> None:
     filepath.stat.st_size = 1024
 
     file_sender = FileResponse(filepath)
-    file_sender._sendfile = make_mocked_coro(None)
+    file_sender._sendfile = make_mocked_coro(None)  # type: ignore[assignment]
 
     loop.run_until_complete(file_sender.prepare(request))
 
@@ -111,7 +111,7 @@ def test_status_controlled_by_user(loop) -> None:
     filepath.stat.st_size = 1024
 
     file_sender = FileResponse(filepath, status=203)
-    file_sender._sendfile = make_mocked_coro(None)
+    file_sender._sendfile = make_mocked_coro(None)  # type: ignore[assignment]
 
     loop.run_until_complete(file_sender.prepare(request))
 


### PR DESCRIPTION
This change covers the entire codebase with strict typings
and makes the ignores granular.

PR #5370 by @derlih.
(cherry picked from commit 742a8b6d09b2623670ddede838c913d2a8a4d89e)

Co-authored-by: Dmitry Erlikh <derlih@gmail.com>

<!-- Thank you for your contribution! -->

## What do these changes do?

mypy strict check

## Are there changes in behavior for the user?

no

## Related issue number

#3927

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
