### PR TITLE
Add Happy Eyeballs support to TCPConnector

### DIFF
--- a/CHANGES/4451.feature
+++ b/CHANGES/4451.feature
@@ -1,0 +1,2 @@
+Add Happy Eyeballs support to ``TCPConnector`` and enable it by default.
+Note, if Python 3.7 is used, the feature is disabled and related arguments are ignored.


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

They add Happy Eyeballs support to `TCPConnector` and enable it by default.

## Are there changes in behavior for the user?

aiohttp should become more responsive to users having dual-stack configuration.

For example, Go enabled Happy Eyeballs (Fast Fallback) by default in 2018 https://github.com/golang/go/commit/efc185029bf770894defe63cec2c72a4c84b2ee9.

Also, in https://github.com/aio-libs/aiohttp/issues/4446#issuecomment-567071597 @asvetlov wrote that Happy Eyeballs may help with enabling aiodns by default. But I would not do so for now because pycares that is a dependency of aiodns uses an old version of c-ares that has security vulnerabilities.

## Related issue number

Closes #4451 

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
