### PR TITLE
Use `MultiLoopChildWatcher` in tests where available

### DIFF
--- a/CHANGES/3450.bugfix
+++ b/CHANGES/3450.bugfix
@@ -1,0 +1,1 @@
+Started using `MultiLoopChildWatcher` when it's available under POSIX while setting up the test I/O loop.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -241,6 +241,7 @@ Pawel Miech
 Pepe Osca
 Philipp A.
 Pieter van Beek
+Qiao Han
 Rafael Viotti
 Raphael Bialon
 Raúl Cumplido

--- a/aiohttp/test_utils.py
+++ b/aiohttp/test_utils.py
@@ -497,7 +497,7 @@ def setup_test_loop(
             # * https://stackoverflow.com/a/58614689/595220
             # * https://bugs.python.org/issue35621
             # * https://github.com/python/cpython/pull/14344
-            watcher = asyncio.ThreadedChildWatcher()
+            watcher = asyncio.MultiLoopChildWatcher()
         except AttributeError:  # Python < 3.8
             watcher = asyncio.SafeChildWatcher()
         watcher.attach_loop(loop)

--- a/aiohttp/test_utils.py
+++ b/aiohttp/test_utils.py
@@ -490,7 +490,16 @@ def setup_test_loop(
     asyncio.set_event_loop(loop)
     if sys.platform != "win32" and not skip_watcher:
         policy = asyncio.get_event_loop_policy()
-        watcher = asyncio.SafeChildWatcher()
+        watcher: asyncio.AbstractChildWatcher
+        try:  # Python >= 3.8
+            # Refs:
+            # * https://github.com/pytest-dev/pytest-xdist/issues/620
+            # * https://stackoverflow.com/a/58614689/595220
+            # * https://bugs.python.org/issue35621
+            # * https://github.com/python/cpython/pull/14344
+            watcher = asyncio.ThreadedChildWatcher()
+        except AttributeError:  # Python < 3.8
+            watcher = asyncio.SafeChildWatcher()
         watcher.attach_loop(loop)
         with contextlib.suppress(NotImplementedError):
             policy.set_child_watcher(watcher)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
Python 3.8 adds a new child watcher class that doesn't require running loop in the main thread: https://docs.python.org/3/library/asyncio-policy.html#asyncio.MultiLoopChildWatcher. This PR uses the new watcher if it is available in asyncio module.

It should reduce test flakiness when parallelized with `pytest-xdist`.

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->
No change for end users. Existing tests in `test_loop.py` covers this change given the current text matrix.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
https://github.com/aio-libs/aiohttp/issues/3450
https://github.com/aio-libs/aiohttp/pull/2075

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
