### PR TITLE
Fix broken references in `docs/web_quickstart.rst`

### DIFF
--- a/docs/web_quickstart.rst
+++ b/docs/web_quickstart.rst
@@ -137,7 +137,7 @@ requests on a *path* having **any** *HTTP method*::
   app.add_routes([web.route('*', '/path', all_handler)])
 
 The *HTTP method* can be queried later in the request handler using the
-:attr:`Request.method` property.
+:attr:`aiohttp.web.BaseRequest.method` property.
 
 By default endpoints added with ``GET`` method will accept
 ``HEAD`` requests and return the same response headers as they would
@@ -355,7 +355,7 @@ Route tables look like Django way::
                           web.post('/post', handle_post),
 
 
-The snippet calls :meth:`~aiohttp.web.UrlDispather.add_routes` to
+The snippet calls :meth:`~aiohttp.web.UrlDispatcher.add_routes` to
 register a list of *route definitions* (:class:`aiohttp.web.RouteDef`
 instances) created by :func:`aiohttp.web.get` or
 :func:`aiohttp.web.post` functions.
@@ -399,7 +399,7 @@ The container is a list-like object with additional decorators
 routes.
 
 After filling the container
-:meth:`~aiohttp.web.UrlDispather.add_routes` is used for adding
+:meth:`~aiohttp.web.UrlDispatcher.add_routes` is used for adding
 registered *route definitions* into application's router.
 
 .. seealso:: :ref:`aiohttp-web-route-table-def` reference.
@@ -468,17 +468,17 @@ HTTP Forms
 HTTP Forms are supported out of the box.
 
 If form's method is ``"GET"`` (``<form method="get">``) use
-:attr:`Request.query` for getting form data.
+:attr:`aiohttp.web.BaseRequest.query` for getting form data.
 
 To access form data with ``"POST"`` method use
-:meth:`Request.post` or :meth:`Request.multipart`.
+:meth:`aiohttp.web.BaseRequest.post` or :meth:`aiohttp.web.BaseRequest.multipart`.
 
-:meth:`Request.post` accepts both
+:meth:`aiohttp.web.BaseRequest.post` accepts both
 ``'application/x-www-form-urlencoded'`` and ``'multipart/form-data'``
 form's data encoding (e.g. ``<form enctype="multipart/form-data">``).
 It stores files data in temporary directory. If `client_max_size` is
 specified `post` raises `ValueError` exception.
-For efficiency use :meth:`Request.multipart`, It is especially effective
+For efficiency use :meth:`aiohttp.web.BaseRequest.multipart`, It is especially effective
 for uploading large files (:ref:`aiohttp-web-file-upload`).
 
 Values submitted by the following form:
@@ -552,10 +552,10 @@ a container for the file as well as some of its metadata::
 
 
 You might have noticed a big warning in the example above. The general issue is
-that :meth:`Request.post` reads the whole payload in memory,
+that :meth:`aiohttp.web.BaseRequest.post` reads the whole payload in memory,
 resulting in possible
 :abbr:`OOM (Out Of Memory)` errors. To avoid this, for multipart uploads, you
-should use :meth:`Request.multipart` which returns a :ref:`multipart reader
+should use :meth:`aiohttp.web.BaseRequest.multipart` which returns a :ref:`multipart reader
 <aiohttp-multipart>`::
 
     async def store_mp3_handler(request):


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

<!-- Please give a short brief about these changes. --> 
This change corrects multiple unrendered intersphinx class reference in the `web_quickstart.rst` document.



## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. --> No

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? --> #5518 

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
