### PR TITLE
Use `client_error` instead of a hard-coded exception in `TCPConnector`

### DIFF
--- a/CHANGES/5502.bugfix
+++ b/CHANGES/5502.bugfix
@@ -1,0 +1,2 @@
+Use variable ``client_error`` instead of a hard-coded ``ClientConnectorError`` exception
+in ``TCPConnector``.

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -985,7 +985,7 @@ class TCPConnector(BaseConnector):
         except OSError as exc:
             # in case of proxy it is not ClientProxyConnectionError
             # it is problem of resolving proxy ip itself
-            raise ClientConnectorError(req.connection_key, exc) from exc
+            raise client_error(req.connection_key, exc) from exc
 
         last_exc = None  # type: Optional[Exception]
 
@@ -1008,7 +1008,7 @@ class TCPConnector(BaseConnector):
                     req=req,
                     client_error=client_error,
                 )
-            except ClientConnectorError as exc:
+            except client_error as exc:
                 last_exc = exc
                 continue
 


### PR DESCRIPTION
## What do these changes do?

Use `client_error` that is an existing method argument instead of a hard-coded exception.

## Are there changes in behavior for the user?

I doubt.
Although, `_create_proxy_connection` passes a different `client_error` and it won't be handled correctly in case of a problem. So the changes may prevent a crash.
Note, I didn't face the problem myself, I found the issue when I was working on #4451. 

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
- [x] Add a new news fragment into the `CHANGES` folder
