### PR TITLE
Fix setting branch protection failure in GHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,16 +183,18 @@ jobs:
         fail_ci_if_error: false
 
   check:  # This job does nothing and is only used for the branch protection
+    if: always()
+
     needs:
     - test
 
     runs-on: ubuntu-latest
 
     steps:
-      - name: Report success of the test matrix
-        run: >-
-          print("All's good")
-        shell: python
+    - name: Decide whether the needed jobs succeeded or failed
+      uses: re-actors/alls-green@release/v1
+      with:
+        jobs: ${{ toJSON(needs) }}
 
   pre-deploy:
     name: Pre-Deploy

--- a/CHANGES/6369.misc
+++ b/CHANGES/6369.misc
@@ -1,0 +1,3 @@
+Fixed the CI check used in the branch protection to gate merging PR, now
+broken pull requests from ``Dependabot`` and others are not auto-merged
+silently anymore -- :user:`webknjaz`.


### PR DESCRIPTION
## What do these changes do?

This is necessary to resolve the problem of GitHub treating the
`skipped` `check` job result as an acceptable outcome and merging
broken Dependabot PRs with auto-merge. For example:
https://github.com/aio-libs/aiohttp/pull/6330.

Inspired by:
https://github.com/pyca/cryptography/pull/6512#discussion_r757982569

## Are there changes in behavior for the user?

No, only for the maintainers.

## Related issue number

#6330 (among others)

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
