### PR TITLE
Adjust aiohttp v3.8 dep pins with `master`

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,7 +6,7 @@ async-generator==1.10
 async-timeout==4.0.0a3
 asynctest==0.13.0; python_version<"3.8"
 attrs==21.2.0
-brotli==1.0.9
+Brotli==1.0.9
 cchardet==2.1.7
 chardet==4.0.0
 frozenlist==1.1.1

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -29,12 +29,14 @@ attrs==21.2.0
     #   pytest
 babel==2.9.0
     # via sphinx
-black==21.6b0 ; implementation_name == "cpython"
+black==21.7b0 ; implementation_name == "cpython"
     # via -r requirements/lint.txt
 blockdiag==2.0.1
     # via sphinxcontrib-blockdiag
 brotli==1.0.9
-    # via -r requirements/base.txt
+    # via
+    #   -r requirements/base.txt
+    #   -r requirements/test.txt
 cchardet==2.1.7
     # via -r requirements/base.txt
 certifi==2020.12.5
@@ -64,7 +66,7 @@ click==7.1.2
     #   wait-for-it
 click-default-group==1.2.2
     # via towncrier
-coverage[toml]==6.0.1
+coverage[toml]==6.0.2
     # via
     #   -r requirements/test.txt
     #   pytest-cov
@@ -82,7 +84,7 @@ filelock==3.0.12
     # via
     #   -r requirements/lint.txt
     #   virtualenv
-flake8==3.9.2
+flake8==4.0.1
     # via
     #   -r requirements/lint.txt
     #   flake8-pyi
@@ -119,9 +121,9 @@ iniconfig==1.1.1
     # via
     #   -r requirements/lint.txt
     #   pytest
-isort==5.9.2
+isort==5.9.3
     # via -r requirements/lint.txt
-jinja2==2.11.2
+jinja2==2.11.3
     # via
     #   sphinx
     #   towncrier
@@ -158,13 +160,13 @@ pathspec==0.8.1
     # via
     #   -r requirements/lint.txt
     #   black
-pillow==8.1.0
+pillow==8.3.2
     # via blockdiag
 pluggy==0.13.1
     # via
     #   -r requirements/lint.txt
     #   pytest
-pre-commit==2.13.0
+pre-commit==2.15.0
     # via -r requirements/lint.txt
 proxy.py==2.3.1
     # via -r requirements/test.txt
@@ -174,7 +176,7 @@ py==1.10.0
     #   pytest
 pycares==4.0.0
     # via aiodns
-pycodestyle==2.7.0
+pycodestyle==2.8.0
     # via
     #   -r requirements/lint.txt
     #   flake8
@@ -182,7 +184,7 @@ pycparser==2.20
     # via cffi
 pydantic==1.8.2
     # via python-on-whales
-pyflakes==2.3.0
+pyflakes==2.4.0
     # via
     #   -r requirements/lint.txt
     #   flake8
@@ -197,7 +199,7 @@ pyparsing==2.4.7
     # via
     #   -r requirements/lint.txt
     #   packaging
-pytest==6.1.2
+pytest==6.2.5
     # via
     #   -r requirements/lint.txt
     #   -r requirements/test.txt
@@ -266,14 +268,16 @@ sphinxcontrib-towncrier==0.2.0a0
 toml==0.10.2
     # via
     #   -r requirements/lint.txt
-    #   black
     #   cherry-picker
     #   mypy
     #   pre-commit
     #   pytest
     #   towncrier
 tomli==1.2.1
-    # via coverage
+    # via
+    #   -r requirements/lint.txt
+    #   black
+    #   coverage
 towncrier==21.3.0
     # via
     #   -r requirements/doc.txt
@@ -300,7 +304,7 @@ typing-extensions==3.7.4.3
     #   pydantic
 uritemplate==3.0.1
     # via gidgethub
-urllib3==1.26.2
+urllib3==1.26.5
     # via requests
 virtualenv==20.4.2
     # via

--- a/requirements/doc-spelling.txt
+++ b/requirements/doc-spelling.txt
@@ -42,7 +42,7 @@ markupsafe==1.1.1
     # via jinja2
 packaging==20.9
     # via sphinx
-pillow==8.1.2
+pillow==8.3.2
     # via blockdiag
 pyenchant==3.2.0
     # via sphinxcontrib-spelling
@@ -91,7 +91,7 @@ towncrier==21.3.0
     # via
     #   -r requirements/doc.txt
     #   sphinxcontrib-towncrier
-urllib3==1.26.3
+urllib3==1.26.5
     # via requests
 webcolors==1.11.1
     # via blockdiag

--- a/requirements/lint.in
+++ b/requirements/lint.in
@@ -1,12 +1,12 @@
-black==21.6b0; implementation_name=="cpython"
+black==21.7b0; implementation_name=="cpython"
 dataclasses==0.8; python_version < "3.7"
-flake8==3.9.2
+flake8==4.0.1
 flake8-pyi==20.10.0
 importlib-metadata==3.7.0; python_version < "3.8"
 importlib-resources; python_version < "3.9"
-isort==5.9.2
+isort==5.9.3
 mypy==0.910; implementation_name=="cpython"
-pre-commit==2.13.0
-pytest==6.2.2
+pre-commit==2.15.0
+pytest==6.2.5
 typed-ast==1.4.3; implementation_name=="cpython"
 types-chardet==0.1.3

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -8,11 +8,11 @@ appdirs==1.4.4
     # via
     #   black
     #   virtualenv
-attrs==21.2.0
+attrs==20.3.0
     # via
     #   flake8-pyi
     #   pytest
-black==21.6b0 ; implementation_name == "cpython"
+black==21.7b0 ; implementation_name == "cpython"
     # via -r requirements/lint.in
 cfgv==3.2.0
     # via pre-commit
@@ -22,17 +22,17 @@ distlib==0.3.1
     # via virtualenv
 filelock==3.0.12
     # via virtualenv
-flake8==3.9.2
+flake8==4.0.1
     # via
     #   -r requirements/lint.in
     #   flake8-pyi
 flake8-pyi==20.10.0
     # via -r requirements/lint.in
-identify==2.1.1
+identify==1.5.14
     # via pre-commit
 iniconfig==1.1.1
     # via pytest
-isort==5.9.2
+isort==5.9.3
     # via -r requirements/lint.in
 mccabe==0.6.1
     # via flake8
@@ -50,19 +50,19 @@ pathspec==0.8.1
     # via black
 pluggy==0.13.1
     # via pytest
-pre-commit==2.13.0
+pre-commit==2.15.0
     # via -r requirements/lint.in
 py==1.10.0
     # via pytest
-pycodestyle==2.7.0
+pycodestyle==2.8.0
     # via flake8
-pyflakes==2.3.0
+pyflakes==2.4.0
     # via
     #   flake8
     #   flake8-pyi
 pyparsing==2.4.7
     # via packaging
-pytest==6.1.2
+pytest==6.2.5
     # via -r requirements/lint.in
 pyyaml==5.4.1
     # via pre-commit
@@ -72,15 +72,17 @@ six==1.16.0
     # via virtualenv
 toml==0.10.2
     # via
-    #   black
+    #   mypy
     #   pre-commit
     #   pytest
+tomli==1.2.1
+    # via black
 typed-ast==1.4.3 ; implementation_name == "cpython"
     # via
     #   -r requirements/lint.in
     #   mypy
 types-chardet==0.1.3
-    # via -r requirements/lint.txt
+    # via -r requirements/lint.in
 typing-extensions==3.7.4.3
     # via mypy
 virtualenv==20.4.2

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,12 +1,13 @@
 
 -r base.txt
+Brotli==1.0.9
 coverage==6.0.2
 cryptography==3.3.1; platform_machine!="i686" and python_version<"3.9" # no 32-bit wheels; no python 3.9 wheels yet
 freezegun==1.1.0
 mypy==0.910; implementation_name=="cpython"
 mypy-extensions==0.4.3; implementation_name=="cpython"
 proxy.py==2.3.1
-pytest==6.1.2
+pytest==6.2.5
 pytest-cov==3.0.0
 pytest-mock==3.6.1
 re-assert==1.1.0


### PR DESCRIPTION
## What do these changes do?

This is an attempt to transfer/backport all of the dep pins from the `master` branch to v3.8.

## Are there changes in behavior for the user?

No.

## Related issue number

N/A

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
(cherry picked from commit dbcf70473af2a55700782c65badc388354c78e1f)