### PR TITLE
Fix double "abstract" in docs for access logger

### DIFF
--- a/docs/abc.rst
+++ b/docs/abc.rst
@@ -161,7 +161,7 @@ Abstract Cookie Jar
 
       .. versionadded:: 3.8
 
-Abstract Abstract Access Logger
+Abstract Access Logger
 -------------------------------
 
 .. class:: AbstractAccessLogger


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Fix a small typo in the docs

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

No

<!-- Outline any notable behaviour for the end users. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."

I do not deem this change significant enough to justify an entry in the `CHANGES` folder