### PR TITLE
Pre commit hooks updates

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,17 +44,13 @@ repos:
   - id: check-xml
   - id: check-executables-have-shebangs
   - id: check-toml
-  - id: check-xml
   - id: check-yaml
   - id: debug-statements
   - id: check-added-large-files
   - id: check-symlinks
-  - id: debug-statements
   - id: fix-byte-order-marker
   - id: fix-encoding-pragma
     args: ['--remove']
-  - id: check-executables-have-shebangs
-  - id: check-case-conflict
   - id: detect-aws-credentials
     args: ['--allow-missing-credentials']
   - id: detect-private-key

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,8 +14,8 @@ repos:
   rev: v1.2.2
   hooks:
   - id: yesqa
-- repo: https://github.com/pre-commit/mirrors-isort
-  rev: 'v5.6.4'
+- repo: https://github.com/pycqa/isort
+  rev: '5.8.0'
   hooks:
   - id: isort
 - repo: https://github.com/psf/black


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Fix up some cruft in the pre-commit hooks configuration file:

- Use the official isort pre-commit hook at <https://github.com/PyCQA/isort/blob/develop/.pre-commit-hooks.yaml> as documented [here](https://pycqa.github.io/isort/docs/configuration/pre-commit/)
- Bump the version of the isort hook to the latest release of [5.8.0](https://github.com/PyCQA/isort/releases/tag/5.8.0)
- Remove duplicate hooks from <https://github.com/pre-commit/pre-commit-hooks>

## Are there changes in behavior for the user?

No, there are no changes for users.

Developers will enjoy the latest isort version (which fixes some bugs, among other things) and faster pre-commit runs because there are no more duplicates.

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
