### PR TITLE
Quick fix: Ignore python internal deprecation warning

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -58,6 +58,7 @@ filterwarnings =
     ignore:Exception ignored in. <coroutine object ClientSession._request at 0x.:pytest.PytestUnraisableExceptionWarning:_pytest.unraisableexception
     ignore:Exception ignored in. <function ClientSession.__del__ at 0x.:pytest.PytestUnraisableExceptionWarning:_pytest.unraisableexception
     ignore:Exception ignored in. <_io.FileIO .closed.>:pytest.PytestUnraisableExceptionWarning:_pytest.unraisableexception
+    ignore:The loop argument is deprecated:DeprecationWarning:asyncio.base_events
 junit_suite_name = aiohttp_test_suite
 norecursedirs = dist docs build .tox .eggs
 minversion = 3.8.2


### PR DESCRIPTION
A change to deprecation warnings in the last python 3.9 release has resulted in warnings appearing in some internal asyncio code. We'll just ignore them for now (think they are fixed in the next release).

For some bizarre reason, they only seem to happen on Windows though...