### PR TITLE
Remove duplicate entries in dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,23 +37,3 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 10
-
-  # Maintain dependencies for GitHub Actions aiohttp 3.8
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    labels:
-      - dependencies
-    target-branch: "3.8"
-    schedule:
-      interval: "daily"
-    open-pull-requests-limit: 10
-
-  # Maintain dependencies for Python aiohttp 3.8
-  - package-ecosystem: "pip"
-    directory: "/"
-    labels:
-      - dependencies
-    target-branch: "3.8"
-    schedule:
-      interval: "daily"
-    open-pull-requests-limit: 10


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
Andrew accidentally created duplicate entries in `.github/dependabot.yml` (see 42881feb6c9b5bb7c74f1b3fa05b5bdec49120e6). 

Dependabot told me about that after I had updated my fork (see more [here](https://github.com/greshilov/aiohttp/runs/3771164336)).

These duplicate entries are removed in this PR.
