### PR TITLE
Update web_advanced.rst that aiohttp-devtools "Removed debugtoolbar integration"

### DIFF
--- a/docs/web_advanced.rst
+++ b/docs/web_advanced.rst
@@ -1075,8 +1075,7 @@ Install with ``pip``:
     $ pip install aiohttp-devtools
 
 * ``runserver`` provides a development server with auto-reload,
-  live-reload, static file serving and `aiohttp-debugtoolbar`_
-  integration.
+  live-reload, static file serving.
 * ``start`` is a `cookiecutter command which does the donkey work
   of creating new :mod:`aiohttp.web` Applications.
 


### PR DESCRIPTION
## What do these changes do?
according to https://github.com/aio-libs/aiohttp-devtools/blob/master/CHANGES.txt#L13, aiohttp-devtools "Removed debugtoolbar integration"

## Are there changes in behavior for the user?
No

## Related issue number
N/A

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
