### PR TITLE
fix: remove deprecated loop argument for asnycio.sleep/gather calls

### DIFF
--- a/CHANGES/5905.bugfix
+++ b/CHANGES/5905.bugfix
@@ -1,0 +1,1 @@
+remove deprecated loop argument for asnycio.sleep/gather calls

--- a/aiohttp/web.py
+++ b/aiohttp/web.py
@@ -441,9 +441,7 @@ def _cancel_tasks(
     for task in to_cancel:
         task.cancel()
 
-    loop.run_until_complete(
-        asyncio.gather(*to_cancel, loop=loop, return_exceptions=True)
-    )
+    loop.run_until_complete(asyncio.gather(*to_cancel, return_exceptions=True))
 
     for task in to_cancel:
         if task.cancelled():

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -188,7 +188,7 @@ async def test_del_with_scheduled_cleanup(loop: Any) -> None:
         # obviously doesn't deletion because loop has a strong
         # reference to connector's instance method, isn't it?
         del conn
-        await asyncio.sleep(0.01, loop=loop)
+        await asyncio.sleep(0.01)
         gc.collect()
 
     assert not conns_impl

--- a/tests/test_locks.py
+++ b/tests/test_locks.py
@@ -19,7 +19,7 @@ class TestEventResultOrError:
             return 1
 
         t = loop.create_task(c())
-        await asyncio.sleep(0, loop=loop)
+        await asyncio.sleep(0)
         e = Exception()
         ev.set(exc=e)
         assert (await t) == e
@@ -32,7 +32,7 @@ class TestEventResultOrError:
             return 1
 
         t = loop.create_task(c())
-        await asyncio.sleep(0, loop=loop)
+        await asyncio.sleep(0)
         ev.set()
         assert (await t) == 1
 
@@ -44,7 +44,7 @@ class TestEventResultOrError:
 
         t1 = loop.create_task(c())
         t2 = loop.create_task(c())
-        await asyncio.sleep(0, loop=loop)
+        await asyncio.sleep(0)
         ev.cancel()
         ev.set()
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Remove deprecated `loop` argument for `asnycio.sleep` and `asyncio.gather` calls.

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

No.
<!-- Outline any notable behaviour for the end users. -->

## Related issue number

Closes #5905 .

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
