### PR TITLE
[PR #5610/7a4cebb backport][3.8] Fix broken references in `abc.rst`

### DIFF
--- a/docs/abc.rst
+++ b/docs/abc.rst
@@ -19,21 +19,21 @@ aiohttp.web is built on top of few concepts: *application*, *router*,
 *router* is a *plugable* part: a library user may build a *router*
 from scratch, all other parts should work with new router seamlessly.
 
-:class:`AbstractRouter` has the only mandatory method:
-:meth:`AbstractRouter.resolve` coroutine. It must return an
-:class:`AbstractMatchInfo` instance.
+:class:`aiohttp.abc.AbstractRouter` has the only mandatory method:
+:meth:`aiohttp.abc.AbstractRouter.resolve` coroutine. It must return an
+:class:`aiohttp.abc.AbstractMatchInfo` instance.
 
 If the requested URL handler is found
-:meth:`AbstractMatchInfo.handler` is a :term:`web-handler` for
-requested URL and :attr:`AbstractMatchInfo.http_exception` is ``None``.
+:meth:`aiohttp.abc.AbstractMatchInfo.handler` is a :term:`web-handler` for
+requested URL and :attr:`aiohttp.abc.AbstractMatchInfo.http_exception` is ``None``.
 
-Otherwise :attr:`AbstractMatchInfo.http_exception` is an instance of
+Otherwise :attr:`aiohttp.abc.AbstractMatchInfo.http_exception` is an instance of
 :exc:`~aiohttp.web.HTTPException` like *404: NotFound* or *405: Method
-Not Allowed*. :meth:`AbstractMatchInfo.handler` raises
-:attr:`~AbstractMatchInfo.http_exception` on call.
+Not Allowed*. :meth:`aiohttp.abc.AbstractMatchInfo.handler` raises
+:attr:`~aiohttp.abc.AbstractMatchInfo.http_exception` on call.
 
 
-.. class:: aiohttp.abc.AbstractRouter
+.. class:: AbstractRouter
 
    Abstract router, :class:`aiohttp.web.Application` accepts it as
    *router* parameter and returns as
@@ -49,12 +49,12 @@ Not Allowed*. :meth:`AbstractMatchInfo.handler` raises
                       :attr:`aiohttp.web.Request.match_info` equals to
                       ``None`` at resolving stage.
 
-      :return: :class:`AbstractMatchInfo` instance.
+      :return: :class:`aiohttp.abc.AbstractMatchInfo` instance.
 
 
-.. class:: aiohttp.abc.AbstractMatchInfo
+.. class:: AbstractMatchInfo
 
-   Abstract *match info*, returned by :meth:`AbstractRouter.resolve` call.
+   Abstract *match info*, returned by :meth:`aiohttp.abc.AbstractRouter.resolve` call.
 
    .. attribute:: http_exception
 
@@ -100,9 +100,9 @@ attribute.
 Abstract Cookie Jar
 -------------------
 
-.. class:: aiohttp.abc.AbstractCookieJar
+.. class:: AbstractCookieJar
 
-   The cookie jar instance is available as :attr:`ClientSession.cookie_jar`.
+   The cookie jar instance is available as :attr:`aiohttp.ClientSession.cookie_jar`.
 
    The jar contains :class:`~http.cookies.Morsel` items for storing
    internal cookie data.
@@ -166,7 +166,7 @@ Abstract Abstract Access Logger
 
 .. class:: aiohttp.abc.AbstractAccessLogger
 
-   An abstract class, base for all :class:`RequestHandler`
+   An abstract class, base for all :class:`aiohttp.web.RequestHandler`
    ``access_logger`` implementations
 
    Method ``log`` should be overridden.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -355,4 +355,5 @@ texinfo_documents = [
 nitpick_ignore = [
     ("py:mod", "aiohttp"),  # undocumented, no `.. currentmodule:: aiohttp` in docs
     ("py:class", "aiohttp.SimpleCookie"),  # undocumented
+    ("py:class", "aiohttp.web.RequestHandler"),  # undocumented
 ]


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

This change corrects multiple unrendered intersphinx class reference in the `abc.rst` document.


## Are there changes in behavior for the user?

No

## Related issue number

#5518

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
