### PR TITLE
Remove `aioauth-client` from third-party apps

### DIFF
--- a/docs/third_party.rst
+++ b/docs/third_party.rst
@@ -172,9 +172,6 @@ period ask to raise the status.
   popular web frameworks, including Flask, Django, Bottle, Tornado,
   Pyramid, webapp2, Falcon, and aiohttp.
 
-- `aioauth-client <https://github.com/klen/aioauth-client>`_ OAuth
-  client for aiohttp.
-
 - `aiohttpretty
   <https://github.com/CenterForOpenScience/aiohttpretty>`_ A simple
   asyncio compatible httpretty mock using aiohttp.


### PR DESCRIPTION


<!-- Thank you for your contribution! -->

## What do these changes do?

`aioauth-client` library has changed its purpose and is now uses `httpx`, so it's no
longer compatible with `aiohttp`.

This is only clarified here: https://github.com/klen/aioauth-client/issues/168

## Are there changes in behavior for the user?

No, just doc changes.

## Related issue number

n/a 

## Checklist

n/a
