### PR TITLE
coroutine is allowed to return web.AppRunner

### DIFF
--- a/aiohttp/worker.py
+++ b/aiohttp/worker.py
@@ -61,23 +61,31 @@ class GunicornWebWorker(base.Worker):  # type: ignore[misc,no-any-unimported]
         sys.exit(self.exit_code)
 
     async def _run(self) -> None:
+        runner = None
         if isinstance(self.wsgi, Application):
             app = self.wsgi
         elif asyncio.iscoroutinefunction(self.wsgi):
-            app = await self.wsgi()
+            wsgi = await self.wsgi()
+            if isinstance(wsgi, web.AppRunner):
+                runner = wsgi
+                app = runner.app
+            else:
+                app = wsgi
         else:
             raise RuntimeError(
                 "wsgi app should be either Application or "
                 "async function returning Application, got {}".format(self.wsgi)
             )
-        access_log = self.log.access_log if self.cfg.accesslog else None
-        runner = web.AppRunner(
-            app,
-            logger=self.log,
-            keepalive_timeout=self.cfg.keepalive,
-            access_log=access_log,
-            access_log_format=self._get_valid_log_format(self.cfg.access_log_format),
-        )
+
+        if runner is None:
+            access_log = self.log.access_log if self.cfg.accesslog else None
+            runner = web.AppRunner(
+                app,
+                logger=self.log,
+                keepalive_timeout=self.cfg.keepalive,
+                access_log=access_log,
+                access_log_format=self._get_valid_log_format(self.cfg.access_log_format),
+            )
         await runner.setup()
 
         ctx = self._create_ssl_context(self.cfg) if self.cfg.is_ssl else None


### PR DESCRIPTION
These changes allow the configuration of web.AppRunner object inside application code. This makes possible to use custom configs of Aiohttp server (like 'max_line_size' parameters setup) in pair with Gunicorn.
Associated issue: https://github.com/aio-libs/aiohttp/issues/2988#ref-pullrequest-607852432

<!-- Thank you for your contribution! -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
