### PR TITLE
Don't cancel tasks when entering a timer context

### DIFF
--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -672,7 +672,6 @@ class TimerContext(BaseTimerContext):
             )
 
         if self._cancelled:
-            task.cancel()
             raise asyncio.TimeoutError from None
 
         self._tasks.append(task)


### PR DESCRIPTION
Fixes #5851 