### PR TITLE
Fix too lax application/json prefix-only matching

### DIFF
--- a/CHANGES/6180.bugfix
+++ b/CHANGES/6180.bugfix
@@ -1,0 +1,1 @@
+Fix JSON media type matching to not accept everything starting with application/json.

--- a/CHANGES/6180.bugfix
+++ b/CHANGES/6180.bugfix
@@ -1,1 +1,1 @@
-Fix JSON media type matching to not accept everything starting with application/json.
+Fixed matching the JSON media type to not accept arbitrary characters after ``application/json`` or the ``+json`` media type suffix.

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -1031,13 +1031,13 @@ class ClientResponse(HeadersMixin):
             await self.read()
 
         if content_type:
-            ctype = self.headers.get(hdrs.CONTENT_TYPE, "").lower()
-            if not is_expected_content_type(ctype, content_type):
+            if not is_expected_content_type(self.content_type, content_type):
                 raise ContentTypeError(
                     self.request_info,
                     self.history,
                     message=(
-                        "Attempt to decode JSON with " "unexpected mimetype: %s" % ctype
+                        "Attempt to decode JSON with "
+                        "unexpected mimetype: %s" % self.content_type
                     ),
                     headers=self.headers,
                 )

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -425,6 +425,7 @@ def is_expected_content_type(
 ) -> bool:
     """Checks if received content type is processable as an expected one.
 
+
     Both arguments should be given without parameters.
     """
     if expected_content_type == "application/json":

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -124,9 +124,7 @@ else:
         return asyncio.iscoroutinefunction(func)
 
 
-json_re = re.compile(
-    r"(?:application/|[\w.-]+/[\w.+-]+?\+)json(?:\s*;.*)?$", re.IGNORECASE
-)
+json_re = re.compile(r"(?:application/|[\w.-]+/[\w.+-]+?\+)json$", re.IGNORECASE)
 
 
 class BasicAuth(namedtuple("BasicAuth", ["login", "password", "encoding"])):
@@ -425,6 +423,9 @@ def content_disposition_header(
 def is_expected_content_type(
     response_content_type: str, expected_content_type: str
 ) -> bool:
+    """Checks if received content type is processable as an expected one.
+    Both arguments should be given without parameters.
+    """
     if expected_content_type == "application/json":
         return json_re.match(response_content_type) is not None
     return expected_content_type in response_content_type

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -124,7 +124,9 @@ else:
         return asyncio.iscoroutinefunction(func)
 
 
-json_re = re.compile(r"(?:application/|[\w.-]+/[\w.+-]+?\+)json", re.IGNORECASE)
+json_re = re.compile(
+    r"(?:application/|[\w.-]+/[\w.+-]+?\+)json(?:\s*;.*)?$", re.IGNORECASE
+)
 
 
 class BasicAuth(namedtuple("BasicAuth", ["login", "password", "encoding"])):

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -424,6 +424,7 @@ def is_expected_content_type(
     response_content_type: str, expected_content_type: str
 ) -> bool:
     """Checks if received content type is processable as an expected one.
+
     Both arguments should be given without parameters.
     """
     if expected_content_type == "application/json":

--- a/aiohttp/web_request.py
+++ b/aiohttp/web_request.py
@@ -661,11 +661,11 @@ class BaseRequest(MutableMapping[str, Any], HeadersMixin):
         """Return BODY as JSON."""
         body = await self.text()
         if content_type:
-            ctype = self.headers.get(hdrs.CONTENT_TYPE, "").lower()
-            if not is_expected_content_type(ctype, content_type):
+            if not is_expected_content_type(self.content_type, content_type):
                 raise HTTPBadRequest(
                     text=(
-                        "Attempt to decode JSON with " "unexpected mimetype: %s" % ctype
+                        "Attempt to decode JSON with "
+                        "unexpected mimetype: %s" % self.content_type
                     )
                 )
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -789,6 +789,14 @@ def test_is_expected_content_type_json_non_lowercase():
     )
 
 
+def test_is_expected_content_type_json_with_charset():
+    expected_ct = "application/json"
+    response_ct = "application/json; charset=UTF-8"
+    assert is_expected_content_type(
+        response_content_type=response_ct, expected_content_type=expected_ct
+    )
+
+
 def test_is_expected_content_type_json_match_not_just_prefix():
     expected_ct = "application/json"
     response_ct = "application/json-seq"

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -798,9 +798,12 @@ def test_is_expected_content_type_json_non_lowercase():
     ids=("with-charset", "non-plus-suffix-should-not-match"),
 )
 def test_is_expected_content_type_json(expected_ct, response_ct, should_match):
-    assert is_expected_content_type(
-        response_content_type=response_ct, expected_content_type=expected_ct
-    ) is should_match
+    assert (
+        is_expected_content_type(
+            response_content_type=response_ct, expected_content_type=expected_ct
+        )
+        is should_match
+    )
 
 
 def test_is_expected_content_type_non_json_match_exact():

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -789,20 +789,18 @@ def test_is_expected_content_type_json_non_lowercase():
     )
 
 
-def test_is_expected_content_type_json_with_charset():
-    expected_ct = "application/json"
-    response_ct = "application/json; charset=UTF-8"
+@pytest.mark.paratetrize(
+    ("expected_ct", "response_ct", "should_match"),
+    (
+        ("application/json", "application/json; charset=UTF-8", True),
+        ("application/json", "application/json-seq", False),
+    ),
+    ids=("with-charset", "non-plus-suffix-should-not-match"),
+)
+def test_is_expected_content_type_json(expected_ct, response_ct, should_match):
     assert is_expected_content_type(
         response_content_type=response_ct, expected_content_type=expected_ct
-    )
-
-
-def test_is_expected_content_type_json_match_not_just_prefix():
-    expected_ct = "application/json"
-    response_ct = "application/json-seq"
-    assert not is_expected_content_type(
-        response_content_type=response_ct, expected_content_type=expected_ct
-    )
+    ) is should_match
 
 
 def test_is_expected_content_type_non_json_match_exact():

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -789,20 +789,11 @@ def test_is_expected_content_type_json_non_lowercase():
     )
 
 
-@pytest.mark.paratetrize(
-    ("expected_ct", "response_ct", "should_match"),
-    (
-        ("application/json", "application/json; charset=UTF-8", True),
-        ("application/json", "application/json-seq", False),
-    ),
-    ids=("with-charset", "non-plus-suffix-should-not-match"),
-)
-def test_is_expected_content_type_json(expected_ct, response_ct, should_match):
-    assert (
-        is_expected_content_type(
-            response_content_type=response_ct, expected_content_type=expected_ct
-        )
-        is should_match
+def test_is_expected_content_type_json_trailing_chars():
+    expected_ct = "application/json"
+    response_ct = "application/json-seq"
+    assert not is_expected_content_type(
+        response_content_type=response_ct, expected_content_type=expected_ct
     )
 
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -789,6 +789,14 @@ def test_is_expected_content_type_json_non_lowercase():
     )
 
 
+def test_is_expected_content_type_json_match_not_just_prefix():
+    expected_ct = "application/json"
+    response_ct = "application/json-seq"
+    assert not is_expected_content_type(
+        response_content_type=response_ct, expected_content_type=expected_ct
+    )
+
+
 def test_is_expected_content_type_non_json_match_exact():
     expected_ct = "text/javascript"
     response_ct = "text/javascript"


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

Fix too lax application/json matching.

For example, `application/jsonfoo` or [`application/json-seq`](https://www.iana.org/assignments/media-types/application/json-seq) should not be treated as valid for JSON.

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

Fixes https://github.com/aio-libs/aiohttp/issues/5896

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
