### PR TITLE
Fix(doc): ClientResponse.release should be a instance method, not a c…

### DIFF
--- a/CHANGES/5836.doc
+++ b/CHANGES/5836.doc
@@ -1,0 +1,1 @@
+Fix the `ClientResponse.release`'s type in the doc. Change from `comethod` to `method`.

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -1225,7 +1225,7 @@ Response object
            assert resp.status == 200
 
    After exiting from ``async with`` block response object will be
-   *released* (see :meth:`release` coroutine).
+   *released* (see :meth:`release` method).
 
    .. attribute:: version
 
@@ -1354,7 +1354,7 @@ Response object
 
       .. seealso:: :meth:`close`, :meth:`release`.
 
-   .. comethod:: release()
+   .. method:: release()
 
       It is not required to call `release` on the response
       object. When the client fully receives the payload, the


### PR DESCRIPTION
## What do these changes do?

From the doc, https://docs.aiohttp.org/en/stable/client_reference.html?highlight=release#aiohttp.ClientResponse.release


The `ClientResponse.release` is a coroutine, but in fact it is a instance method in the source code.


https://github.com/aio-libs/aiohttp/blob/10995e833d42b2ec0dc31f8d2ea099cefef9978e/aiohttp/client_reqrep.py#L906-L918


## Are there changes in behavior for the user?

Only change the doc.

## Related issue number

#5836

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
