### PR TITLE
Set more reasonable default header limits (64kb)

### DIFF
--- a/CHANGES/2304.bugfix
+++ b/CHANGES/2304.bugfix
@@ -1,0 +1,1 @@
+Set more reasonable default header limits and make them configurable via environment variables.

--- a/aiohttp/_http_parser.pyx
+++ b/aiohttp/_http_parser.pyx
@@ -18,6 +18,7 @@ from libc.string cimport memcpy
 
 from multidict import CIMultiDict as _CIMultiDict, CIMultiDictProxy as _CIMultiDictProxy
 from yarl import URL as _URL
+from os import getenv
 
 from aiohttp import hdrs
 
@@ -48,6 +49,10 @@ include "_headers.pxi"
 from aiohttp cimport _find_header
 
 DEF DEFAULT_FREELIST_SIZE = 250
+
+DEFAULT_MAX_LINE_SIZE = int(os.getenv('AIOHTTP_DEFAULT_MAX_LINE_SIZE', 8190))
+DEFAULT_MAX_HEADERS = int(os.getenv('AIOHTTP_DEFAULT_MAX_HEADERS', 32768))
+DEFAULT_MAX_FIELD_SIZE = int(os.getenv('AIOHTTP_DEFAULT_MAX_FIELD_SIZE', 65536))
 
 cdef extern from "Python.h":
     int PyByteArray_Resize(object, Py_ssize_t) except -1
@@ -327,8 +332,8 @@ cdef class HttpParser:
     cdef _init(self, cparser.http_parser_type mode,
                    object protocol, object loop, int limit,
                    object timer=None,
-                   size_t max_line_size=8190, size_t max_headers=32768,
-                   size_t max_field_size=65536, payload_exception=None,
+                   size_t max_line_size=DEFAULT_MAX_LINE_SIZE, size_t max_headers=DEFAULT_MAX_HEADERS,
+                   size_t max_field_size=DEFAULT_MAX_FIELD_SIZE, payload_exception=None,
                    bint response_with_body=True, bint read_until_eof=False,
                    bint auto_decompress=True):
         cparser.http_parser_init(self._cparser, mode)
@@ -563,8 +568,8 @@ cdef class HttpParser:
 cdef class HttpRequestParser(HttpParser):
 
     def __init__(self, protocol, loop, int limit, timer=None,
-                 size_t max_line_size=8190, size_t max_headers=32768,
-                 size_t max_field_size=65536, payload_exception=None,
+                 size_t max_line_size=DEFAULT_MAX_LINE_SIZE, size_t max_headers=DEFAULT_MAX_HEADERS,
+                 size_t max_field_size=DEFAULT_MAX_FIELD_SIZE, payload_exception=None,
                  bint response_with_body=True, bint read_until_eof=False,
     ):
          self._init(cparser.HTTP_REQUEST, protocol, loop, limit, timer,
@@ -591,8 +596,8 @@ cdef class HttpRequestParser(HttpParser):
 cdef class HttpResponseParser(HttpParser):
 
     def __init__(self, protocol, loop, int limit, timer=None,
-                 size_t max_line_size=8190, size_t max_headers=32768,
-                 size_t max_field_size=65536, payload_exception=None,
+                 size_t max_line_size=DEFAULT_MAX_LINE_SIZE, size_t max_headers=DEFAULT_MAX_HEADERS,
+                 size_t max_field_size=DEFAULT_MAX_FIELD_SIZE, payload_exception=None,
                  bint response_with_body=True, bint read_until_eof=False,
                  bint auto_decompress=True
     ):

--- a/aiohttp/_http_parser.pyx
+++ b/aiohttp/_http_parser.pyx
@@ -328,7 +328,7 @@ cdef class HttpParser:
                    object protocol, object loop, int limit,
                    object timer=None,
                    size_t max_line_size=8190, size_t max_headers=32768,
-                   size_t max_field_size=8190, payload_exception=None,
+                   size_t max_field_size=65536, payload_exception=None,
                    bint response_with_body=True, bint read_until_eof=False,
                    bint auto_decompress=True):
         cparser.http_parser_init(self._cparser, mode)
@@ -564,7 +564,7 @@ cdef class HttpRequestParser(HttpParser):
 
     def __init__(self, protocol, loop, int limit, timer=None,
                  size_t max_line_size=8190, size_t max_headers=32768,
-                 size_t max_field_size=8190, payload_exception=None,
+                 size_t max_field_size=65536, payload_exception=None,
                  bint response_with_body=True, bint read_until_eof=False,
     ):
          self._init(cparser.HTTP_REQUEST, protocol, loop, limit, timer,
@@ -592,7 +592,7 @@ cdef class HttpResponseParser(HttpParser):
 
     def __init__(self, protocol, loop, int limit, timer=None,
                  size_t max_line_size=8190, size_t max_headers=32768,
-                 size_t max_field_size=8190, payload_exception=None,
+                 size_t max_field_size=65536, payload_exception=None,
                  bint response_with_body=True, bint read_until_eof=False,
                  bint auto_decompress=True
     ):

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -125,7 +125,7 @@ class HeadersParser:
         self,
         max_line_size: int = 8190,
         max_headers: int = 32768,
-        max_field_size: int = 8190,
+        max_field_size: int = 65536,
     ) -> None:
         self.max_line_size = max_line_size
         self.max_headers = max_headers
@@ -222,7 +222,7 @@ class HttpParser(abc.ABC, Generic[_MsgT]):
         limit: int,
         max_line_size: int = 8190,
         max_headers: int = 32768,
-        max_field_size: int = 8190,
+        max_field_size: int = 65536,
         timer: Optional[BaseTimerContext] = None,
         code: Optional[int] = None,
         method: Optional[str] = None,

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -1,6 +1,7 @@
 import abc
 import asyncio
 import collections
+import os
 import re
 import string
 import zlib
@@ -71,6 +72,9 @@ METHRE: Final[Pattern[str]] = re.compile(r"[!#$%&'*+\-.^_`|~0-9A-Za-z]+")
 VERSRE: Final[Pattern[str]] = re.compile(r"HTTP/(\d+).(\d+)")
 HDRRE: Final[Pattern[bytes]] = re.compile(rb"[\x00-\x1F\x7F()<>@,;:\[\]={} \t\\\\\"]")
 
+DEFAULT_MAX_LINE_SIZE = int(os.getenv('AIOHTTP_DEFAULT_MAX_LINE_SIZE', 8190))
+DEFAULT_MAX_HEADERS = int(os.getenv('AIOHTTP_DEFAULT_MAX_HEADERS', 32768))
+DEFAULT_MAX_FIELD_SIZE = int(os.getenv('AIOHTTP_DEFAULT_MAX_FIELD_SIZE', 65536))
 
 class RawRequestMessage(NamedTuple):
     method: str
@@ -123,9 +127,9 @@ class ChunkState(IntEnum):
 class HeadersParser:
     def __init__(
         self,
-        max_line_size: int = 8190,
-        max_headers: int = 32768,
-        max_field_size: int = 65536,
+        max_line_size: int = DEFAULT_MAX_LINE_SIZE,
+        max_headers: int = DEFAULT_MAX_HEADERS,
+        max_field_size: int = DEFAULT_MAX_FIELD_SIZE,
     ) -> None:
         self.max_line_size = max_line_size
         self.max_headers = max_headers
@@ -220,9 +224,9 @@ class HttpParser(abc.ABC, Generic[_MsgT]):
         protocol: BaseProtocol,
         loop: asyncio.AbstractEventLoop,
         limit: int,
-        max_line_size: int = 8190,
-        max_headers: int = 32768,
-        max_field_size: int = 65536,
+        max_line_size: int = DEFAULT_MAX_LINE_SIZE,
+        max_headers: int = DEFAULT_MAX_HEADERS,
+        max_field_size: int = DEFAULT_MAX_FIELD_SIZE,
         timer: Optional[BaseTimerContext] = None,
         code: Optional[int] = None,
         method: Optional[str] = None,


### PR DESCRIPTION
## What do these changes do?

Set more reasonable default header limits (64kb) and make them configurable via environment variables.
I opted to go with environment variables because it was a lot quicker and easier than traversing the entire callstack and adding it to the client code. 

My use-case is to process responses from Trino, which has a default limit of 2MB, so configurability is a must.

## Are there changes in behavior for the user?

No

## Related issue number

#2304, at least partially. 

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
