### PR TITLE
Remove overlapping slots and fix broken slots inheritance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,9 +51,12 @@ jobs:
         python -m pip install .
       env:
         AIOHTTP_NO_EXTENSIONS: 1
-    - name: Run linters
+    - name: Run mypy
       run: |
         make mypy
+    - name: Run slotscheck
+      run: |
+        slotscheck -m aiohttp
     - name: Install libenchant-dev
       run: |
         sudo apt install libenchant-dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
         make mypy
     - name: Run slotscheck
       run: |
-        slotscheck -m aiohttp
+        python -m slotscheck -m aiohttp
     - name: Install libenchant-dev
       run: |
         sudo apt install libenchant-dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,10 @@ jobs:
         make mypy
     - name: Run slotscheck
       run: |
-        python -m slotscheck -m aiohttp
+        # Some extra requirements are needed to ensure all modules
+        # can be scanned by slotscheck.
+        pip install -r requirements/base.txt -c requirements/constraints.txt
+        slotscheck -v -m aiohttp
     - name: Install libenchant-dev
       run: |
         sudo apt install libenchant-dev

--- a/CHANGES/6547.bugfix
+++ b/CHANGES/6547.bugfix
@@ -1,2 +1,2 @@
-Remove overlapping slots in :py:class:`~aiohttp.web_protocol.RequestHandler`, 
+Remove overlapping slots in :py:class:`~aiohttp.web_protocol.RequestHandler`,
 fix broken slots inheritance in :py:class:`~aiohttp.web_response.StreamResponse`.

--- a/CHANGES/6547.bugfix
+++ b/CHANGES/6547.bugfix
@@ -1,2 +1,2 @@
-Remove overlapping slots in :py:class:`~aiohttp.web_protocol.RequestHandler`,
-fix broken slots inheritance in :py:class:`~aiohttp.web_response.StreamResponse`.
+Remove overlapping slots in ``RequestHandler``,
+fix broken slots inheritance in :py:class:`~aiohttp.web.StreamResponse`.

--- a/CHANGES/6547.bugfix
+++ b/CHANGES/6547.bugfix
@@ -1,0 +1,2 @@
+Remove overlapping slots in :py:class:`~aiohttp.web_protocol.RequestHandler`, 
+fix broken slots inheritance in :py:class:`~aiohttp.web_response.StreamResponse`.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -46,6 +46,7 @@ Anes Abismail
 Antoine Pietri
 Anton Kasyanov
 Anton Zhdan-Pushkin
+Arie Bovenberg
 Arseny Timoniq
 Artem Yushkovskiy
 Arthur Darcet

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -831,9 +831,15 @@ class ChainMapProxy(Mapping[str, Any]):
 
 
 class CookieMixin:
+    # The `_cookies` slots is not defined here because non-empty slots cannot
+    # be combined with an Exception base class, as is done in HTTPException.
+    # CookieMixin subclasses with slots should
+    # define the `_cookies` slot themselves.
+    __slots__ = ()
+
     def __init__(self) -> None:
         super().__init__()
-        self._cookies: SimpleCookie[str] = SimpleCookie()
+        self._cookies: SimpleCookie[str] = SimpleCookie()  # type: ignore
 
     @property
     def cookies(self) -> "SimpleCookie[str]":

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -833,13 +833,15 @@ class ChainMapProxy(Mapping[str, Any]):
 class CookieMixin:
     # The `_cookies` slots is not defined here because non-empty slots cannot
     # be combined with an Exception base class, as is done in HTTPException.
-    # CookieMixin subclasses with slots should
-    # define the `_cookies` slot themselves.
+    # CookieMixin subclasses with slots should define the `_cookies`
+    # slot themselves.
     __slots__ = ()
 
     def __init__(self) -> None:
         super().__init__()
-        self._cookies: SimpleCookie[str] = SimpleCookie()  # type: ignore
+        # Mypy doesn't like that _cookies isn't in __slots__.
+        # See the comment on this class's __slots__ for why this is OK.
+        self._cookies: SimpleCookie[str] = SimpleCookie()  # type: ignore[misc]
 
     @property
     def cookies(self) -> "SimpleCookie[str]":

--- a/aiohttp/web_protocol.py
+++ b/aiohttp/web_protocol.py
@@ -170,7 +170,6 @@ class RequestHandler(BaseProtocol):
         "_upgrade",
         "_payload_parser",
         "_request_parser",
-        "_reading_paused",
         "logger",
         "access_log",
         "access_logger",

--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -92,6 +92,7 @@ class StreamResponse(BaseClass, HeadersMixin, CookieMixin):
         "_headers",
         "_status",
         "_reason",
+        "_cookies",
         "__weakref__",
     )
 

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -2,3 +2,4 @@
 mypy==0.931; implementation_name=="cpython"
 pre-commit==2.17.0
 pytest==6.2.5
+slotscheck==0.8.0

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -850,8 +850,14 @@ def test_is_expected_content_type_non_json_not_match():
     )
 
 
+# It's necessary to subclass CookieMixin before using it.
+# See the comments on its __slots__.
+class CookieImplementation(helpers.CookieMixin):
+    pass
+
+
 def test_cookies_mixin():
-    sut = helpers.CookieMixin()
+    sut = CookieImplementation()
 
     assert sut.cookies == {}
     assert str(sut.cookies) == ""
@@ -880,7 +886,7 @@ def test_cookies_mixin():
 
 
 def test_cookies_mixin_path():
-    sut = helpers.CookieMixin()
+    sut = CookieImplementation()
 
     assert sut.cookies == {}
 
@@ -914,7 +920,7 @@ def test_cookies_mixin_path():
 
 
 def test_sutonse_cookie__issue_del_cookie():
-    sut = helpers.CookieMixin()
+    sut = CookieImplementation()
 
     assert sut.cookies == {}
     assert str(sut.cookies) == ""
@@ -928,7 +934,7 @@ def test_sutonse_cookie__issue_del_cookie():
 
 
 def test_cookie_set_after_del():
-    sut = helpers.CookieMixin()
+    sut = CookieImplementation()
 
     sut.del_cookie("name")
     sut.set_cookie("name", "val")
@@ -938,7 +944,7 @@ def test_cookie_set_after_del():
 
 
 def test_populate_with_cookies():
-    cookies_mixin = helpers.CookieMixin()
+    cookies_mixin = CookieImplementation()
     cookies_mixin.set_cookie("name", "value")
     headers = CIMultiDict()
 


### PR DESCRIPTION
## What do these changes do?

There were a few `__slots__` related mistakes:

```shell
python -m slotscheck aiohttp -v
ERROR: 'aiohttp.web_protocol:RequestHandler' defines overlapping slots.
       - _reading_paused (aiohttp.base_protocol:BaseProtocol)
ERROR: 'aiohttp.web_response:StreamResponse' has slots but superclass does not.
       - aiohttp.helpers:CookieMixin
```

Fixing the second error was more problematic than it seems. The straightforward solution of adding `__slots__ = ('_cookies', )` was not possible, because this triggered a `TypeError: multiple bases have instance lay-out conflict` in `HTTPException` since non-emptly slots cannot be combined with an `Exception` case class:

```python
>>> class CookieMixin:
...  __slots__ = ('_cookies', )
...
>>> class HTTPException(CookieMixin, Exception):
...  pass
...
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: multiple bases have instance lay-out conflict
```

There are several possible solutions:
1. put empty slots in `CookieMixin`, since it's an abstract class. This is the currently implemented solution.
2. leave the situation as-is. The `__slots__` in `StreamResponse` will be mostly ineffective.
3. remove `__slots__` from `StreamResponse`. They aren't saving memory or preventing `__dict__` from being created. 

## Are there changes in behavior for the user?

`StreamResponse` will no longer have a `__dict__`, so arbitrary attributes cannot be set. This is not documented, so likely not a problem

## Related issue number

No issue. This is a small change.

## Checklist

- [x] I think the code is well written
- [x] ~~Unit tests for the changes exist~~ n/a (see questions below)
- [x] ~~Documentation reflects the changes~~ n/a
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."

## Questions

- regarding tests: probably not needed. I discovered the slots issue with [slotscheck](https://github.com/ariebovenberg/slotscheck), a tool I wrote. Of course, If you like, I can add it to tox/CI as I've done for [instagram/LibCST](https://github.com/Instagram/LibCST/pull/615) and [dry-python/returns](https://github.com/dry-python/returns/pull/1233).
