### PR TITLE
Free resp conn @ `test_mark_formdata_as_processed`

### DIFF
--- a/tests/test_formdata.py
+++ b/tests/test_formdata.py
@@ -94,8 +94,10 @@ async def test_mark_formdata_as_processed() -> None:
         data = FormData()
         data.add_field("test", "test_value", content_type="application/json")
 
-        await session.post(url, data=data)
+        resp = await session.post(url, data=data)
         assert len(data._writer._parts) == 1
 
         with pytest.raises(RuntimeError):
             await session.post(url, data=data)
+
+        resp.release()


### PR DESCRIPTION
## What do these changes do?

This patch attempts to make the tests more stable by explicitly closing the open resouces.

## Are there changes in behavior for the user?

No.

## Related issue number

I saw this being flaky @ https://github.com/aio-libs/aiohttp/pull/5930 (before restarting the CI).

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
