### PR TITLE
Recover missing import in circular import test

### DIFF
--- a/tests/test_circular_imports.py
+++ b/tests/test_circular_imports.py
@@ -71,6 +71,6 @@ def test_no_warnings(import_path: str) -> None:
     This is seeking for any import errors including ones caused
     by circular imports.
     """
-    imp_cmd = sys.executable, "-W", "error"
+    imp_cmd = sys.executable, "-W", "error", "-c", f"import {import_path!s}"
 
     subprocess.check_call(imp_cmd)


### PR DESCRIPTION
This corrects the $sbj test by re-adding the import instruction that was lost during copy-paste from other projects to the invocation.