### PR TITLE
Make JSON media type matching case insensitive

### DIFF
--- a/CHANGES/6181.bugfix
+++ b/CHANGES/6181.bugfix
@@ -1,0 +1,1 @@
+Make JSON media type matching case insensitive per RFC 2045.

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -124,7 +124,7 @@ else:
         return asyncio.iscoroutinefunction(func)
 
 
-json_re = re.compile(r"(?:application/|[\w.-]+/[\w.+-]+?\+)json")
+json_re = re.compile(r"(?:application/|[\w.-]+/[\w.+-]+?\+)json", re.IGNORECASE)
 
 
 class BasicAuth(namedtuple("BasicAuth", ["login", "password", "encoding"])):

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -747,6 +747,15 @@ def test_is_expected_content_type_non_application_json_private_suffix():
     )
 
 
+def test_is_expected_content_type_json_non_lowercase():
+    """Per RFC 2045, media type matching is case insensitive."""
+    expected_ct = "application/json"
+    response_ct = "Application/JSON"
+    assert is_expected_content_type(
+        response_content_type=response_ct, expected_content_type=expected_ct
+    )
+
+
 def test_is_expected_content_type_non_json_match_exact():
     expected_ct = "text/javascript"
     response_ct = "text/javascript"


### PR DESCRIPTION


<!-- Thank you for your contribution! -->

## What do these changes do?

Per RFC 2045, section 2 and appendix A, make JSON media type matching case insensitive.

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
