### PR TITLE
Raise SystemExit or KeyboardInterrupt instead of wrapping them

### DIFF
--- a/CHANGES/7125.bugfix
+++ b/CHANGES/7125.bugfix
@@ -1,0 +1,1 @@
+Raise SystemExit or KeyboardInterrupt instead of wrapping them.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -211,6 +211,7 @@ Lukasz Marcin Dobrzanski
 Makc Belousow
 Manuel Miranda
 Marat Sharafutdinov
+Marcel Jackwerth
 Marco Paolini
 Mariano Anaya
 Mariusz Masztalerczuk

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -426,7 +426,10 @@ class HttpParser(abc.ABC, Generic[_MsgT]):
                 try:
                     eof, data = self._payload_parser.feed_data(data[start_pos:])
                 except BaseException as exc:
-                    if isinstance(exc, Exception) and self.payload_exception is not None:
+                    if (
+                        isinstance(exc, Exception)
+                        and self.payload_exception is not None
+                    ):
                         exc = self.payload_exception(str(exc))
                     self._payload_parser.payload.set_exception(exc)
 

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -426,12 +426,9 @@ class HttpParser(abc.ABC, Generic[_MsgT]):
                 try:
                     eof, data = self._payload_parser.feed_data(data[start_pos:])
                 except BaseException as exc:
-                    if self.payload_exception is not None:
-                        self._payload_parser.payload.set_exception(
-                            self.payload_exception(str(exc))
-                        )
-                    else:
-                        self._payload_parser.payload.set_exception(exc)
+                    if isinstance(exc, Exception) and self.payload_exception is not None:
+                        exc = self.payload_exception(str(exc))
+                    self._payload_parser.payload.set_exception(exc)
 
                     eof = True
                     data = b""


### PR DESCRIPTION
## What do these changes do?

Only wrap regular exceptions in `ClientPayloadError`, but leave other `BaseExceptions` (like `SystemExit` or `KeyboardInterrupt`) alone.

## Are there changes in behavior for the user?

Users that only had an `except ClientPayloadError` to catch "all exceptions" might now see these exceptions coming through as well.

## Related issue number

- None

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
