### PR TITLE
auto_decompress is optional in server

### DIFF
--- a/CHANGES/5957.feature
+++ b/CHANGES/5957.feature
@@ -1,0 +1,1 @@
+optional auto_decompress for HttpRequestParser

--- a/aiohttp/_http_parser.pyx
+++ b/aiohttp/_http_parser.pyx
@@ -566,10 +566,12 @@ cdef class HttpRequestParser(HttpParser):
                  size_t max_line_size=8190, size_t max_headers=32768,
                  size_t max_field_size=8190, payload_exception=None,
                  bint response_with_body=True, bint read_until_eof=False,
+                 bint auto_decompress=True,
     ):
          self._init(cparser.HTTP_REQUEST, protocol, loop, limit, timer,
                     max_line_size, max_headers, max_field_size,
-                    payload_exception, response_with_body, read_until_eof)
+                    payload_exception, response_with_body, read_until_eof,
+                    auto_decompress)
 
     cdef object _on_status_complete(self):
          cdef Py_buffer py_buf

--- a/aiohttp/web_protocol.py
+++ b/aiohttp/web_protocol.py
@@ -194,6 +194,7 @@ class RequestHandler(BaseProtocol):
         max_field_size: int = 8190,
         lingering_time: float = 10.0,
         read_bufsize: int = 2 ** 16,
+        auto_decompress: bool = True,
     ):
         super().__init__(loop)
 
@@ -227,6 +228,7 @@ class RequestHandler(BaseProtocol):
             max_field_size=max_field_size,
             max_headers=max_headers,
             payload_exception=RequestPayloadError,
+            auto_decompress=auto_decompress,
         )  # type: Optional[HttpRequestParser]
 
         self.logger = logger

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -2583,6 +2583,10 @@ application on specific TCP or Unix socket, e.g.::
                             it means that the session global value is used.
 
       .. versionadded:: 3.7
+   :param bool auto_decompress: Automatically decompress request body,
+      ``True`` by default.
+
+      .. versionadded:: 4.0
 
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

auto_decompress was able to be disabled for client but unfortunately not for server. I've exported the API for server.

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->

The change should be backward compatible, I've only added an optional argument.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

#5957

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
