### PR TITLE
Parse boundary from headers while making POST

### DIFF
--- a/CHANGES/5558.bugfix
+++ b/CHANGES/5558.bugfix
@@ -1,0 +1,1 @@
+Add parsing boundary from Content-Type header while making POST request

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -233,6 +233,7 @@ Paulius Šileikis
 Paulus Schoutsen
 Pavel Kamaev
 Pavel Polyakov
+Pavel Sapezhko
 Pawel Kowalski
 Pawel Miech
 Pepe Osca

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -38,6 +38,7 @@ from .client_exceptions import (
     ServerFingerprintMismatch,
 )
 from .formdata import FormData
+from .hdrs import CONTENT_TYPE
 from .helpers import (
     BaseTimerContext,
     BasicAuth,
@@ -45,6 +46,7 @@ from .helpers import (
     TimerNoop,
     is_expected_content_type,
     noop,
+    parse_mimetype,
     reify,
     set_result,
 )
@@ -443,7 +445,12 @@ class ClientRequest:
         try:
             body = payload.PAYLOAD_REGISTRY.get(body, disposition=None)
         except payload.LookupError:
-            body = FormData(body)()
+            boundary = None
+            if CONTENT_TYPE in self.headers:
+                boundary = parse_mimetype(self.headers[CONTENT_TYPE]).parameters.get(
+                    "boundary"
+                )
+            body = FormData(body, boundary=boundary)()
 
         self.body = body
 

--- a/aiohttp/formdata.py
+++ b/aiohttp/formdata.py
@@ -20,8 +20,10 @@ class FormData:
         fields: Iterable[Any] = (),
         quote_fields: bool = True,
         charset: Optional[str] = None,
+        boundary: Optional[str] = None,
     ) -> None:
-        self._writer = multipart.MultipartWriter("form-data")
+        self._boundary = boundary
+        self._writer = multipart.MultipartWriter("form-data", boundary=self._boundary)
         self._fields = []  # type: List[Any]
         self._is_multipart = False
         self._is_processed = False

--- a/aiohttp/multipart.py
+++ b/aiohttp/multipart.py
@@ -779,6 +779,10 @@ class MultipartWriter(Payload):
             self._boundary = boundary.encode("ascii")
         except UnicodeEncodeError:
             raise ValueError("boundary should contain ASCII only chars") from None
+
+        if len(boundary) > 70:
+            raise ValueError("boundary %r is too long (70 chars max)" % boundary)
+
         ctype = f"multipart/{subtype}; boundary={self._boundary_value}"
 
         super().__init__(None, content_type=ctype)

--- a/tests/test_client_request.py
+++ b/tests/test_client_request.py
@@ -653,6 +653,21 @@ async def test_urlencoded_formdata_charset(loop: Any, conn: Any) -> None:
     )
 
 
+async def test_formdata_boundary_from_headers(loop: Any, conn: Any) -> None:
+    boundary = "some_boundary"
+    file_path = pathlib.Path(__file__).parent / "aiohttp.png"
+    with file_path.open("rb") as f:
+        req = ClientRequest(
+            "post",
+            URL("http://python.org"),
+            data={"aiohttp.png": f},
+            headers={"Content-Type": f"multipart/form-data; boundary={boundary}"},
+            loop=loop,
+        )
+        await req.send(conn)
+        assert req.body._boundary == boundary.encode()
+
+
 async def test_post_data(loop: Any, conn: Any) -> None:
     for meth in ClientRequest.POST_METHODS:
         req = ClientRequest(

--- a/tests/test_formdata.py
+++ b/tests/test_formdata.py
@@ -99,3 +99,9 @@ async def test_mark_formdata_as_processed() -> None:
 
         with pytest.raises(RuntimeError):
             await session.post(url, data=data)
+
+
+async def test_formdata_boundary_param() -> None:
+    boundary = "some_boundary"
+    form = FormData(boundary=boundary)
+    assert form._writer.boundary == boundary

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -1225,6 +1225,8 @@ class TestMultipartWriter:
             aiohttp.MultipartWriter(boundary="тест")
         with pytest.raises(ValueError):
             aiohttp.MultipartWriter(boundary="test\n")
+        with pytest.raises(ValueError):
+            aiohttp.MultipartWriter(boundary="X" * 71)
 
     def test_default_headers(self, writer: Any) -> None:
         expected = {CONTENT_TYPE: 'multipart/mixed; boundary=":"'}


### PR DESCRIPTION
## What do these changes do?

Now, while making POST request with formdata and explicitly set header `Content-Type` the `boundary` will be used from header param if present. Without these changes, HTTP servers will fail to parse formdata because they will be waiting for `boundary` from `Content-Type` header, but aiohttp will generate random.  

## Are there changes in behavior for the user?

Only fixes behavior when `boundary` explicitly set. Another cases works as earlier.

## Related issue number

#5558

## Checklist

- [X] I think the code is well written
- [X] Unit tests for the changes exist
- [X] Documentation reflects the changes
- [X] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [X] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
