### PR TITLE
Typo in docs, should mention cchardet

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -51,7 +51,7 @@ This option is highly recommended:
 Installing speedups altogether
 ------------------------------
 
-The following will get you ``aiohttp`` along with :term:`charset-normalizer`,
+The following will get you ``aiohttp`` along with :term:`cchardet`,
 :term:`aiodns` and ``Brotli`` in one bundle. No need to type
 separate commands anymore!
 


### PR DESCRIPTION
Should mention cchardet Instead of charset-normalizer, as cchardet is the one installed with `pip install aiohttp[speedups]`

<!-- Thank you for your contribution! -->

## What do these changes do?

Minor typo fix in the docs