### PR TITLE
Deprecate @unittest_run_loop

### DIFF
--- a/CHANGES/5515.misc
+++ b/CHANGES/5515.misc
@@ -1,0 +1,1 @@
+Deprecate @unittest_run_loop. This behaviour is now the default.

--- a/CHANGES/5515.misc
+++ b/CHANGES/5515.misc
@@ -1,1 +1,1 @@
-Deprecate @unittest_run_loop. This behaviour is now the default.
+Deprecate ``@unittest_run_loop``. This behaviour is now the default.

--- a/aiohttp/test_utils.py
+++ b/aiohttp/test_utils.py
@@ -477,7 +477,8 @@ def unittest_run_loop(func: Any, *args: Any, **kwargs: Any) -> Any:
     In 3.8+, this does nothing.
     """
     warnings.warn(
-        "Decorator `@unittest_run_loop` is no longer needed in aiohttp 3.8+", DeprecationWarning,
+        "Decorator `@unittest_run_loop` is no longer needed in aiohttp 3.8+",
+        DeprecationWarning,
         stacklevel=2,
     )
     return func

--- a/aiohttp/test_utils.py
+++ b/aiohttp/test_utils.py
@@ -8,6 +8,7 @@ import inspect
 import os
 import socket
 import sys
+import warnings
 from abc import ABC, abstractmethod
 from types import TracebackType
 from typing import (
@@ -472,17 +473,12 @@ class AioHTTPTestCase(TestCase):
 
 def unittest_run_loop(func: Any, *args: Any, **kwargs: Any) -> Any:
     """A decorator dedicated to use with asynchronous methods of an
-    AioHTTPTestCase.
-
-    Handles executing an asynchronous function, using
-    the self.loop of the AioHTTPTestCase.
+    AioHTTPTestCase in aiohttp <3.7.
+    
+    In 3.8+, this does nothing.
     """
-
-    @functools.wraps(func, *args, **kwargs)
-    def new_func(self: Any, *inner_args: Any, **inner_kwargs: Any) -> Any:
-        return self.loop.run_until_complete(func(self, *inner_args, **inner_kwargs))
-
-    return new_func
+    warnings.warn("Decorator no longer needed in 3.8+", DeprecationWarning)
+    return func
 
 
 _LOOP_FACTORY = Callable[[], asyncio.AbstractEventLoop]

--- a/aiohttp/test_utils.py
+++ b/aiohttp/test_utils.py
@@ -473,7 +473,7 @@ class AioHTTPTestCase(TestCase):
 
 def unittest_run_loop(func: Any, *args: Any, **kwargs: Any) -> Any:
     """A decorator dedicated to use with asynchronous methods of an
-    AioHTTPTestCase in aiohttp <3.7.
+    AioHTTPTestCase in aiohttp <3.8.
     
     In 3.8+, this does nothing.
     """

--- a/aiohttp/test_utils.py
+++ b/aiohttp/test_utils.py
@@ -477,7 +477,7 @@ def unittest_run_loop(func: Any, *args: Any, **kwargs: Any) -> Any:
     In 3.8+, this does nothing.
     """
     warnings.warn(
-        "Decorator no longer needed in 3.8+", DeprecationWarning, stacklever=2
+        "Decorator no longer needed in 3.8+", DeprecationWarning, stacklevel=2
     )
     return func
 

--- a/aiohttp/test_utils.py
+++ b/aiohttp/test_utils.py
@@ -474,7 +474,7 @@ class AioHTTPTestCase(TestCase):
 def unittest_run_loop(func: Any, *args: Any, **kwargs: Any) -> Any:
     """A decorator dedicated to use with asynchronous methods of an
     AioHTTPTestCase in aiohttp <3.8.
-    
+
     In 3.8+, this does nothing.
     """
     warnings.warn("Decorator no longer needed in 3.8+", DeprecationWarning)

--- a/aiohttp/test_utils.py
+++ b/aiohttp/test_utils.py
@@ -477,7 +477,8 @@ def unittest_run_loop(func: Any, *args: Any, **kwargs: Any) -> Any:
     In 3.8+, this does nothing.
     """
     warnings.warn(
-        "Decorator no longer needed in 3.8+", DeprecationWarning, stacklevel=2
+        "Decorator `@unittest_run_loop` is no longer needed in aiohttp 3.8+", DeprecationWarning,
+        stacklevel=2,
     )
     return func
 

--- a/aiohttp/test_utils.py
+++ b/aiohttp/test_utils.py
@@ -2,7 +2,6 @@
 
 import asyncio
 import contextlib
-import functools
 import gc
 import inspect
 import os

--- a/aiohttp/test_utils.py
+++ b/aiohttp/test_utils.py
@@ -476,7 +476,9 @@ def unittest_run_loop(func: Any, *args: Any, **kwargs: Any) -> Any:
 
     In 3.8+, this does nothing.
     """
-    warnings.warn("Decorator no longer needed in 3.8+", DeprecationWarning)
+    warnings.warn(
+        "Decorator no longer needed in 3.8+", DeprecationWarning, stacklever=2
+    )
     return func
 
 

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -350,7 +350,6 @@ functionality, the AioHTTPTestCase is provided::
 
          class TestA(AioHTTPTestCase):
 
-             @unittest_run_loop
              async def test_f(self):
                  async with self.client.get('/') as resp:
                      body = await resp.text()

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -243,7 +243,7 @@ Unittest
 To test applications with the standard library's unittest or unittest-based
 functionality, the AioHTTPTestCase is provided::
 
-    from aiohttp.test_utils import AioHTTPTestCase, unittest_run_loop
+    from aiohttp.test_utils import AioHTTPTestCase
     from aiohttp import web
 
     class MyAppTestCase(AioHTTPTestCase):
@@ -259,26 +259,11 @@ functionality, the AioHTTPTestCase is provided::
             app.router.add_get('/', hello)
             return app
 
-        # the unittest_run_loop decorator can be used in tandem with
-        # the AioHTTPTestCase to simplify running
-        # tests that are asynchronous
-        @unittest_run_loop
         async def test_example(self):
-            resp = await self.client.request("GET", "/")
-            assert resp.status == 200
-            text = await resp.text()
-            assert "Hello, world" in text
-
-        # a vanilla example
-        def test_example_vanilla(self):
-            async def test_get_route():
-                url = "/"
-                resp = await self.client.request("GET", url)
+            async with self.client.request("GET", "/") as resp:
                 assert resp.status == 200
                 text = await resp.text()
-                assert "Hello, world" in text
-
-            self.loop.run_until_complete(test_get_route())
+            assert "Hello, world" in text
 
 .. class:: AioHTTPTestCase
 
@@ -361,16 +346,14 @@ functionality, the AioHTTPTestCase is provided::
    .. note::
 
       The ``TestClient``'s methods are asynchronous: you have to
-      execute function on the test client using asynchronous methods.
-
-      A basic test class wraps every test method by
-      :func:`unittest_run_loop` decorator::
+      execute functions on the test client using asynchronous methods.
 
          class TestA(AioHTTPTestCase):
 
              @unittest_run_loop
              async def test_f(self):
-                 resp = await self.client.get('/')
+                 async with self.client.get('/') as resp:
+                     body = await resp.text()
 
 
 .. decorator:: unittest_run_loop:
@@ -380,6 +363,10 @@ functionality, the AioHTTPTestCase is provided::
 
    Handles executing an asynchronous function, using
    the :attr:`AioHTTPTestCase.loop` of the :class:`AioHTTPTestCase`.
+
+   .. deprecated:: 3.8
+       In 3.8+ :class:`AioHTTPTestCase` inherits from :class:`unittest.IsolatedAsyncioTestCase`
+       making this decorator unneeded.
 
 
 Faking request object

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -346,7 +346,7 @@ functionality, the AioHTTPTestCase is provided::
    .. note::
 
       The ``TestClient``'s methods are asynchronous: you have to
-      execute functions on the test client using asynchronous methods.
+      execute functions on the test client using asynchronous methods.::
 
          class TestA(AioHTTPTestCase):
 

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -365,7 +365,7 @@ functionality, the AioHTTPTestCase is provided::
 
    .. deprecated:: 3.8
        In 3.8+ :class:`AioHTTPTestCase` inherits from :class:`unittest.IsolatedAsyncioTestCase`
-       making this decorator unneeded.
+       making this decorator unneeded. It is now a no-op.
 
 
 Faking request object

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -261,9 +261,9 @@ functionality, the AioHTTPTestCase is provided::
 
         async def test_example(self):
             async with self.client.request("GET", "/") as resp:
-                assert resp.status == 200
+                self.assertEqual(resp.status, 200)
                 text = await resp.text()
-            assert "Hello, world" in text
+            self.assertIn("Hello, world", text)
 
 .. class:: AioHTTPTestCase
 

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -5,7 +5,7 @@ import threading
 import pytest
 
 from aiohttp import web
-from aiohttp.test_utils import AioHTTPTestCase, unittest_run_loop
+from aiohttp.test_utils import AioHTTPTestCase
 
 
 @pytest.mark.skipif(
@@ -31,7 +31,6 @@ class TestCase(AioHTTPTestCase):
     async def on_startup_hook(self, app):
         self.on_startup_called = True
 
-    @unittest_run_loop
     async def test_on_startup_hook(self) -> None:
         self.assertTrue(self.on_startup_called)
 

--- a/tests/test_test_utils.py
+++ b/tests/test_test_utils.py
@@ -134,7 +134,7 @@ class TestAioHTTPTestCase(AioHTTPTestCase):
 
 
 def test_unittest_run_loop() -> None:
-    with pytest.warns(DeprecationWarning):
+    with pytest.warns(DeprecationWarning, match=r"Decorator no longer needed in 3\.8\+"):
 
         @unittest_run_loop
         def foo():

--- a/tests/test_test_utils.py
+++ b/tests/test_test_utils.py
@@ -134,7 +134,7 @@ class TestAioHTTPTestCase(AioHTTPTestCase):
 
 
 def test_unittest_run_loop() -> None:
-    with pytest.warns(DeprecationWarning, match=r"Decorator no longer needed in 3\.8\+"):
+    with pytest.warns(DeprecationWarning, match=r"Decorator `@unittest_run_loop` is no longer needed in aiohttp 3\.8\+"):
 
         @unittest_run_loop
         def foo():

--- a/tests/test_test_utils.py
+++ b/tests/test_test_utils.py
@@ -134,7 +134,10 @@ class TestAioHTTPTestCase(AioHTTPTestCase):
 
 
 def test_unittest_run_loop() -> None:
-    with pytest.warns(DeprecationWarning, match=r"Decorator `@unittest_run_loop` is no longer needed in aiohttp 3\.8\+"):
+    with pytest.warns(
+        DeprecationWarning,
+        match=r"Decorator `@unittest_run_loop` is no longer needed in aiohttp 3\.8\+",
+    ):
 
         @unittest_run_loop
         def foo():

--- a/tests/test_test_utils.py
+++ b/tests/test_test_utils.py
@@ -135,6 +135,7 @@ class TestAioHTTPTestCase(AioHTTPTestCase):
 
 def test_unittest_run_loop() -> None:
     with pytest.warns(DeprecationWarning):
+
         @unittest_run_loop
         def foo():
             pass

--- a/tests/test_test_utils.py
+++ b/tests/test_test_utils.py
@@ -102,7 +102,6 @@ class TestAioHTTPTestCase(AioHTTPTestCase):
     def get_app(self):
         return _create_example_app()
 
-    @unittest_run_loop
     async def test_example_with_loop(self) -> None:
         request = await self.client.request("GET", "/")
         assert request.status == 200
@@ -132,6 +131,13 @@ class TestAioHTTPTestCase(AioHTTPTestCase):
             assert _hello_world_str == text
 
         await test_get_route()
+
+
+def test_unittest_run_loop() -> None:
+    with pytest.warns(DeprecationWarning):
+        @unittest_run_loop
+        def foo():
+            pass
 
 
 def test_get_route(loop, test_client) -> None:


### PR DESCRIPTION
Deprecate the now unneeded `@unittest_run_loop` function.