### PR TITLE
Add cov-dev makefile target

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -233,6 +233,7 @@ Paulius Šileikis
 Paulus Schoutsen
 Pavel Kamaev
 Pavel Polyakov
+Pavel Sapezhko
 Pawel Kowalski
 Pawel Miech
 Pepe Osca

--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ vvtest: .develop
 .PHONY: cov-dev
 cov-dev: .develop
 	@pytest --cov-report=html
-	@echo "open file://`pwd`/htmlcov/index.html"
+	@echo "xdg-open file://`pwd`/htmlcov/index.html"
 
 .PHONY: clean
 clean:

--- a/Makefile
+++ b/Makefile
@@ -97,6 +97,11 @@ vtest: .develop
 vvtest: .develop
 	@pytest -vv
 
+.PHONY: cov-dev
+cov-dev: .develop
+	@pytest --cov-report=html
+	@echo "open file://`pwd`/htmlcov/index.html"
+
 .PHONY: clean
 clean:
 	@rm -rf `find . -name __pycache__`


### PR DESCRIPTION
## What do these changes do?

Add `cov-dev` target to makefile to run tests with coverage on dev host. Was removed in #5145, but stayed in [docs](https://docs.aiohttp.org/en/stable/contributing.html#tests-coverage). Just thought it's useful because now there is no way to get coverage except explicit pytest run

## Are there changes in behavior for the user?

No.

## Related issue number

#5145 

## Checklist

- [X] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [X] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
