### PR TITLE
Remove external test dependency to http://httpbin.org

### DIFF
--- a/CHANGES/5840.bugfix
+++ b/CHANGES/5840.bugfix
@@ -1,0 +1,1 @@
+Remove external test dependency to http://httpbin.org

--- a/tests/test_formdata.py
+++ b/tests/test_formdata.py
@@ -4,7 +4,7 @@ from unittest import mock
 
 import pytest
 
-from aiohttp import ClientSession, FormData
+from aiohttp import FormData, web
 
 
 @pytest.fixture
@@ -88,14 +88,20 @@ async def test_formdata_field_name_is_not_quoted(buf: Any, writer: Any) -> None:
     assert b'name="email 1"' in buf
 
 
-async def test_mark_formdata_as_processed() -> None:
-    async with ClientSession() as session:
-        url = "http://httpbin.org/anything"
-        data = FormData()
-        data.add_field("test", "test_value", content_type="application/json")
+async def test_mark_formdata_as_processed(aiohttp_client: Any) -> None:
+    async def handler(request):
+        return web.Response()
 
-        await session.post(url, data=data)
-        assert len(data._writer._parts) == 1
+    app = web.Application()
+    app.add_routes([web.post("/", handler)])
 
-        with pytest.raises(RuntimeError):
-            await session.post(url, data=data)
+    client = await aiohttp_client(app)
+
+    data = FormData()
+    data.add_field("test", "test_value", content_type="application/json")
+
+    await client.post("/", data=data)
+    assert len(data._writer._parts) == 1
+
+    with pytest.raises(RuntimeError):
+        await client.post("/", data=data)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Remove external test dependency to http://httpbin.org

## Are there changes in behavior for the user?

No

## Related issue number

#5840 

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
