### PR TITLE
Let concurrency groups cancel in-progress PR jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,10 @@ on:
   schedule:
     - cron:  '0 6 * * *'  # Daily 6AM UTC build
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
 
 jobs:
 


### PR DESCRIPTION
## What do these changes do?

This patch enables GitHub Actions CI/CD workflows to prevent a huge backlog which normally decreases the responsiveness and makes the DX worse.

Borrowed from what the PyCA folks did in their projects:
* https://github.com/pyca/cryptography/pull/6203
* https://github.com/pyca/cryptography/commit/a22a410e

## Are there changes in behavior for the user?

For contributors only. Better CI experience.

## Related issue number

N/A

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
