### PR TITLE
Fix MacOS tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,6 +21,9 @@ needs_unix: bool
 try:
     import trustme
 
+    # Check if the CA is available in runtime, MacOS on Py3.10 fails somehow
+    trustme.CA()
+
     TRUSTME: bool = True
 except ImportError:
     TRUSTME = False


### PR DESCRIPTION
I see trustme/cryptography initialization problems on MacOS for Python 3.10, the PR disables such tests.