### PR TITLE
Modify _drain_helper() to handle parallel calls without race-condition

### DIFF
--- a/CHANGES/2934.bugfix
+++ b/CHANGES/2934.bugfix
@@ -1,0 +1,1 @@
+Modify _drain_helper() to handle parallel calls of _send_frame() without race-condition.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -225,6 +225,7 @@ Navid Sheikhol
 Nicolas Braem
 Nikolay Kim
 Nikolay Novik
+Nándor Mátravölgyi
 Oisin Aylward
 Olaf Conradi
 Oleg Höfling

--- a/aiohttp/base_protocol.py
+++ b/aiohttp/base_protocol.py
@@ -81,7 +81,7 @@ class BaseProtocol(asyncio.Protocol):
         if not self._paused:
             return
         waiter = self._drain_waiter
-        assert waiter is None or waiter.cancelled()
-        waiter = self._loop.create_future()
-        self._drain_waiter = waiter
-        await waiter
+        if waiter is None:
+            waiter = self._loop.create_future()
+            self._drain_waiter = waiter
+        await asyncio.shield(waiter)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

These changes fix a bug/race-condition on the BaseProtocol's drain-waiter.

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?
There are no API or behavioral changes. This should exclusively handle the case of the race-condition when multiple coroutines produce messages to a websocket for example.

<!-- Outline any notable behaviour for the end users. -->

## Related issue number

This fix is aimed at the #2934 issue directly.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes - Not applicable AFAIK
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
