### PR TITLE
Fix broken references in `docs/testing.rst`

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -366,4 +366,10 @@ nitpick_ignore = [
     ("py:meth", "start"),  # undocumented
     ("py:exc", "aiohttp.ServerDisconnectionError"),  # undocumented
     ("py:exc", "aiohttp.ClientHttpProxyError"),  # undocumented
+    ("py:class", "asyncio.AbstractServer"),  # undocumented
+    ("py:mod", "aiohttp.test_tools"),  # undocumented
+    ("py:class", "list of pairs"),  # undocumented
+    ("py:class", "aiohttp.protocol.HttpVersion"),  # undocumented
+    ("py:meth", "aiohttp.ClientSession.request"),  # undocumented
+    ("py:class", "aiohttp.StreamWriter"),  # undocumented
 ]

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -57,7 +57,7 @@ requests to this server.
 
 :class:`~aiohttp.test_utils.TestServer` runs :class:`aiohttp.web.Application`
 based server, :class:`~aiohttp.test_utils.RawTestServer` starts
-:class:`aiohttp.web.WebServer` low level server.
+:class:`aiohttp.web.Server` low level server.
 
 For performing HTTP requests to these servers you have to create a
 test client: :class:`~aiohttp.test_utils.TestClient` instance.
@@ -338,7 +338,7 @@ functionality, the AioHTTPTestCase is provided::
 
     .. attribute:: app
 
-       The application returned by :meth:`get_app`
+       The application returned by :meth:`~aiohttp.test_utils.AioHTTPTestCase.get_application`
        (:class:`aiohttp.web.Application` instance).
 
     .. comethod:: get_client()
@@ -544,7 +544,7 @@ conditions that hard to reproduce on real server::
    :type writer: aiohttp.StreamWriter
 
    :param transport: asyncio transport instance
-   :type transport: asyncio.transports.Transport
+   :type transport: asyncio.Transport
 
    :param payload: raw payload reader object
    :type  payload: aiohttp.StreamReader
@@ -623,8 +623,8 @@ Test server
 Runs given :class:`aiohttp.web.Application` instance on random TCP port.
 
 After creation the server is not started yet, use
-:meth:`~aiohttp.test_utils.TestServer.start_server` for actual server
-starting and :meth:`~aiohttp.test_utils.TestServer.close` for
+:meth:`~aiohttp.test_utils.BaseTestServer.start_server` for actual server
+starting and :meth:`~aiohttp.test_utils.BaseTestServer.close` for
 stopping/cleanup.
 
 Test server usually works in conjunction with
@@ -660,7 +660,7 @@ for accessing to the server.
 
    .. attribute:: handler
 
-      :class:`aiohttp.web.WebServer` used for HTTP requests serving.
+      :class:`aiohttp.web.Server` used for HTTP requests serving.
 
    .. attribute:: server
 
@@ -772,7 +772,7 @@ Test Client
 
    .. attribute:: app
 
-      An alias for :attr:`self.server.app`. return ``None`` if
+      An alias for ``self.server.app``. return ``None`` if
       ``self.server`` is not :class:`TestServer`
       instance(e.g. :class:`RawTestServer` instance for test low-level server).
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

This change corrects multiple unrendered intersphinx class reference in the `testing.rst` document.


## Are there changes in behavior for the user?

No

## Related issue number

#5518 

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
