### PR TITLE
add test, typedef and session implementation

### DIFF
--- a/aiohttp/typedefs.py
+++ b/aiohttp/typedefs.py
@@ -24,6 +24,7 @@ Byteish = Union[bytes, bytearray, memoryview]
 JSONEncoder = Callable[[Any], str]
 JSONDecoder = Callable[[str], Any]
 LooseHeaders = Union[Mapping[Union[str, istr], str], _CIMultiDict, _CIMultiDictProxy]
+LooseParams = Union[Mapping[Union[str, istr], str], _CIMultiDict, _CIMultiDictProxy]
 RawHeaders = Tuple[Tuple[bytes, bytes], ...]
 StrOrURL = Union[str, URL]
 


### PR DESCRIPTION
- new test solution
- new type def
- modification of existing session class to implement params argument similar to actual header implementation.

Why this pull request:
to have a simple and elegant way to share common query parameter with session object, like actual implementation of header.

typical usage:

```python
with session(headers=headers, params={apikey=someRandomKey}) as session:
    response = await session.get("http://randomsecurewebsite")
    response2 = await session.post("http://otherSecureWebsite")
```
instead of

```python
some_random_key = ''
with session(headers=headers) as session:
    response = await session.get("http://randomsecurewebsite", params={some_random_key})
    response2 = await session.post("http://otherSecureWebsite", params={some_random_key})
```

thank for reading, feel free to respond.