### PR TITLE
 Do not restrict +json media type suffix to application/ 

### DIFF
--- a/CHANGES/5894.bugfix
+++ b/CHANGES/5894.bugfix
@@ -1,0 +1,1 @@
+Fix JSON media type suffix matching with main types other than application.

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -120,7 +120,7 @@ else:
         return asyncio.iscoroutinefunction(func)
 
 
-json_re = re.compile(r"^application/(?:[\w.+-]+?\+)?json")
+json_re = re.compile(r"(?:application/|[\w.-]+/[\w.+-]+?\+)json")
 
 
 class BasicAuth(namedtuple("BasicAuth", ["login", "password", "encoding"])):

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -730,6 +730,22 @@ def test_is_expected_content_type_json_match_partially():
     )
 
 
+def test_is_expected_content_type_non_application_json_suffix():
+    expected_ct = "application/json"
+    response_ct = "model/gltf+json"  # rfc 6839
+    assert is_expected_content_type(
+        response_content_type=response_ct, expected_content_type=expected_ct
+    )
+
+
+def test_is_expected_content_type_non_application_json_private_suffix():
+    expected_ct = "application/json"
+    response_ct = "x-foo/bar+json"  # rfc 6839
+    assert is_expected_content_type(
+        response_content_type=response_ct, expected_content_type=expected_ct
+    )
+
+
 def test_is_expected_content_type_non_json_match_exact():
     expected_ct = "text/javascript"
     response_ct = "text/javascript"


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Fix +json media type suffix handling to apply to other main types besides application/.

An example of a registered media type triggering this issue is https://www.iana.org/assignments/media-types/model/gltf+json

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->

Media types with main type other than `application` using the '+json` suffix are accepted as JSON now.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
