### PR TITLE
Preserve default total client timeout value

### DIFF
--- a/CHANGES/7274.feature
+++ b/CHANGES/7274.feature
@@ -1,0 +1,1 @@
+Changed default value for ``ClientTimeout.total`` so that the default is always present, even if not explicitly specified.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -351,6 +351,7 @@ Ye Cao
 Yegor Roganov
 Yifei Kong
 Young-Ho Cha
+Yuri Sukhov
 Yuriy Shatrov
 Yury Pliner
 Yury Selivanov

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -31,7 +31,7 @@ from typing import (
 )
 
 from multidict import CIMultiDict, MultiDict, MultiDictProxy, istr
-from typing_extensions import Final, final
+from typing_extensions import final
 from yarl import URL
 
 from . import hdrs, http, payload
@@ -134,7 +134,7 @@ except ImportError:  # pragma: no cover
 
 @dataclasses.dataclass(frozen=True)
 class ClientTimeout:
-    total: Optional[float] = None
+    total: Optional[float] = 5 * 60  # 5 minute default timeout
     connect: Optional[float] = None
     sock_read: Optional[float] = None
     sock_connect: Optional[float] = None
@@ -153,9 +153,6 @@ class ClientTimeout:
     # - or use https://docs.python.org/3/library/dataclasses.html#dataclasses.replace
     # to overwrite the defaults
 
-
-# 5 Minute default read timeout
-DEFAULT_TIMEOUT: Final[ClientTimeout] = ClientTimeout(total=5 * 60)
 
 _RetType = TypeVar("_RetType")
 
@@ -257,7 +254,7 @@ class ClientSession:
         self._version = version
         self._json_serialize = json_serialize
         if timeout is sentinel or timeout is None:
-            self._timeout = DEFAULT_TIMEOUT
+            self._timeout = ClientTimeout()
         else:
             self._timeout = timeout
         self._raise_for_status = raise_for_status

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -1684,7 +1684,7 @@ Utilities
 ClientTimeout
 ^^^^^^^^^^^^^
 
-.. class:: ClientTimeout(*, total=None, connect=None, \
+.. class:: ClientTimeout(*, total=5*60, connect=None, \
                          sock_connect=None, sock_read=None)
 
    A data class for client timeout settings.
@@ -1695,7 +1695,7 @@ ClientTimeout
 
       Total number of seconds for the whole request.
 
-      :class:`float`, ``None`` by default.
+      :class:`float`, 300 seconds (5 min) by default.
 
    .. attribute:: connect
 

--- a/tests/test_client_session.py
+++ b/tests/test_client_session.py
@@ -790,7 +790,7 @@ async def test_client_session_custom_attr() -> None:
 
 async def test_client_session_timeout_default_args(loop: Any) -> None:
     session1 = ClientSession()
-    assert session1.timeout == client.DEFAULT_TIMEOUT
+    assert session1.timeout == client.ClientTimeout(total=5 * 60)
     await session1.close()
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Changed default value for ``ClientTimeout.total`` so that the default is always present, even if not explicitly specified.

## Are there changes in behavior for the user?

If a user wants to adjust some specific client timeout, i.e. `connect` or `sock_connect`, they won't need to explicitly specify `total` timeout value in order to preserve it.

## Related issue number

Closes #7274

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES` folder
  * name it `<issue_id>.<type>` for example (588.bugfix)
  * if you don't have an `issue_id` change it to the pr id after creating the pr
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation, for example: "Fix issue with non-ascii contents in doctest text files."
