### PR TITLE
Ignore protocol exceptions after it is closed

### DIFF
--- a/CHANGES/4526.bugfix
+++ b/CHANGES/4526.bugfix
@@ -1,0 +1,1 @@
+Ignore protocol exceptions after it is closed.

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -45,7 +45,7 @@ from .client_exceptions import (
 )
 from .client_proto import ResponseHandler
 from .client_reqrep import SSL_ALLOWED_TYPES, ClientRequest, Fingerprint
-from .helpers import _SENTINEL, ceil_timeout, is_ip_address, sentinel
+from .helpers import _SENTINEL, ceil_timeout, is_ip_address, sentinel, set_result
 from .http import RESPONSES
 from .locks import EventResultOrError
 from .resolver import DefaultResolver
@@ -628,6 +628,9 @@ class BaseConnector:
         if should_close or protocol.should_close:
             transport = protocol.transport
             protocol.close()
+            # Ignore the following protocol exceptions
+            # See PR #6321
+            set_result(protocol.closed, None)
 
             if key.is_ssl and not self._cleanup_closed_disabled:
                 self._cleanup_closed_transports.append(transport)

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -628,7 +628,7 @@ class BaseConnector:
         if should_close or protocol.should_close:
             transport = protocol.transport
             protocol.close()
-            # Ignore the following protocol exceptions
+            # TODO: Remove once fixed: https://bugs.python.org/issue39951
             # See PR #6321
             set_result(protocol.closed, None)
 

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -508,6 +508,14 @@ async def test_release_close(key: Any) -> None:
     assert proto.close.called
 
 
+async def test_release_proto_closed_future(loop: Any, key: Any):
+    conn = aiohttp.BaseConnector()
+    protocol = mock.Mock(should_close=True, closed=loop.create_future())
+    conn._release(key, protocol)
+    # See PR #6321
+    assert protocol.closed.result() is None
+
+
 async def test__drop_acquire_per_host1(loop: Any) -> None:
     conn = aiohttp.BaseConnector()
     conn._drop_acquired_per_host(123, 456)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## Issue

I've recently started to experience strange ssl exceptions with `aiohttp 4+` (master branch) with the following message:
```
Future exception was never retrieved
future: <Future finished exception=SSLError(1, '[SSL: APPLICATION_DATA_AFTER_CLOSE_NOTIFY] application data after close notify (_ssl.c:2756)') created at /usr/lib/python3.9/asyncio/base_events.py:424>
source_traceback: 
 ...
  File "/usr/lib/python3.9/asyncio/base_events.py", line 1081, in create_connection
    transport, protocol = await self._create_connection_transport(
  File "/usr/lib/python3.9/asyncio/base_events.py", line 1099, in _create_connection_transport
    protocol = protocol_factory()
  File "/home/s/python/aiohttp/aiohttp/client_proto.py", line 39, in __init__
    self.closed = self._loop.create_future()  # type: asyncio.Future[None]
  File "/usr/lib/python3.9/asyncio/base_events.py", line 424, in create_future
    return futures.Future(loop=self)
Traceback (most recent call last):
  File "/usr/lib/python3.9/asyncio/sslproto.py", line 528, in data_received
    ssldata, appdata = self._sslpipe.feed_ssldata(data)
  File "/usr/lib/python3.9/asyncio/sslproto.py", line 206, in feed_ssldata
    self._sslobj.unwrap()
  File "/usr/lib/python3.9/ssl.py", line 948, in unwrap
    return self._sslobj.shutdown()
ssl.SSLError: [SSL: APPLICATION_DATA_AFTER_CLOSE_NOTIFY] application data after close notify (_ssl.c:2756
```
## Reproducer
Code to reproduce the error.
```
import asyncio
import aiohttp

async def main():

    async with aiohttp.ClientSession() as session:
        async with session.get(f'http://drive.google.com') as resp:
            print(resp.status)

if __name__ == '__main__':
    asyncio.run(main(), debug=True)
```

## Description

After some digging I found out a related issue in python bug tracker:
https://bugs.python.org/issue39951

It describes possible scenario for this type of SSL exception to happen:
* client closes the ssl connection and sends `close notify`.
* however server sends some data before receiving that `close notify`.
* client receives the data, but the connection is already closed, thus SSL exception.

In `aiohttp` this exception happens when `BaseConnector._release` is called with `should_close=True`
https://github.com/aio-libs/aiohttp/blob/d149eff62e1e110d2eafac8a79219dd2e56b8581/aiohttp/connector.py#L628-L633

After execution of this branch `protocol` is on its way to be removed by GC. But if the `protocol.connection_lost` is called with exception **before** the removal (which is exactly what is happening) the `protocol.closed` future will store this exception.
https://github.com/aio-libs/aiohttp/blob/d149eff62e1e110d2eafac8a79219dd2e56b8581/aiohttp/client_proto.py#L73-L79

During the removal of the `protocol` object, the following exception will be produced: `Future exception was never retrieved`.

## Solution
I solved it by setting the result of `self.closed` to `None` explicitly during the `_release` call with `should_close=True`.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Fixes #4526 

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
