### PR TITLE
Ascola/add middleware type alias

### DIFF
--- a/CHANGES/4686.feature
+++ b/CHANGES/4686.feature
@@ -1,1 +1,1 @@
-Add a request handler type alias ``aiohttp.typedefs.Handler``.
+Add a request handler and a middleware type alias ``aiohttp.typedefs.Handler``.

--- a/aiohttp/typedefs.py
+++ b/aiohttp/typedefs.py
@@ -49,5 +49,6 @@ LooseCookies = Union[
 ]
 
 Handler = Callable[["Request"], Awaitable["StreamResponse"]]
+Middleware = Callable[["Request", Handler], Awaitable["StreamResponse"]]
 
 PathLike = Union[str, "os.PathLike[str]"]

--- a/aiohttp/web_app.py
+++ b/aiohttp/web_app.py
@@ -46,20 +46,18 @@ __all__ = ("Application", "CleanupError")
 
 
 if TYPE_CHECKING:  # pragma: no cover
-    from .typedefs import Handler
+    from .typedefs import Middleware
 
     _AppSignal = Signal[Callable[["Application"], Awaitable[None]]]
     _RespPrepareSignal = Signal[Callable[[Request, StreamResponse], Awaitable[None]]]
-    _Middleware = Callable[[Request, Handler], Awaitable[StreamResponse]]
-    _Middlewares = FrozenList[_Middleware]
-    _MiddlewaresHandlers = Sequence[_Middleware]
+    _Middlewares = FrozenList[Middleware]
+    _MiddlewaresHandlers = Sequence[Middleware]
     _Subapps = List["Application"]
 else:
     # No type checker mode, skip types
     _AppSignal = Signal
     _RespPrepareSignal = Signal
     _Handler = Callable
-    _Middleware = Callable
     _Middlewares = FrozenList
     _MiddlewaresHandlers = Sequence
     _Subapps = List
@@ -92,7 +90,7 @@ class Application(MutableMapping[str, Any]):
         self,
         *,
         logger: logging.Logger = web_logger,
-        middlewares: Iterable[_Middleware] = (),
+        middlewares: Iterable[Middleware] = (),
         handler_args: Optional[Mapping[str, Any]] = None,
         client_max_size: int = 1024 ** 2,
         debug: Any = ...,  # mypy doesn't support ellipsis
@@ -325,7 +323,7 @@ class Application(MutableMapping[str, Any]):
             # If an exception occurs in startup, ensure cleanup contexts are completed.
             await self._cleanup_ctx._on_cleanup(self)
 
-    def _prepare_middleware(self) -> Iterator[_Middleware]:
+    def _prepare_middleware(self) -> Iterator[Middleware]:
         yield from reversed(self._middlewares)
         yield _fix_request_current_app(self)
 

--- a/aiohttp/web_middlewares.py
+++ b/aiohttp/web_middlewares.py
@@ -1,8 +1,8 @@
 import re
 import warnings
-from typing import TYPE_CHECKING, Awaitable, Callable, Tuple, Type, TypeVar
+from typing import TYPE_CHECKING, Tuple, Type, TypeVar
 
-from .typedefs import Handler
+from .typedefs import Handler, Middleware
 from .web_exceptions import HTTPMove, HTTPPermanentRedirect
 from .web_request import Request
 from .web_response import StreamResponse
@@ -42,16 +42,13 @@ def middleware(f: _Func) -> _Func:
     return f
 
 
-_Middleware = Callable[[Request, Handler], Awaitable[StreamResponse]]
-
-
 def normalize_path_middleware(
     *,
     append_slash: bool = True,
     remove_slash: bool = False,
     merge_slashes: bool = True,
     redirect_class: Type[HTTPMove] = HTTPPermanentRedirect,
-) -> _Middleware:
+) -> Middleware:
     """
     Middleware factory which produces a middleware that normalizes
     the path of a request. By normalizing it means:
@@ -118,7 +115,7 @@ def normalize_path_middleware(
     return impl
 
 
-def _fix_request_current_app(app: "Application") -> _Middleware:
+def _fix_request_current_app(app: "Application") -> Middleware:
     async def impl(request: Request, handler: Handler) -> StreamResponse:
         with request.match_info.set_current_app(app):
             return await handler(request)


### PR DESCRIPTION
## What do these changes do?
Add a middleware type alias and change some code to use it.

## Are there changes in behavior for the user?
Users can now use the `Middleware` type alias in their code.

## Related issue number
#4686

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
