### PR TITLE
fix(5432): add query parameters in tracing url

### DIFF
--- a/CHANGES/5432.bugfix
+++ b/CHANGES/5432.bugfix
@@ -1,0 +1,1 @@
+Include query parameters from `params` keyword argument in tracing `URL`.

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -403,7 +403,7 @@ class ClientSession:
         ]
 
         for trace in traces:
-            await trace.send_request_start(method, url, headers)
+            await trace.send_request_start(method, url.update_query(params), headers)
 
         timer = tm.timer()
         try:
@@ -519,7 +519,7 @@ class ClientSession:
 
                         for trace in traces:
                             await trace.send_request_redirect(
-                                method, url, headers, resp
+                                method, url.update_query(params), headers, resp
                             )
 
                         redirects += 1
@@ -607,7 +607,9 @@ class ClientSession:
             resp._history = tuple(history)
 
             for trace in traces:
-                await trace.send_request_end(method, url, headers, resp)
+                await trace.send_request_end(
+                    method, url.update_query(params), headers, resp
+                )
             return resp
 
         except BaseException as e:
@@ -618,7 +620,9 @@ class ClientSession:
                 handle = None
 
             for trace in traces:
-                await trace.send_request_exception(method, url, headers, e)
+                await trace.send_request_exception(
+                    method, url.update_query(params), headers, e
+                )
             raise
 
     def ws_connect(

--- a/tests/test_client_session.py
+++ b/tests/test_client_session.py
@@ -6,7 +6,7 @@ import json
 import sys
 from http.cookies import SimpleCookie
 from io import BytesIO
-from typing import Any
+from typing import Any, List
 from unittest import mock
 
 import pytest
@@ -592,6 +592,116 @@ async def test_request_tracing(loop: Any, aiohttp_client: Any) -> None:
         assert gathered_req_body.getvalue() == body.encode("utf8")
         assert gathered_res_body.getvalue() == json.dumps({"ok": True}).encode("utf8")
         assert gathered_req_headers["Custom-Header"] == "Custom value"
+
+
+async def test_request_tracing_url_params(loop: Any, aiohttp_client: Any) -> None:
+    async def root_handler(request):
+        return web.Response()
+
+    async def redirect_handler(request):
+        raise web.HTTPFound("/")
+
+    app = web.Application()
+    app.router.add_get("/", root_handler)
+    app.router.add_get("/redirect", redirect_handler)
+
+    mocks = [mock.Mock(side_effect=make_mocked_coro(mock.Mock())) for _ in range(7)]
+    (
+        on_request_start,
+        on_request_redirect,
+        on_request_end,
+        on_request_exception,
+        on_request_chunk_sent,
+        on_response_chunk_received,
+        on_request_headers_sent,
+    ) = mocks
+
+    trace_config = aiohttp.TraceConfig(
+        trace_config_ctx_factory=mock.Mock(return_value=mock.Mock())
+    )
+    trace_config.on_request_start.append(on_request_start)
+    trace_config.on_request_redirect.append(on_request_redirect)
+    trace_config.on_request_end.append(on_request_end)
+    trace_config.on_request_exception.append(on_request_exception)
+    trace_config.on_request_chunk_sent.append(on_request_chunk_sent)
+    trace_config.on_response_chunk_received.append(on_response_chunk_received)
+    trace_config.on_request_headers_sent.append(on_request_headers_sent)
+
+    session = await aiohttp_client(app, trace_configs=[trace_config])
+
+    def reset_mocks() -> None:
+        for m in mocks:
+            m.reset_mock()
+
+    def to_trace_urls(mock_func: mock.Mock) -> List[URL]:
+        return [call_args.args[-1].url for call_args in mock_func.call_args_list]
+
+    def to_url(path: str) -> URL:
+        return session.make_url(path)
+
+    # Standard
+    for req in [
+        lambda: session.get("/?x=0"),
+        lambda: session.get("/", params=dict(x=0)),
+    ]:
+        reset_mocks()
+        async with req() as resp:
+            await resp.text()
+            assert to_trace_urls(on_request_start) == [to_url("/?x=0")]
+            assert to_trace_urls(on_request_redirect) == []
+            assert to_trace_urls(on_request_end) == [to_url("/?x=0")]
+            assert to_trace_urls(on_request_exception) == []
+            assert to_trace_urls(on_request_chunk_sent) == [to_url("/?x=0")]
+            assert to_trace_urls(on_response_chunk_received) == [to_url("/?x=0")]
+            assert to_trace_urls(on_request_headers_sent) == [to_url("/?x=0")]
+
+    # Redirect
+    for req in [
+        lambda: session.get("/redirect?x=0"),
+        lambda: session.get("/redirect", params=dict(x=0)),
+    ]:
+        reset_mocks()
+        async with req() as resp:
+            await resp.text()
+            assert to_trace_urls(on_request_start) == [to_url("/redirect?x=0")]
+            assert to_trace_urls(on_request_redirect) == [to_url("/redirect?x=0")]
+            assert to_trace_urls(on_request_end) == [to_url("/")]
+            assert to_trace_urls(on_request_exception) == []
+            assert to_trace_urls(on_request_chunk_sent) == [
+                to_url("/redirect?x=0"),
+                to_url("/"),
+            ]
+            assert to_trace_urls(on_response_chunk_received) == [to_url("/")]
+            assert to_trace_urls(on_request_headers_sent) == [
+                to_url("/redirect?x=0"),
+                to_url("/"),
+            ]
+
+    # Exception
+    with mock.patch("aiohttp.client.TCPConnector.connect") as connect_patched:
+        error = Exception()
+        if sys.version_info >= (3, 8, 1):
+            connect_patched.side_effect = error
+        else:
+            loop = asyncio.get_event_loop()
+            f = loop.create_future()
+            f.set_exception(error)
+            connect_patched.return_value = f
+
+        for req in [
+            lambda: session.get("/?x=0"),
+            lambda: session.get("/", params=dict(x=0)),
+        ]:
+            reset_mocks()
+            with contextlib.suppress(Exception):
+                await req()
+            assert to_trace_urls(on_request_start) == [to_url("/?x=0")]
+            assert to_trace_urls(on_request_redirect) == []
+            assert to_trace_urls(on_request_end) == []
+            assert to_trace_urls(on_request_exception) == [to_url("?x=0")]
+            assert to_trace_urls(on_request_chunk_sent) == []
+            assert to_trace_urls(on_response_chunk_received) == []
+            assert to_trace_urls(on_request_headers_sent) == []
 
 
 async def test_request_tracing_exception() -> None:

--- a/tests/test_client_session.py
+++ b/tests/test_client_session.py
@@ -634,7 +634,7 @@ async def test_request_tracing_url_params(loop: Any, aiohttp_client: Any) -> Non
             m.reset_mock()
 
     def to_trace_urls(mock_func: mock.Mock) -> List[URL]:
-        return [call_args.args[-1].url for call_args in mock_func.call_args_list]
+        return [call_args[0][-1].url for call_args in mock_func.call_args_list]
 
     def to_url(path: str) -> URL:
         return session.make_url(path)


### PR DESCRIPTION
## What do these changes do?

Fixes https://github.com/aio-libs/aiohttp/issues/5432

As demonstrated in the issue, when query parameters are passed via `params` keyword argument, some of tracing callback doesn't provide `URL` with those parameters. Note that it's been working correctly if query parameters are passed in an "inline" fashion as in `session.get("/?x=0")` instead of `session.get("/", params=dict(x=0))`.

Currently, as far as I can tell, out of 7 tracing callbacks which give `URL` information:

```
on_request_start
on_request_redirect
on_request_end
on_request_exception
on_request_chunk_sent
on_response_chunk_received
on_request_headers_sent
```

these 4 tracing types don't include query parameters when passed via `params`.

```
on_request_start
on_request_redirect
on_request_end
on_request_exception
```

In this PR, I addressed this issue and added tests to demonstrate all 7 cases working as expected.
If there's something I'm missing, please let me know.
Thanks for the review!

## Are there changes in behavior for the user?

Yes, as explained above.

## Related issue number

- https://github.com/aio-libs/aiohttp/issues/5432

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] (NA) Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
