### PR TITLE
Fix how pure-Python HTTP parser interprets `//`

### DIFF
--- a/CHANGES/5498.bugfix
+++ b/CHANGES/5498.bugfix
@@ -1,0 +1,6 @@
+Fix interpretation difference of the pure-Python and the Cython-based
+HTTP parsers construct a ``yarl.URL`` object for HTTP request-target.
+
+Before this fix, the Python parser would turn the URI's absolute-path
+for ``//some-path`` into ``/`` while the Cython code preserved it as
+``//some-path``. Now, both do the latter.

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -522,6 +522,9 @@ class HttpRequestParser(HttpParser[RawRequestMessage]):
                 "Status line is too long", str(self.max_line_size), str(len(path))
             )
 
+        path_part, _hash_separator, url_fragment = path.partition("#")
+        path_part, _question_mark_separator, qs_part = path_part.partition("?")
+
         # method
         if not METHRE.match(method):
             raise BadStatusLine(method)
@@ -562,7 +565,16 @@ class HttpRequestParser(HttpParser[RawRequestMessage]):
             compression,
             upgrade,
             chunked,
-            URL(path),
+            # NOTE: `yarl.URL.build()` is used to mimic what the Cython-based
+            # NOTE: parser does, otherwise it results into the same
+            # NOTE: HTTP Request-Line input producing different
+            # NOTE: `yarl.URL()` objects
+            URL.build(
+                path=path_part,
+                query_string=qs_part,
+                fragment=url_fragment,
+                encoded=True,
+            ),
         )
 
 

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -530,6 +530,7 @@ def test_http_request_parser_two_slashes(parser: Any) -> None:
 
     assert msg.method == "GET"
     assert msg.path == "//path"
+    assert msg.url.path == "//path"
     assert msg.version == (1, 1)
     assert not msg.should_close
     assert msg.compression is None


### PR DESCRIPTION
## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

This makes the HTTP queries with a leading double slash to
be parsed as a query-path and not a hostname by the
pure-Python HTTP parser.

## Related issue number

N/A

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
