### PR TITLE
Quick fix: Ignore python internal deprecation warning

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -53,6 +53,7 @@ addopts =
 filterwarnings =
     error
     ignore:module 'ssl' has no attribute 'OP_NO_COMPRESSION'. The Python interpreter is compiled against OpenSSL < 1.0.0. Ref. https.//docs.python.org/3/library/ssl.html#ssl.OP_NO_COMPRESSION:UserWarning
+    ignore:The loop argument is deprecated:DeprecationWarning:asyncio.base_events
 junit_suite_name = aiohttp_test_suite
 norecursedirs = dist docs build .tox .eggs
 minversion = 3.8.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,7 +53,7 @@ addopts =
 filterwarnings =
     error
     ignore:module 'ssl' has no attribute 'OP_NO_COMPRESSION'. The Python interpreter is compiled against OpenSSL < 1.0.0. Ref. https.//docs.python.org/3/library/ssl.html#ssl.OP_NO_COMPRESSION:UserWarning
-    ignore:The loop argument is deprecated:DeprecationWarning:asyncio.base_events
+    ignore:The loop argument is deprecated since Python 3.8, and scheduled for removal in Python 3.10.:DeprecationWarning:asyncio.base_events
 junit_suite_name = aiohttp_test_suite
 norecursedirs = dist docs build .tox .eggs
 minversion = 3.8.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,6 +53,7 @@ addopts =
 filterwarnings =
     error
     ignore:module 'ssl' has no attribute 'OP_NO_COMPRESSION'. The Python interpreter is compiled against OpenSSL < 1.0.0. Ref. https.//docs.python.org/3/library/ssl.html#ssl.OP_NO_COMPRESSION:UserWarning
+    # Temporarily ignore warnings internal to Python 3.9.7, can be removed again in 3.9.8.
     ignore:The loop argument is deprecated since Python 3.8, and scheduled for removal in Python 3.10.:DeprecationWarning:asyncio.base_events
 junit_suite_name = aiohttp_test_suite
 norecursedirs = dist docs build .tox .eggs


### PR DESCRIPTION
A change to deprecation warnings in the last python 3.9 release has resulted in warnings appearing in some internal asyncio code. We'll just ignore them for now (think they are fixed in the next release).

For some bizarre reason, they only seem to happen on Windows though...