### PR TITLE
Fix broken references in `docs/client_reference.rst`

### DIFF
--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -88,14 +88,14 @@ The client session supports the context manager protocol for self closing.
       that generation. Note that ``Content-Length`` autogeneration can't
       be skipped.
 
-      Iterable of :class:`str` or :class:`~aiohttp.istr` (optional)
+      Iterable of :class:`str` or :class:`~multidict.istr` (optional)
 
    :param aiohttp.BasicAuth auth: an object that represents HTTP Basic
                                   Authorization (optional)
 
    :param version: supported HTTP version, ``HTTP 1.1`` by default.
 
-   :param cookie_jar: Cookie Jar, :class:`AbstractCookieJar` instance.
+   :param cookie_jar: Cookie Jar, :class:`~aiohttp.abc.AbstractCookieJar` instance.
 
       By default every session instance has own private cookie jar for
       automatic cookies processing but user may redefine this behavior
@@ -108,7 +108,7 @@ The client session supports the context manager protocol for self closing.
       :class:`aiohttp.DummyCookieJar` instance can be
       provided.
 
-   :param callable json_serialize: Json *serializer* callable.
+   :param collections.abc.Callable json_serialize: Json *serializer* callable.
 
       By default :func:`json.dumps` function.
 
@@ -210,7 +210,7 @@ The client session supports the context manager protocol for self closing.
 
    .. attribute:: cookie_jar
 
-      The session cookies, :class:`~aiohttp.AbstractCookieJar` instance.
+      The session cookies, :class:`~aiohttp.abc.AbstractCookieJar` instance.
 
       Gives access to cookie jar's content and modifiers.
 
@@ -261,7 +261,7 @@ The client session supports the context manager protocol for self closing.
 
       Set of headers for which autogeneration skipped.
 
-      :class:`frozenset` of :class:`str` or :class:`~aiohttp.istr` (optional)
+      :class:`frozenset` of :class:`str` or :class:`~multidict.istr` (optional)
 
       .. versionadded:: 3.7
 
@@ -293,7 +293,7 @@ The client session supports the context manager protocol for self closing.
 
       Should :meth:`ClientResponse.raise_for_status()` be called for each response
 
-      Either :class:`bool` or :class:`callable`
+      Either :class:`bool` or :class:`collections.abc.Callable`
 
       .. versionadded:: 3.7
 
@@ -351,8 +351,8 @@ The client session supports the context manager protocol for self closing.
                      Allowed values are:
 
                      - :class:`collections.abc.Mapping` e.g. :class:`dict`,
-                       :class:`aiohttp.MultiDict` or
-                       :class:`aiohttp.MultiDictProxy`
+                       :class:`multidict.MultiDict` or
+                       :class:`multidict.MultiDictProxy`
                      - :class:`collections.abc.Iterable` e.g. :class:`tuple` or
                        :class:`list`
                      - :class:`str` with preferably url-encoded content
@@ -386,7 +386,7 @@ The client session supports the context manager protocol for self closing.
          passed. Using ``skip_auto_headers`` parameter allows to skip
          that generation.
 
-         Iterable of :class:`str` or :class:`~aiohttp.istr`
+         Iterable of :class:`str` or :class:`~multidict.istr`
          (optional)
 
       :param aiohttp.BasicAuth auth: an object that represents HTTP
@@ -492,7 +492,7 @@ The client session supports the context manager protocol for self closing.
 
             Use ``ssl=ssl_context``
 
-      :param abc.Mapping proxy_headers: HTTP headers to send to the proxy if the
+      :param collections.abc.Mapping proxy_headers: HTTP headers to send to the proxy if the
          parameter proxy has been provided.
 
          .. versionadded:: 2.3
@@ -1082,14 +1082,14 @@ TCPConnector
       very rare cases.
 
    :param int family: TCP socket family, both IPv4 and IPv6 by default.
-                      For *IPv4* only use :const:`socket.AF_INET`,
-                      for  *IPv6* only -- :const:`socket.AF_INET6`.
+                      For *IPv4* only use :data:`socket.AF_INET`,
+                      for  *IPv6* only -- :data:`socket.AF_INET6`.
 
                       *family* is ``0`` by default, that means both
                       IPv4 and IPv6 are accepted. To specify only
                       concrete version please pass
-                      :const:`socket.AF_INET` or
-                      :const:`socket.AF_INET6` explicitly.
+                      :data:`socket.AF_INET` or
+                      :data:`socket.AF_INET6` explicitly.
 
    :param ssl.SSLContext ssl_context: SSL context used for processing
       *HTTPS* requests (optional).
@@ -1110,8 +1110,8 @@ TCPConnector
 
    .. attribute:: family
 
-      *TCP* socket family e.g. :const:`socket.AF_INET` or
-      :const:`socket.AF_INET6`
+      *TCP* socket family e.g. :data:`socket.AF_INET` or
+      :data:`socket.AF_INET6`
 
       Read-only property.
 
@@ -1213,7 +1213,7 @@ Response object
 
 .. class:: ClientResponse
 
-   Client response returned by :meth:`ClientSession.request` and family.
+   Client response returned by :meth:`aiohttp.ClientSession.request` and family.
 
    User never creates the instance of ClientResponse class but gets it
    from API calls.
@@ -1229,7 +1229,7 @@ Response object
 
    .. attribute:: version
 
-      Response's version, :class:`HttpVersion` instance.
+      Response's version, :class:`~aiohttp.protocol.HttpVersion` instance.
 
    .. attribute:: status
 
@@ -1428,7 +1428,7 @@ Response object
                            responses. Autodetection works pretty fine
                            anyway.
 
-      :param callable loads: :func:`callable` used for loading *JSON*
+      :param collections.abc.Callable loads: :term:`callable` used for loading *JSON*
                              data, :func:`json.loads` by default.
 
       :param str content_type: specify response's content-type, if content type
@@ -1441,7 +1441,7 @@ Response object
 
    .. attribute:: request_info
 
-       A namedtuple with request URL and headers from :class:`ClientRequest`
+       A namedtuple with request URL and headers from :class:`~aiohttp.ClientRequest`
        object, :class:`aiohttp.RequestInfo` instance.
 
    .. method:: get_encoding()
@@ -1562,7 +1562,7 @@ manually.
                            single message,
                            ``None`` for not overriding per-socket setting.
 
-      :param callable dumps: any :term:`callable` that accepts an object and
+      :param collections.abc.Callable dumps: any :term:`callable` that accepts an object and
                              returns a JSON string
                              (:func:`json.dumps` by default).
 
@@ -1630,7 +1630,7 @@ manually.
       A :ref:`coroutine<coroutine>` that calls :meth:`receive_str` and loads
       the JSON string to a Python dict.
 
-      :param callable loads: any :term:`callable` that accepts
+      :param collections.abc.Callable loads: any :term:`callable` that accepts
                               :class:`str` and returns :class:`dict`
                               with parsed JSON (:func:`json.loads` by
                               default).
@@ -1710,7 +1710,7 @@ RequestInfo
 
 .. class:: RequestInfo()
 
-   A data class with request URL and headers from :class:`ClientRequest`
+   A data class with request URL and headers from :class:`~aiohttp.ClientRequest`
    object, available as :attr:`ClientResponse.request_info` attribute.
 
    .. attribute:: url
@@ -1745,7 +1745,7 @@ BasicAuth
 
 
    Should be used for specifying authorization data in client API,
-   e.g. *auth* parameter for :meth:`ClientSession.request`.
+   e.g. *auth* parameter for :meth:`~aiohttp.ClientSession.request`.
 
 
    .. classmethod:: decode(auth_header, encoding='latin1')
@@ -1797,7 +1797,7 @@ CookieJar
 
    The class implements :class:`collections.abc.Iterable`,
    :class:`collections.abc.Sized` and
-   :class:`aiohttp.AbstractCookieJar` interfaces.
+   :class:`aiohttp.abc.AbstractCookieJar` interfaces.
 
    Implements cookie storage adhering to RFC 6265.
 
@@ -1917,7 +1917,7 @@ added with at least one optional argument to :meth:`add_field<aiohttp.FormData.a
 (``content_type``, ``filename``, or ``content_transfer_encoding``).
 Otherwise, ``application/x-www-form-urlencoded`` is used.
 
-:class:`FormData` instances are callable and return a :class:`Payload`
+:class:`FormData` instances are callable and return a :class:`aiohttp.payload.Payload`
 on being called.
 
 .. class:: FormData(fields, quote_fields=True, charset=None)
@@ -1952,14 +1952,14 @@ on being called.
                     Possible types are:
 
                     - :class:`str`
-                    - :class:`bytes`, :class:`bytesarray`, or :class:`memoryview`
+                    - :class:`bytes`, :class:`bytearray`, or :class:`memoryview`
                     - :class:`io.IOBase`, e.g. a file-like object
 
       :param str content_type: The field's content-type header (optional)
 
       :param str filename: The field's filename (optional)
 
-                           If this is not set and ``value`` is a :class:`bytes`, :class:`bytesarray`,
+                           If this is not set and ``value`` is a :class:`bytes`, :class:`bytearray`,
                            or :class:`memoryview` object, the `name` argument is used as the filename
                            unless ``content_transfer_encoding`` is specified.
 
@@ -2163,7 +2163,7 @@ Connection errors
 
    Server disconnected.
 
-   Derived from :exc:`ServerDisconnectionError`
+   Derived from :exc:`~aiohttp.ServerDisconnectionError`
 
    .. attribute:: message
 
@@ -2192,7 +2192,7 @@ Hierarchy of exceptions
 
     * :exc:`ContentTypeError`
     * :exc:`WSServerHandshakeError`
-    * :exc:`ClientHttpProxyError`
+    * :exc:`aiohttp.ClientHttpProxyError`
 
   * :exc:`ClientConnectionError`
 

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -2192,7 +2192,7 @@ Hierarchy of exceptions
 
     * :exc:`ContentTypeError`
     * :exc:`WSServerHandshakeError`
-    * :exc:`aiohttp.ClientHttpProxyError`
+    * :exc:`~aiohttp.ClientHttpProxyError`
 
   * :exc:`ClientConnectionError`
 

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -1745,7 +1745,7 @@ BasicAuth
 
 
    Should be used for specifying authorization data in client API,
-   e.g. *auth* parameter for :meth:`~aiohttp.ClientSession.request`.
+   e.g. *auth* parameter for :meth:`ClientSession.request() <aiohttp.ClientSession.request>`.
 
 
    .. classmethod:: decode(auth_header, encoding='latin1')

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -357,4 +357,13 @@ nitpick_ignore = [
     ("py:class", "aiohttp.SimpleCookie"),  # undocumented
     ("py:class", "aiohttp.web.RequestHandler"),  # undocumented
     ("py:class", "aiohttp.NamedPipeConnector"),  # undocumented
+    ("py:meth", "aiohttp.ClientSession.request"),  # undocumented
+    ("py:class", "aiohttp.protocol.HttpVersion"),  # undocumented
+    ("py:class", "aiohttp.ClientRequest"),  # undocumented
+    ("py:class", "aiohttp.payload.Payload"),  # undocumented
+    ("py:class", "aiohttp.abc.AbstractResolver"),  # undocumented
+    ("py:func", "aiohttp.ws_connect"),  # undocumented
+    ("py:meth", "start"),  # undocumented
+    ("py:exc", "aiohttp.ServerDisconnectionError"),  # undocumented
+    ("py:exc", "aiohttp.ClientHttpProxyError"),  # undocumented
 ]


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

This change corrects multiple unrendered intersphinx class reference in the `client_reference.rst` document.

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. --> NO

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? --> #5518 

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
