### PR TITLE
Use iter_chunked in "Streaming Response Content" docs

### DIFF
--- a/docs/client_quickstart.rst
+++ b/docs/client_quickstart.rst
@@ -245,10 +245,7 @@ In general, however, you should use a pattern like this to save what is being
 streamed to a file::
 
     with open(filename, 'wb') as fd:
-        while True:
-            chunk = await resp.content.read(chunk_size)
-            if not chunk:
-                break
+        async for chunk in resp.content.iter_chunked(chunk_size):
             fd.write(chunk)
 
 It is not possible to use :meth:`~ClientResponse.read`,


### PR DESCRIPTION


<!-- Thank you for your contribution! -->

## What do these changes do?

In the client quickstart docs, the "Streaming Response Content" section uses a while loop to read the response content in chunks. But, using `iter_chunked` is cleaner. It also highlights the existence of the streaming API (something I didn't know about until someone pointed it out to me).

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

No, these are documentation changes only.
<!-- Outline any notable behaviour for the end users. -->

## Related issue number

N/A
<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [X] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
