### PR TITLE
Fix the regexp in the fragment checking script

### DIFF
--- a/tools/check_changes.py
+++ b/tools/check_changes.py
@@ -5,7 +5,7 @@ import sys
 from pathlib import Path
 
 ALLOWED_SUFFIXES = ["feature", "bugfix", "doc", "removal", "misc"]
-PATTERN = re.compile(r"\d+\.(" + "|".join(ALLOWED_SUFFIXES) + r")(\.d+)?(.rst)?")
+PATTERN = re.compile(r"\d+\.(" + "|".join(ALLOWED_SUFFIXES) + r")(\.\d+)?(\.rst)?")
 
 
 def get_root(script_path):


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

$sbj.

Obligatory comic:
[![](https://imgs.xkcd.com/comics/regex_golf.png)](https://xkcd.com/1313/)

## Are there changes in behavior for the user?

Nope.

## Related issue number

N/A

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
