### PR TITLE
Add ClientResponse.certificate and populate it, if appropriate

### DIFF
--- a/CHANGES/2816.feature
+++ b/CHANGES/2816.feature
@@ -1,1 +1,1 @@
-Add `ClientResponse.certificate` and populate it, if appropriate.
+Added ``ClientResponse.certificate``, which is populated, if appropriate, with the certificate of the server.

--- a/CHANGES/2816.feature
+++ b/CHANGES/2816.feature
@@ -1,0 +1,1 @@
+Add `ClientResponse.certificate` and populate it, if appropriate.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -260,6 +260,7 @@ Pavol Vargovčík
 Pawel Kowalski
 Pawel Miech
 Pepe Osca
+Petros Blanis
 Philipp A.
 Pieter van Beek
 Qiao Han

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -861,11 +861,7 @@ class ClientResponse(HeadersMixin):
                     set_result(self._continue, True)
                     self._continue = None
 
-        # certificate
-        is_tls_transport = (
-            self._connection is not None and self._connection.transport is not None
-        )
-        if is_tls_transport:
+        if self._connection is not None and self._connection.transport is not None:
             self.certificate = self._connection.transport.get_extra_info("peercert")
 
         # payload eof handler

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -882,7 +882,9 @@ class ClientResponse(HeadersMixin):
                 client_logger.warning("Can not load response cookies: %s", exc)
 
         # certificate
-        is_tls_transport = self._connection is not None and self._connection.transport is not None
+        is_tls_transport = (
+            self._connection is not None and self._connection.transport is not None
+        )
         if is_tls_transport:
             self.certificate = self._connection.transport.get_extra_info("peercert")
         return self

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -882,7 +882,8 @@ class ClientResponse(HeadersMixin):
                 client_logger.warning("Can not load response cookies: %s", exc)
 
         # certificate
-        if self._connection is not None and self._connection.transport is not None:
+        is_tls_transport = self._connection is not None and self._connection.transport is not None
+        if is_tls_transport:
             self.certificate = self._connection.transport.get_extra_info("peercert")
         return self
 

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -862,7 +862,9 @@ class ClientResponse(HeadersMixin):
                     self._continue = None
 
         # certificate
-        is_tls_transport = self._connection is not None and self._connection.transport is not None
+        is_tls_transport = (
+            self._connection is not None and self._connection.transport is not None
+        )
         if is_tls_transport:
             self.certificate = self._connection.transport.get_extra_info("peercert")
 

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -861,6 +861,11 @@ class ClientResponse(HeadersMixin):
                     set_result(self._continue, True)
                     self._continue = None
 
+        # certificate
+        is_tls_transport = self._connection is not None and self._connection.transport is not None
+        if is_tls_transport:
+            self.certificate = self._connection.transport.get_extra_info("peercert")
+
         # payload eof handler
         payload.on_eof(self._response_eof)
 
@@ -882,13 +887,6 @@ class ClientResponse(HeadersMixin):
                 self.cookies.load(hdr)
             except CookieError as exc:
                 client_logger.warning("Can not load response cookies: %s", exc)
-
-        # certificate
-        is_tls_transport = (
-            self._connection is not None and self._connection.transport is not None
-        )
-        if is_tls_transport:
-            self.certificate = self._connection.transport.get_extra_info("peercert")
         return self
 
     def _response_eof(self) -> None:

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -697,6 +697,7 @@ class ClientResponse(HeadersMixin):
 
         self.method = method
         self.cookies: SimpleCookie[str] = SimpleCookie()
+        self.certificate: Optional[Dict[str, Union[Tuple[Any, ...], int, str]]] = None
 
         self._real_url = url
         self._url = url.with_fragment(None)
@@ -879,6 +880,10 @@ class ClientResponse(HeadersMixin):
                 self.cookies.load(hdr)
             except CookieError as exc:
                 client_logger.warning("Can not load response cookies: %s", exc)
+
+        # certificate
+        if self._connection is not None and self._connection.transport is not None:
+            self.certificate = self._connection.transport.get_extra_info("peercert")
         return self
 
     def _response_eof(self) -> None:

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -1360,6 +1360,10 @@ Response object
       objects of preceding requests (earliest request first) if there were
       redirects, an empty sequence otherwise.
 
+   .. attribute:: certificate
+
+      The server certificate, if available.
+
    .. method:: close()
 
       Close response and underlying connection.

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -1362,7 +1362,9 @@ Response object
 
    .. attribute:: certificate
 
-      The server certificate, if available.
+      The server certificate. This is available with TLS connections,
+      if the certificate is retrieved before the connection or the TLS session are
+      closed, otherwise it is ``None``.
 
    .. method:: close()
 

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -1363,7 +1363,7 @@ Response object
    .. attribute:: certificate
 
       The server certificate. This is available with TLS connections,
-      if the certificate is retrieved before the connection or the TLS session are
+      if the certificate is retrieved before the connection or the TLS session is
       closed, otherwise it is ``None``.
 
    .. method:: close()

--- a/tests/test_client_request.py
+++ b/tests/test_client_request.py
@@ -1232,7 +1232,9 @@ def test_gen_default_accept_encoding(has_brotli: Any, expected: Any) -> None:
         assert _gen_default_accept_encoding() == expected
 
 
-async def test_certificate(loop: Any, conn: Any) -> None:
+async def test_certificate_exists(loop: Any, conn: Any) -> None:
     req = ClientRequest("get", URL("https://www.python.org"), loop=loop)
     resp = await req.send(conn)
     assert resp.certificate is not None
+    await req.close()
+    resp.close()

--- a/tests/test_client_request.py
+++ b/tests/test_client_request.py
@@ -1245,7 +1245,15 @@ async def test_certificate_exists(ssl_ctx, client_ssl_ctx) -> None:
     async with aiohttp.ClientSession() as session:
         resp = await session.get("https://127.0.0.1:8443", ssl=client_ssl_ctx)
     assert frozenset(resp.certificate) >= frozenset(
-        ("subject", "issuer", "version", "serialNumber", "notBefore", "notAfter", "subjectAltName")
+        (
+            "subject",
+            "issuer",
+            "version",
+            "serialNumber",
+            "notBefore",
+            "notAfter",
+            "subjectAltName",
+        )
     )
     resp.close()
     await site.stop()

--- a/tests/test_client_request.py
+++ b/tests/test_client_request.py
@@ -1230,3 +1230,9 @@ def test_loose_cookies_types(loop: Any) -> None:
 def test_gen_default_accept_encoding(has_brotli: Any, expected: Any) -> None:
     with mock.patch("aiohttp.client_reqrep.HAS_BROTLI", has_brotli):
         assert _gen_default_accept_encoding() == expected
+
+
+async def test_certificate(loop: Any, conn: Any) -> None:
+    req = ClientRequest("get", URL("https://www.python.org"), loop=loop)
+    resp = await req.send(conn)
+    assert resp.certificate is not None


### PR DESCRIPTION
Fixes #2816.

<!-- Thank you for your contribution! -->

## What do these changes do?
Add `ClientResponse.certificate` and populate it, if appropriate.

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?
Yes, the `ClientResponse.certificate` property contains the server certificate, if available.

<!-- Outline any notable behaviour for the end users. -->

## Related issue number
#2816

<!-- Are there any issues opened that will be resolved by merging this change? -->

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."