### PR TITLE
Fix broken references in `docs/web_advanced.rst`

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -376,4 +376,6 @@ nitpick_ignore = [
     ("py:class", "aiohttp.abc.AbstractAsyncAccessLogger"),  # undocumented
     ("py:meth", "aiohttp.payload.Payload.set_content_disposition"),  # undocumented
     ("py:class", "cgi.FieldStorage"),  # undocumented
+    ("py:meth", "aiohttp.web.UrlDispatcher.register_resource"),  # undocumented
+    ("py:func", "aiohttp_debugtoolbar.setup"),  # undocumented
 ]

--- a/docs/web_advanced.rst
+++ b/docs/web_advanced.rst
@@ -436,7 +436,7 @@ the keyword-only ``middlewares`` parameter::
 
 Internally, a single :ref:`request handler <aiohttp-web-handler>` is constructed
 by applying the middleware chain to the original handler in reverse order,
-and is called by the :class:`aiohttp.web.RequestHandler` as a regular *handler*.
+and is called by the :class:`~aiohttp.web.RequestHandler` as a regular *handler*.
 
 Since *middlewares* are themselves coroutines, they may perform extra
 ``await`` calls when creating a new handler, e.g. call database etc.

--- a/docs/web_advanced.rst
+++ b/docs/web_advanced.rst
@@ -436,7 +436,7 @@ the keyword-only ``middlewares`` parameter::
 
 Internally, a single :ref:`request handler <aiohttp-web-handler>` is constructed
 by applying the middleware chain to the original handler in reverse order,
-and is called by the :class:`RequestHandler` as a regular *handler*.
+and is called by the :class:`aiohttp.web.RequestHandler` as a regular *handler*.
 
 Since *middlewares* are themselves coroutines, they may perform extra
 ``await`` calls when creating a new handler, e.g. call database etc.
@@ -748,7 +748,7 @@ header::
 Custom resource implementation
 ------------------------------
 
-To register custom resource use :meth:`UrlDispatcher.register_resource`.
+To register custom resource use :meth:`~aiohttp.web.UrlDispatcher.register_resource`.
 Resource instance must implement `AbstractResource` interface.
 
 .. _aiohttp-web-app-runners:
@@ -849,9 +849,9 @@ sources (e.g. ZeroMQ, Redis Pub/Sub, AMQP, etc.) to react to received messages
 within the application.
 
 For example the background task could listen to ZeroMQ on
-:data:`zmq.SUB` socket, process and forward retrieved messages to
+``zmq.SUB`` socket, process and forward retrieved messages to
 clients connected via WebSocket that are stored somewhere in the
-application (e.g. in the :obj:`application['websockets']` list).
+application (e.g. in the ``application['websockets']`` list).
 
 To run such short and long running background tasks aiohttp provides an
 ability to register :attr:`Application.on_startup` signal handler(s) that
@@ -893,7 +893,7 @@ signal handlers as shown in the example below::
   web.run_app(app)
 
 
-The task :func:`listen_to_redis` will run forever.
+The task ``listen_to_redis`` will run forever.
 To shut it down correctly :attr:`Application.on_cleanup` signal handler
 may be used to send a cancellation to it.
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

<!-- Please give a short brief about these changes. --> This change corrects multiple unrendered intersphinx class reference in the `web_advanced.rst` document.


## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. --> No

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? --> #5518 

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
