### PR TITLE
Do not require typing_extensions on Python 3.8+

### DIFF
--- a/CHANGES/5912.misc
+++ b/CHANGES/5912.misc
@@ -1,0 +1,1 @@
+Fix unnecessary dependency on typing_extensions on Python 3.8+.

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -30,8 +30,12 @@ from typing import (
     Union,
 )
 
+try:
+    from typing import Final, final
+except ImportError:  # pragma: no cover
+    from typing_extensions import Final, final
+
 from multidict import CIMultiDict, MultiDict, MultiDictProxy, istr
-from typing_extensions import Final, final
 from yarl import URL
 
 from . import hdrs, http, payload

--- a/aiohttp/client_ws.py
+++ b/aiohttp/client_ws.py
@@ -4,8 +4,12 @@ import asyncio
 import dataclasses
 from typing import Any, Optional, cast
 
+try:
+    from typing import Final
+except ImportError:  # pragma: no cover
+    from typing_extensions import Final
+
 import async_timeout
-from typing_extensions import Final
 
 from .client_exceptions import ClientError
 from .client_reqrep import ClientResponse

--- a/aiohttp/hdrs.py
+++ b/aiohttp/hdrs.py
@@ -4,8 +4,12 @@
 # to regenerate the headers parser
 from typing import Set
 
+try:
+    from typing import Final
+except ImportError:  # pragma: no cover
+    from typing_extensions import Final
+
 from multidict import istr
-from typing_extensions import Final
 
 METH_ANY: Final[str] = "*"
 METH_CONNECT: Final[str] = "CONNECT"

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -42,9 +42,13 @@ from typing import (
 from urllib.parse import quote
 from urllib.request import getproxies, proxy_bypass
 
+try:
+    from typing import Protocol, final
+except ImportError:  # pragma: no cover
+    from typing_extensions import Protocol, final
+
 import async_timeout
 from multidict import CIMultiDict, MultiDict, MultiDictProxy
-from typing_extensions import Protocol, final
 from yarl import URL
 
 from . import hdrs

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -21,8 +21,12 @@ from typing import (
     cast,
 )
 
+try:
+    from typing import Final
+except ImportError:  # pragma: no cover
+    from typing_extensions import Final
+
 from multidict import CIMultiDict, CIMultiDictProxy, istr
-from typing_extensions import Final
 from yarl import URL
 
 from . import hdrs

--- a/aiohttp/http_websocket.py
+++ b/aiohttp/http_websocket.py
@@ -11,7 +11,10 @@ from enum import IntEnum
 from struct import Struct
 from typing import Any, Callable, List, Optional, Pattern, Set, Tuple, Union, cast
 
-from typing_extensions import Final
+try:
+    from typing import Final
+except ImportError:  # pragma: no cover
+    from typing_extensions import Final
 
 from .base_protocol import BaseProtocol
 from .helpers import NO_EXTENSIONS

--- a/aiohttp/payload.py
+++ b/aiohttp/payload.py
@@ -22,8 +22,12 @@ from typing import (
     Union,
 )
 
+try:
+    from typing import Final
+except ImportError:  # pragma: no cover
+    from typing_extensions import Final
+
 from multidict import CIMultiDict
-from typing_extensions import Final
 
 from . import hdrs
 from .abc import AbstractStreamWriter

--- a/aiohttp/streams.py
+++ b/aiohttp/streams.py
@@ -3,7 +3,10 @@ import collections
 import warnings
 from typing import Awaitable, Callable, Generic, List, Optional, Tuple, TypeVar
 
-from typing_extensions import Final
+try:
+    from typing import Final
+except ImportError:  # pragma: no cover
+    from typing_extensions import Final
 
 from .base_protocol import BaseProtocol
 from .helpers import BaseTimerContext, set_exception, set_result

--- a/aiohttp/tracing.py
+++ b/aiohttp/tracing.py
@@ -9,7 +9,10 @@ from yarl import URL
 from .client_reqrep import ClientResponse
 
 if TYPE_CHECKING:  # pragma: no cover
-    from typing_extensions import Protocol
+    try:
+        from typing import Protocol
+    except ImportError:  # pragma: no cover
+        from typing_extensions import Protocol
 
     from .client import ClientSession
 

--- a/aiohttp/web_app.py
+++ b/aiohttp/web_app.py
@@ -22,9 +22,13 @@ from typing import (  # noqa
     cast,
 )
 
+try:
+    from typing import final
+except ImportError:  # pragma: no cover
+    from typing_extensions import final
+
 from aiosignal import Signal
 from frozenlist import FrozenList
-from typing_extensions import final
 
 from . import hdrs
 from .log import web_logger

--- a/aiohttp/web_fileresponse.py
+++ b/aiohttp/web_fileresponse.py
@@ -17,7 +17,10 @@ from typing import (  # noqa
     cast,
 )
 
-from typing_extensions import Final
+try:
+    from typing import Final
+except ImportError:  # pragma: no cover
+    from typing_extensions import Final
 
 from . import hdrs
 from .abc import AbstractStreamWriter

--- a/aiohttp/web_request.py
+++ b/aiohttp/web_request.py
@@ -26,8 +26,12 @@ from typing import (
 )
 from urllib.parse import parse_qsl
 
+try:
+    from typing import Final
+except ImportError:  # pragma: no cover
+    from typing_extensions import Final
+
 from multidict import CIMultiDict, CIMultiDictProxy, MultiDict, MultiDictProxy
-from typing_extensions import Final
 from yarl import URL
 
 from . import hdrs

--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -29,7 +29,11 @@ from typing import (
     cast,
 )
 
-from typing_extensions import Final, TypedDict
+try:
+    from typing import Final, TypedDict
+except ImportError:  # pragma: no cover
+    from typing_extensions import Final, TypedDict
+
 from yarl import URL, __version__ as yarl_version  # type: ignore[attr-defined]
 
 from . import hdrs

--- a/aiohttp/web_ws.py
+++ b/aiohttp/web_ws.py
@@ -6,9 +6,13 @@ import hashlib
 import json
 from typing import Any, Iterable, Optional, Tuple, cast
 
+try:
+    from typing import Final
+except ImportError:  # pragma: no cover
+    from typing_extensions import Final
+
 import async_timeout
 from multidict import CIMultiDict
-from typing_extensions import Final
 
 from . import hdrs
 from .abc import AbstractStreamWriter

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -9,6 +9,6 @@ cchardet==2.1.7
 chardet==4.0.0
 frozenlist==1.1.1
 gunicorn==20.1.0
-typing_extensions==3.7.4.3
+typing_extensions==3.7.4.3; python_version<"3.8"
 uvloop==0.14.0; platform_system!="Windows" and implementation_name=="cpython" and python_version<"3.9" # MagicStack/uvloop#14
 yarl==1.6.3

--- a/requirements/cython.in
+++ b/requirements/cython.in
@@ -1,3 +1,3 @@
 -r multidict.txt
 cython==0.29.23
-typing_extensions==3.7.4.3  # required for parsing aiohttp/hdrs.py by tools/gen.py
+typing_extensions==3.7.4.3; python_version<"3.8"  # required for parsing aiohttp/hdrs.py by tools/gen.py

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ install_requires = [
     "async_timeout>=4.0a2,<5.0",
     'asynctest==0.13.0; python_version<"3.8"',
     "yarl>=1.0,<2.0",
-    "typing_extensions>=3.7.4",
+    'typing_extensions>=3.7.4; python_version<"3.8"',
     "frozenlist>=1.1.1",
     "aiosignal>=1.1.2",
 ]


### PR DESCRIPTION
## What do these changes do?

All the types imported from typing_extensions are present in Python 3.8.
Support using the built-in types and restrict typing_extensions
requirement to Python < 3.8.

## Are there changes in behavior for the user?

No.

## Related issue number

n/a

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist (NFC)
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
