### PR TITLE
test_proxy_from_env did not clear proxies already set in the

### DIFF
--- a/CHANGES/5554.bugfix
+++ b/CHANGES/5554.bugfix
@@ -1,0 +1,1 @@
+Fixes failing tests when an environment variable <scheme>_proxy is set.

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -2,7 +2,6 @@
 import asyncio
 import base64
 import gc
-import os
 import platform
 from math import isclose, modf
 from unittest import mock
@@ -482,35 +481,69 @@ def test_set_content_disposition_bad_param() -> None:
 # --------------------- proxies_from_env ------------------------------
 
 
-@pytest.mark.parametrize("protocol", ["http", "https", "ws", "wss"])
-def test_proxies_from_env(monkeypatch, protocol) -> None:
-    url = URL("http://aiohttp.io/path")
-    monkeypatch.setenv(protocol + "_proxy", str(url))
+@pytest.mark.parametrize(
+    ("proxy_env_vars", "url_input", "expected_scheme"),
+    (
+        ({"http_proxy": "http://aiohttp.io/path"}, "http://aiohttp.io/path", "http"),
+        ({"https_proxy": "http://aiohttp.io/path"}, "http://aiohttp.io/path", "https"),
+        ({"ws_proxy": "http://aiohttp.io/path"}, "http://aiohttp.io/path", "ws"),
+        ({"wss_proxy": "http://aiohttp.io/path"}, "http://aiohttp.io/path", "wss"),
+    ),
+    indirect=["proxy_env_vars"],
+    ids=("http", "https", "ws", "wss"),
+)
+@pytest.mark.usefixtures("proxy_env_vars")
+def test_proxies_from_env(url_input, expected_scheme) -> None:
+    url = URL(url_input)
     ret = helpers.proxies_from_env()
-    assert ret.keys() == {protocol}
-    assert ret[protocol].proxy == url
-    assert ret[protocol].proxy_auth is None
+    assert ret.keys() == {expected_scheme}
+    assert ret[expected_scheme].proxy == url
+    assert ret[expected_scheme].proxy_auth is None
 
 
-@pytest.mark.parametrize("protocol", ["https", "wss"])
-def test_proxies_from_env_skipped(monkeypatch, caplog, protocol) -> None:
-    url = URL(protocol + "://aiohttp.io/path")
-    monkeypatch.setenv(protocol + "_proxy", str(url))
+@pytest.mark.parametrize(
+    ("proxy_env_vars", "url_input", "expected_scheme"),
+    (
+        (
+            {"https_proxy": "https://aiohttp.io/path"},
+            "https://aiohttp.io/path",
+            "https",
+        ),
+        ({"wss_proxy": "wss://aiohttp.io/path"}, "wss://aiohttp.io/path", "wss"),
+    ),
+    indirect=["proxy_env_vars"],
+    ids=("https", "wss"),
+)
+@pytest.mark.usefixtures("proxy_env_vars")
+def test_proxies_from_env_skipped(caplog, url_input, expected_scheme) -> None:
+    url = URL(url_input)
     assert helpers.proxies_from_env() == {}
     assert len(caplog.records) == 1
     log_message = "{proto!s} proxies {url!s} are not supported, ignoring".format(
-        proto=protocol.upper(), url=url
+        proto=expected_scheme.upper(), url=url
     )
     assert caplog.record_tuples == [("aiohttp.client", 30, log_message)]
 
 
-def test_proxies_from_env_http_with_auth(mocker) -> None:
+@pytest.mark.parametrize(
+    ("proxy_env_vars", "url_input", "expected_scheme"),
+    (
+        (
+            {"http_proxy": "http://user:pass@aiohttp.io/path"},
+            "http://user:pass@aiohttp.io/path",
+            "http",
+        ),
+    ),
+    indirect=["proxy_env_vars"],
+    ids=("http",),
+)
+@pytest.mark.usefixtures("proxy_env_vars")
+def test_proxies_from_env_http_with_auth(url_input, expected_scheme) -> None:
     url = URL("http://user:pass@aiohttp.io/path")
-    mocker.patch.dict(os.environ, {"http_proxy": str(url)})
     ret = helpers.proxies_from_env()
-    assert ret.keys() == {"http"}
-    assert ret["http"].proxy == url.with_user(None)
-    proxy_auth = ret["http"].proxy_auth
+    assert ret.keys() == {expected_scheme}
+    assert ret[expected_scheme].proxy == url.with_user(None)
+    proxy_auth = ret[expected_scheme].proxy_auth
     assert proxy_auth.login == "user"
     assert proxy_auth.password == "pass"
     assert proxy_auth.encoding == "latin1"


### PR DESCRIPTION


<!-- Thank you for your contribution! -->

## What do these changes do?
Fix failing tests when a environment proxy is set.

test_proxy_from_env did not clear proxies already set in the environment. Added code to first clear proxies that were already set.

Refactored the parametrize input on test_proxy_from_env to work more like test_get_env_proxy_for_url to be consistent.
<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?
No.
<!-- Outline any notable behaviour for the end users. -->

## Related issue number
#5554
<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
