### PR TITLE
Adjust type of iscoroutine() argument

### DIFF
--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -114,7 +114,7 @@ if PY_38:
     iscoroutinefunction = asyncio.iscoroutinefunction
 else:
 
-    def iscoroutinefunction(func: Callable[..., Any]) -> bool:
+    def iscoroutinefunction(func: Any) -> bool:
         while isinstance(func, functools.partial):
             func = func.func
         return asyncio.iscoroutinefunction(func)


### PR DESCRIPTION
This will be needed to make mypy pass after python/typeshed#5517 is released. The function accepts all objects, so `object` is the appropriate annotation, but `Any` is necessary for now here to make the conditional definition work with the previous type annotation.

<!-- Thank you for your contribution! -->

## What do these changes do?

Minor change in type annotation
<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

No
<!-- Outline any notable behaviour for the end users. -->

## Related issue number

I don't think this change requires an issue or changelog entry, but happy to provide one if you disagree.