### PR TITLE
Added "strategy" argument to StreamResponse.enable_compression() method

### DIFF
--- a/CHANGES/6256.feature
+++ b/CHANGES/6256.feature
@@ -1,0 +1,9 @@
+Added `strategy` argument to `StreamResponse.enable_compression()` method
+The end users can significantly speed up compression using this parameter.
+Example of usage:
+```
+async def get_png(request):
+    response = web.FileResponse("./content.png")
+    response.enable_compression(strategy=zlib.Z_RLE)
+    return response
+```

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -183,8 +183,8 @@ Kevin Samuel
 Kimmo Parviainen-Jalanko
 Kirill Klenov
 Kirill Malovitsa
-Konstantin Valetov
 Konstantin Shutkin
+Konstantin Valetov
 Krzysztof Blazewicz
 Kyrylo Perevozchikov
 Kyungmin Lee

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -184,6 +184,7 @@ Kimmo Parviainen-Jalanko
 Kirill Klenov
 Kirill Malovitsa
 Konstantin Valetov
+Konstantin Shutkin
 Krzysztof Blazewicz
 Kyrylo Perevozchikov
 Kyungmin Lee

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -656,7 +656,7 @@ StreamResponse
 
       .. seealso:: :meth:`enable_compression`
 
-   .. method:: enable_compression(force=None)
+   .. method:: enable_compression(force=None, strategy=zlib.Z_DEFAULT_STRATEGY)
 
       Enable compression.
 
@@ -665,6 +665,11 @@ StreamResponse
 
       *Accept-Encoding* is not checked if *force* is set to a
       :class:`ContentCoding`.
+
+      *strategy* means zlib compression strategy.
+      Possible values are zlib.Z_DEFAULT_STRATEGY,
+      zlib.Z_FILTERED, zlib.Z_HUFFMAN_ONLY, zlib.Z_RLE and zlib.Z_FIXED.
+
 
       .. seealso:: :attr:`compression`
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

This PR adds "strategy" argument to StreamResponse.enable_compression() method
The end users can significantly speed up compression using this parameter.
Example of usage:
```
async def get_png(request):
    response = web.FileResponse("./content.png")
    response.enable_compression(strategy=zlib.Z_RLE)
    return response
```

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
