### PR TITLE
Fix broken references in `docs/whats_new_1_1.rst`

### DIFF
--- a/docs/whats_new_1_1.rst
+++ b/docs/whats_new_1_1.rst
@@ -20,8 +20,8 @@ e.g. ``session.get('http://example.com')`` works as well as
 Internal API has been switched to :class:`yarl.URL`.
 :class:`aiohttp.CookieJar` accepts :class:`~yarl.URL` instances only.
 
-On server side has added :class:`web.Request.url` and
-:class:`web.Request.rel_url` properties for representing relative and
+On server side has added :attr:`aiohttp.web.BaseRequest.url` and
+:attr:`aiohttp.web.BaseRequest.rel_url` properties for representing relative and
 absolute request's URL.
 
 URL using is the recommended way, already existed properties for
@@ -32,7 +32,7 @@ parameter. :class:`str` is still supported and will be supported forever.
 
 Reverse URL processing for *router* has been changed.
 
-The main API is :class:`aiohttp.web.Request.url_for(name, **kwargs)`
+The main API is :``aiohttp.web.Request.url_for``
 which returns a :class:`yarl.URL` instance for named resource. It
 does not support *query args* but adding *args* is trivial:
 ``request.url_for('named_resource', param='a').with_query(arg='val')``.

--- a/docs/whats_new_1_1.rst
+++ b/docs/whats_new_1_1.rst
@@ -32,7 +32,7 @@ parameter. :class:`str` is still supported and will be supported forever.
 
 Reverse URL processing for *router* has been changed.
 
-The main API is :``aiohttp.web.Request.url_for``
+The main API is ``aiohttp.web.Request.url_for``
 which returns a :class:`yarl.URL` instance for named resource. It
 does not support *query args* but adding *args* is trivial:
 ``request.url_for('named_resource', param='a').with_query(arg='val')``.


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

<!-- Please give a short brief about these changes. --> This change corrects multiple unrendered intersphinx class reference in the `whats_new_1_1.rst` document.


## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. --> No

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? --> #5518 
 
## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
