### PR TITLE
[backport 3.8] Add socket factory to BaseTestServer (#5845)

### DIFF
--- a/CHANGES/5844.feature
+++ b/CHANGES/5844.feature
@@ -1,0 +1,1 @@
+Added a ``socket_factory`` argument to ``BaseTestServer``.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -415,6 +415,7 @@ nitpick_ignore = [
     ("py:class", "aiohttp.web.MatchedSubAppResource"),  # undocumented
     ("py:attr", "body"),  # undocumented
     ("py:class", "socket.socket"),  # undocumented
+    ("py:class", "socket.AddressFamily"),  # undocumented
     ("py:obj", "logging.DEBUG"),  # undocumented
     ("py:class", "aiohttp.abc.AbstractAsyncAccessLogger"),  # undocumented
     ("py:meth", "aiohttp.web.Response.write_eof"),  # undocumented

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -533,7 +533,7 @@ Test server usually works in conjunction with
 :class:`aiohttp.test_utils.TestClient` which provides handy client methods
 for accessing to the server.
 
-.. class:: BaseTestServer(*, scheme='http', host='127.0.0.1', port=None)
+.. class:: BaseTestServer(*, scheme='http', host='127.0.0.1', port=None, socket_factory=get_port_socket)
 
    Base class for test servers.
 
@@ -546,6 +546,13 @@ for accessing to the server.
       random unused port is used.
 
       .. versionadded:: 3.0
+
+   :param collections.abc.Callable[[str,int,socket.AddressFamily],socket.socket] socket_factory: optional
+                          Factory to create a socket for the server.
+                          By default creates a TCP socket and binds it
+                          to ``host`` and ``port``.
+
+      .. versionadded:: 3.8
 
    .. attribute:: scheme
 
@@ -567,6 +574,12 @@ for accessing to the server.
    .. attribute:: server
 
       :class:`asyncio.AbstractServer` used for managing accepted connections.
+
+   .. attribute:: socket_factory
+
+      *socket_factory* used to create and bind a server socket.
+
+      .. versionadded:: 3.8
 
    .. comethod:: start_server(loop=None, **kwargs)
 


### PR DESCRIPTION
* Add socket factory to BaseTestServer

* Fix the change note style

Co-authored-by: Sviatoslav Sydorenko <wk.cvs.github@sydorenko.org.ua>
(cherry picked from commit 573916f0ebea517bdb6b162bcf74078acb0dfaf9)

<!-- Thank you for your contribution! -->

## What do these changes do?

Add a socket factory to BaseTestServer. It enables using custom sockets in tests.

## Are there changes in behavior for the user?

No

## Related issue number

#5844 

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
