### PR TITLE
[PR #6055/079e9c5a backport][3.8] Implement future changelog previews in the docs (#6055)

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,5 +1,21 @@
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html
+# for details
+
+---
+version: 2
+
+submodules:
+  include: all  # []
+  exclude: []
+  recursive: true
+
 build:
   image: latest
 python:
-  version: 3.6
-  pip_install: false
+  version: 3.8
+  install:
+  - method: pip
+    path: .
+  - requirements: requirements/doc.txt
+...

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,3 @@
-=========
-Changelog
-=========
-
 ..
     You should *NOT* be adding new change log entries to this file, this
     file is managed by towncrier. You *may* edit previous change logs to

--- a/CHANGES/4054.feature
+++ b/CHANGES/4054.feature
@@ -1,1 +1,1 @@
-Implemented readuntil in StreamResponse
+Implemented ``readuntil`` in ``StreamResponse``

--- a/CHANGES/4700.feature
+++ b/CHANGES/4700.feature
@@ -1,6 +1,6 @@
-AioHTTPTestCase is more async friendly now.
+``AioHTTPTestCase`` is more async friendly now.
 
-For people who use unittest and are used to use unittest.TestCase
-it will be easier to write new test cases like the sync version of the TestCase class,
+For people who use unittest and are used to use :py:exc:`~unittest.TestCase`
+it will be easier to write new test cases like the sync version of the :py:exc:`~unittest.TestCase` class,
 without using the decorator `@unittest_run_loop`, just `async def test_*`.
-The only difference is that for the people using python3.7 and below a new dependency is needed, it is `asynctestcase`.
+The only difference is that for the people using python3.7 and below a new dependency is needed, it is ``asynctestcase``.

--- a/CHANGES/5326.doc
+++ b/CHANGES/5326.doc
@@ -1,1 +1,1 @@
-Refactor OpenAPI/Swagger aiohttp addons, added aio-openapi
+Refactored OpenAPI/Swagger aiohttp addons, added ``aio-openapi``

--- a/CHANGES/5905.bugfix
+++ b/CHANGES/5905.bugfix
@@ -1,1 +1,1 @@
-remove deprecated loop argument for asnycio.sleep/gather calls
+Removed the deprecated ``loop`` argument from the ``asyncio.sleep``/``gather`` calls

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -1,5 +1,17 @@
 .. _aiohttp_changes:
 
+=========
+Changelog
+=========
+
+To be included in v\ |release| (if present)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. towncrier-draft-entries:: |release| [UNRELEASED DRAFT]
+
+Released versions
+^^^^^^^^^^^^^^^^^
+
 .. include:: ../CHANGES.rst
 
 .. include:: ../HISTORY.rst

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,6 +15,9 @@
 import io
 import os
 import re
+from pathlib import Path
+
+PROJECT_ROOT_DIR = Path(__file__).parents[1].resolve()
 
 _docs_path = os.path.dirname(__file__)
 _version_path = os.path.abspath(
@@ -51,6 +54,7 @@ extensions = [
     # Third-party extensions:
     "sphinxcontrib.asyncio",
     "sphinxcontrib.blockdiag",
+    "sphinxcontrib.towncrier",  # provides `towncrier-draft-entries` directive
 ]
 
 
@@ -434,3 +438,10 @@ nitpick_ignore = [
     ("py:exc", "HTTPMethodNotAllowed"),  # undocumented
     ("py:class", "HTTPMethodNotAllowed"),  # undocumented
 ]
+
+# -- Options for towncrier_draft extension -----------------------------------
+
+towncrier_draft_autoversion_mode = "draft"  # or: 'sphinx-version', 'sphinx-release'
+towncrier_draft_include_empty = True
+towncrier_draft_working_directory = PROJECT_ROOT_DIR
+# Not yet supported: towncrier_draft_config_path = 'pyproject.toml'  # relative to cwd

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -82,6 +82,7 @@ WSMsgType
 Websockets
 Workflow
 abc
+addons
 aiodns
 aioes
 aiohttp
@@ -115,6 +116,7 @@ botocore
 bugfix
 builtin
 cChardet
+callables
 cancelled
 canonicalization
 canonicalize
@@ -202,6 +204,7 @@ login
 lookup
 lookups
 lossless
+lowercased
 manylinux
 metadata
 microservice
@@ -258,6 +261,7 @@ redirections
 refactor
 refactored
 refactoring
+referenceable
 regex
 regexps
 regexs
@@ -316,6 +320,7 @@ unittest
 unix
 unsets
 unstripped
+uppercased
 upstr
 url
 urldispatcher

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -62,7 +62,7 @@ click==7.1.2
     #   towncrier
 click-default-group==1.2.2
     # via towncrier
-coverage==5.5
+coverage[toml]==6.0
     # via
     #   -r requirements/test.txt
     #   pytest-cov
@@ -129,7 +129,7 @@ mccabe==0.6.1
     # via
     #   -r requirements/lint.txt
     #   flake8
-multidict==5.1.0
+multidict==5.2.0
     # via
     #   -r requirements/multidict.txt
     #   yarl
@@ -199,7 +199,7 @@ pytest==6.1.2
     #   -r requirements/test.txt
     #   pytest-cov
     #   pytest-mock
-pytest-cov==2.12.1
+pytest-cov==3.0.0
     # via -r requirements/test.txt
 pytest-mock==3.6.1
     # via -r requirements/test.txt
@@ -237,6 +237,7 @@ sphinx==4.2.0
     #   -r requirements/doc.txt
     #   sphinxcontrib-asyncio
     #   sphinxcontrib-blockdiag
+    #   sphinxcontrib-towncrier
 sphinxcontrib-applehelp==1.0.2
     # via sphinx
 sphinxcontrib-asyncio==0.3.0
@@ -253,6 +254,8 @@ sphinxcontrib-qthelp==1.0.3
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
+sphinxcontrib-towncrier==0.2.0a0
+    # via -r requirements/doc.txt
 toml==0.10.2
     # via
     #   -r requirements/lint.txt
@@ -261,10 +264,11 @@ toml==0.10.2
     #   mypy
     #   pre-commit
     #   pytest
-    #   pytest-cov
     #   towncrier
 towncrier==21.3.0
-    # via -r requirements/doc.txt
+    # via
+    #   -r requirements/doc.txt
+    #   sphinxcontrib-towncrier
 trustme==0.9.0 ; platform_machine != "i686"
     # via -r requirements/test.txt
 typed-ast==1.4.3 ; implementation_name == "cpython"

--- a/requirements/doc-spelling.txt
+++ b/requirements/doc-spelling.txt
@@ -64,6 +64,7 @@ sphinx==4.2.0
     #   sphinxcontrib-asyncio
     #   sphinxcontrib-blockdiag
     #   sphinxcontrib-spelling
+    #   sphinxcontrib-towncrier
 sphinxcontrib-applehelp==1.0.2
     # via sphinx
 sphinxcontrib-asyncio==0.3.0
@@ -82,10 +83,14 @@ sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
 sphinxcontrib-spelling==7.2.1 ; platform_system != "Windows"
     # via -r requirements/doc-spelling.in
+sphinxcontrib-towncrier==0.2.0a0
+    # via -r requirements/doc.txt
 toml==0.10.2
     # via towncrier
 towncrier==21.3.0
-    # via -r requirements/doc.txt
+    # via
+    #   -r requirements/doc.txt
+    #   sphinxcontrib-towncrier
 urllib3==1.26.3
     # via requests
 webcolors==1.11.1

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -5,4 +5,5 @@ pygments==2.10.0
 sphinx==4.2.0
 sphinxcontrib-asyncio==0.3.0
 sphinxcontrib-blockdiag==2.0.0
+sphinxcontrib-towncrier==0.2.0a0
 towncrier==21.3.0


### PR DESCRIPTION
**This is a backport of PR #6055 as merged into master (079e9c5a7e6fede74be6fabd689b875f2065e084).**

* Implement future changelog previews in the docs

* Self-install on RTD

* Fix spelling mistakes in the check notes

(cherry picked from commit 079e9c5a7e6fede74be6fabd689b875f2065e084)

## What do these changes do?

This patch injects towncrier preview into the docs.

## Are there changes in behavior for the user?

They'll be able to see what's coming in the next release.

## Related issue number

N/A