### PR TITLE
docs: Fix statement about `setUpAsync()` and `tearDownAsync()`

### DIFF
--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -369,17 +369,33 @@ functionality, the AioHTTPTestCase is provided::
 
     .. comethod:: setUpAsync()
 
-       This async method do nothing by default and can be overridden to execute
-       asynchronous code during the ``setUp`` stage of the ``TestCase``.
+       This async method can be overridden to execute asynchronous code during
+       the ``setUp`` stage of the ``TestCase``::
+
+           async def setUpAsync(self):
+               await super().setUpAsync()
+               await foo()
 
        .. versionadded:: 2.3
+
+       .. versionchanged:: 3.8
+
+          ``await super().setUpAsync()`` call is required.
 
     .. comethod:: tearDownAsync()
 
-       This async method do nothing by default and can be overridden to execute
-       asynchronous code during the ``tearDown`` stage of the ``TestCase``.
+       This async method can be overridden to execute asynchronous code during
+       the ``tearDown`` stage of the ``TestCase``::
+
+           async def tearDownAsync(self):
+               await super().tearDownAsync()
+               await foo()
 
        .. versionadded:: 2.3
+
+       .. versionchanged:: 3.8
+
+          ``await super().tearDownAsync()`` call is required.
 
     .. method:: setUp()
 


### PR DESCRIPTION
Since https://github.com/aio-libs/aiohttp/pull/4732, it's wrong to says that
`setUpAsync()` and `tearDownAsync()` do nothing and can be overridden without
calling `super.setUpAsync()` and `super.tearDownAsync()`.

## What do these changes do?

Fix documentation

## Are there changes in behavior for the user?

No

## Related issue number

None

## Checklist

Only docs.

----

Remark:
My rst preview wasn't working, I hope there is no rst mistakes.
