### PR TITLE
Fix Python 3.11 alpha incompatibilities

### DIFF
--- a/CHANGES/6396.bugfix
+++ b/CHANGES/6396.bugfix
@@ -1,0 +1,1 @@
+Fix Python 3.11 alpha incompatibilities by using Cython 0.29.25

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -59,7 +59,7 @@ cryptography==36.0.0 ; platform_machine != "i686"
     #   -r requirements/test.txt
     #   pyjwt
     #   trustme
-cython==0.29.24
+cython==0.29.25
     # via -r requirements/cython.txt
 distlib==0.3.3
     # via virtualenv

--- a/requirements/cython.txt
+++ b/requirements/cython.txt
@@ -1,3 +1,3 @@
 -r multidict.txt
 -r typing-extensions.txt  # required for parsing aiohttp/hdrs.py by tools/gen.py
-cython==0.29.24
+cython==0.29.25


### PR DESCRIPTION
By using Cython 0.29.25