### PR TITLE
Update return type of Resource.__iter__()

### DIFF
--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -367,7 +367,7 @@ class Resource(AbstractResource):
     def __len__(self) -> int:
         return len(self._routes)
 
-    def __iter__(self) -> Iterator[ResourceRoute]:
+    def __iter__(self) -> Iterator["ResourceRoute"]:
         return iter(self._routes)
 
     # TODO: implement all abstract methods

--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -367,7 +367,7 @@ class Resource(AbstractResource):
     def __len__(self) -> int:
         return len(self._routes)
 
-    def __iter__(self) -> Iterator[AbstractRoute]:
+    def __iter__(self) -> Iterator[ResourceRoute]:
         return iter(self._routes)
 
     # TODO: implement all abstract methods


### PR DESCRIPTION
`_routes` doesn't declare the type as `AbstractRoute`, so we should match it in `__iter__()`.