### PR TITLE
Do not install C sources in binary distributions

### DIFF
--- a/CHANGES/6399.misc
+++ b/CHANGES/6399.misc
@@ -1,0 +1,1 @@
+Do not install C sources with binary distributions.

--- a/setup.cfg
+++ b/setup.cfg
@@ -56,6 +56,11 @@ install_requires =
   frozenlist >= 1.1.1
   aiosignal >= 1.1.2
 
+[options.exclude_package_data]
+* =
+    *.c
+    *.h
+
 [options.extras_require]
 speedups =
   aiodns >= 1.1
@@ -71,7 +76,6 @@ exclude =
 # https://setuptools.readthedocs.io/en/latest/setuptools.html#options
 # (see notes for the asterisk/`*` meaning)
 * =
-#    *.c
     *.so
 
 [pep8]


### PR DESCRIPTION
This does not affect source distributions, and Cython sources (`.pyx`) are
still installed.

## What do these changes do?

<!-- Please give a short brief about these changes. -->
Prevent C sources (`_find_header.c`, `_find_header.h`, `_helpers.c`, `_http_parser.c`, `_http_writer.c`, and `_websocket.c`) from being included in binary distributions such as wheels, without affecting Cython sources (`_cparser.pxd`, `_find_header.pxd`, `_headers.pxi`, `_helpers.pyx`, `_http_parser.pyx`, `_http_writer.pyx`, and `_websocket.pyx`) or source distributions.

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->
Nothing changes except that the binary wheels are much smaller because they do not contain ~1.7MB of C sources.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
Resolves #6399.

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist **This doesn’t seem necessary.**
- [ ] Documentation reflects the changes **No changes seem necessary.**
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
  * **This contribution is trivial, so this doesn’t seem necessary, but I can add it if  desired.**
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
