### PR TITLE
Fix the order of checks in `test_proxy_functional`

### DIFF
--- a/tests/test_proxy_functional.py
+++ b/tests/test_proxy_functional.py
@@ -179,14 +179,14 @@ async def test_https_proxy_unsupported_tls_in_tls(
         r"An HTTPS request is being sent through an HTTPS proxy\. "
         "This support for TLS in TLS is known to be disabled "
         r"in the stdlib asyncio\. This is why you'll probably see "
-        r"an error in the log below.\n\n"
+        r"an error in the log below\.\n\n"
         "It is possible to enable it via monkeypatching under "
         r"Python 3\.7 or higher\. For more details, see:\n"
-        r"* https://bugs\.python\.org/issue37179\n"
-        r"* https://github\.com/python/cpython/pull/28073\n\n"
+        r"\* https://bugs\.python\.org/issue37179\n"
+        r"\* https://github\.com/python/cpython/pull/28073\n\n"
         r"You can temporarily patch this as follows:\n"
-        r"* https://docs\.aiohttp\.org/en/stable/client_advanced\.html#proxy-support\n",
-        r"* https://github\.com/aio-libs/aiohttp/discussions/6044\n$",
+        r"\* https://docs\.aiohttp\.org/en/stable/client_advanced\.html#proxy-support\n"
+        r"\* https://github\.com/aio-libs/aiohttp/discussions/6044\n$"
     )
     type_err = (
         r"transport <asyncio\.sslproto\._SSLProtocolTransport object at "
@@ -201,13 +201,10 @@ async def test_https_proxy_unsupported_tls_in_tls(
         r"$"
     )
 
-    with pytest.raises(
+    with pytest.warns(RuntimeWarning, match=expected_warning_text,), pytest.raises(
         ClientConnectionError,
         match=expected_exception_reason,
-    ) as conn_err, pytest.warns(
-        RuntimeWarning,
-        match=expected_warning_text,
-    ):
+    ) as conn_err:
         await sess.get(url, proxy=secure_proxy_url, ssl=client_ssl_ctx)
 
     assert type(conn_err.value.__cause__) == TypeError


### PR DESCRIPTION
Apparently, if an exception gets raised before the warning gets a
chance to be emitted, it doesn't emit an assertion error. Pytest bug?

(cherry picked from commit 109747391ef70d57501d0a110cdf4dc6a8e89182)

## What do these changes do?

This patch fixes a bug in tests added in #5992 that I discovered while
preparing a backport in #6049.

## Are there changes in behavior for the user?

No.
<!-- Outline any notable behaviour for the end users. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
N/A

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
