### PR TITLE
Fix broken references in `multipart_reference.rst`

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -366,4 +366,5 @@ nitpick_ignore = [
     ("py:meth", "start"),  # undocumented
     ("py:exc", "aiohttp.ServerDisconnectionError"),  # undocumented
     ("py:exc", "aiohttp.ClientHttpProxyError"),  # undocumented
+    ("py:class", "aiohttp.MultipartBodyReader"),  # undocumented
 ]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -366,5 +366,4 @@ nitpick_ignore = [
     ("py:meth", "start"),  # undocumented
     ("py:exc", "aiohttp.ServerDisconnectionError"),  # undocumented
     ("py:exc", "aiohttp.ClientHttpProxyError"),  # undocumented
-    ("py:class", "aiohttp.MultipartBodyReader"),  # undocumented
 ]

--- a/docs/multipart_reference.rst
+++ b/docs/multipart_reference.rst
@@ -7,7 +7,7 @@ Multipart reference
 
 .. class:: MultipartResponseWrapper(resp, stream)
 
-   Wrapper around the :class:`MultipartBodyReader` to take care about
+   Wrapper around the :class:`~aiohttp.MultipartBodyReader` to take care about
    underlying connection and close it when it needs in.
 
 
@@ -135,7 +135,7 @@ Multipart reference
 
       Constructs reader instance from HTTP response.
 
-      :param response: :class:`~aiohttp.client.ClientResponse` instance
+      :param response: :class:`~aiohttp.ClientResponse` instance
 
    .. method:: at_eof()
 

--- a/docs/multipart_reference.rst
+++ b/docs/multipart_reference.rst
@@ -7,7 +7,7 @@ Multipart reference
 
 .. class:: MultipartResponseWrapper(resp, stream)
 
-   Wrapper around the :class:`~aiohttp.MultipartBodyReader` to take care about
+   Wrapper around the :class:`MultipartReader` to take care about
    underlying connection and close it when it needs in.
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

<!-- Please give a short brief about these changes. --> This change corrects multiple unrendered intersphinx class reference in the `multipart_reference.rst` document.

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. --> No

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? --> #5518 

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
