### PR TITLE
Fix broken references in `websocket_utilities.rst`

### DIFF
--- a/docs/websocket_utilities.rst
+++ b/docs/websocket_utilities.rst
@@ -43,8 +43,8 @@ WebSocket utilities
        received a message that violates its policy.  This is a generic
        status code that can be returned when there is no other more
        suitable status code (e.g.,
-       :attr:`~WSCloseCode.unsupported_data` or
-       :attr:`~WSCloseCode.message_too_big`) or if there is a need to
+       :attr:`~aiohttp.WSCloseCode.UNSUPPORTED_DATA` or
+       :attr:`~aiohttp.WSCloseCode.MESSAGE_TOO_BIG`) or if there is a need to
        hide specific details about the policy.
 
     .. attribute:: MESSAGE_TOO_BIG


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

<!-- Please give a short brief about these changes. --> This change corrects multiple unrendered intersphinx class reference in the `websocket_utilities.rst` document.



## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? --> #5518 

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
