### PR TITLE
Cleanup after dropping Python 3.6

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,7 +37,7 @@ repos:
   rev: '21.12b0'
   hooks:
     - id: black
-      language_version: python3 # Should be a command that runs python3.6+
+      language_version: python3 # Should be a command that runs python
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: 'v4.1.0'
   hooks:

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -1302,7 +1302,7 @@ class NamedPipeConnector(BaseConnector):
     """Named pipe connector.
 
     Only supported by the proactor event loop.
-    See also: https://docs.python.org/3.7/library/asyncio-eventloop.html
+    See also: https://docs.python.org/3/library/asyncio-eventloop.html
 
     path - Windows named pipe path.
     keepalive_timeout - (optional) Keep-alive timeout.

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -81,9 +81,7 @@ sentinel = _SENTINEL.sentinel
 
 NO_EXTENSIONS: bool = bool(os.environ.get("AIOHTTP_NO_EXTENSIONS"))
 
-# N.B. sys.flags.dev_mode is available on Python 3.7+, use getattr
-# for compatibility with older versions
-DEBUG: bool = getattr(sys.flags, "dev_mode", False) or (
+DEBUG: bool = sys.flags.dev_mode or (
     not sys.flags.ignore_environment and bool(os.environ.get("PYTHONASYNCIODEBUG"))
 )
 

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -79,9 +79,9 @@ _S = TypeVar("_S")
 _SENTINEL = enum.Enum("_SENTINEL", "sentinel")
 sentinel = _SENTINEL.sentinel
 
-NO_EXTENSIONS: bool = bool(os.environ.get("AIOHTTP_NO_EXTENSIONS"))
+NO_EXTENSIONS = bool(os.environ.get("AIOHTTP_NO_EXTENSIONS"))
 
-DEBUG: bool = sys.flags.dev_mode or (
+DEBUG = sys.flags.dev_mode or (
     not sys.flags.ignore_environment and bool(os.environ.get("PYTHONASYNCIODEBUG"))
 )
 

--- a/aiohttp/multipart.py
+++ b/aiohttp/multipart.py
@@ -270,7 +270,6 @@ class BodyPartReader:
         length = self.headers.get(CONTENT_LENGTH, None)
         self._length = int(length) if length is not None else None
         self._read_bytes = 0
-        # TODO: typeing.Deque is not supported by Python 3.5
         self._unread: Deque[bytes] = deque()
         self._prev_chunk: Optional[bytes] = None
         self._content_eof = 0

--- a/aiohttp/streams.py
+++ b/aiohttp/streams.py
@@ -65,19 +65,13 @@ class AsyncStreamReaderMixin:
         return AsyncStreamIterator(self.readline)  # type: ignore[attr-defined]
 
     def iter_chunked(self, n: int) -> AsyncStreamIterator[bytes]:
-        """Returns an asynchronous iterator that yields chunks of size n.
-
-        Python-3.5 available for Python 3.5+ only
-        """
+        """Returns an asynchronous iterator that yields chunks of size n."""
         return AsyncStreamIterator(
             lambda: self.read(n)  # type: ignore[attr-defined,no-any-return]
         )
 
     def iter_any(self) -> AsyncStreamIterator[bytes]:
-        """Yield all available data as soon as it is received.
-
-        Python-3.5 available for Python 3.5+ only
-        """
+        """Yield all available data as soon as it is received."""
         return AsyncStreamIterator(self.readany)  # type: ignore[attr-defined]
 
     def iter_chunks(self) -> ChunkTupleAsyncStreamIterator:
@@ -85,8 +79,6 @@ class AsyncStreamReaderMixin:
 
         The yielded objects are tuples
         of (bytes, bool) as returned by the StreamReader.readchunk method.
-
-        Python-3.5 available for Python 3.5+ only
         """
         return ChunkTupleAsyncStreamIterator(self)  # type: ignore[arg-type]
 

--- a/aiohttp/web_fileresponse.py
+++ b/aiohttp/web_fileresponse.py
@@ -2,7 +2,6 @@ import asyncio
 import mimetypes
 import os
 import pathlib
-import sys
 from typing import (  # noqa
     IO,
     TYPE_CHECKING,
@@ -90,7 +89,7 @@ class FileResponse(StreamResponse):
         writer = await super().prepare(request)
         assert writer is not None
 
-        if NOSENDFILE or sys.version_info < (3, 7) or self.compression:
+        if NOSENDFILE or self.compression:
             return await self._sendfile_fallback(writer, fobj, offset, count)
 
         loop = request._loop

--- a/docs/third_party.rst
+++ b/docs/third_party.rst
@@ -131,7 +131,7 @@ support to aiohttp web servers.
 
 - `rororo <https://github.com/playpauseandstop/rororo>`_
   Implement ``aiohttp.web`` OpenAPI 3 server applications with schema first
-  approach. Python 3.6+ required.
+  approach.
 
 Others
 ------
@@ -147,7 +147,7 @@ ask to raise the status.
   Pytest fixture with simpler api, payload decoding and status code assertions.
 
 - `octomachinery <https://octomachinery.dev>`_ A framework for developing
-  GitHub Apps and GitHub Actions. Python 3.7+ is required.
+  GitHub Apps and GitHub Actions.
 
 - `aiomixcloud <https://github.com/amikrop/aiomixcloud>`_
   Mixcloud API wrapper for Python and Async IO.
@@ -241,16 +241,16 @@ ask to raise the status.
   GraphQL and GraphIQL interface for aiohttp.
 
 - `aiohttp-sentry <https://github.com/underyx/aiohttp-sentry>`_
-  An aiohttp middleware for reporting errors to Sentry. Python 3.5+ is required.
+  An aiohttp middleware for reporting errors to Sentry.
 
 - `aiohttp-datadog <https://github.com/underyx/aiohttp-datadog>`_
-  An aiohttp middleware for reporting metrics to DataDog. Python 3.5+ is required.
+  An aiohttp middleware for reporting metrics to DataDog.
 
 - `async-v20 <https://github.com/jamespeterschinner/async_v20>`_
-  Asynchronous FOREX client for OANDA's v20 API. Python 3.6+
+  Asynchronous FOREX client for OANDA's v20 API.
 
 - `aiohttp-jwt <https://github.com/hzlmn/aiohttp-jwt>`_
-  An aiohttp middleware for JWT(JSON Web Token) support. Python 3.5+ is required.
+  An aiohttp middleware for JWT(JSON Web Token) support.
 
 - `AWS Xray Python SDK <https://github.com/aws/aws-xray-sdk-python>`_
   Native tracing support for Aiohttp applications.
@@ -269,24 +269,23 @@ ask to raise the status.
   servers to collect web apps telemetry.
 
 - `aiogmaps <https://github.com/hzlmn/aiogmaps>`_
-  Asynchronous client for Google Maps API Web Services. Python 3.6+ required.
+  Asynchronous client for Google Maps API Web Services.
 
 - `DBGR <https://github.com/JakubTesarek/dbgr>`_
   Terminal based tool to test and debug HTTP APIs with ``aiohttp``.
 
 - `aiohttp-middlewares <https://github.com/playpauseandstop/aiohttp-middlewares>`_
-  Collection of useful middlewares for ``aiohttp.web`` applications. Python
-  3.6+ required.
+  Collection of useful middlewares for ``aiohttp.web`` applications.
 
 - `aiohttp-tus <https://github.com/pylotcode/aiohttp-tus>`_
   `tus.io <https://tus.io>`_ protocol implementation for ``aiohttp.web``
-  applications. Python 3.6+ required.
+  applications.
 
 - `aiohttp-sse-client <https://github.com/rtfol/aiohttp-sse-client>`_
-  A Server-Sent Event python client base on aiohttp. Python 3.6+ required.
+  A Server-Sent Event python client base on aiohttp.
 
 - `aiohttp-retry <https://github.com/inyutin/aiohttp_retry>`_
-  Wrapper for aiohttp client for retrying requests. Python 3.6+ required.
+  Wrapper for aiohttp client for retrying requests.
 
 - `aiohttp-socks <https://github.com/romis2012/aiohttp-socks>`_
   SOCKS proxy connector for aiohttp.

--- a/docs/web_advanced.rst
+++ b/docs/web_advanced.rst
@@ -339,9 +339,8 @@ Otherwise, something based on your company name/url would be satisfactory (i.e.
 ContextVars support
 -------------------
 
-Starting from Python 3.7 asyncio has :mod:`Context Variables <contextvars>` as a
-context-local storage (a generalization of thread-local concept that works with asyncio
-tasks also).
+Asyncio has :mod:`Context Variables <contextvars>` as a context-local storage
+(a generalization of thread-local concept that works with asyncio tasks also).
 
 
 *aiohttp* server supports it in the following way:

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,7 +1,7 @@
 -r multidict.txt
 -r typing-extensions.txt
-# required c-ares will not build on windows and has build problems on Macos Python<3.7
-aiodns==3.0.0; sys_platform=="linux" or sys_platform=="darwin" and python_version>="3.7"
+# required c-ares will not build on windows
+aiodns==3.0.0; sys_platform=="linux" or sys_platform=="darwin"
 aiosignal==1.2.0
 async-timeout==4.0.2
 asynctest==0.13.0; python_version<"3.8"

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -1,4 +1,4 @@
-aiodns==3.0.0 ; sys_platform == "linux" or sys_platform == "darwin" and python_version >= "3.7"
+aiodns==3.0.0 ; sys_platform == "linux" or sys_platform == "darwin"
     # via -r requirements/base.txt
 aiohttp-theme==0.1.6
     # via -r requirements/doc.txt
@@ -34,7 +34,7 @@ charset-normalizer==2.0.10
     # via
     #   -r requirements/base.txt
     #   requests
-cherry_picker==2.1.0 ; python_version >= "3.6"
+cherry_picker==2.1.0
     # via -r requirements/dev.txt
 click==8.0.3
     # via
@@ -156,7 +156,7 @@ pytest-mock==3.6.1
     # via -r requirements/test.txt
 python-dateutil==2.8.2
     # via freezegun
-python-on-whales==0.36.1 ; python_version >= "3.7"
+python-on-whales==0.36.1
     # via -r requirements/test.txt
 pytz==2021.3
     # via babel
@@ -238,7 +238,7 @@ urllib3==1.26.7
     # via requests
 virtualenv==20.10.0
     # via pre-commit
-wait-for-it==2.2.1 ; python_version >= "3.7"
+wait-for-it==2.2.1
     # via -r requirements/test.txt
 webcolors==1.11.1
     # via blockdiag

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,5 +1,5 @@
 -r lint.txt
 -r test.txt
 -r doc.txt
-cherry_picker==2.1.0; python_version>="3.6"
+cherry_picker==2.1.0
 pip-tools==6.4.0

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -9,8 +9,8 @@ proxy.py ~= 2.4.0rc6
 pytest==6.2.5
 pytest-cov==3.0.0
 pytest-mock==3.6.1
-python-on-whales==0.36.1; python_version>="3.7"
+python-on-whales==0.36.1
 re-assert==1.1.0
 setuptools-git==1.2
 trustme==0.9.0; platform_machine!="i686"    # no 32-bit wheels
-wait-for-it==2.2.1; python_version>="3.7"
+wait-for-it==2.2.1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -188,15 +188,11 @@ def unix_sockname(tmp_path: Any, tmp_path_factory: Any):
 
 @pytest.fixture
 def selector_loop() -> None:
-    if sys.version_info < (3, 7):
-        policy = asyncio.get_event_loop_policy()
-        policy._loop_factory = asyncio.SelectorEventLoop
+    if sys.version_info >= (3, 8):
+        policy = asyncio.WindowsSelectorEventLoopPolicy()
     else:
-        if sys.version_info >= (3, 8):
-            policy = asyncio.WindowsSelectorEventLoopPolicy()
-        else:
-            policy = asyncio.DefaultEventLoopPolicy()
-        asyncio.set_event_loop_policy(policy)
+        policy = asyncio.DefaultEventLoopPolicy()
+    asyncio.set_event_loop_policy(policy)
 
     with loop_context(policy.new_event_loop) as _loop:
         asyncio.set_event_loop(_loop)

--- a/tests/test_client_exceptions.py
+++ b/tests/test_client_exceptions.py
@@ -3,7 +3,6 @@
 
 import errno
 import pickle
-import sys
 from typing import Any
 
 from aiohttp import client, client_reqrep
@@ -222,16 +221,10 @@ class TestServerDisconnectedError:
 
     def test_repr(self) -> None:
         err = client.ServerDisconnectedError()
-        if sys.version_info < (3, 7):
-            assert repr(err) == ("ServerDisconnectedError" "('Server disconnected',)")
-        else:
-            assert repr(err) == ("ServerDisconnectedError" "('Server disconnected')")
+        assert repr(err) == ("ServerDisconnectedError" "('Server disconnected')")
 
         err = client.ServerDisconnectedError(message="No connection")
-        if sys.version_info < (3, 7):
-            assert repr(err) == "ServerDisconnectedError('No connection',)"
-        else:
-            assert repr(err) == "ServerDisconnectedError('No connection')"
+        assert repr(err) == "ServerDisconnectedError('No connection')"
 
     def test_str(self) -> None:
         err = client.ServerDisconnectedError()


### PR DESCRIPTION
FYI, to find these, I skim through the results of:
`fgrep -Rn -e '36' -e '3.6' -e '3,6' -e '3, 6'`
`fgrep -Rn -e '37' -e '3.7' -e '3,7' -e '3, 7'`