### PR TITLE
Fix broken references in `docs/web_reference.rst`

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -372,4 +372,16 @@ nitpick_ignore = [
     ("py:class", "aiohttp.protocol.HttpVersion"),  # undocumented
     ("py:meth", "aiohttp.ClientSession.request"),  # undocumented
     ("py:class", "aiohttp.StreamWriter"),  # undocumented
+    ("py:attr", "aiohttp.StreamResponse.body"),  # undocumented
+    ("py:class", "aiohttp.payload.StringPayload"),  # undocumented
+    ("py:meth", "aiohttp.web.Application.copy"),  # undocumented
+    ("py:meth", "asyncio.AbstractEventLoop.create_server"),  # undocumented
+    ("py:data", "aiohttp.log.server_logger"),  # undocumented
+    ("py:data", "aiohttp.log.access_logger"),  # undocumented
+    ("py:data", "aiohttp.helpers.AccessLogger"),  # undocumented
+    ("py:attr", "helpers.AccessLogger.LOG_FORMAT"),  # undocumented
+    ("py:meth", "aiohttp.web.AbstractRoute.url"),  # undocumented
+    ("py:class", "aiohttp.web.MatchedSubAppResource"),  # undocumented
+    ("py:attr", "body"),  # undocumented
+    ("py:class", "socket.socket"),  # undocumented
 ]

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -1473,7 +1473,7 @@ duplicated like one using :meth:`~aiohttp.web.Application.copy`.
 
       :param Application subapp: nested application.
 
-      :returns: a :class:`MatchedSubAppResource` instance.
+      :returns: a :class:`~aiohttp.web.MatchedSubAppResource` instance.
 
    .. method:: add_routes(routes_table)
 
@@ -1754,11 +1754,11 @@ Router is any object that implements :class:`~aiohttp.abc.AbstractRouter` interf
       :param bool append_version: flag for adding file version (hash)
                               to the url query string, this value will
                               be used as default when you call to
-                              :meth:`StaticRoute.url` and
-                              :meth:`StaticRoute.url_for` methods.
+                              :meth:`~aiohttp.web.AbstractRoute.url` and
+                              :meth:`~aiohttp.web.AbstractRoute.url_for` methods.
 
 
-      :returns: new :class:`StaticRoute` instance.
+      :returns: new :class:`~aiohttp.web.AbstractRoute` instance.
 
    .. comethod:: resolve(request)
 

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -2747,7 +2747,7 @@ Utilities
 
 .. class:: FileField
 
-   A :class:`~typing.NamedTuple` instance that is returned as
+   A :mod:`dataclass <dataclasses>` instance that is returned as
    multidict value by :meth:`aiohttp.web.BaseRequest.post` if field is uploaded file.
 
    .. attribute:: name

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -1763,10 +1763,10 @@ Router is any object that implements :class:`~aiohttp.abc.AbstractRouter` interf
    .. comethod:: resolve(request)
 
       A :ref:`coroutine<coroutine>` that returns
-      :class:`aiohttp.abc.AbstractMatchInfo` for *request*.
+      :class:`~aiohttp.abc.AbstractMatchInfo` for *request*.
 
       The method never raises exception, but returns
-      :class:`aiohttp.abc.AbstractMatchInfo` instance with:
+      :class:`~aiohttp.abc.AbstractMatchInfo` instance with:
 
       1. :attr:`~aiohttp.abc.AbstractMatchInfo.http_exception` assigned to
          :exc:`HTTPException` instance.

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -1527,7 +1527,7 @@ duplicated like one using :meth:`~aiohttp.web.Application.copy`.
       based but traversal ones).
 
       For sake of that fact we have very trivial ABC for
-      :class:`aiohttp.abc.AbstractRouter`: it should have only
+      :class:`~aiohttp.abc.AbstractRouter`: it should have only
       :meth:`aiohttp.abc.AbstractRouter.resolve` coroutine.
 
       No methods for adding routes or route reversing (getting URL by

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -118,7 +118,7 @@ and :ref:`aiohttp-web-signals` handlers.
 
       - Overridden value by :meth:`~BaseRequest.clone` call.
       - *Host* HTTP header
-      - :func:`socket.gtfqdn`
+      - :func:`socket.getfqdn`
 
       Read-only :class:`str` property.
 
@@ -320,20 +320,20 @@ and :ref:`aiohttp-web-signals` handlers.
 
    .. attribute:: if_match
 
-      Read-only property that returns :class:`ETag` objects specified
+      Read-only property that returns :class:`~aiohttp.ETag` objects specified
       in the *If-Match* header.
 
-      Returns :class:`tuple` of :class:`ETag` or ``None`` if
+      Returns :class:`tuple` of :class:`~aiohttp.ETag` or ``None`` if
       *If-Match* header is absent.
 
       .. versionadded:: 3.8
 
    .. attribute:: if_none_match
 
-      Read-only property that returns :class:`ETag` objects specified
+      Read-only property that returns :class:`~aiohttp.ETag` objects specified
       *If-None-Match* header.
 
-      Returns :class:`tuple` of :class:`ETag` or ``None`` if
+      Returns :class:`tuple` of :class:`~aiohttp.ETag` or ``None`` if
       *If-None-Match* header is absent.
 
       .. versionadded:: 3.8
@@ -385,7 +385,7 @@ and :ref:`aiohttp-web-signals` handlers.
       .. note::
 
          The method **does** store read data internally, subsequent
-         :meth:`~Request.read` call will return the same value.
+         :meth:`~aiohttp.web.BaseRequest.read` call will return the same value.
 
    .. comethod:: text()
 
@@ -397,16 +397,16 @@ and :ref:`aiohttp-web-signals` handlers.
       .. note::
 
          The method **does** store read data internally, subsequent
-         :meth:`~Request.text` call will return the same value.
+         :meth:`~aiohttp.web.BaseRequest.text` call will return the same value.
 
    .. comethod:: json(*, loads=json.loads, \
                     content_type='application/json')
 
       Read request body decoded as *json*. If request's content-type does not
-      match `content_type` parameter, :class:`web.HTTPBadRequest` get raised.
+      match `content_type` parameter, :exc:`aiohttp.web.HTTPBadRequest` get raised.
       To disable content type check pass ``None`` value.
 
-      :param callable loads: any :term:`callable` that accepts
+      :param collections.abc.Callable loads: any :term:`callable` that accepts
                               :class:`str` and returns :class:`dict`
                               with parsed JSON (:func:`json.loads` by
                               default).
@@ -416,12 +416,12 @@ and :ref:`aiohttp-web-signals` handlers.
       .. note::
 
          The method **does** store read data internally, subsequent
-         :meth:`~Request.json` call will return the same value.
+         :meth:`~aiohttp.web.BaseRequest.json` call will return the same value.
 
 
    .. comethod:: multipart()
 
-      Returns :class:`aiohttp.multipart.MultipartReader` which processes
+      Returns :class:`aiohttp.MultipartReader` which processes
       incoming *multipart* request.
 
       The method is just a boilerplate :ref:`coroutine <coroutine>`
@@ -460,7 +460,7 @@ and :ref:`aiohttp-web-signals` handlers.
       .. note::
 
          The method **does** store read data internally, subsequent
-         :meth:`~Request.post` call will return the same value.
+         :meth:`~aiohttp.web.BaseRequest.post` call will return the same value.
 
    .. comethod:: release()
 
@@ -470,7 +470,7 @@ and :ref:`aiohttp-web-signals` handlers.
 
       .. note::
 
-          User code may never call :meth:`~Request.release`, all
+          User code may never call :meth:`~aiohttp.web.BaseRequest.release`, all
           required work will be processed by :mod:`aiohttp.web`
           internal machinery.
 
@@ -631,7 +631,7 @@ StreamResponse
 
    .. attribute:: keep_alive
 
-      Read-only property, copy of :attr:`Request.keep_alive` by default.
+      Read-only property, copy of :attr:`aiohttp.web.BaseRequest.keep_alive` by default.
 
       Can be switched to ``False`` by :meth:`force_close` call.
 
@@ -798,7 +798,7 @@ StreamResponse
 
       *ETag* header for outgoing response.
 
-      This property accepts raw :class:`str` values, :class:`ETag`
+      This property accepts raw :class:`str` values, :class:`~aiohttp.ETag`
       objects and the value ``None`` to unset the header.
 
       In case of :class:`str` input, etag is considered as strong by default.
@@ -911,7 +911,7 @@ Response
 
       Setting :attr:`text` also recalculates
       :attr:`~StreamResponse.content_length` value and
-      :attr:`~StreamResponse.body` value
+      :attr:`~aiohttp.StreamResponse.body` value
 
       Resetting :attr:`text` (assigning ``None``) sets
       :attr:`~StreamResponse.content_length` to ``None`` too, dropping
@@ -1136,7 +1136,7 @@ WebSocketResponse
                            single message,
                            ``None`` for not overriding per-socket setting.
 
-      :param callable dumps: any :term:`callable` that accepts an object and
+      :param collections.abc.Callable dumps: any :term:`callable` that accepts an object and
                              returns a JSON string
                              (:func:`json.dumps` by default).
 
@@ -1235,7 +1235,7 @@ WebSocketResponse
 
          Can only be called by the request handling task.
 
-      :param callable loads: any :term:`callable` that accepts
+      :param collections.abc.Callable loads: any :term:`callable` that accepts
                               :class:`str` and returns :class:`dict`
                               with parsed JSON (:func:`json.loads` by
                               default).
@@ -1323,7 +1323,7 @@ properties for later access from a :ref:`handler<aiohttp-web-handler>` via the
            conn.execute("DELETE * FROM table")
 
 Although :class:`Application` is a :obj:`dict`-like object, it can't be
-duplicated like one using :meth:`Application.copy`.
+duplicated like one using :meth:`~aiohttp.web.Application.copy`.
 
 .. class:: Application(*, logger=<default>, middlewares=(), \
                        handler_args=None, client_max_size=1024**2, \
@@ -1527,8 +1527,8 @@ duplicated like one using :meth:`Application.copy`.
       based but traversal ones).
 
       For sake of that fact we have very trivial ABC for
-      :class:`AbstractRouter`: it should have only
-      :meth:`AbstractRouter.resolve` coroutine.
+      :class:`aiohttp.abc.AbstractRouter`: it should have only
+      :meth:`aiohttp.abc.AbstractRouter.resolve` coroutine.
 
       No methods for adding routes or route reversing (getting URL by
       route name). All those are router implementation details (but,
@@ -1540,7 +1540,7 @@ Server
 ^^^^^^
 
 A protocol factory compatible with
-:meth:`~asyncio.AbstreactEventLoop.create_server`.
+:meth:`~asyncio.AbstractEventLoop.create_server`.
 
 .. class:: Server
 
@@ -1567,11 +1567,11 @@ Router
 For dispatching URLs to :ref:`handlers<aiohttp-web-handler>`
 :mod:`aiohttp.web` uses *routers*.
 
-Router is any object that implements :class:`AbstractRouter` interface.
+Router is any object that implements :class:`~aiohttp.abc.AbstractRouter` interface.
 
 :mod:`aiohttp.web` provides an implementation called :class:`UrlDispatcher`.
 
-:class:`Application` uses :class:`UrlDispatcher` as :meth:`router` by default.
+:class:`Application` uses :class:`UrlDispatcher` as :meth:`~aiohttp.web.Application.router` by default.
 
 .. class:: UrlDispatcher()
 
@@ -1629,13 +1629,13 @@ Router is any object that implements :class:`AbstractRouter` interface.
 
       :param str path: route path. Should be started with slash (``'/'``).
 
-      :param callable handler: route handler.
+      :param collections.abc.Callable handler: route handler.
 
       :param str name: optional route name.
 
-      :param coroutine expect_handler: optional *expect* header handler.
+      :param collections.abc.Coroutine expect_handler: optional *expect* header handler.
 
-      :returns: new :class:`PlainRoute` or :class:`DynamicRoute` instance.
+      :returns: new :class:`AbstractRoute` instance.
 
    .. method:: add_routes(routes_table)
 
@@ -1734,7 +1734,7 @@ Router is any object that implements :class:`AbstractRouter` interface.
 
       :param str name: optional route name.
 
-      :param coroutine expect_handler: optional *expect* header handler.
+      :param collections.abc.Coroutine expect_handler: optional *expect* header handler.
 
       :param int chunk_size: size of single chunk for file
                              downloading, 256Kb by default.
@@ -1763,14 +1763,14 @@ Router is any object that implements :class:`AbstractRouter` interface.
    .. comethod:: resolve(request)
 
       A :ref:`coroutine<coroutine>` that returns
-      :class:`AbstractMatchInfo` for *request*.
+      :class:`aiohttp.abc.AbstractMatchInfo` for *request*.
 
       The method never raises exception, but returns
-      :class:`AbstractMatchInfo` instance with:
+      :class:`aiohttp.abc.AbstractMatchInfo` instance with:
 
-      1. :attr:`~AbstractMatchInfo.http_exception` assigned to
+      1. :attr:`~aiohttp.abc.AbstractMatchInfo.http_exception` assigned to
          :exc:`HTTPException` instance.
-      2. :attr:`~AbstractMatchInfo.handler` which raises
+      2. :meth:`~aiohttp.abc.AbstractMatchInfo.handler` which raises
          :exc:`HTTPNotFound` or :exc:`HTTPMethodNotAllowed` on handler's
          execution if there is no registered route for *request*.
 
@@ -1779,7 +1779,7 @@ Router is any object that implements :class:`AbstractRouter` interface.
 
       Used by internal machinery, end user unlikely need to call the method.
 
-      .. note:: The method uses :attr:`Request.raw_path` for pattern
+      .. note:: The method uses :attr:`aiohttp.web.BaseRequest.raw_path` for pattern
          matching against registered routes.
 
    .. method:: resources()
@@ -1811,7 +1811,7 @@ Router is any object that implements :class:`AbstractRouter` interface.
       *all* named **resources**.
 
       The view maps every named resource's **name** to the
-      :class:`BaseResource` instance. It supports the usual
+      :class:`AbstractResource` instance. It supports the usual
       :obj:`dict`-like operations, except for any mutable operations
       (i.e. it's **read-only**)::
 
@@ -1845,11 +1845,11 @@ unique *name* and at least one :term:`route`.
    finished.
 4. Otherwise router tries next resource from the *routing table*.
 5. If the end of *routing table* is reached and no *resource* /
-   *route* pair found the *router* returns special :class:`AbstractMatchInfo`
-   instance with :attr:`AbstractMatchInfo.http_exception` is not ``None``
+   *route* pair found the *router* returns special :class:`~aiohttp.abc.AbstractMatchInfo`
+   instance with :attr:`aiohttp.abc.AbstractMatchInfo.http_exception` is not ``None``
    but :exc:`HTTPException` with  either *HTTP 404 Not Found* or
    *HTTP 405 Method Not Allowed* status code.
-   Registered :attr:`AbstractMatchInfo.handler` raises this exception on call.
+   Registered :meth:`~aiohttp.abc.AbstractMatchInfo.handler` raises this exception on call.
 
 User should never instantiate resource classes but give it by
 :meth:`UrlDispatcher.add_resource` call.
@@ -1945,9 +1945,9 @@ Resource classes hierarchy::
 
                          The method should be unique for resource.
 
-      :param callable handler: route handler.
+      :param collections.abc.Callable handler: route handler.
 
-      :param coroutine expect_handler: optional *expect* header handler.
+      :param collections.abc.Coroutine expect_handler: optional *expect* header handler.
 
       :returns: new :class:`ResourceRoute` instance.
 
@@ -2332,7 +2332,7 @@ A routes table definition used for describing routes by decorators
 .. class:: RouteTableDef()
 
    A sequence of :class:`RouteDef` instances (implements
-   :class:`abc.collections.Sequence` protocol).
+   :class:`collections.abc.Sequence` protocol).
 
    In addition to all standard :class:`list` methods the class
    provides also methods like ``get()`` and ``post()`` for adding new
@@ -2416,12 +2416,12 @@ Matching result can be accessible from handler as
 :attr:`Request.match_info` attribute.
 
 In general the result may be any object derived from
-:class:`AbstractMatchInfo` (:class:`UrlMappingMatchInfo` for default
+:class:`~aiohttp.abc.AbstractMatchInfo` (:class:`UrlMappingMatchInfo` for default
 :class:`UrlDispatcher` router).
 
 .. class:: UrlMappingMatchInfo
 
-   Inherited from :class:`dict` and :class:`AbstractMatchInfo`. Dict
+   Inherited from :class:`dict` and :class:`~aiohttp.abc.AbstractMatchInfo`. Dict
    items are filled by matching info and is :term:`resource`\-specific.
 
    .. attribute:: expect_handler
@@ -2434,7 +2434,7 @@ In general the result may be any object derived from
 
    .. attribute:: route
 
-      :class:`Route` instance for url matching.
+      :class:`AbstractRoute` instance for url matching.
 
 
 View
@@ -2442,7 +2442,7 @@ View
 
 .. class:: View(request)
 
-   Inherited from :class:`AbstractView`.
+   Inherited from :class:`~aiohttp.abc.AbstractView`.
 
    Base class for class based views. Implementations should derive from
    :class:`View` and override methods for handling HTTP verbs like
@@ -2519,7 +2519,7 @@ application on specific TCP or Unix socket, e.g.::
 
       A  :class:`list` of served sockets addresses.
 
-      See :meth:`socket.getsockname` for items type.
+      See :meth:`socket.getsockname() <socket.socket.getsockname>` for items type.
 
       .. versionadded:: 3.3
 
@@ -2667,7 +2667,7 @@ application on specific TCP or Unix socket, e.g.::
 
    :param int backlog: a number of unaccepted connections that the
                        system will allow before refusing new
-                       connections, see :meth:`socket.listen` for details.
+                       connections, see :meth:`socket.socket.listen` for details.
 
                        ``128`` by default.
 
@@ -2702,7 +2702,7 @@ application on specific TCP or Unix socket, e.g.::
 
    :param int backlog: a number of unaccepted connections that the
                        system will allow before refusing new
-                       connections, see :meth:`socket.listen` for details.
+                       connections, see :meth:`socket.socket.listen` for details.
 
                        ``128`` by default.
 
@@ -2726,7 +2726,7 @@ application on specific TCP or Unix socket, e.g.::
 
    :param runner: a runner to serve.
 
-   :param sock: :class:`socket.socket` to listen.
+   :param sock: A :ref:`socket instance <socket-objects>` to listen to.
 
    :param float shutdown_timeout: a timeout for closing opened
                                   connections on :meth:`BaseSite.stop`
@@ -2738,7 +2738,7 @@ application on specific TCP or Unix socket, e.g.::
 
    :param int backlog: a number of unaccepted connections that the
                        system will allow before refusing new
-                       connections, see :meth:`socket.listen` for details.
+                       connections, see :meth:`socket.socket.listen` for details.
 
                        ``128`` by default.
 
@@ -2747,8 +2747,8 @@ Utilities
 
 .. class:: FileField
 
-   A :class:`~collections.namedtuple` instance that is returned as
-   multidict value by :meth:`Request.POST` if field is uploaded file.
+   A :class:`~typing.NamedTuple` instance that is returned as
+   multidict value by :meth:`aiohttp.web.BaseRequest.post` if field is uploaded file.
 
    .. attribute:: name
 
@@ -2815,7 +2815,7 @@ Utilities
                     multiple domain sockets. Listening on Unix domain
                     sockets is not supported by all operating systems.
 
-   :param socket sock: a preexisting socket object to accept connections on.
+   :param socket.socket sock: a preexisting socket object to accept connections on.
                        A sequence of socket objects can be passed.
 
    :param int shutdown_timeout: a delay to wait for graceful server


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

<!-- Please give a short brief about these changes. --> This change corrects multiple unrendered intersphinx class reference in the `web_reference.rst` document.


## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. --> No

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? --> #5518 

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
