### PR TITLE
Fix broken references in `docs/multipart.rst`

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -374,4 +374,6 @@ nitpick_ignore = [
     ("py:class", "aiohttp.StreamWriter"),  # undocumented
     ("py:obj", "logging.DEBUG"),  # undocumented
     ("py:class", "aiohttp.abc.AbstractAsyncAccessLogger"),  # undocumented
+    ("py:meth", "aiohttp.payload.Payload.set_content_disposition"),  # undocumented
+    ("py:class", "cgi.FieldStorage"),  # undocumented
 ]

--- a/docs/multipart.rst
+++ b/docs/multipart.rst
@@ -152,9 +152,9 @@ will include the file's basename::
     part = root.append(open(__file__, 'rb'))
 
 If you want to send a file with a different name, just handle the
-:class:`Payload` instance which :meth:`MultipartWriter.append` will
+:class:`~aiohttp.payload.Payload` instance which :meth:`MultipartWriter.append` will
 always return and set `Content-Disposition` explicitly by using
-the :meth:`Payload.set_content_disposition` helper::
+the :meth:`Payload.set_content_disposition() <aiohttp.payload.Payload.set_content_disposition>` helper::
 
     part.set_content_disposition('attachment', filename='secret.txt')
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

<!-- Please give a short brief about these changes. --> This change corrects multiple unrendered intersphinx class reference in the `multipart.rst` document.


## Are there changes in behavior for the user? 

<!-- Outline any notable behaviour for the end users. -->  No

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? --> #5518 

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
