### PR TITLE
Switch to ThreadedChildWatcher and test

### DIFF
--- a/CHANGES/5877.bugfix
+++ b/CHANGES/5877.bugfix
@@ -1,0 +1,1 @@
+Uses `ThreadedChildWatcher` under POSIX to allow setting up test loop in non-main thread.

--- a/CHANGES/5877.bugfix
+++ b/CHANGES/5877.bugfix
@@ -1,1 +1,1 @@
-Uses `ThreadedChildWatcher` under POSIX to allow setting up test loop in non-main thread.
+Uses :py:class:`~asyncio.ThreadedChildWatcher` under POSIX to allow setting up test loop in non-main thread.

--- a/aiohttp/test_utils.py
+++ b/aiohttp/test_utils.py
@@ -497,7 +497,7 @@ def setup_test_loop(
             # * https://stackoverflow.com/a/58614689/595220
             # * https://bugs.python.org/issue35621
             # * https://github.com/python/cpython/pull/14344
-            watcher = asyncio.MultiLoopChildWatcher()
+            watcher = asyncio.ThreadedChildWatcher()
         except AttributeError:  # Python < 3.8
             watcher = asyncio.SafeChildWatcher()
         watcher.attach_loop(loop)

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -13,7 +13,6 @@ from aiohttp.test_utils import AioHTTPTestCase, loop_context
     platform.system() == "Windows", reason="the test is not valid for Windows"
 )
 async def test_subprocess_co(loop: Any) -> None:
-    assert threading.current_thread() is threading.main_thread()
     proc = await asyncio.create_subprocess_shell(
         "exit 0",
         stdin=asyncio.subprocess.DEVNULL,
@@ -47,8 +46,9 @@ def test_default_loop(loop: Any) -> None:
 
 def test_setup_loop_non_main_thread() -> None:
     def target() -> None:
-        with loop_context():
-            pass
+        with loop_context() as loop:
+            assert asyncio.get_event_loop() is loop
+            loop.run_until_complete(test_subprocess_co(loop))
 
     # Ensures setup_test_loop can be called by pytest-xdist in non-main thread.
     t = threading.Thread(target=target)

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -14,6 +14,7 @@ from aiohttp.test_utils import AioHTTPTestCase, loop_context
     platform.system() == "Windows", reason="the test is not valid for Windows"
 )
 async def test_subprocess_co(loop: Any) -> None:
+    assert PY_38 or threading.current_thread() is threading.main_thread()
     proc = await asyncio.create_subprocess_shell(
         "exit 0",
         stdin=asyncio.subprocess.DEVNULL,

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -45,7 +45,7 @@ def test_default_loop(loop: Any) -> None:
     assert asyncio.get_event_loop() is loop
 
 
-def test_setup_loop_non_main_thread():
+def test_setup_loop_non_main_thread() -> None:
     # Ensures setup_test_loop can be called by pytest-xdist in non-main thread.
     t = threading.Thread(target=setup_test_loop)
     t.start()

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -46,7 +46,7 @@ def test_default_loop(loop: Any) -> None:
 
 
 def test_setup_loop_non_main_thread() -> None:
-    def target():
+    def target() -> None:
         with loop_context():
             pass
 

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -6,7 +6,7 @@ from typing import Any
 import pytest
 
 from aiohttp import web
-from aiohttp.test_utils import AioHTTPTestCase
+from aiohttp.test_utils import AioHTTPTestCase, setup_test_loop
 
 
 @pytest.mark.skipif(
@@ -43,3 +43,10 @@ class TestCase(AioHTTPTestCase):
 
 def test_default_loop(loop: Any) -> None:
     assert asyncio.get_event_loop() is loop
+
+
+def test_setup_loop_non_main_thread():
+    # Ensures setup_test_loop can be called by pytest-xdist in non-main thread.
+    t = threading.Thread(target=setup_test_loop)
+    t.start()
+    t.join()

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -6,7 +6,7 @@ from typing import Any
 import pytest
 
 from aiohttp import web
-from aiohttp.test_utils import AioHTTPTestCase, setup_test_loop
+from aiohttp.test_utils import AioHTTPTestCase, loop_context
 
 
 @pytest.mark.skipif(
@@ -46,7 +46,11 @@ def test_default_loop(loop: Any) -> None:
 
 
 def test_setup_loop_non_main_thread() -> None:
+    def target():
+        with loop_context():
+            pass
+
     # Ensures setup_test_loop can be called by pytest-xdist in non-main thread.
-    t = threading.Thread(target=setup_test_loop)
+    t = threading.Thread(target=target)
     t.start()
     t.join()


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
Switch back to using `ThreadedChildWatcher` (originally introduced in #5862). Adds a unit test to ensure loop can be setup from non-main thread by `pytest-xdist`.

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->
NA

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
#5852

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
