### PR TITLE
Fix broken references in `docs/new_router.rst`

### DIFF
--- a/docs/new_router.rst
+++ b/docs/new_router.rst
@@ -45,7 +45,7 @@ User still may use wildcard for accepting all HTTP methods (maybe we
 will add something like ``resource.add_wildcard(handler)`` later).
 
 Since **names** belongs to **resources** now ``app.router['name']``
-returns a **resource** instance instead of :class:`aiohttp.web.Route`.
+returns a **resource** instance instead of :class:`aiohttp.web.AbstractRoute`.
 
 **resource** has ``.url()`` method, so
 ``app.router['name'].url(parts={'a': 'b'}, query={'arg': 'param'})``
@@ -65,8 +65,8 @@ The refactoring is 99% compatible with previous implementation.
 99% means all example and the most of current code works without
 modifications but we have subtle API backward incompatibles.
 
-``app.router['name']`` returns a :class:`aiohttp.web.BaseResource`
-instance instead of :class:`aiohttp.web.Route` but resource has the
+``app.router['name']`` returns a :class:`aiohttp.web.AbstractResource`
+instance instead of :class:`aiohttp.web.AbstractRoute` but resource has the
 same ``resource.url(...)`` most useful method, so end user should feel no
 difference.
 
@@ -81,4 +81,4 @@ shortcut for::
     return route
 
 ``app.router.register_route(...)`` is still supported, it creates
-:class:`aiohttp.web.ResourceAdapter` for every call (but it's deprecated now).
+``aiohttp.web.ResourceAdapter`` for every call (but it's deprecated now).


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

<!-- Please give a short brief about these changes. --> This change corrects multiple unrendered intersphinx class reference in the `new_router.rst` document.


## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. --> No

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? --> #5518 

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
