### PR TITLE
[Backport 3.8] Fix broken references in `docs/web_reference.rst` (#5711)

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -372,6 +372,18 @@ nitpick_ignore = [
     ("py:class", "aiohttp.protocol.HttpVersion"),  # undocumented
     ("py:meth", "aiohttp.ClientSession.request"),  # undocumented
     ("py:class", "aiohttp.StreamWriter"),  # undocumented
+    ("py:attr", "aiohttp.StreamResponse.body"),  # undocumented
+    ("py:class", "aiohttp.payload.StringPayload"),  # undocumented
+    ("py:meth", "aiohttp.web.Application.copy"),  # undocumented
+    ("py:meth", "asyncio.AbstractEventLoop.create_server"),  # undocumented
+    ("py:data", "aiohttp.log.server_logger"),  # undocumented
+    ("py:data", "aiohttp.log.access_logger"),  # undocumented
+    ("py:data", "aiohttp.helpers.AccessLogger"),  # undocumented
+    ("py:attr", "helpers.AccessLogger.LOG_FORMAT"),  # undocumented
+    ("py:meth", "aiohttp.web.AbstractRoute.url"),  # undocumented
+    ("py:class", "aiohttp.web.MatchedSubAppResource"),  # undocumented
+    ("py:attr", "body"),  # undocumented
+    ("py:class", "socket.socket"),  # undocumented
     ("py:obj", "logging.DEBUG"),  # undocumented
     ("py:class", "aiohttp.abc.AbstractAsyncAccessLogger"),  # undocumented
     ("py:meth", "aiohttp.payload.Payload.set_content_disposition"),  # undocumented

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -118,7 +118,7 @@ and :ref:`aiohttp-web-signals` handlers.
 
       - Overridden value by :meth:`~BaseRequest.clone` call.
       - *Host* HTTP header
-      - :func:`socket.gtfqdn`
+      - :func:`socket.getfqdn`
 
       Read-only :class:`str` property.
 
@@ -338,20 +338,20 @@ and :ref:`aiohttp-web-signals` handlers.
 
    .. attribute:: if_match
 
-      Read-only property that returns :class:`ETag` objects specified
+      Read-only property that returns :class:`~aiohttp.ETag` objects specified
       in the *If-Match* header.
 
-      Returns :class:`tuple` of :class:`ETag` or ``None`` if
+      Returns :class:`tuple` of :class:`~aiohttp.ETag` or ``None`` if
       *If-Match* header is absent.
 
       .. versionadded:: 3.8
 
    .. attribute:: if_none_match
 
-      Read-only property that returns :class:`ETag` objects specified
+      Read-only property that returns :class:`~aiohttp.ETag` objects specified
       *If-None-Match* header.
 
-      Returns :class:`tuple` of :class:`ETag` or ``None`` if
+      Returns :class:`tuple` of :class:`~aiohttp.ETag` or ``None`` if
       *If-None-Match* header is absent.
 
       .. versionadded:: 3.8
@@ -403,7 +403,7 @@ and :ref:`aiohttp-web-signals` handlers.
       .. note::
 
          The method **does** store read data internally, subsequent
-         :meth:`~Request.read` call will return the same value.
+         :meth:`~aiohttp.web.BaseRequest.read` call will return the same value.
 
    .. comethod:: text()
 
@@ -415,7 +415,7 @@ and :ref:`aiohttp-web-signals` handlers.
       .. note::
 
          The method **does** store read data internally, subsequent
-         :meth:`~Request.text` call will return the same value.
+         :meth:`~aiohttp.web.BaseRequest.text` call will return the same value.
 
    .. comethod:: json(*, loads=json.loads)
 
@@ -428,7 +428,7 @@ and :ref:`aiohttp-web-signals` handlers.
              body = await self.text()
              return loads(body)
 
-      :param callable loads: any :term:`callable` that accepts
+      :param collections.abc.Callable loads: any :term:`callable` that accepts
                               :class:`str` and returns :class:`dict`
                               with parsed JSON (:func:`json.loads` by
                               default).
@@ -436,12 +436,12 @@ and :ref:`aiohttp-web-signals` handlers.
       .. note::
 
          The method **does** store read data internally, subsequent
-         :meth:`~Request.json` call will return the same value.
+         :meth:`~aiohttp.web.BaseRequest.json` call will return the same value.
 
 
    .. comethod:: multipart()
 
-      Returns :class:`aiohttp.multipart.MultipartReader` which processes
+      Returns :class:`aiohttp.MultipartReader` which processes
       incoming *multipart* request.
 
       The method is just a boilerplate :ref:`coroutine <coroutine>`
@@ -480,7 +480,7 @@ and :ref:`aiohttp-web-signals` handlers.
       .. note::
 
          The method **does** store read data internally, subsequent
-         :meth:`~Request.post` call will return the same value.
+         :meth:`~aiohttp.web.BaseRequest.post` call will return the same value.
 
    .. comethod:: release()
 
@@ -490,7 +490,7 @@ and :ref:`aiohttp-web-signals` handlers.
 
       .. note::
 
-          User code may never call :meth:`~Request.release`, all
+          User code may never call :meth:`~aiohttp.web.BaseRequest.release`, all
           required work will be processed by :mod:`aiohttp.web`
           internal machinery.
 
@@ -639,7 +639,7 @@ StreamResponse
 
    .. attribute:: keep_alive
 
-      Read-only property, copy of :attr:`Request.keep_alive` by default.
+      Read-only property, copy of :attr:`aiohttp.web.BaseRequest.keep_alive` by default.
 
       Can be switched to ``False`` by :meth:`force_close` call.
 
@@ -806,7 +806,7 @@ StreamResponse
 
       *ETag* header for outgoing response.
 
-      This property accepts raw :class:`str` values, :class:`ETag`
+      This property accepts raw :class:`str` values, :class:`~aiohttp.ETag`
       objects and the value ``None`` to unset the header.
 
       In case of :class:`str` input, etag is considered as strong by default.
@@ -919,7 +919,7 @@ Response
 
       Setting :attr:`text` also recalculates
       :attr:`~StreamResponse.content_length` value and
-      :attr:`~StreamResponse.body` value
+      :attr:`~aiohttp.StreamResponse.body` value
 
       Resetting :attr:`text` (assigning ``None``) sets
       :attr:`~StreamResponse.content_length` to ``None`` too, dropping
@@ -1117,7 +1117,7 @@ WebSocketResponse
                            single message,
                            ``None`` for not overriding per-socket setting.
 
-      :param callable dumps: any :term:`callable` that accepts an object and
+      :param collections.abc.Callable dumps: any :term:`callable` that accepts an object and
                              returns a JSON string
                              (:func:`json.dumps` by default).
 
@@ -1216,7 +1216,7 @@ WebSocketResponse
 
          Can only be called by the request handling task.
 
-      :param callable loads: any :term:`callable` that accepts
+      :param collections.abc.Callable loads: any :term:`callable` that accepts
                               :class:`str` and returns :class:`dict`
                               with parsed JSON (:func:`json.loads` by
                               default).
@@ -1338,7 +1338,7 @@ properties for later access from a :ref:`handler<aiohttp-web-handler>` via the
            conn.execute("DELETE * FROM table")
 
 Although :class:`Application` is a :obj:`dict`-like object, it can't be
-duplicated like one using :meth:`Application.copy`.
+duplicated like one using :meth:`~aiohttp.web.Application.copy`.
 
 .. class:: Application(*, logger=<default>, router=None,middlewares=(), \
                        handler_args=None, client_max_size=1024**2, \
@@ -1508,7 +1508,7 @@ duplicated like one using :meth:`Application.copy`.
 
       :param Application subapp: nested application.
 
-      :returns: a :class:`MatchedSubAppResource` instance.
+      :returns: a :class:`~aiohttp.web.MatchedSubAppResource` instance.
 
    .. method:: add_routes(routes_table)
 
@@ -1615,8 +1615,8 @@ duplicated like one using :meth:`Application.copy`.
       based but traversal ones).
 
       For sake of that fact we have very trivial ABC for
-      :class:`AbstractRouter`: it should have only
-      :meth:`AbstractRouter.resolve` coroutine.
+      :class:`~aiohttp.abc.AbstractRouter`: it should have only
+      :meth:`aiohttp.abc.AbstractRouter.resolve` coroutine.
 
       No methods for adding routes or route reversing (getting URL by
       route name). All those are router implementation details (but,
@@ -1628,7 +1628,7 @@ Server
 ^^^^^^
 
 A protocol factory compatible with
-:meth:`~asyncio.AbstreactEventLoop.create_server`.
+:meth:`~asyncio.AbstractEventLoop.create_server`.
 
 .. class:: Server
 
@@ -1655,11 +1655,11 @@ Router
 For dispatching URLs to :ref:`handlers<aiohttp-web-handler>`
 :mod:`aiohttp.web` uses *routers*.
 
-Router is any object that implements :class:`AbstractRouter` interface.
+Router is any object that implements :class:`~aiohttp.abc.AbstractRouter` interface.
 
 :mod:`aiohttp.web` provides an implementation called :class:`UrlDispatcher`.
 
-:class:`Application` uses :class:`UrlDispatcher` as :meth:`router` by default.
+:class:`Application` uses :class:`UrlDispatcher` as :meth:`~aiohttp.web.Application.router` by default.
 
 .. class:: UrlDispatcher()
 
@@ -1718,13 +1718,13 @@ Router is any object that implements :class:`AbstractRouter` interface.
 
       :param str path: route path. Should be started with slash (``'/'``).
 
-      :param callable handler: route handler.
+      :param collections.abc.Callable handler: route handler.
 
       :param str name: optional route name.
 
-      :param coroutine expect_handler: optional *expect* header handler.
+      :param collections.abc.Coroutine expect_handler: optional *expect* header handler.
 
-      :returns: new :class:`PlainRoute` or :class:`DynamicRoute` instance.
+      :returns: new :class:`AbstractRoute` instance.
 
    .. method:: add_routes(routes_table)
 
@@ -1823,7 +1823,7 @@ Router is any object that implements :class:`AbstractRouter` interface.
 
       :param str name: optional route name.
 
-      :param coroutine expect_handler: optional *expect* header handler.
+      :param collections.abc.Coroutine expect_handler: optional *expect* header handler.
 
       :param int chunk_size: size of single chunk for file
                              downloading, 256Kb by default.
@@ -1843,23 +1843,23 @@ Router is any object that implements :class:`AbstractRouter` interface.
       :param bool append_version: flag for adding file version (hash)
                               to the url query string, this value will
                               be used as default when you call to
-                              :meth:`StaticRoute.url` and
-                              :meth:`StaticRoute.url_for` methods.
+                              :meth:`~aiohttp.web.AbstractRoute.url` and
+                              :meth:`~aiohttp.web.AbstractRoute.url_for` methods.
 
 
-      :returns: new :class:`StaticRoute` instance.
+      :returns: new :class:`~aiohttp.web.AbstractRoute` instance.
 
    .. comethod:: resolve(request)
 
       A :ref:`coroutine<coroutine>` that returns
-      :class:`AbstractMatchInfo` for *request*.
+      :class:`~aiohttp.abc.AbstractMatchInfo` for *request*.
 
       The method never raises exception, but returns
-      :class:`AbstractMatchInfo` instance with:
+      :class:`~aiohttp.abc.AbstractMatchInfo` instance with:
 
-      1. :attr:`~AbstractMatchInfo.http_exception` assigned to
+      1. :attr:`~aiohttp.abc.AbstractMatchInfo.http_exception` assigned to
          :exc:`HTTPException` instance.
-      2. :attr:`~AbstractMatchInfo.handler` which raises
+      2. :meth:`~aiohttp.abc.AbstractMatchInfo.handler` which raises
          :exc:`HTTPNotFound` or :exc:`HTTPMethodNotAllowed` on handler's
          execution if there is no registered route for *request*.
 
@@ -1868,7 +1868,7 @@ Router is any object that implements :class:`AbstractRouter` interface.
 
       Used by internal machinery, end user unlikely need to call the method.
 
-      .. note:: The method uses :attr:`Request.raw_path` for pattern
+      .. note:: The method uses :attr:`aiohttp.web.BaseRequest.raw_path` for pattern
          matching against registered routes.
 
    .. method:: resources()
@@ -1900,7 +1900,7 @@ Router is any object that implements :class:`AbstractRouter` interface.
       *all* named **resources**.
 
       The view maps every named resource's **name** to the
-      :class:`BaseResource` instance. It supports the usual
+      :class:`AbstractResource` instance. It supports the usual
       :obj:`dict`-like operations, except for any mutable operations
       (i.e. it's **read-only**)::
 
@@ -1934,11 +1934,11 @@ unique *name* and at least one :term:`route`.
    finished.
 4. Otherwise router tries next resource from the *routing table*.
 5. If the end of *routing table* is reached and no *resource* /
-   *route* pair found the *router* returns special :class:`AbstractMatchInfo`
-   instance with :attr:`AbstractMatchInfo.http_exception` is not ``None``
+   *route* pair found the *router* returns special :class:`~aiohttp.abc.AbstractMatchInfo`
+   instance with :attr:`aiohttp.abc.AbstractMatchInfo.http_exception` is not ``None``
    but :exc:`HTTPException` with  either *HTTP 404 Not Found* or
    *HTTP 405 Method Not Allowed* status code.
-   Registered :attr:`AbstractMatchInfo.handler` raises this exception on call.
+   Registered :meth:`~aiohttp.abc.AbstractMatchInfo.handler` raises this exception on call.
 
 User should never instantiate resource classes but give it by
 :meth:`UrlDispatcher.add_resource` call.
@@ -2034,9 +2034,9 @@ Resource classes hierarchy::
 
                          The method should be unique for resource.
 
-      :param callable handler: route handler.
+      :param collections.abc.Callable handler: route handler.
 
-      :param coroutine expect_handler: optional *expect* header handler.
+      :param collections.abc.Coroutine expect_handler: optional *expect* header handler.
 
       :returns: new :class:`ResourceRoute` instance.
 
@@ -2421,7 +2421,7 @@ A routes table definition used for describing routes by decorators
 .. class:: RouteTableDef()
 
    A sequence of :class:`RouteDef` instances (implements
-   :class:`abc.collections.Sequence` protocol).
+   :class:`collections.abc.Sequence` protocol).
 
    In addition to all standard :class:`list` methods the class
    provides also methods like ``get()`` and ``post()`` for adding new
@@ -2505,12 +2505,12 @@ Matching result can be accessible from handler as
 :attr:`Request.match_info` attribute.
 
 In general the result may be any object derived from
-:class:`AbstractMatchInfo` (:class:`UrlMappingMatchInfo` for default
+:class:`~aiohttp.abc.AbstractMatchInfo` (:class:`UrlMappingMatchInfo` for default
 :class:`UrlDispatcher` router).
 
 .. class:: UrlMappingMatchInfo
 
-   Inherited from :class:`dict` and :class:`AbstractMatchInfo`. Dict
+   Inherited from :class:`dict` and :class:`~aiohttp.abc.AbstractMatchInfo`. Dict
    items are filled by matching info and is :term:`resource`\-specific.
 
    .. attribute:: expect_handler
@@ -2523,7 +2523,7 @@ In general the result may be any object derived from
 
    .. attribute:: route
 
-      :class:`Route` instance for url matching.
+      :class:`AbstractRoute` instance for url matching.
 
 
 View
@@ -2531,7 +2531,7 @@ View
 
 .. class:: View(request)
 
-   Inherited from :class:`AbstractView`.
+   Inherited from :class:`~aiohttp.abc.AbstractView`.
 
    Base class for class based views. Implementations should derive from
    :class:`View` and override methods for handling HTTP verbs like
@@ -2608,7 +2608,7 @@ application on specific TCP or Unix socket, e.g.::
 
       A  :class:`list` of served sockets addresses.
 
-      See :meth:`socket.getsockname` for items type.
+      See :meth:`socket.getsockname() <socket.socket.getsockname>` for items type.
 
       .. versionadded:: 3.3
 
@@ -2755,7 +2755,7 @@ application on specific TCP or Unix socket, e.g.::
 
    :param int backlog: a number of unaccepted connections that the
                        system will allow before refusing new
-                       connections, see :meth:`socket.listen` for details.
+                       connections, see :meth:`socket.socket.listen` for details.
 
                        ``128`` by default.
 
@@ -2790,7 +2790,7 @@ application on specific TCP or Unix socket, e.g.::
 
    :param int backlog: a number of unaccepted connections that the
                        system will allow before refusing new
-                       connections, see :meth:`socket.listen` for details.
+                       connections, see :meth:`socket.socket.listen` for details.
 
                        ``128`` by default.
 
@@ -2814,7 +2814,7 @@ application on specific TCP or Unix socket, e.g.::
 
    :param runner: a runner to serve.
 
-   :param sock: :class:`socket.socket` to listen.
+   :param sock: A :ref:`socket instance <socket-objects>` to listen to.
 
    :param float shutdown_timeout: a timeout for closing opened
                                   connections on :meth:`BaseSite.stop`
@@ -2826,7 +2826,7 @@ application on specific TCP or Unix socket, e.g.::
 
    :param int backlog: a number of unaccepted connections that the
                        system will allow before refusing new
-                       connections, see :meth:`socket.listen` for details.
+                       connections, see :meth:`socket.socket.listen` for details.
 
                        ``128`` by default.
 
@@ -2835,8 +2835,8 @@ Utilities
 
 .. class:: FileField
 
-   A :class:`~collections.namedtuple` instance that is returned as
-   multidict value by :meth:`Request.POST` if field is uploaded file.
+   A :mod:`dataclass <dataclasses>` instance that is returned as
+   multidict value by :meth:`aiohttp.web.BaseRequest.post` if field is uploaded file.
 
    .. attribute:: name
 
@@ -2901,7 +2901,7 @@ Utilities
                     multiple domain sockets. Listening on Unix domain
                     sockets is not supported by all operating systems.
 
-   :param socket sock: a preexisting socket object to accept connections on.
+   :param socket.socket sock: a preexisting socket object to accept connections on.
                        A sequence of socket objects can be passed.
 
    :param int shutdown_timeout: a delay to wait for graceful server


### PR DESCRIPTION
* fix broken references

* add references to ignore

* Fix reference

Co-authored-by: Sviatoslav Sydorenko <wk.cvs.github@sydorenko.org.ua>

* Add `~`

Co-authored-by: Sviatoslav Sydorenko <wk.cvs.github@sydorenko.org.ua>

* Add `~`

Co-authored-by: Sviatoslav Sydorenko <wk.cvs.github@sydorenko.org.ua>

Co-authored-by: Sviatoslav Sydorenko <wk.cvs.github@sydorenko.org.ua>
(cherry picked from commit d43b41d90dd42e77f60a7232c0f917423f2f8c1d)

<!-- Thank you for your contribution! -->

## What do these changes do?

<!-- Please give a short brief about these changes. --> This change corrects multiple unrendered intersphinx class reference in the `web_reference.rst` document.


## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. --> No

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? --> #5518 

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
