### PR TITLE
Expose main package constants for default Server and User-Agent headers

### DIFF
--- a/CHANGES/5986.feature
+++ b/CHANGES/5986.feature
@@ -1,0 +1,1 @@
+Add ``DEFAULT_SERVER_HEADER`` and ``DEFAULT_USER_AGENT_HEADER`` constants to the ``aiohttp`` package.

--- a/aiohttp/__init__.py
+++ b/aiohttp/__init__.py
@@ -43,6 +43,8 @@ from .http import (
     HttpVersion as HttpVersion,
     HttpVersion10 as HttpVersion10,
     HttpVersion11 as HttpVersion11,
+    SERVER_SOFTWARE as DEFAULT_SERVER_HEADER,
+    SERVER_SOFTWARE as DEFAULT_USER_AGENT_HEADER,
     WebSocketError as WebSocketError,
     WSCloseCode as WSCloseCode,
     WSMessage as WSMessage,

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -27,7 +27,7 @@ from typing import (
 from multidict import CIMultiDict, CIMultiDictProxy, MultiDict, MultiDictProxy
 from yarl import URL
 
-from . import hdrs, helpers, http, multipart, payload
+from . import DEFAULT_USER_AGENT_HEADER, hdrs, helpers, http, multipart, payload
 from .abc import AbstractStreamWriter
 from .client_exceptions import (
     ClientConnectionError,
@@ -48,7 +48,7 @@ from .helpers import (
     reify,
     set_result,
 )
-from .http import SERVER_SOFTWARE, HttpVersion10, HttpVersion11, StreamWriter
+from .http import HttpVersion10, HttpVersion11, StreamWriter
 from .http_parser import HAS_BROTLI
 from .log import client_logger
 from .streams import StreamReader
@@ -354,7 +354,7 @@ class ClientRequest:
                 self.headers.add(hdr, val)
 
         if hdrs.USER_AGENT not in used_headers:
-            self.headers[hdrs.USER_AGENT] = SERVER_SOFTWARE
+            self.headers[hdrs.USER_AGENT] = DEFAULT_USER_AGENT_HEADER
 
     def update_cookies(self, cookies: Optional[LooseCookies]) -> None:
         """Update request cookies header."""

--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -25,7 +25,7 @@ from typing import (
 
 from multidict import CIMultiDict, istr
 
-from . import hdrs, payload
+from . import DEFAULT_SERVER_HEADER, hdrs, payload
 from .abc import AbstractStreamWriter
 from .helpers import (
     ETAG_ANY,
@@ -39,7 +39,7 @@ from .helpers import (
     sentinel,
     validate_etag_value,
 )
-from .http import RESPONSES, SERVER_SOFTWARE, HttpVersion10, HttpVersion11
+from .http import RESPONSES, HttpVersion10, HttpVersion11
 from .payload import Payload
 from .typedefs import JSONEncoder, LooseHeaders
 
@@ -407,7 +407,7 @@ class StreamResponse(BaseClass, HeadersMixin, CookieMixin):
         if self.status not in (204, 304):
             headers.setdefault(hdrs.CONTENT_TYPE, "application/octet-stream")
         headers.setdefault(hdrs.DATE, rfc822_formatted_time())
-        headers.setdefault(hdrs.SERVER, SERVER_SOFTWARE)
+        headers.setdefault(hdrs.SERVER, DEFAULT_SERVER_HEADER)
 
         # connection header
         if hdrs.CONNECTION not in headers:


### PR DESCRIPTION

<!-- Thank you for your contribution! -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

Add constants for default `Server` and `User-Agent` headers that are a (more) explicit part of the API to the main `aiohttp` package.

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->

No.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

https://github.com/aio-libs/aiohttp/issues/5986

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
