### PR TITLE
Feature: Add trace_request_ctx for WS connections

### DIFF
--- a/CHANGES/6761.feature
+++ b/CHANGES/6761.feature
@@ -1,0 +1,1 @@
+Add `trace_request_ctx` argument for `ws_connect` function replicating the behavior of the other requests.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -211,6 +211,7 @@ Manuel Miranda
 Marat Sharafutdinov
 Marco Paolini
 Mariano Anaya
+Mario Sánchez García
 Mariusz Masztalerczuk
 Marko Kohtala
 Martijn Pieters

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -668,6 +668,7 @@ class ClientSession:
         proxy_headers: Optional[LooseHeaders] = None,
         compress: int = 0,
         max_msg_size: int = 4 * 1024 * 1024,
+        trace_request_ctx: Optional[SimpleNamespace] = None,
     ) -> "_WSRequestContextManager":
         """Initiate websocket connection."""
         return _WSRequestContextManager(
@@ -690,6 +691,7 @@ class ClientSession:
                 proxy_headers=proxy_headers,
                 compress=compress,
                 max_msg_size=max_msg_size,
+                trace_request_ctx=trace_request_ctx,
             )
         )
 
@@ -714,6 +716,7 @@ class ClientSession:
         proxy_headers: Optional[LooseHeaders] = None,
         compress: int = 0,
         max_msg_size: int = 4 * 1024 * 1024,
+        trace_request_ctx: Optional[SimpleNamespace] = None,
     ) -> ClientWebSocketResponse:
         if timeout is sentinel or timeout is None:
             ws_timeout = DEFAULT_WS_CLIENT_TIMEOUT
@@ -783,6 +786,7 @@ class ClientSession:
             proxy_auth=proxy_auth,
             ssl=ssl,
             proxy_headers=proxy_headers,
+            trace_request_ctx=trace_request_ctx,
         )
 
         try:


### PR DESCRIPTION
## What do these changes do?

Adding the possibility to pass `trace_request_ctx` when opening a Websocket connection. It's supported for all HTTP requests, but for some reason it was not an option for this method.

## Are there changes in behavior for the user?

The argument is optional, so it shouldn't affect the current behavior of the method.

## Related issue number

None

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
- [x] Add a new news fragment into the `CHANGES` folder
