### PR TITLE
Revert "[PR #5793/55f02560 backport][3.8] Pass timeout to initial websocket request"

### DIFF
--- a/CHANGES/5793.bugfix
+++ b/CHANGES/5793.bugfix
@@ -1,1 +1,0 @@
-Properly adhere to timeout passed to ws_connect

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -759,7 +759,6 @@ class ClientSession:
             proxy_auth=proxy_auth,
             ssl=ssl,
             proxy_headers=proxy_headers,
-            timeout=timeout,
         )
 
         try:


### PR DESCRIPTION
Reverts aio-libs/aiohttp#6126