### PR TITLE
Fix broken reference in `docs/web-lowlevel.rst`

### DIFF
--- a/docs/web_lowlevel.rst
+++ b/docs/web_lowlevel.rst
@@ -19,7 +19,7 @@ request and returns a response object.
 
 This is done by introducing :class:`aiohttp.web.Server` class which
 serves a *protocol factory* role for
-:meth:`asyncio.AbstractEventLoop.create_server` and bridges data
+:meth:`asyncio.loop.create_server` and bridges data
 stream to *web handler* and sends result back.
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

<!-- Please give a short brief about these changes. --> This change corrects an unrendered intersphinx class reference in the `web-lowlevel.rst` document.


## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. --> No

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? --> #5518 

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
