### PR TITLE
Fix `StreamReader` reference @ `client_quickstart`

### DIFF
--- a/docs/client_quickstart.rst
+++ b/docs/client_quickstart.rst
@@ -318,7 +318,7 @@ You can set the ``filename`` and ``content_type`` explicitly::
     await session.post(url, data=data)
 
 If you pass a file object as data parameter, aiohttp will stream it to
-the server automatically. Check :class:`~aiohttp.streams.StreamReader`
+the server automatically. Check :class:`~aiohttp.StreamReader`
 for supported format information.
 
 .. seealso:: :ref:`aiohttp-multipart`
@@ -327,7 +327,7 @@ for supported format information.
 Streaming uploads
 =================
 
-:mod:`aiohttp` supports multiple types of streaming uploads, which allows you to
+:mod:`~aiohttp.web` supports multiple types of streaming uploads, which allows you to
 send large files without reading them into memory.
 
 As a simple case, simply provide a file-like object for your body::
@@ -366,7 +366,7 @@ can chain get and post requests together::
 WebSockets
 ==========
 
-:mod:`aiohttp` works with client websockets out-of-the-box.
+:mod:`~aiohttp.web` works with client websockets out-of-the-box.
 
 You have to use the :meth:`aiohttp.ClientSession.ws_connect` coroutine
 for client websocket connection. It accepts a *url* as a first

--- a/docs/client_quickstart.rst
+++ b/docs/client_quickstart.rst
@@ -327,7 +327,7 @@ for supported format information.
 Streaming uploads
 =================
 
-:mod:`~aiohttp.web` supports multiple types of streaming uploads, which allows you to
+:mod:`aiohttp` supports multiple types of streaming uploads, which allows you to
 send large files without reading them into memory.
 
 As a simple case, simply provide a file-like object for your body::
@@ -366,7 +366,7 @@ can chain get and post requests together::
 WebSockets
 ==========
 
-:mod:`~aiohttp.web` works with client websockets out-of-the-box.
+:mod:`aiohttp` works with client websockets out-of-the-box.
 
 You have to use the :meth:`aiohttp.ClientSession.ws_connect` coroutine
 for client websocket connection. It accepts a *url* as a first

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -349,5 +349,6 @@ texinfo_documents = [
 
 # -------------------------------------------------------------------------
 # nitpicky = True
-
-nitpick_ignore = [("py:mod", "aiohttp")]
+nitpick_ignore = [
+    ("py:mod", "aiohttp"),  # undocumented, no `.. currentmodule:: aiohttp` in docs
+]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -349,3 +349,5 @@ texinfo_documents = [
 
 # -------------------------------------------------------------------------
 # nitpicky = True
+
+nitpick_ignore = [("py:mod", "aiohttp")]


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

This change corrects multiple unrendered intersphinx class reference in the `client_quickstart.rst` document.

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->
No.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
#5518

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
