### PR TITLE
Keep auth header during http->https redirect

### DIFF
--- a/CHANGES/5783.feature
+++ b/CHANGES/5783.feature
@@ -1,1 +1,1 @@
-Keep ``Authorization`` header during the http->https redirect if the host remains the same.
+Started keeping the ``Authorization`` header during http->https redirects when the host remains the same.

--- a/CHANGES/5783.feature
+++ b/CHANGES/5783.feature
@@ -1,0 +1,1 @@
+Keep ``Authorization`` header during the http->https redirect if the host remains the same.

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -572,7 +572,10 @@ class ClientSession:
                             and url.scheme == "http"
                         )
 
-                        if url.origin() != parsed_url.origin() and not https_redirect:
+                        if (
+                            url.origin() != parsed_url.origin()
+                            and not is_same_host_https_redirect
+                        ):
                             auth = None
                             headers.pop(hdrs.AUTHORIZATION, None)
 

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -566,7 +566,7 @@ class ClientSession:
                         elif not scheme:
                             parsed_url = url.join(parsed_url)
 
-                        https_redirect = (
+                        is_same_host_https_redirect = (
                             url.host == parsed_url.host
                             and parsed_url.scheme == "https"
                             and url.scheme == "http"

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -566,7 +566,13 @@ class ClientSession:
                         elif not scheme:
                             parsed_url = url.join(parsed_url)
 
-                        if url.origin() != parsed_url.origin():
+                        https_redirect = (
+                            url.host == parsed_url.host
+                            and parsed_url.scheme == "https"
+                            and url.scheme == "http"
+                        )
+
+                        if url.origin() != parsed_url.origin() and not https_redirect:
                             auth = None
                             headers.pop(hdrs.AUTHORIZATION, None)
 

--- a/docs/client_advanced.rst
+++ b/docs/client_advanced.rst
@@ -62,6 +62,10 @@ For *text/plain* ::
    to a different host or protocol, except the case when  ``HTTP -> HTTPS``
    redirect is performed on the same host.
 
+.. versionchanged:: 4.0
+
+   Started keeping the ``Authorization`` header during ``HTTP -> HTTPS``
+   redirects when the host remains the same.
 
 Custom Cookies
 --------------

--- a/docs/client_advanced.rst
+++ b/docs/client_advanced.rst
@@ -56,6 +56,14 @@ For *text/plain* ::
 
     await session.post(url, data='Привет, Мир!')
 
+.. note::
+   ``Authorization`` header will be removed if you get redirected
+   to a different host or protocol.
+
+.. versionchanged:: 4.0
+   ``Authorization`` header will **not** be removed during the
+   ``HTTP -> HTTPS`` redirect if the host remains the same.
+
 Custom Cookies
 --------------
 

--- a/docs/client_advanced.rst
+++ b/docs/client_advanced.rst
@@ -57,6 +57,7 @@ For *text/plain* ::
     await session.post(url, data='Привет, Мир!')
 
 .. note::
+
    ``Authorization`` header will be removed if you get redirected
    to a different host or protocol, except the case when  ``HTTP -> HTTPS``
    redirect is performed on the same host.

--- a/docs/client_advanced.rst
+++ b/docs/client_advanced.rst
@@ -58,11 +58,9 @@ For *text/plain* ::
 
 .. note::
    ``Authorization`` header will be removed if you get redirected
-   to a different host or protocol.
+   to a different host or protocol, except the case when  ``HTTP -> HTTPS``
+   redirect is performed on the same host.
 
-.. versionchanged:: 4.0
-   ``Authorization`` header will **not** be removed during the
-   ``HTTP -> HTTPS`` redirect if the host remains the same.
 
 Custom Cookies
 --------------

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -2350,9 +2350,7 @@ def create_server_for_url_and_handler(
             )
             ssl_ctx = ssl.SSLContext(ssl.PROTOCOL_SSLv23)
             cert.configure_cert(ssl_ctx)
-            kwargs = dict(ssl=ssl_ctx)
-        else:
-            kwargs = {}
+            kwargs['ssl'] = ssl_ctx
         return await aiohttp_server(app, **kwargs)
 
     return create

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -2350,7 +2350,7 @@ def create_server_for_url_and_handler(
             )
             ssl_ctx = ssl.SSLContext(ssl.PROTOCOL_SSLv23)
             cert.configure_cert(ssl_ctx)
-            kwargs['ssl'] = ssl_ctx
+            kwargs["ssl"] = ssl_ctx
         return await aiohttp_server(app, **kwargs)
 
     return create
@@ -2363,10 +2363,15 @@ def create_server_for_url_and_handler(
             "http://host1.com/path1",
             "http://host2.com/path2",
             True,
-        ],  # entirely different hosts
-        ["http://host1.com/path1", "https://host1.com/path1", False],  # http -> https
-        ["https://host1.com/path1", "http://host1.com/path2", True],  # https -> http
+        ],
+        ["http://host1.com/path1", "https://host1.com/path1", False],
+        ["https://host1.com/path1", "http://host1.com/path2", True],
     ],
+    ids=(
+        "entirely different hosts",
+        "http -> https",
+        "https -> http",
+    ),
 )
 async def test_drop_auth_on_redirect_to_other_host(
     create_server_for_url_and_handler: Any,

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -2343,6 +2343,7 @@ def create_server_for_url_and_handler(
         app = web.Application()
         app.router.add_route("GET", url.path, srv)
 
+        kwargs = {}
         if url.scheme == "https":
             cert = tls_certificate_authority.issue_cert(
                 url.host, "localhost", "127.0.0.1"


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
`http->https` redirect is a common thing today. It's safe to keep `Authorization` header in that situation if the host remains the same.
I'll create a separate PR for the `3.8` branch without this feature, but with the test and doc update (to emphasize, that this feature is `4+` only).

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->
 `Authorization` header wouldn't be dropped during the `http->https` redirect if the host remains the same.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Resolves #5783

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
