### PR TITLE
[PR #3752/12b8e8c0 backport][3.8] Drop setup.py test support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -80,18 +80,6 @@ def read(f):
     return (here / f).read_text("utf-8").strip()
 
 
-NEEDS_PYTEST = {"pytest", "test"}.intersection(sys.argv)
-pytest_runner = ["pytest-runner"] if NEEDS_PYTEST else []
-
-tests_require = [
-    "pytest",
-    "gunicorn",
-    "pytest-timeout",
-    "async-generator",
-    "pytest-xdist",
-]
-
-
 args = dict(
     name="aiohttp",
     version=version,
@@ -144,8 +132,6 @@ args = dict(
             "cchardet",
         ],
     },
-    tests_require=tests_require,
-    setup_requires=pytest_runner,
     include_package_data=True,
     ext_modules=extensions,
     cmdclass=dict(build_ext=ve_build_ext),


### PR DESCRIPTION
(cherry picked from commit 12b8e8c036df3b7e5ae2b7cff91f20b7c760ee62)

**This is a backport of PR #3752 as merged into master (12b8e8c036df3b7e5ae2b7cff91f20b7c760ee62).**

Closes #3518

We decided to not support `setup.py test` facility anymore.
Use `make test` now.
@webknjaz has a plan to add `tox` configuration -- it would be a nice addition.
`tox` can be used by CI and users who comfortable with this workflow.
For now on my daily aiohttp hacking I personally prefer old good makefiles