### PR TITLE
Add way to read http response for failed ws connect

### DIFF
--- a/CHANGES/6515.feature
+++ b/CHANGES/6515.feature
@@ -1,0 +1,1 @@
+Add `session.try_ws_connect` method that allows access to ClientResponse in case WS handshake failed.

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -66,6 +66,7 @@ from .client_reqrep import (
 )
 from .client_ws import (
     DEFAULT_WS_CLIENT_TIMEOUT,
+    ClientWebSocketHandshakeResponse,
     ClientWebSocketResponse as ClientWebSocketResponse,
     ClientWSTimeout,
 )
@@ -714,7 +715,97 @@ class ClientSession:
         proxy_headers: Optional[LooseHeaders] = None,
         compress: int = 0,
         max_msg_size: int = 4 * 1024 * 1024,
-    ) -> ClientWebSocketResponse:
+    ) -> "ClientWebSocketResponse":
+        ws_handshake_resp = await self.try_ws_connect(
+            url,
+            method=method,
+            protocols=protocols,
+            timeout=timeout,
+            receive_timeout=receive_timeout,
+            autoclose=autoclose,
+            autoping=autoping,
+            heartbeat=heartbeat,
+            auth=auth,
+            origin=origin,
+            params=params,
+            headers=headers,
+            proxy=proxy,
+            proxy_auth=proxy_auth,
+            ssl=ssl,
+            proxy_headers=proxy_headers,
+            compress=compress,
+            max_msg_size=max_msg_size,
+        )
+        return ws_handshake_resp.upgrade()
+
+    def try_ws_connect(
+        self,
+        url: StrOrURL,
+        *,
+        method: str = hdrs.METH_GET,
+        protocols: Iterable[str] = (),
+        timeout: Union[ClientWSTimeout, float, _SENTINEL, None] = sentinel,
+        receive_timeout: Optional[float] = None,
+        autoclose: bool = True,
+        autoping: bool = True,
+        heartbeat: Optional[float] = None,
+        auth: Optional[BasicAuth] = None,
+        origin: Optional[str] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[LooseHeaders] = None,
+        proxy: Optional[StrOrURL] = None,
+        proxy_auth: Optional[BasicAuth] = None,
+        ssl: Union[SSLContext, bool, None, Fingerprint] = None,
+        proxy_headers: Optional[LooseHeaders] = None,
+        compress: int = 0,
+        max_msg_size: int = 4 * 1024 * 1024,
+    ) -> "_WSTryRequestContextManager":
+        """Initiate websocket connection."""
+        return _WSTryRequestContextManager(
+            self._try_ws_connect(
+                url,
+                method=method,
+                protocols=protocols,
+                timeout=timeout,
+                receive_timeout=receive_timeout,
+                autoclose=autoclose,
+                autoping=autoping,
+                heartbeat=heartbeat,
+                auth=auth,
+                origin=origin,
+                params=params,
+                headers=headers,
+                proxy=proxy,
+                proxy_auth=proxy_auth,
+                ssl=ssl,
+                proxy_headers=proxy_headers,
+                compress=compress,
+                max_msg_size=max_msg_size,
+            )
+        )
+
+    async def _try_ws_connect(
+        self,
+        url: StrOrURL,
+        *,
+        method: str = hdrs.METH_GET,
+        protocols: Iterable[str] = (),
+        timeout: Union[ClientWSTimeout, float, _SENTINEL, None] = sentinel,
+        receive_timeout: Optional[float] = None,
+        autoclose: bool = True,
+        autoping: bool = True,
+        heartbeat: Optional[float] = None,
+        auth: Optional[BasicAuth] = None,
+        origin: Optional[str] = None,
+        params: Optional[Mapping[str, str]] = None,
+        headers: Optional[LooseHeaders] = None,
+        proxy: Optional[StrOrURL] = None,
+        proxy_auth: Optional[BasicAuth] = None,
+        ssl: Union[SSLContext, bool, None, Fingerprint] = None,
+        proxy_headers: Optional[LooseHeaders] = None,
+        compress: int = 0,
+        max_msg_size: int = 4 * 1024 * 1024,
+    ) -> ClientWebSocketHandshakeResponse:
         if timeout is sentinel or timeout is None:
             ws_timeout = DEFAULT_WS_CLIENT_TIMEOUT
         else:
@@ -788,42 +879,54 @@ class ClientSession:
         try:
             # check handshake
             if resp.status != 101:
-                raise WSServerHandshakeError(
-                    resp.request_info,
-                    resp.history,
-                    message="Invalid response status",
-                    status=resp.status,
-                    headers=resp.headers,
+                return ClientWebSocketHandshakeResponse(
+                    error=WSServerHandshakeError(
+                        resp.request_info,
+                        resp.history,
+                        message="Invalid response status",
+                        status=resp.status,
+                        headers=resp.headers,
+                    ),
+                    error_response=resp,
                 )
 
             if resp.headers.get(hdrs.UPGRADE, "").lower() != "websocket":
-                raise WSServerHandshakeError(
-                    resp.request_info,
-                    resp.history,
-                    message="Invalid upgrade header",
-                    status=resp.status,
-                    headers=resp.headers,
+                return ClientWebSocketHandshakeResponse(
+                    error=WSServerHandshakeError(
+                        resp.request_info,
+                        resp.history,
+                        message="Invalid upgrade header",
+                        status=resp.status,
+                        headers=resp.headers,
+                    ),
+                    error_response=resp,
                 )
 
             if resp.headers.get(hdrs.CONNECTION, "").lower() != "upgrade":
-                raise WSServerHandshakeError(
-                    resp.request_info,
-                    resp.history,
-                    message="Invalid connection header",
-                    status=resp.status,
-                    headers=resp.headers,
+                return ClientWebSocketHandshakeResponse(
+                    error=WSServerHandshakeError(
+                        resp.request_info,
+                        resp.history,
+                        message="Invalid connection header",
+                        status=resp.status,
+                        headers=resp.headers,
+                    ),
+                    error_response=resp,
                 )
 
             # key calculation
             r_key = resp.headers.get(hdrs.SEC_WEBSOCKET_ACCEPT, "")
             match = base64.b64encode(hashlib.sha1(sec_key + WS_KEY).digest()).decode()
             if r_key != match:
-                raise WSServerHandshakeError(
-                    resp.request_info,
-                    resp.history,
-                    message="Invalid challenge response",
-                    status=resp.status,
-                    headers=resp.headers,
+                return ClientWebSocketHandshakeResponse(
+                    error=WSServerHandshakeError(
+                        resp.request_info,
+                        resp.history,
+                        message="Invalid challenge response",
+                        status=resp.status,
+                        headers=resp.headers,
+                    ),
+                    error_response=resp,
                 )
 
             # websocket protocol
@@ -847,13 +950,18 @@ class ClientSession:
                     try:
                         compress, notakeover = ws_ext_parse(compress_hdrs)
                     except WSHandshakeError as exc:
-                        raise WSServerHandshakeError(
+                        error = WSServerHandshakeError(
                             resp.request_info,
                             resp.history,
                             message=exc.args[0],
                             status=resp.status,
                             headers=resp.headers,
-                        ) from exc
+                        )
+                        error.__cause__ = exc
+                        return ClientWebSocketHandshakeResponse(
+                            error=error,
+                            error_response=resp,
+                        )
                 else:
                     compress = 0
                     notakeover = False
@@ -879,18 +987,20 @@ class ClientSession:
             resp.close()
             raise
         else:
-            return self._ws_response_class(
-                reader,
-                writer,
-                protocol,
-                resp,
-                ws_timeout,
-                autoclose,
-                autoping,
-                self._loop,
-                heartbeat=heartbeat,
-                compress=compress,
-                client_notakeover=notakeover,
+            return ClientWebSocketHandshakeResponse(
+                ws_response=self._ws_response_class(
+                    reader,
+                    writer,
+                    protocol,
+                    resp,
+                    ws_timeout,
+                    autoclose,
+                    autoping,
+                    self._loop,
+                    heartbeat=heartbeat,
+                    compress=compress,
+                    client_notakeover=notakeover,
+                )
             )
 
     def _prepare_headers(self, headers: Optional[LooseHeaders]) -> "CIMultiDict[str]":
@@ -1125,6 +1235,20 @@ class _RequestContextManager(_BaseRequestContextManager[ClientResponse]):
 
 
 class _WSRequestContextManager(_BaseRequestContextManager[ClientWebSocketResponse]):
+    __slots__ = ()
+
+    async def __aexit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc: Optional[BaseException],
+        tb: Optional[TracebackType],
+    ) -> None:
+        await self._resp.close()
+
+
+class _WSTryRequestContextManager(
+    _BaseRequestContextManager[ClientWebSocketHandshakeResponse]
+):
     __slots__ = ()
 
     async def __aexit__(

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -642,7 +642,7 @@ The client session supports the context manager protocol for self closing.
       :return ClientResponse: a :class:`client response
                               <ClientResponse>` object.
 
-   .. comethod:: ws_connect(url, *, method='GET', \
+   .. comethod:: try_ws_connect(url, *, method='GET', \
                             protocols=(), timeout=10.0,\
                             receive_timeout=None,\
                             auth=None,\
@@ -660,7 +660,7 @@ The client session supports the context manager protocol for self closing.
       :coroutine:
 
       Create a websocket connection. Returns a
-      :class:`ClientWebSocketResponse` object.
+      :class:`ClientWebSocketHandshakeResponse` object.
 
       :param url: Websocket server url, :class:`str` or :class:`~yarl.URL`
 
@@ -783,6 +783,25 @@ The client session supports the context manager protocol for self closing.
                          ``'GET'`` by default.
 
          .. versionadded:: 3.5
+
+   .. comethod:: ws_connect(url, *, **kwargs)
+      :async-with:
+      :coroutine:
+
+      Create a websocket connection. Returns a
+      :class:`ClientWebSocketResponse` object.
+
+      This is shortcut to::
+
+        async with session.try_ws_connect(url, **kwargs) as handshake_resp:
+           resp = handshake_resp.upgrade()
+
+      In order to modify inner
+      :meth:`try_ws_connect<aiohttp.ClientSession.try_ws_connect>`
+      parameters, provide `kwargs`.
+
+      :param url: Request URL, :class:`str` or :class:`~yarl.URL`
+
 
 
    .. comethod:: close()
@@ -1661,6 +1680,34 @@ manually.
 
       :raise TypeError: if message is :const:`~aiohttp.WSMsgType.BINARY`.
       :raise ValueError: if message is not valid JSON.
+
+
+ClientWebSocketHandshakeResponse
+--------------------------------
+
+
+.. class:: ClientWebSocketHandshakeResponse()
+
+   Class for handling client-side websockets handshake result.
+
+   .. method:: upgrade()
+
+      Get a underlying :class:`ClientWebSocketResponse` if handshake
+      was a successful or raise an exception
+
+      :return:  :class:`ClientWebSocketResponse`.
+
+   .. attribute:: error
+
+      Read-only property, :exc:`WSServerHandshakeError` if handshake
+      failed or ``None`` otherwise.
+
+   .. attribute:: error_response
+
+      Read-only property, :class:`ClientResponse` of initial http
+      request if handshake failed or ``None`` otherwise.
+
+      This property allows to read error response body.
 
 
 Utilities


### PR DESCRIPTION
## What do these changes do?

It adds `session.try_ws_connect` methods that return an intermediate object that allows reading HTTP response body in
cases WS handshake failed.

## Are there changes in behavior for the user?

Old  `session.ws_connect` should continue to work same it did before.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
