### PR TITLE
DNSCacheTable as a public class and TcpConnector with dns override

### DIFF
--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -647,7 +647,7 @@ class BaseConnector:
         raise NotImplementedError()
 
 
-class _DNSCacheTable:
+class DNSCacheTable:
     def __init__(self, ttl: Optional[float] = None) -> None:
         self._addrs_rr = (
             {}
@@ -718,6 +718,7 @@ class TCPConnector(BaseConnector):
         *,
         use_dns_cache: bool = True,
         ttl_dns_cache: Optional[int] = 10,
+        dns_cache_override: Optional[DNSCacheTable] = None,
         family: int = 0,
         ssl: Union[None, bool, Fingerprint, SSLContext] = None,
         local_addr: Optional[Tuple[str, int]] = None,
@@ -747,7 +748,7 @@ class TCPConnector(BaseConnector):
         self._resolver: AbstractResolver = resolver
 
         self._use_dns_cache = use_dns_cache
-        self._cached_hosts = _DNSCacheTable(ttl=ttl_dns_cache)
+        self._cached_hosts = DNSCacheTable(ttl=ttl_dns_cache) if dns_cache_override is None else dns_cache_override
         self._throttle_dns_events = (
             {}
         )  # type: Dict[Tuple[str, int], EventResultOrError]

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -748,7 +748,11 @@ class TCPConnector(BaseConnector):
         self._resolver: AbstractResolver = resolver
 
         self._use_dns_cache = use_dns_cache
-        self._cached_hosts = DNSCacheTable(ttl=ttl_dns_cache) if dns_cache_override is None else dns_cache_override
+        self._cached_hosts = (
+            DNSCacheTable(ttl=ttl_dns_cache)
+            if dns_cache_override is None
+            else dns_cache_override
+        )
         self._throttle_dns_events = (
             {}
         )  # type: Dict[Tuple[str, int], EventResultOrError]

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -21,7 +21,7 @@ import aiohttp
 from aiohttp import client, web
 from aiohttp.client import ClientRequest, ClientTimeout
 from aiohttp.client_reqrep import ConnectionKey
-from aiohttp.connector import Connection, TCPConnector, DNSCacheTable
+from aiohttp.connector import Connection, DNSCacheTable, TCPConnector
 from aiohttp.locks import EventResultOrError
 from aiohttp.test_utils import make_mocked_coro, unused_port
 from aiohttp.tracing import Trace

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -21,7 +21,7 @@ import aiohttp
 from aiohttp import client, web
 from aiohttp.client import ClientRequest, ClientTimeout
 from aiohttp.client_reqrep import ConnectionKey
-from aiohttp.connector import Connection, TCPConnector, _DNSCacheTable
+from aiohttp.connector import Connection, TCPConnector, DNSCacheTable
 from aiohttp.locks import EventResultOrError
 from aiohttp.test_utils import make_mocked_coro, unused_port
 from aiohttp.tracing import Trace
@@ -2133,7 +2133,7 @@ async def test_named_pipe_connector(
 class TestDNSCacheTable:
     @pytest.fixture
     def dns_cache_table(self):
-        return _DNSCacheTable()
+        return DNSCacheTable()
 
     def test_next_addrs_basic(self, dns_cache_table: Any) -> None:
         dns_cache_table.add("localhost", ["127.0.0.1"])
@@ -2163,12 +2163,12 @@ class TestDNSCacheTable:
         assert not dns_cache_table.expired("localhost")
 
     def test_not_expired_ttl(self) -> None:
-        dns_cache_table = _DNSCacheTable(ttl=0.1)
+        dns_cache_table = DNSCacheTable(ttl=0.1)
         dns_cache_table.add("localhost", ["127.0.0.1"])
         assert not dns_cache_table.expired("localhost")
 
     async def test_expired_ttl(self, loop: Any) -> None:
-        dns_cache_table = _DNSCacheTable(ttl=0.01)
+        dns_cache_table = DNSCacheTable(ttl=0.01)
         dns_cache_table.add("localhost", ["127.0.0.1"])
         await asyncio.sleep(0.02)
         assert dns_cache_table.expired("localhost")


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?
Add DNSCacheTable as a possible override for TCPConnector, and makes DNSCacheTable a public class

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?
The changes are only to allow external definition of the DNSCacheTable, as it may be reused from multiple connectors

<!-- Outline any notable behaviour for the end users. -->
Issue on #6010
## Related issue number 

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES` folder
