### PR TITLE
Fix resolving IPv6-only hosts

### DIFF
--- a/CHANGES/6195.bugfix
+++ b/CHANGES/6195.bugfix
@@ -1,0 +1,1 @@
+Fix the threaded dns resolver skip the correct dns response when connecting a IPv6-only host.

--- a/aiohttp/resolver.py
+++ b/aiohttp/resolver.py
@@ -37,9 +37,10 @@ class ThreadedResolver(AbstractResolver):
 
         hosts = []
         for family, _, proto, _, address in infos:
-            if family == socket.AF_INET6:
-                if not (socket.has_ipv6 and address[3]):  # type: ignore[misc]
-                    continue
+            if family == socket.AF_INET6 and not socket.has_ipv6:
+                continue
+
+            if family == socket.AF_INET6 and address[3]:  # type: ignore[misc]
                 # This is essential for link-local IPv6 addresses.
                 # LL IPv6 is a VERY rare case. Strictly speaking, we should use
                 # getnameinfo() unconditionally, but performance makes sense.

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -143,6 +143,29 @@ async def test_threaded_negative_lookup_with_unknown_result() -> None:
     assert len(res) == 0
 
 
+async def test_threaded_resolver_ipv6_only_host() -> None:
+    loop = Mock()
+
+    async def ipv6_addrinfo(*args: Any, **kwargs: Any) -> List[Any]:
+        return [
+            (
+                socket.AF_INET6,
+                socket.SOCK_STREAM,
+                6,
+                "",
+                ("2404:6800:4004:819::200", 443, 0, 0),
+            )
+        ]
+
+    loop.getaddrinfo = ipv6_addrinfo
+    resolver = ThreadedResolver()
+    resolver._loop = loop
+    res = await resolver.resolve("https://ipv6.google.com")
+    assert len(res) == 1
+    assert res[0]["hostname"] == "https://ipv6.google.com"
+    assert res[0]["host"] == "2404:6800:4004:819::200"
+
+
 async def test_close_for_threaded_resolver(loop: Any) -> None:
     resolver = ThreadedResolver()
     await resolver.close()


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Fix the threaded dns resolver skip the correct dns response when connecting a IPv6-only host.

It will resolve #6195 .

## Are there changes in behavior for the user?

No.

## Related issue number

#6195 

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
