### PR TITLE
Fix FileResponse fallback code

### DIFF
--- a/CHANGES/6726.bugfix
+++ b/CHANGES/6726.bugfix
@@ -1,0 +1,1 @@
+Fixed a bug in ``FileResponse`` fallback code when the requested range is smaller than the chunk size.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -247,6 +247,7 @@ Martin Sucha
 Mathias Fröjdman
 Mathieu Dugré
 Matt VanEseltine
+Matthias Dellweg
 Matthias Marquardt
 Matthieu Hauglustaine
 Matthieu Rigal

--- a/aiohttp/http_writer.py
+++ b/aiohttp/http_writer.py
@@ -123,7 +123,6 @@ class StreamWriter(AbstractStreamWriter):
             if self.length >= chunk_len:
                 self.length = self.length - chunk_len
             else:
-                chunk = chunk[: self.length]
                 self.length = 0
                 if not chunk:
                     return

--- a/aiohttp/web_fileresponse.py
+++ b/aiohttp/web_fileresponse.py
@@ -114,7 +114,7 @@ class FileResponse(StreamResponse):
         chunk_size = self._chunk_size
         loop = asyncio.get_event_loop()
         chunk = await loop.run_in_executor(
-            None, self._seek_and_read, fobj, offset, chunk_size
+            None, self._seek_and_read, fobj, offset, min(chunk_size, count)
         )
         while chunk:
             await writer.write(chunk)

--- a/aiohttp/web_fileresponse.py
+++ b/aiohttp/web_fileresponse.py
@@ -114,7 +114,7 @@ class FileResponse(StreamResponse):
         chunk_size = self._chunk_size
         loop = asyncio.get_event_loop()
         chunk = await loop.run_in_executor(
-            None, self._seek_and_read, fobj, offset, min(chunk_size, count)
+            None, self._seek_and_read, fobj, offset, chunk_size
         )
         while chunk:
             await writer.write(chunk)


### PR DESCRIPTION
In case the FileResponse is using _sendfile_fallback and the requested
range is smaller then the chunk size, we need to only read and send
count bytes.

<!-- Thank you for your contribution! -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
