### PR TITLE
Fix cookie handling

### DIFF
--- a/CHANGES/6638.bugfix
+++ b/CHANGES/6638.bugfix
@@ -1,0 +1,1 @@
+Do not overwrite cookies with same name and domain when the path is different.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -63,6 +63,7 @@ Brian Bouterse
 Brian C. Lane
 Brian Muller
 Bruce Merry
+Bruno Souza Cabral
 Bryan Kok
 Bryce Drennan
 Carl George

--- a/aiohttp/cookiejar.py
+++ b/aiohttp/cookiejar.py
@@ -65,7 +65,7 @@ class CookieJar(AbstractCookieJar):
         treat_as_secure_origin: Union[StrOrURL, List[StrOrURL], None] = None
     ) -> None:
         self._loop = asyncio.get_running_loop()
-        self._cookies: DefaultDict[str, SimpleCookie[str]] = defaultdict(SimpleCookie)
+        self._cookies: DefaultDict[Tuple[str, str], SimpleCookie[str]] = defaultdict(SimpleCookie)
         self._host_only_cookies: Set[Tuple[str, str]] = set()
         self._unsafe = unsafe
         self._quote_cookie = quote_cookie
@@ -82,7 +82,7 @@ class CookieJar(AbstractCookieJar):
             ]
         self._treat_as_secure_origin = treat_as_secure_origin
         self._next_expiration = next_whole_second()
-        self._expirations: Dict[Tuple[str, str], datetime.datetime] = {}
+        self._expirations: Dict[Tuple[str, str, str], datetime.datetime] = {}
         # #4515: datetime.max may not be representable on 32-bit platforms
         self._max_time = self.MAX_TIME
         try:
@@ -110,20 +110,21 @@ class CookieJar(AbstractCookieJar):
 
         to_del = []
         now = datetime.datetime.now(datetime.timezone.utc)
-        for domain, cookie in self._cookies.items():
+        for (domain, path), cookie in self._cookies.items():
             for name, morsel in cookie.items():
-                key = (domain, name)
+                key = (domain, path, name)
                 if (
                     key in self._expirations and self._expirations[key] <= now
                 ) or predicate(morsel):
                     to_del.append(key)
 
-        for domain, name in to_del:
+        for domain, path, name in to_del:
             key = (domain, name)
             self._host_only_cookies.discard(key)
+            key = (domain, path, name)
             if key in self._expirations:
-                del self._expirations[(domain, name)]
-            self._cookies[domain].pop(name, None)
+                del self._expirations[(domain, path, name)]
+            self._cookies[(domain, path)].pop(name, None)
 
         next_expiration = min(self._expirations.values(), default=self._max_time)
         try:
@@ -147,9 +148,9 @@ class CookieJar(AbstractCookieJar):
     def _do_expiration(self) -> None:
         self.clear(lambda x: False)
 
-    def _expire_cookie(self, when: datetime.datetime, domain: str, name: str) -> None:
+    def _expire_cookie(self, when: datetime.datetime, domain: str, path: str, name: str) -> None:
         self._next_expiration = min(self._next_expiration, when)
-        self._expirations[(domain, name)] = when
+        self._expirations[(domain, path, name)] = when
 
     def update_cookies(self, cookies: LooseCookies, response_url: URL = URL()) -> None:
         """Update cookies."""
@@ -211,7 +212,7 @@ class CookieJar(AbstractCookieJar):
                         ) + datetime.timedelta(seconds=delta_seconds)
                     except OverflowError:
                         max_age_expiration = self._max_time
-                    self._expire_cookie(max_age_expiration, domain, name)
+                    self._expire_cookie(max_age_expiration, domain, path, name)
                 except ValueError:
                     cookie["max-age"] = ""
 
@@ -220,11 +221,11 @@ class CookieJar(AbstractCookieJar):
                 if expires:
                     expire_time = self._parse_date(expires)
                     if expire_time:
-                        self._expire_cookie(expire_time, domain, name)
+                        self._expire_cookie(expire_time, domain, path, name)
                     else:
                         cookie["expires"] = ""
 
-            self._cookies[domain][name] = cookie
+            self._cookies[(domain, path)][name] = cookie
 
         self._do_expiration()
 

--- a/aiohttp/cookiejar.py
+++ b/aiohttp/cookiejar.py
@@ -121,8 +121,7 @@ class CookieJar(AbstractCookieJar):
                     to_del.append(key)
 
         for domain, path, name in to_del:
-            key = (domain, name)
-            self._host_only_cookies.discard(key)
+            self._host_only_cookies.discard((domain, name))
             key = (domain, path, name)
             if key in self._expirations:
                 del self._expirations[(domain, path, name)]

--- a/aiohttp/cookiejar.py
+++ b/aiohttp/cookiejar.py
@@ -65,7 +65,9 @@ class CookieJar(AbstractCookieJar):
         treat_as_secure_origin: Union[StrOrURL, List[StrOrURL], None] = None
     ) -> None:
         self._loop = asyncio.get_running_loop()
-        self._cookies: DefaultDict[Tuple[str, str], SimpleCookie[str]] = defaultdict(SimpleCookie)
+        self._cookies: DefaultDict[Tuple[str, str], SimpleCookie[str]] = defaultdict(
+            SimpleCookie
+        )
         self._host_only_cookies: Set[Tuple[str, str]] = set()
         self._unsafe = unsafe
         self._quote_cookie = quote_cookie
@@ -148,7 +150,9 @@ class CookieJar(AbstractCookieJar):
     def _do_expiration(self) -> None:
         self.clear(lambda x: False)
 
-    def _expire_cookie(self, when: datetime.datetime, domain: str, path: str, name: str) -> None:
+    def _expire_cookie(
+        self, when: datetime.datetime, domain: str, path: str, name: str
+    ) -> None:
         self._next_expiration = min(self._next_expiration, when)
         self._expirations[(domain, path, name)] = when
 

--- a/tests/test_cookiejar.py
+++ b/tests/test_cookiejar.py
@@ -682,23 +682,26 @@ class TestCookieJarSafe(TestCookieJarBase):
         assert len(jar) == 1
 
     def test_path_filter_diff_folder_same_name(self) -> None:
-
         async def make_jar():
             return CookieJar(unsafe=True)
 
         jar = self.loop.run_until_complete(make_jar())
 
-        jar.update_cookies(SimpleCookie("path-cookie=zero; Domain=pathtest.com; Path=/; "))
-        jar.update_cookies(SimpleCookie("path-cookie=one; Domain=pathtest.com; Path=/one; "))
+        jar.update_cookies(
+            SimpleCookie("path-cookie=zero; Domain=pathtest.com; Path=/; ")
+        )
+        jar.update_cookies(
+            SimpleCookie("path-cookie=one; Domain=pathtest.com; Path=/one; ")
+        )
         self.assertEqual(len(jar), 2)
 
         jar_filtered = jar.filter_cookies(URL("http://pathtest.com/"))
         self.assertEqual(len(jar_filtered), 1)
-        self.assertEqual(jar_filtered['path-cookie'].value, "zero")
+        self.assertEqual(jar_filtered["path-cookie"].value, "zero")
 
         jar_filtered = jar.filter_cookies(URL("http://pathtest.com/one"))
         self.assertEqual(len(jar_filtered), 1)
-        self.assertEqual(jar_filtered['path-cookie'].value, "one")
+        self.assertEqual(jar_filtered["path-cookie"].value, "one")
 
 
 async def test_dummy_cookie_jar() -> None:

--- a/tests/test_cookiejar.py
+++ b/tests/test_cookiejar.py
@@ -681,6 +681,25 @@ class TestCookieJarSafe(TestCookieJarBase):
         # Assert that there is a cookie.
         assert len(jar) == 1
 
+    def test_path_filter_diff_folder_same_name(self) -> None:
+
+        async def make_jar():
+            return CookieJar(unsafe=True)
+
+        jar = self.loop.run_until_complete(make_jar())
+
+        jar.update_cookies(SimpleCookie("path-cookie=zero; Domain=pathtest.com; Path=/; "))
+        jar.update_cookies(SimpleCookie("path-cookie=one; Domain=pathtest.com; Path=/one; "))
+        self.assertEqual(len(jar), 2)
+
+        jar_filtered = jar.filter_cookies(URL("http://pathtest.com/"))
+        self.assertEqual(len(jar_filtered), 1)
+        self.assertEqual(jar_filtered['path-cookie'].value, "zero")
+
+        jar_filtered = jar.filter_cookies(URL("http://pathtest.com/one"))
+        self.assertEqual(len(jar_filtered), 1)
+        self.assertEqual(jar_filtered['path-cookie'].value, "one")
+
 
 async def test_dummy_cookie_jar() -> None:
     cookie = SimpleCookie("foo=bar; Domain=example.com;")


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

There is an error in cookie handling that override the existing cookie even if the path is different. This is a huge bug in aiohttp, as it makes requests to some sites impossible to work.

This is an updated PR as asked by @Dreamsorcerer 

The RFC 6265 is clear on this point (https://datatracker.ietf.org/doc/html/rfc6265) , for example:

```
Finally, to remove a cookie, the server returns a Set-Cookie header
   with an expiration date in the past.  The server will be successful
   in removing the cookie only **if the Path and the Domain attribute** in
   the Set-Cookie header match the values used when the cookie was
   created.

```

Actually aiohttp only consider domain and name. Pull request #3627 tried to fix this, but the code has been updated vastly since then. 

Pay attention to another library, such as requests. It always consider the path as a key to the cookie jar.
https://github.com/psf/requests/blob/79f60274f7e461b8fd2f579e741f748438d7eadb/requests/cookies.py#L189



<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

No

<!-- Outline any notable behaviour for the end users. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [X] I think the code is well written
- [X] Unit tests for the changes exist
- [X] Documentation reflects the changes
- [X] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [X] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
