### PR TITLE
[backport][3.8] Release hanging resources in tests

### DIFF
--- a/CHANGES/5494.bugfix
+++ b/CHANGES/5494.bugfix
@@ -1,0 +1,4 @@
+Fixed the multipart POST requests processing to always release file
+descriptors for the ``tempfile.Temporaryfile``-created
+``_io.BufferedRandom`` instances of files sent within multipart request
+bodies via HTTP POST requests -- by :user:`webknjaz`.

--- a/CHANGES/5494.misc
+++ b/CHANGES/5494.misc
@@ -1,0 +1,3 @@
+Made sure to always close most of file descriptors and release other
+resouces in tests. Started ignoring ``ResourceWarning``s in pytest for
+warnings that are hard to track -- by :user:`webknjaz`.

--- a/aiohttp/web_request.py
+++ b/aiohttp/web_request.py
@@ -720,6 +720,7 @@ class BaseRequest(MutableMapping[str, Any], HeadersMixin):
                             tmp.write(chunk)
                             size += len(chunk)
                             if 0 < max_size < size:
+                                tmp.close()
                                 raise HTTPRequestEntityTooLarge(
                                     max_size=max_size, actual_size=size
                                 )

--- a/setup.cfg
+++ b/setup.cfg
@@ -54,6 +54,11 @@ addopts =
 filterwarnings =
     error
     ignore:module 'ssl' has no attribute 'OP_NO_COMPRESSION'. The Python interpreter is compiled against OpenSSL < 1.0.0. Ref. https.//docs.python.org/3/library/ssl.html#ssl.OP_NO_COMPRESSION:UserWarning
+    ignore:Exception ignored in. <function _SSLProtocolTransport.__del__ at.:pytest.PytestUnraisableExceptionWarning:_pytest.unraisableexception
+    ignore:Exception ignored in. <coroutine object BaseConnector.close at 0x.:pytest.PytestUnraisableExceptionWarning:_pytest.unraisableexception
+    ignore:Exception ignored in. <coroutine object ClientSession._request at 0x.:pytest.PytestUnraisableExceptionWarning:_pytest.unraisableexception
+    ignore:Exception ignored in. <function ClientSession.__del__ at 0x.:pytest.PytestUnraisableExceptionWarning:_pytest.unraisableexception
+    ignore:Exception ignored in. <_io.FileIO .closed.>:pytest.PytestUnraisableExceptionWarning:_pytest.unraisableexception
     # Temporarily ignore warnings internal to Python 3.9.7, can be removed again in 3.9.8.
     ignore:The loop argument is deprecated since Python 3.8, and scheduled for removal in Python 3.10.:DeprecationWarning:asyncio
 junit_suite_name = aiohttp_test_suite

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -2581,6 +2581,8 @@ async def test_aiohttp_request_coroutine(aiohttp_server) -> None:
     with pytest.raises(TypeError):
         await aiohttp.request("GET", server.make_url("/"))
 
+    server.close()
+
 
 async def test_yield_from_in_session_request(aiohttp_client) -> None:
     # a test for backward compatibility with yield from syntax
@@ -2770,7 +2772,7 @@ async def test_server_close_keepalive_connection() -> None:
         await r.read()
         assert 0 == len(connector._conns)
     await session.close()
-    connector.close()
+    await connector.close()
     server.close()
     await server.wait_closed()
 
@@ -2812,7 +2814,7 @@ async def test_handle_keepalive_on_closed_connection() -> None:
     assert 0 == len(connector._conns)
 
     await session.close()
-    connector.close()
+    await connector.close()
     server.close()
     await server.wait_closed()
 

--- a/tests/test_client_response.py
+++ b/tests/test_client_response.py
@@ -46,6 +46,7 @@ async def test_http_processing_error(session) -> None:
         await response.start(connection)
 
     assert info.value.request_info is request_info
+    response.close()
 
 
 def test_del(session) -> None:

--- a/tests/test_client_session.py
+++ b/tests/test_client_session.py
@@ -30,7 +30,7 @@ def connector(loop):
     proto = mock.Mock()
     conn._conns["a"] = [(proto, 123)]
     yield conn
-    conn.close()
+    loop.run_until_complete(conn.close())
 
 
 @pytest.fixture
@@ -292,7 +292,7 @@ async def test_connector(create_session, loop, mocker) -> None:
 
     await session.close()
     assert connector.close.called
-    connector.close()
+    await connector.close()
 
 
 async def test_create_connector(create_session, loop, mocker) -> None:
@@ -314,7 +314,6 @@ def test_connector_loop(loop) -> None:
 
         connector = another_loop.run_until_complete(make_connector())
 
-        stack.enter_context(contextlib.closing(connector))
         with pytest.raises(RuntimeError) as ctx:
 
             async def make_sess():
@@ -326,8 +325,11 @@ def test_connector_loop(loop) -> None:
             == str(ctx.value).strip()
         )
 
+        # Cannot use `AsyncExitStack` as it's Python 3.7+:
+        another_loop.run_until_complete(connector.close())
 
-def test_detach(session) -> None:
+
+def test_detach(loop, session) -> None:
     conn = session.connector
     try:
         assert not conn.closed
@@ -336,7 +338,7 @@ def test_detach(session) -> None:
         assert session.closed
         assert not conn.closed
     finally:
-        conn.close()
+        loop.run_until_complete(conn.close())
 
 
 async def test_request_closed_session(session) -> None:
@@ -345,10 +347,10 @@ async def test_request_closed_session(session) -> None:
         await session.request("get", "/")
 
 
-def test_close_flag_for_closed_connector(session) -> None:
+def test_close_flag_for_closed_connector(loop, session) -> None:
     conn = session.connector
     assert not session.closed
-    conn.close()
+    loop.run_until_complete(conn.close())
     assert session.closed
 
 
@@ -514,6 +516,7 @@ async def test_cookie_jar_usage(loop, aiohttp_client) -> None:
 async def test_session_default_version(loop) -> None:
     session = aiohttp.ClientSession(loop=loop)
     assert session.version == aiohttp.HttpVersion11
+    await session.close()
 
 
 async def test_session_loop(loop) -> None:
@@ -639,6 +642,8 @@ async def test_request_tracing_exception() -> None:
         )
         assert not on_request_end.called
 
+    await session.close()
+
 
 async def test_request_tracing_interpose_headers(loop, aiohttp_client) -> None:
     async def handler(request):
@@ -681,6 +686,7 @@ async def test_client_session_custom_attr(loop) -> None:
     session = ClientSession(loop=loop)
     with pytest.warns(DeprecationWarning):
         session.custom = None
+    await session.close()
 
 
 async def test_client_session_timeout_args(loop) -> None:
@@ -701,15 +707,20 @@ async def test_client_session_timeout_args(loop) -> None:
             loop=loop, timeout=client.ClientTimeout(total=10 * 60), conn_timeout=30 * 60
         )
 
+    await session1.close()
+    await session2.close()
+
 
 async def test_client_session_timeout_default_args(loop) -> None:
     session1 = ClientSession()
     assert session1.timeout == client.DEFAULT_TIMEOUT
+    await session1.close()
 
 
 async def test_client_session_timeout_argument() -> None:
     session = ClientSession(timeout=500)
     assert session.timeout == 500
+    await session.close()
 
 
 async def test_client_session_timeout_zero() -> None:
@@ -724,11 +735,13 @@ async def test_client_session_timeout_zero() -> None:
 async def test_requote_redirect_url_default() -> None:
     session = ClientSession()
     assert session.requote_redirect_url
+    await session.close()
 
 
 async def test_requote_redirect_url_default_disable() -> None:
     session = ClientSession(requote_redirect_url=False)
     assert not session.requote_redirect_url
+    await session.close()
 
 
 async def test_requote_redirect_setter() -> None:
@@ -737,3 +750,4 @@ async def test_requote_redirect_setter() -> None:
     with pytest.warns(DeprecationWarning):
         session.requote_redirect_url = False
     assert not session.requote_redirect_url
+    await session.close()

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -73,6 +73,8 @@ class TestProxy(unittest.TestCase):
             ssl=None,
         )
 
+        conn.close()
+
     @mock.patch("aiohttp.connector.ClientRequest")
     def test_proxy_headers(self, ClientRequestMock) -> None:
         req = ClientRequest(
@@ -112,6 +114,8 @@ class TestProxy(unittest.TestCase):
             loop=self.loop,
             ssl=None,
         )
+
+        conn.close()
 
     def test_proxy_auth(self) -> None:
         with self.assertRaises(ValueError) as ctx:

--- a/tests/test_proxy_functional.py
+++ b/tests/test_proxy_functional.py
@@ -164,6 +164,9 @@ async def test_secure_https_proxy_absolute_path(
     await sess.close()
     await conn.close()
 
+    # https://docs.aiohttp.org/en/v3.8.0/client_advanced.html#graceful-shutdown
+    await asyncio.sleep(0.1)
+
 
 @secure_proxy_xfail_under_py310_except_macos(raises=AssertionError)
 @pytest.mark.xfail(

--- a/tests/test_run_app.py
+++ b/tests/test_run_app.py
@@ -646,27 +646,29 @@ web.run_app(app, host=())
 def test_sigint() -> None:
     skip_if_on_windows()
 
-    proc = subprocess.Popen(
-        [sys.executable, "-u", "-c", _script_test_signal], stdout=subprocess.PIPE
-    )
-    for line in proc.stdout:
-        if line.startswith(b"======== Running on"):
-            break
-    proc.send_signal(signal.SIGINT)
-    assert proc.wait() == 0
+    with subprocess.Popen(
+        [sys.executable, "-u", "-c", _script_test_signal],
+        stdout=subprocess.PIPE,
+    ) as proc:
+        for line in proc.stdout:
+            if line.startswith(b"======== Running on"):
+                break
+        proc.send_signal(signal.SIGINT)
+        assert proc.wait() == 0
 
 
 def test_sigterm() -> None:
     skip_if_on_windows()
 
-    proc = subprocess.Popen(
-        [sys.executable, "-u", "-c", _script_test_signal], stdout=subprocess.PIPE
-    )
-    for line in proc.stdout:
-        if line.startswith(b"======== Running on"):
-            break
-    proc.terminate()
-    assert proc.wait() == 0
+    with subprocess.Popen(
+        [sys.executable, "-u", "-c", _script_test_signal],
+        stdout=subprocess.PIPE,
+    ) as proc:
+        for line in proc.stdout:
+            if line.startswith(b"======== Running on"):
+                break
+        proc.terminate()
+        assert proc.wait() == 0
 
 
 def test_startup_cleanup_signals_even_on_failure(patched_loop) -> None:

--- a/tests/test_streams.py
+++ b/tests/test_streams.py
@@ -89,6 +89,12 @@ class TestStreamReader:
 
         assert stream._loop is loop
 
+        # Cleanup, leaks into `test_at_eof` otherwise:
+        loop.stop()
+        loop.run_forever()
+        loop.close()
+        gc.collect()
+
     async def test_at_eof(self) -> None:
         stream = self._make_one()
         assert not stream.at_eof()

--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -1,4 +1,5 @@
 import asyncio
+import gc
 from unittest import mock
 
 import pytest
@@ -48,6 +49,12 @@ def test_set_loop_default_loop() -> None:
         assert app.loop is loop
     asyncio.set_event_loop(None)
 
+    # Cleanup, leaks into `test_app_make_handler_debug_exc[True]` otherwise:
+    loop.stop()
+    loop.run_forever()
+    loop.close()
+    gc.collect()
+
 
 def test_set_loop_with_different_loops() -> None:
     loop = asyncio.new_event_loop()
@@ -58,6 +65,12 @@ def test_set_loop_with_different_loops() -> None:
 
     with pytest.raises(RuntimeError):
         app._set_loop(loop=object())
+
+    # Cleanup, leaks into `test_app_make_handler_debug_exc[True]` otherwise:
+    loop.stop()
+    loop.run_forever()
+    loop.close()
+    gc.collect()
 
 
 @pytest.mark.parametrize("debug", [True, False])

--- a/tests/test_web_functional.py
+++ b/tests/test_web_functional.py
@@ -325,7 +325,8 @@ async def test_post_single_file(aiohttp_client) -> None:
 
     fname = here / "data.unknown_mime_type"
 
-    resp = await client.post("/", data=[fname.open("rb")])
+    with fname.open("rb") as fd:
+        resp = await client.post("/", data=[fd])
     assert 200 == resp.status
 
 
@@ -876,12 +877,15 @@ async def test_response_with_streamer_no_params(aiohttp_client, fname) -> None:
 
 
 async def test_response_with_file(aiohttp_client, fname) -> None:
+    outer_file_descriptor = None
 
     with fname.open("rb") as f:
         data = f.read()
 
     async def handler(request):
-        return web.Response(body=fname.open("rb"))
+        nonlocal outer_file_descriptor
+        outer_file_descriptor = fname.open("rb")
+        return web.Response(body=outer_file_descriptor)
 
     app = web.Application()
     app.router.add_get("/", handler)
@@ -902,15 +906,21 @@ async def test_response_with_file(aiohttp_client, fname) -> None:
     assert resp.headers.get("Content-Length") == str(len(resp_data))
     assert resp.headers.get("Content-Disposition") == expected_content_disposition
 
+    outer_file_descriptor.close()
+
 
 async def test_response_with_file_ctype(aiohttp_client, fname) -> None:
+    outer_file_descriptor = None
 
     with fname.open("rb") as f:
         data = f.read()
 
     async def handler(request):
+        nonlocal outer_file_descriptor
+        outer_file_descriptor = fname.open("rb")
+
         return web.Response(
-            body=fname.open("rb"), headers={"content-type": "text/binary"}
+            body=outer_file_descriptor, headers={"content-type": "text/binary"}
         )
 
     app = web.Application()
@@ -928,14 +938,19 @@ async def test_response_with_file_ctype(aiohttp_client, fname) -> None:
     assert resp.headers.get("Content-Length") == str(len(resp_data))
     assert resp.headers.get("Content-Disposition") == expected_content_disposition
 
+    outer_file_descriptor.close()
+
 
 async def test_response_with_payload_disp(aiohttp_client, fname) -> None:
+    outer_file_descriptor = None
 
     with fname.open("rb") as f:
         data = f.read()
 
     async def handler(request):
-        pl = aiohttp.get_payload(fname.open("rb"))
+        nonlocal outer_file_descriptor
+        outer_file_descriptor = fname.open("rb")
+        pl = aiohttp.get_payload(outer_file_descriptor)
         pl.set_content_disposition("inline", filename="test.txt")
         return web.Response(body=pl, headers={"content-type": "text/binary"})
 
@@ -953,6 +968,8 @@ async def test_response_with_payload_disp(aiohttp_client, fname) -> None:
         resp.headers.get("Content-Disposition")
         == "inline; filename=\"test.txt\"; filename*=utf-8''test.txt"
     )
+
+    outer_file_descriptor.close()
 
 
 async def test_response_with_payload_stringio(aiohttp_client, fname) -> None:
@@ -1566,6 +1583,7 @@ async def test_post_max_client_size(aiohttp_client) -> None:
     assert (
         "Maximum request body size 10 exceeded, " "actual body size 1024" in resp_text
     )
+    data["file"].close()
 
 
 async def test_post_max_client_size_for_file(aiohttp_client) -> None:
@@ -1619,11 +1637,12 @@ async def test_response_with_bodypart_named(aiohttp_client, tmpdir) -> None:
 
     f = tmpdir.join("foobar.txt")
     f.write_text("test", encoding="utf8")
-    data = {"file": open(str(f), "rb")}
-    resp = await client.post("/", data=data)
+    with open(str(f), "rb") as fd:
+        data = {"file": fd}
+        resp = await client.post("/", data=data)
 
-    assert 200 == resp.status
-    body = await resp.read()
+        assert 200 == resp.status
+        body = await resp.read()
     assert body == b"test"
 
     disp = multipart.parse_content_disposition(resp.headers["content-disposition"])
@@ -1701,11 +1720,14 @@ async def test_response_context_manager(aiohttp_server) -> None:
     app = web.Application()
     app.router.add_route("GET", "/", handler)
     server = await aiohttp_server(app)
-    resp = await aiohttp.ClientSession().get(server.make_url("/"))
+    session = aiohttp.ClientSession()
+    resp = await session.get(server.make_url("/"))
     async with resp:
         assert resp.status == 200
         assert resp.connection is None
     assert resp.connection is None
+
+    await session.close()
 
 
 async def test_response_context_manager_error(aiohttp_server) -> None:
@@ -1726,6 +1748,8 @@ async def test_response_context_manager_error(aiohttp_server) -> None:
     assert resp.closed
 
     assert len(session._connector._conns) == 1
+
+    await session.close()
 
 
 async def aiohttp_client_api_context_manager(aiohttp_server):

--- a/tests/test_web_urldispatcher.py
+++ b/tests/test_web_urldispatcher.py
@@ -153,6 +153,7 @@ async def test_access_to_the_file_with_spaces(
     r = await client.get(url)
     assert r.status == 200
     assert (await r.text()) == data
+    await r.release()
 
 
 async def test_access_non_existing_resource(tmp_dir_path, aiohttp_client) -> None:


### PR DESCRIPTION
This change makes sure to release most of the hanging resources
in the lib and tests. They were detected by pytest v6.2+.

PR #5494

(cherry picked from commit 8c82ba11b9e38851d75476d261a1442402cc7592)