### PR TITLE
Improve the default fallback encoding detection

### DIFF
--- a/CHANGES/5928.feature
+++ b/CHANGES/5928.feature
@@ -1,0 +1,1 @@
+Switch chardet to charset-normalizer when aiohttp need to guess the body encoding

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -335,3 +335,4 @@ Zeal Wierslee
 Zlatan Sičanica
 Марк Коренберг
 Семён Марьясин
+Ahmed Tahri

--- a/README.rst
+++ b/README.rst
@@ -165,14 +165,14 @@ Requirements
 - Python >= 3.7
 - async-timeout_
 - attrs_
-- chardet_
+- charset-normalizer_
 - multidict_
 - yarl_
 
 Optionally you may install the cChardet_ and aiodns_ libraries (highly
 recommended for sake of speed).
 
-.. _chardet: https://pypi.python.org/pypi/chardet
+.. _charset-normalizer: https://pypi.org/project/charset-normalizer
 .. _aiodns: https://pypi.python.org/pypi/aiodns
 .. _attrs: https://github.com/python-attrs/attrs
 .. _multidict: https://pypi.python.org/pypi/multidict

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -70,7 +70,7 @@ except ImportError:  # pragma: no cover
 try:
     import cchardet as chardet
 except ImportError:  # pragma: no cover
-    import chardet  # type: ignore[no-redef]
+    import charset_normalizer as chardet  # type: ignore[no-redef]
 
 
 __all__ = ("ClientRequest", "ClientResponse", "RequestInfo", "Fingerprint")

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -1374,10 +1374,10 @@ Response object
       specified *encoding* parameter.
 
       If *encoding* is ``None`` content encoding is autocalculated
-      using ``Content-Type`` HTTP header and *chardet* tool if the
+      using ``Content-Type`` HTTP header and *charset-normalizer* tool if the
       header is not provided by server.
 
-      :term:`cchardet` is used with fallback to :term:`chardet` if
+      :term:`cchardet` is used with fallback to :term:`charset-normalizer` if
       *cchardet* is not available.
 
       Close underlying connection if data reading gets an error,
@@ -1389,14 +1389,14 @@ Response object
 
       :return str: decoded *BODY*
 
-      :raise LookupError: if the encoding detected by chardet or cchardet is
-                          unknown by Python (e.g. VISCII).
+      :raise LookupError: if the encoding detected by charset-normalizer or
+                          cchardet is unknown by Python (e.g. VISCII).
 
       .. note::
 
          If response has no ``charset`` info in ``Content-Type`` HTTP
-         header :term:`cchardet` / :term:`chardet` is used for content
-         encoding autodetection.
+         header :term:`cchardet` / :term:`charset-normalizer` is used for
+         content encoding autodetection.
 
          It may hurt performance. If page encoding is known passing
          explicit *encoding* parameter might help::
@@ -1411,7 +1411,7 @@ Response object
       a ``read`` call will be done,
 
       If *encoding* is ``None`` content encoding is autocalculated
-      using :term:`cchardet` or :term:`chardet` as fallback if
+      using :term:`cchardet` or :term:`charset-normalizer` as fallback if
       *cchardet* is not available.
 
       if response's `content-type` does not match `content_type` parameter
@@ -1449,11 +1449,11 @@ Response object
       Automatically detect content encoding using ``charset`` info in
       ``Content-Type`` HTTP header. If this info is not exists or there
       are no appropriate codecs for encoding then :term:`cchardet` /
-      :term:`chardet` is used.
+      :term:`charset-normalizer` is used.
 
       Beware that it is not always safe to use the result of this function to
       decode a response. Some encodings detected by cchardet are not known by
-      Python (e.g. VISCII).
+      Python (e.g. VISCII). *charset-normalizer* is not concerned by that issue.
 
       :raise RuntimeError: if called before the body has been read,
                            for :term:`cchardet` usage

--- a/docs/glossary.rst
+++ b/docs/glossary.rst
@@ -45,11 +45,12 @@
       Any object that can be called. Use :func:`callable` to check
       that.
 
-   chardet
+   charset-normalizer
 
-       The Universal Character Encoding Detector
+       The Real First Universal Charset Detector.
+       Open, modern and actively maintained alternative to Chardet.
 
-       https://pypi.python.org/pypi/chardet/
+       https://pypi.org/project/charset-normalizer/
 
    cchardet
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -34,7 +34,7 @@ Library Installation
    $ pip install aiohttp
 
 You may want to install *optional* :term:`cchardet` library as faster
-replacement for :term:`chardet`:
+replacement for :term:`charset-normalizer`:
 
 .. code-block:: bash
 
@@ -51,7 +51,7 @@ This option is highly recommended:
 Installing speedups altogether
 ------------------------------
 
-The following will get you ``aiohttp`` along with :term:`chardet`,
+The following will get you ``aiohttp`` along with :term:`charset-normalizer`,
 :term:`aiodns` and ``Brotli`` in one bundle. No need to type
 separate commands anymore!
 
@@ -149,11 +149,11 @@ Dependencies
 - Python 3.7+
 - *async_timeout*
 - *attrs*
-- *chardet*
+- *charset-normalizer*
 - *multidict*
 - *yarl*
 - *Optional* :term:`cchardet` as faster replacement for
-  :term:`chardet`.
+  :term:`charset-normalizer`.
 
   Install it explicitly via:
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,7 +6,7 @@ async-timeout==4.0.0a3
 asynctest==0.13.0; python_version<"3.8"
 Brotli==1.0.9
 cchardet==2.1.7
-chardet==4.0.0
+charset-normalizer==2.0.4
 frozenlist==1.1.1
 gunicorn==20.1.0
 typing_extensions==3.7.4.3

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -46,7 +46,7 @@ cfgv==3.2.0
     # via
     #   -r requirements/lint.txt
     #   pre-commit
-chardet==4.0.0
+charset-normalizer==2.0.4
     # via
     #   -r requirements/base.txt
     #   requests

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ except IndexError:
     raise RuntimeError("Unable to determine version.")
 
 install_requires = [
-    "chardet>=2.0,<5.0",
+    "charset-normalizer>=2.0,<3.0",
     "multidict>=4.5,<7.0",
     "async_timeout>=4.0a2,<5.0",
     'asynctest==0.13.0; python_version<"3.8"',


### PR DESCRIPTION
## What do these changes do?

Switch **Chardet** dependency to **Charset-Normalizer** for the fallback encoding detection.

## Are there changes in behavior for the user?

This change is mostly backward-compatible, exception of a thing:

- This new library support way more code pages (x3) than its counterpart Chardet.
  - Based on the 30-ich charsets that Chardet support, expect roughly 90% BC results https://github.com/Ousret/charset_normalizer/pull/77/checks?check_run_id=3244585065

## Why should you bother with such a change? Is it worth it?  

Short answer, absolutely.

Long answer:

- On average x4 faster than Chardet and countless times faster in the larger payload cases (>1MB)
  - https://github.com/Ousret/charset_normalizer/pull/77/checks?check_run_id=3244584863 
- Put a definitive end to the licensing debate around Chardet and LGPL. Remove ANY license ambiguity/restriction for projects bundling aiohttp.
- Never return an encoding if not suited for the given decoder. Eg. Never get UnicodeDecodeError!
- The package size is X4 lower than Chardet’s (4.0)!
- Binary files should never be detected as potential texts.
  - https://github.com/Ousret/char-dataset/blob/master/None/sample-1.gif 
    - Chardet and cChardet sees it as `Windows-1252`
    - None for charset-normalizer
- Especially, because the Unicode detection is far better than Chardet (or cChardet).
  - Some representative examples:
    - https://github.com/Ousret/char-dataset/blob/master/utf_8/reddit_wsb.csv
    - https://github.com/Ousret/char-dataset/blob/master/utf_8/_ude_1.md
      - Chardet sees it as `Windows-1254`
      - cChardet sees it as `ISO-8859-7`
      - `utf_8` for charset-normalizer
    - https://github.com/Ousret/char-dataset/blob/master/utf_8/_ude_1.rst
      - Chardet and cChardet sees it as `Windows-1252`
      - `utf_8` for charset-normalizer
- Actively maintained, watching closely for any concerns.
  - Many workflows are set up to ensure quality continuous delivery.
- `requests` did integrate it first and for total transparency, the lib needed some minors adjustments. But it is going well so far.

It's still a heuristic lib, therefore cannot be trusted blindly of course.

## Is UTF-8 everywhere already?

Not really, that is a dangerous assumption. Looking at https://w3techs.com/technologies/overview/character_encoding may seem like encoding detection is a thing of the past but not really. Solo based on 33k websites, you will find 3,4k responses without predefined encoding. (Top 1000 sites from 80 countries in the world according to Data for SEO) https://github.com/potiuk/test-charset-normalizer

First of all, neither aiohttp, chardet or charset-normalizer are dedicated to HTML content. The detection concern every text document (SubRip Subtitle for ex.). 
It is so hard to find any stats at all regarding this matter. Users' usages can be very dispersed, so making assumptions is unwise.

The real debate is to state if the detection is an HTTP client matter or not. That is more complicated and not my field.

## Related issue number

No related issue.

## Checklist

- [x] I think the code is well written
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
- [x] Add a new news fragment into the `CHANGES` folder

