### PR TITLE
Use str.partition() instead of .split() with a limit and a check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
         twine check --strict dist/*
     - name: Making sure that CONTRIBUTORS.txt remains sorted
       run: |
-        LC_ALL=C sort -c CONTRIBUTORS.txt
+        LC_ALL=C sort --check --ignore-case CONTRIBUTORS.txt
 
   gen_llhttp:
     name: Generate llhttp sources

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,6 +49,7 @@ repos:
       ^requirements/constraints[.]txt$
   - id: trailing-whitespace
   - id: file-contents-sorter
+    args: ['--ignore-case']
     files: |
       CONTRIBUTORS.txt|
       docs/spelling_wordlist.txt|

--- a/CHANGES/6345.misc
+++ b/CHANGES/6345.misc
@@ -1,0 +1,1 @@
+Use str.partition() instead of .split() with a limit and a check.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -331,6 +331,7 @@ Willem de Groot
 William Grzybowski
 William S.
 Wilson Ong
+wouter bolsterlee
 Yang Zhou
 Yannick Koechlin
 Yannick Péroux

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -322,23 +322,15 @@ def parse_mimetype(mimetype: str) -> MimeType:
     for item in parts[1:]:
         if not item:
             continue
-        key, value = cast(
-            Tuple[str, str], item.split("=", 1) if "=" in item else (item, "")
-        )
+        key, _, value = item.partition("=")
         params.add(key.lower().strip(), value.strip(' "'))
 
     fulltype = parts[0].strip().lower()
     if fulltype == "*":
         fulltype = "*/*"
 
-    mtype, stype = (
-        cast(Tuple[str, str], fulltype.split("/", 1))
-        if "/" in fulltype
-        else (fulltype, "")
-    )
-    stype, suffix = (
-        cast(Tuple[str, str], stype.split("+", 1)) if "+" in stype else (stype, "")
-    )
+    mtype, _, stype = fulltype.partition("/")
+    stype, _, suffix = stype.partition("+")
 
     return MimeType(
         type=mtype, subtype=stype, suffix=suffix, parameters=MultiDictProxy(params)


### PR DESCRIPTION
It's shorter, more idiomatic, and doesn't need noisy type casting.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
- [x] Add a new news fragment into the `CHANGES` folder
