### PR TITLE
Fix setup.cfg not to install "examples" top-level package

### DIFF
--- a/CHANGES/6189.bugfix
+++ b/CHANGES/6189.bugfix
@@ -1,0 +1,1 @@
+Do not install "examples" as a top-level package.

--- a/setup.cfg
+++ b/setup.cfg
@@ -62,6 +62,10 @@ speedups =
   Brotli
   cchardet
 
+[options.packages.find]
+exclude =
+  examples
+
 [options.package_data]
 # Ref:
 # https://setuptools.readthedocs.io/en/latest/setuptools.html#options


### PR DESCRIPTION
## What do these changes do?

They fix `setup.cfg` to not to install `examples` as top-level packages.

## Are there changes in behavior for the user?

No.

## Related issue number

n/a

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
