### PR TITLE
Stop codecov emailing bad reports

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,5 +1,6 @@
 codecov:
   branch: master
+  require_ci_to_pass: true
 
 coverage:
   range: "95..100"


### PR DESCRIPTION
On every PR, we get a notification email from codecov telling us that the coverage has dropped. This is only because the other tests have not yet finished running.

This should stop codecov reporting until the other tests are complete.