### PR TITLE
Fix missing references in client_advanced.rst

### DIFF
--- a/docs/client_advanced.rst
+++ b/docs/client_advanced.rst
@@ -295,7 +295,7 @@ nature are installed to perform their job in each signal handle::
 
 All signals take as a parameters first, the :class:`ClientSession`
 instance used by the specific request related to that signals and
-second, a :class:`SimpleNamespace` instance called
+second, a :class:`~types.SimpleNamespace` instance called
 ``trace_config_ctx``. The ``trace_config_ctx`` object can be used to
 share the state through to the different signals that belong to the
 same request and to the same :class:`TraceConfig` class, perhaps::
@@ -310,7 +310,7 @@ same request and to the same :class:`TraceConfig` class, perhaps::
 
 
 The ``trace_config_ctx`` param is by default a
-:class:`SimpleNampespace` that is initialized at the beginning of the
+:class:`~types.SimpleNamespace` that is initialized at the beginning of the
 request flow. However, the factory used to create this object can be
 overwritten using the ``trace_config_ctx_factory`` constructor param of
 the :class:`TraceConfig` class.
@@ -587,7 +587,7 @@ as it results in more compact code::
 
 This approach can be successfully used to define numerous of session given certain
 requirements. It benefits from having a single location where :class:`aiohttp.ClientSession`
-instances are created and where artifacts such as :class:`aiohttp.connector.BaseConnector`
+instances are created and where artifacts such as :class:`aiohttp.BaseConnector`
 can be safely shared between sessions if needed.
 
 In the end all you have to do is to close all sessions after `yield` statement::

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -351,4 +351,5 @@ texinfo_documents = [
 # nitpicky = True
 nitpick_ignore = [
     ("py:mod", "aiohttp"),  # undocumented, no `.. currentmodule:: aiohttp` in docs
+    ("py:class", "aiohttp.SimpleCookie"),  # undocumented
 ]


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

This change corrects multiple unrendered intersphinx class reference in the `client_advanced.rst` document.

## Are there changes in behavior for the user?

No

## Related issue number

#5518 

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."