### PR TITLE
Enable test coverage collection in pytest

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -50,6 +50,7 @@ addopts =
 
     # `pytest-cov`:
     --cov=aiohttp
+    --cov=tests/
 filterwarnings =
     error
     ignore:module 'ssl' has no attribute 'OP_NO_COMPRESSION'. The Python interpreter is compiled against OpenSSL < 1.0.0. Ref. https.//docs.python.org/3/library/ssl.html#ssl.OP_NO_COMPRESSION:UserWarning


### PR DESCRIPTION
## What do these changes do?

This patch should enable codecov track the coverage for the test modules as it does for the normal source code.

## Are there changes in behavior for the user?

No.

## Related issue number

N/A