### PR TITLE
Added support orjson for dumps of response

### DIFF
--- a/CHANGES/5578.feature
+++ b/CHANGES/5578.feature
@@ -1,0 +1,1 @@
+Added support for JSONEncoder implementations that return bytes instead of string, for example, such as orjson

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -262,6 +262,7 @@ Serhiy Storchaka
 Simon Kennedy
 Sin-Woo Bang
 Stanislas Plum
+Stanislav Kiryukhin (korsar-zn)
 Stanislav Prokop
 Stefan Tjarks
 Stepan Pletnev

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -4,7 +4,6 @@ import asyncio
 import base64
 import dataclasses
 import hashlib
-import json
 import os
 import sys
 import traceback
@@ -89,7 +88,13 @@ from .http import WS_KEY, HttpVersion, WebSocketReader, WebSocketWriter
 from .http_websocket import WSHandshakeError, WSMessage, ws_ext_gen, ws_ext_parse
 from .streams import FlowControlDataQueue
 from .tracing import Trace, TraceConfig
-from .typedefs import JSONEncoder, LooseCookies, LooseHeaders, StrOrURL
+from .typedefs import (
+    DEFAULT_JSON_ENCODER,
+    JSONEncoder,
+    LooseCookies,
+    LooseHeaders,
+    StrOrURL,
+)
 
 __all__ = (
     # client_exceptions
@@ -199,7 +204,7 @@ class ClientSession:
         headers: Optional[LooseHeaders] = None,
         skip_auto_headers: Optional[Iterable[str]] = None,
         auth: Optional[BasicAuth] = None,
-        json_serialize: JSONEncoder = json.dumps,
+        json_serialize: JSONEncoder = DEFAULT_JSON_ENCODER,
         request_class: Type[ClientRequest] = ClientRequest,
         response_class: Type[ClientResponse] = ClientResponse,
         ws_response_class: Type[ClientWebSocketResponse] = ClientWebSocketResponse,

--- a/aiohttp/client_ws.py
+++ b/aiohttp/client_ws.py
@@ -173,7 +173,9 @@ class ClientWebSocketResponse:
         *,
         dumps: JSONEncoder = DEFAULT_JSON_ENCODER,
     ) -> None:
-        await self.send_str(dumps(data), compress=compress)
+        data = dumps(data)
+        data = data if isinstance(data, str) else data.decode("utf-8")
+        await self.send_str(data, compress=compress)
 
     async def close(self, *, code: int = WSCloseCode.OK, message: bytes = b"") -> bool:
         # we need to break `receive()` cycle first,

--- a/aiohttp/payload.py
+++ b/aiohttp/payload.py
@@ -1,7 +1,6 @@
 import asyncio
 import enum
 import io
-import json
 import mimetypes
 import os
 import warnings
@@ -35,7 +34,7 @@ from .helpers import (
     sentinel,
 )
 from .streams import StreamReader
-from .typedefs import JSONEncoder, _CIMultiDict
+from .typedefs import DEFAULT_JSON_ENCODER, JSONEncoder, _CIMultiDict
 
 __all__ = (
     "PAYLOAD_REGISTRY",
@@ -390,13 +389,13 @@ class JsonPayload(BytesPayload):
         value: Any,
         encoding: str = "utf-8",
         content_type: str = "application/json",
-        dumps: JSONEncoder = json.dumps,
+        dumps: JSONEncoder = DEFAULT_JSON_ENCODER,
         *args: Any,
         **kwargs: Any,
     ) -> None:
-
+        value = dumps(value)
         super().__init__(
-            dumps(value).encode(encoding),
+            value if isinstance(value, bytes) else value.encode(encoding),
             content_type=content_type,
             encoding=encoding,
             *args,

--- a/aiohttp/typedefs.py
+++ b/aiohttp/typedefs.py
@@ -21,7 +21,7 @@ else:
     _MultiDictProxy = MultiDictProxy
 
 Byteish = Union[bytes, bytearray, memoryview]
-JSONEncoder = Callable[[Any], str]
+JSONEncoder = Callable[[Any], Union[str, bytes]]
 JSONDecoder = Callable[[str], Any]
 LooseHeaders = Union[Mapping[Union[str, istr], str], _CIMultiDict, _CIMultiDictProxy]
 RawHeaders = Tuple[Tuple[bytes, bytes], ...]

--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -2,7 +2,6 @@ import asyncio
 import collections.abc
 import datetime
 import enum
-import json
 import math
 import time
 import warnings
@@ -41,7 +40,7 @@ from .helpers import (
 )
 from .http import RESPONSES, SERVER_SOFTWARE, HttpVersion10, HttpVersion11
 from .payload import Payload
-from .typedefs import JSONEncoder, LooseHeaders
+from .typedefs import DEFAULT_JSON_ENCODER, JSONEncoder, LooseHeaders
 
 __all__ = ("ContentCoding", "StreamResponse", "Response", "json_response")
 
@@ -745,13 +744,15 @@ def json_response(
     reason: Optional[str] = None,
     headers: Optional[LooseHeaders] = None,
     content_type: str = "application/json",
-    dumps: JSONEncoder = json.dumps,
+    dumps: JSONEncoder = DEFAULT_JSON_ENCODER,
 ) -> Response:
     if data is not sentinel:
         if text or body:
             raise ValueError("only one of data, text, or body should be specified")
         else:
-            text = dumps(data)
+            text = dumps(data)  # type: ignore[assignment]
+            if isinstance(text, bytes):
+                text = text.decode("utf-8")
     return Response(
         text=text,
         body=body,

--- a/aiohttp/web_ws.py
+++ b/aiohttp/web_ws.py
@@ -28,7 +28,7 @@ from .http import (
 )
 from .log import ws_logger
 from .streams import EofStream, FlowControlDataQueue
-from .typedefs import JSONDecoder, JSONEncoder
+from .typedefs import DEFAULT_JSON_ENCODER, JSONDecoder, JSONEncoder
 from .web_exceptions import HTTPBadRequest, HTTPException
 from .web_request import BaseRequest
 from .web_response import StreamResponse
@@ -342,9 +342,11 @@ class WebSocketResponse(StreamResponse):
         data: Any,
         compress: Optional[bool] = None,
         *,
-        dumps: JSONEncoder = json.dumps,
+        dumps: JSONEncoder = DEFAULT_JSON_ENCODER,
     ) -> None:
-        await self.send_str(dumps(data), compress=compress)
+        data = dumps(data)
+        data = data if isinstance(data, str) else data.decode("utf-8")
+        await self.send_str(data, compress=compress)
 
     async def write_eof(self) -> None:  # type: ignore[override]
         if self._eof_sent:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 # type: ignore
 import asyncio
+import json
 import os
 import socket
 import ssl
@@ -198,3 +199,16 @@ def selector_loop() -> None:
     with loop_context(policy.new_event_loop) as _loop:
         asyncio.set_event_loop(_loop)
         yield _loop
+
+
+@pytest.fixture(
+    params=[
+        lambda x: json.dumps(x),
+        lambda x: json.dumps(x).encode(
+            "utf-8"
+        ),  # emulate json-encoder that return bytes (for example as orjson)
+    ],
+    ids=["json_serialize(obj) -> string", "json_serialize(obj) -> bytes"],
+)
+def json_serialize(request) -> mock.Mock:
+    return mock.Mock(wraps=request.param)

--- a/tests/test_web_response.py
+++ b/tests/test_web_response.py
@@ -1168,6 +1168,12 @@ class TestJSONResponse:
         resp = json_response({"foo": 42})
         assert json.dumps({"foo": 42}) == resp.text
 
+    def test_data_custom_json_serialize(self, json_serialize):
+        payload = {"foo": 42}
+        resp = json_response(payload, dumps=json_serialize)
+        assert json.dumps(payload) == resp.text
+        json_serialize.assert_called_with(payload)
+
     def test_content_type_is_overrideable(self) -> None:
         resp = json_response({"foo": 42}, content_type="application/vnd.json+api")
         assert "application/vnd.json+api" == resp.content_type


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Added support for JSONEncoder implementations that return bytes instead of string, for example, such as orjson

## Are there changes in behavior for the user?

No

## Related issue number

No

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
