### PR TITLE
Fix the link to `MultiDict` in `client_quickstart.rst`

### DIFF
--- a/docs/client_quickstart.rst
+++ b/docs/client_quickstart.rst
@@ -99,9 +99,9 @@ following code::
 
 You can see that the URL has been correctly encoded by printing the URL.
 
-For sending data with multiple values for the same key :class:`MultiDict` may be
-used; the library support nested lists (``{'key': ['value1', 'value2']}``)
-alternative as well.
+For sending data with multiple values for the same key
+:class:`~multidict.MultiDict` may be used; the library support nested lists
+(``{'key': ['value1', 'value2']}``) alternative as well.
 
 It is also possible to pass a list of 2 item tuples as parameters, in
 that case you can specify multiple values for each key::


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

This change corrects an unrendered intersphinx class reference in the `client_quickstart.rst` document.

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->

## Related issue number

#5518

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
