### PR TITLE
[PR #4661/50753eac backport][3.8] Support websocket proxies configured via environment variables

### DIFF
--- a/CHANGES/4648.bugfix
+++ b/CHANGES/4648.bugfix
@@ -1,0 +1,1 @@
+Fix supporting WebSockets proxies configured via environment variables.

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -240,14 +240,20 @@ class ProxyInfo:
 
 
 def proxies_from_env() -> Dict[str, ProxyInfo]:
-    proxy_urls = {k: URL(v) for k, v in getproxies().items() if k in ("http", "https")}
+    proxy_urls = {
+        k: URL(v)
+        for k, v in getproxies().items()
+        if k in ("http", "https", "ws", "wss")
+    }
     netrc_obj = netrc_from_env()
     stripped = {k: strip_auth_from_url(v) for k, v in proxy_urls.items()}
     ret = {}
     for proto, val in stripped.items():
         proxy, auth = val
-        if proxy.scheme == "https":
-            client_logger.warning("HTTPS proxies %s are not supported, ignoring", proxy)
+        if proxy.scheme in ("https", "wss"):
+            client_logger.warning(
+                "%s proxies %s are not supported, ignoring", proxy.scheme.upper(), proxy
+            )
             continue
         if netrc_obj and auth is None:
             auth_from_netrc = None

--- a/docs/client_advanced.rst
+++ b/docs/client_advanced.rst
@@ -555,12 +555,16 @@ Contrary to the ``requests`` library, it won't read environment
 variables by default. But you can do so by passing
 ``trust_env=True`` into :class:`aiohttp.ClientSession`
 constructor for extracting proxy configuration from
-*HTTP_PROXY* or *HTTPS_PROXY* *environment variables* (both are case
-insensitive)::
+*HTTP_PROXY*, *HTTPS_PROXY*, *WS_PROXY* or *WSS_PROXY* *environment
+variables* (all are case insensitive)::
 
    async with aiohttp.ClientSession(trust_env=True) as session:
        async with session.get("http://python.org") as resp:
            print(resp.status)
+
+.. versionadded:: 3.8
+
+   *WS_PROXY* and *WSS_PROXY* are supported since aiohttp v3.8.
 
 Proxy credentials are given from ``~/.netrc`` file if present (see
 :class:`aiohttp.ClientSession` for more details).

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -462,32 +462,26 @@ def test_set_content_disposition_bad_param() -> None:
 # --------------------- proxies_from_env ------------------------------
 
 
-def test_proxies_from_env_http(mocker) -> None:
+@pytest.mark.parametrize("protocol", ["http", "https", "ws", "wss"])
+def test_proxies_from_env(monkeypatch, protocol) -> None:
     url = URL("http://aiohttp.io/path")
-    mocker.patch.dict(os.environ, {"http_proxy": str(url)})
+    monkeypatch.setenv(protocol + "_proxy", str(url))
     ret = helpers.proxies_from_env()
-    assert ret.keys() == {"http"}
-    assert ret["http"].proxy == url
-    assert ret["http"].proxy_auth is None
+    assert ret.keys() == {protocol}
+    assert ret[protocol].proxy == url
+    assert ret[protocol].proxy_auth is None
 
 
-def test_proxies_from_env_http_proxy_for_https_proto(mocker) -> None:
-    url = URL("http://aiohttp.io/path")
-    mocker.patch.dict(os.environ, {"https_proxy": str(url)})
-    ret = helpers.proxies_from_env()
-    assert ret.keys() == {"https"}
-    assert ret["https"].proxy == url
-    assert ret["https"].proxy_auth is None
-
-
-def test_proxies_from_env_https_proxy_skipped(mocker) -> None:
-    url = URL("https://aiohttp.io/path")
-    mocker.patch.dict(os.environ, {"https_proxy": str(url)})
-    log = mocker.patch("aiohttp.log.client_logger.warning")
+@pytest.mark.parametrize("protocol", ["https", "wss"])
+def test_proxies_from_env_skipped(monkeypatch, caplog, protocol) -> None:
+    url = URL(protocol + "://aiohttp.io/path")
+    monkeypatch.setenv(protocol + "_proxy", str(url))
     assert helpers.proxies_from_env() == {}
-    log.assert_called_with(
-        "HTTPS proxies %s are not supported, ignoring", URL("https://aiohttp.io/path")
+    assert len(caplog.records) == 1
+    log_message = "{proto!s} proxies {url!s} are not supported, ignoring".format(
+        proto=protocol.upper(), url=url
     )
+    assert caplog.record_tuples == [("aiohttp.client", 30, log_message)]
 
 
 def test_proxies_from_env_http_with_auth(mocker) -> None:


### PR DESCRIPTION
**This is a backport of PR #4661 as merged into master (50753eace15da24a9fb9774bcfcaa1dc7650164e).**

PR #4661

Resolves #4648

Co-authored-by: Sviatoslav Sydorenko <wk.cvs.github@sydorenko.org.ua>
(cherry picked from commit 50753eace15da24a9fb9774bcfcaa1dc7650164e)

## What do these changes do?

Fixes a problem with the non-working configuration of the proxy
for wss (when a proxy URL was set via env var).

## Are there changes in behavior for the user?

Working proxy

## Related issue number

Resolves #4648

## Checklist

- [ ] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names. 
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."