### PR TITLE
Add an argument to override request body size

### DIFF
--- a/CHANGES/5704.feature
+++ b/CHANGES/5704.feature
@@ -1,1 +1,1 @@
-A new argument `client_max_size` was added to `BaseRequest.clone` method to allow overriding the request body size -- :user:`anesabml`.
+A new argument ``client_max_size`` was added to ``BaseRequest.clone`` method to allow overriding the request body size -- :user:`anesabml`.

--- a/CHANGES/5704.feature
+++ b/CHANGES/5704.feature
@@ -1,0 +1,1 @@
+A new argument `client_max_size` was added to `BaseRequest.clone` method to allow overriding the request body size -- :user:`anesabml`.

--- a/aiohttp/web_request.py
+++ b/aiohttp/web_request.py
@@ -205,6 +205,7 @@ class BaseRequest(MutableMapping[str, Any], HeadersMixin):
         scheme: Union[str, _SENTINEL] = sentinel,
         host: Union[str, _SENTINEL] = sentinel,
         remote: Union[str, _SENTINEL] = sentinel,
+        client_max_size: int = sentinel,
     ) -> "BaseRequest":
         """Clone itself with replacement some attributes.
 
@@ -239,6 +240,8 @@ class BaseRequest(MutableMapping[str, Any], HeadersMixin):
             kwargs["host"] = host
         if remote is not sentinel:
             kwargs["remote"] = remote
+        if client_max_size is sentinel:
+            client_max_size = self._client_max_size
 
         return self.__class__(
             message,
@@ -247,7 +250,7 @@ class BaseRequest(MutableMapping[str, Any], HeadersMixin):
             self._payload_writer,
             self._task,
             self._loop,
-            client_max_size=self._client_max_size,
+            client_max_size=client_max_size,
             state=self._state.copy(),
             **kwargs,
         )
@@ -269,6 +272,10 @@ class BaseRequest(MutableMapping[str, Any], HeadersMixin):
     @property
     def writer(self) -> AbstractStreamWriter:
         return self._payload_writer
+
+    @property
+    def client_max_size(self) -> int:
+        return self._client_max_size
 
     @reify
     def rel_url(self) -> URL:
@@ -852,6 +859,7 @@ class Request(BaseRequest):
         scheme: Union[str, _SENTINEL] = sentinel,
         host: Union[str, _SENTINEL] = sentinel,
         remote: Union[str, _SENTINEL] = sentinel,
+        client_max_size: int = sentinel,
     ) -> "Request":
         ret = super().clone(
             method=method,
@@ -860,6 +868,7 @@ class Request(BaseRequest):
             scheme=scheme,
             host=host,
             remote=remote,
+            client_max_size=client_max_size,
         )
         new_ret = cast(Request, ret)
         new_ret._match_info = self._match_info

--- a/aiohttp/web_request.py
+++ b/aiohttp/web_request.py
@@ -205,7 +205,7 @@ class BaseRequest(MutableMapping[str, Any], HeadersMixin):
         scheme: Union[str, _SENTINEL] = sentinel,
         host: Union[str, _SENTINEL] = sentinel,
         remote: Union[str, _SENTINEL] = sentinel,
-        client_max_size: int = sentinel,
+        client_max_size: int = 1024 ** 2,
     ) -> "BaseRequest":
         """Clone itself with replacement some attributes.
 
@@ -240,8 +240,6 @@ class BaseRequest(MutableMapping[str, Any], HeadersMixin):
             kwargs["host"] = host
         if remote is not sentinel:
             kwargs["remote"] = remote
-        if client_max_size is sentinel:
-            client_max_size = self._client_max_size
 
         return self.__class__(
             message,

--- a/aiohttp/web_request.py
+++ b/aiohttp/web_request.py
@@ -205,7 +205,7 @@ class BaseRequest(MutableMapping[str, Any], HeadersMixin):
         scheme: Union[str, _SENTINEL] = sentinel,
         host: Union[str, _SENTINEL] = sentinel,
         remote: Union[str, _SENTINEL] = sentinel,
-        client_max_size: int = 1024 ** 2,
+        client_max_size: Union[int, _SENTINEL] = sentinel,
     ) -> "BaseRequest":
         """Clone itself with replacement some attributes.
 
@@ -240,6 +240,8 @@ class BaseRequest(MutableMapping[str, Any], HeadersMixin):
             kwargs["host"] = host
         if remote is not sentinel:
             kwargs["remote"] = remote
+        if client_max_size is sentinel:
+            client_max_size = self._client_max_size
 
         return self.__class__(
             message,
@@ -857,7 +859,7 @@ class Request(BaseRequest):
         scheme: Union[str, _SENTINEL] = sentinel,
         host: Union[str, _SENTINEL] = sentinel,
         remote: Union[str, _SENTINEL] = sentinel,
-        client_max_size: int = sentinel,
+        client_max_size: Union[int, _SENTINEL] = sentinel,
     ) -> "Request":
         ret = super().clone(
             method=method,

--- a/docs/web_advanced.rst
+++ b/docs/web_advanced.rst
@@ -974,9 +974,9 @@ headers too, pushing non-trusted data values.
 That's why *aiohttp server* should setup *forwarded* headers in custom
 middleware in tight conjunction with *reverse proxy configuration*.
 
-For changing :attr:`BaseRequest.scheme` :attr:`BaseRequest.host` and
-:attr:`BaseRequest.remote` the middleware might use
-:meth:`BaseRequest.clone`.
+For changing :attr:`BaseRequest.scheme` :attr:`BaseRequest.host`
+:attr:`BaseRequest.remote` and :attr:`BaseRequest.client_max_size`
+the middleware might use :meth:`BaseRequest.clone`.
 
 .. seealso::
 

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -157,7 +157,7 @@ and :ref:`aiohttp-web-signals` handlers.
 
       Read-only :class:`int` property.
 
-      .. versionchanged:: 4.0
+      .. versionchanged:: 3.8
 
          *Forwarded* and *X-Forwarded-Proto* are not used anymore.
 

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -149,6 +149,23 @@ and :ref:`aiohttp-web-signals` handlers.
 
       .. seealso:: :ref:`aiohttp-web-forwarded-support`
 
+   .. attribute:: client_max_size
+
+      The maximum size of the request body.
+
+      The value could be overridden by :meth:`~BaseRequest.clone`.
+
+      Read-only :class:`int` property.
+
+      .. versionchanged:: 4.0
+
+         *Forwarded* and *X-Forwarded-Proto* are not used anymore.
+
+         Call ``.clone(client_max_size=new_size)`` for setting up the value
+         explicitly.
+
+      .. seealso:: :ref:`aiohttp-web-forwarded-support`
+
    .. attribute:: path_qs
 
       The URL including PATH_INFO and the query string. e.g.,

--- a/tests/test_web_request.py
+++ b/tests/test_web_request.py
@@ -513,6 +513,12 @@ def test_clone_client_max_size() -> None:
     assert req2._client_max_size == 1024
 
 
+def test_clone_override_client_max_size() -> None:
+    req = make_mocked_request("GET", "/path", client_max_size=1024)
+    req2 = req.clone(client_max_size=2048)
+    assert req2.client_max_size == 2048
+
+
 def test_clone_method() -> None:
     req = make_mocked_request("GET", "/path")
     req2 = req.clone(method="POST")


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
A new argument `client_max_size` was added to `BaseRequest.clone` method to allow overriding the request body size.

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->
The new argument adds the ability to customize the request body size for each request.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Resolves #5704

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
