### PR TITLE
Avoid compressing empty body

### DIFF
--- a/CHANGES/9108.bugfix.rst
+++ b/CHANGES/9108.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed compressed requests failing when no body was provided -- by :user:`Dreamsorcerer`.

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -171,7 +171,7 @@ class _RequestOptions(TypedDict, total=False):
     auth: Union[BasicAuth, None]
     allow_redirects: bool
     max_redirects: int
-    compress: Union[str, None]
+    compress: Union[str, bool, None]
     chunked: Union[bool, None]
     expect100: bool
     raise_for_status: Union[None, bool, Callable[[ClientResponse], Awaitable[None]]]
@@ -416,7 +416,7 @@ class ClientSession:
         auth: Optional[BasicAuth] = None,
         allow_redirects: bool = True,
         max_redirects: int = 10,
-        compress: Optional[str] = None,
+        compress: Union[str, bool, None] = None,
         chunked: Optional[bool] = None,
         expect100: bool = False,
         raise_for_status: Union[

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -203,7 +203,7 @@ class ClientRequest:
         cookies: Optional[LooseCookies] = None,
         auth: Optional[BasicAuth] = None,
         version: http.HttpVersion = http.HttpVersion11,
-        compress: Optional[str] = None,
+        compress: Union[str, bool, None] = None,
         chunked: Optional[bool] = None,
         expect100: bool = False,
         loop: asyncio.AbstractEventLoop,
@@ -424,7 +424,9 @@ class ClientRequest:
 
     def update_content_encoding(self, data: Any) -> None:
         """Set request content encoding."""
-        if data is None:
+        if not data:
+            # Don't compress an empty body.
+            self.compress = None
             return
 
         enc = self.headers.get(hdrs.CONTENT_ENCODING, "").lower()
@@ -640,7 +642,7 @@ class ClientRequest:
         )
 
         if self.compress:
-            writer.enable_compression(self.compress)
+            writer.enable_compression(self.compress)  # type: ignore[arg-type]
 
         if self.chunked is not None:
             writer.enable_chunking()

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -1540,18 +1540,24 @@ async def test_POST_MultiDict(aiohttp_client: AiohttpClient) -> None:
 
 
 @pytest.mark.parametrize("data", (None, b""))
-async def test_GET_DEFLATE(aiohttp_client: AiohttpClient, data: Optional[bytes]) -> None:
+async def test_GET_DEFLATE(
+    aiohttp_client: AiohttpClient, data: Optional[bytes]
+) -> None:
     async def handler(request: web.Request) -> web.Response:
         return web.json_response({"ok": True})
 
     write_mock = None
     original_write_bytes = ClientRequest.write_bytes
 
-    async def write_bytes(self: ClientRequest, writer: StreamWriter, conn: Connection) -> None:
+    async def write_bytes(
+        self: ClientRequest, writer: StreamWriter, conn: Connection
+    ) -> None:
         nonlocal write_mock
         original_write = writer._write
 
-        with mock.patch.object(writer, "_write", autospec=True, spec_set=True, side_effect=original_write) as write_mock:
+        with mock.patch.object(
+            writer, "_write", autospec=True, spec_set=True, side_effect=original_write
+        ) as write_mock:
             await original_write_bytes(self, writer, conn)
 
     with mock.patch.object(ClientRequest, "write_bytes", write_bytes):

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -44,6 +44,9 @@ from aiohttp.client_exceptions import (
     SocketTimeoutError,
     TooManyRedirects,
 )
+from aiohttp.client_reqrep import ClientRequest
+from aiohttp.connector import Connection
+from aiohttp.http_writer import StreamWriter
 from aiohttp.pytest_plugin import AiohttpClient, AiohttpServer
 from aiohttp.test_utils import TestClient, TestServer, unused_port
 from aiohttp.typedefs import Handler
@@ -1536,6 +1539,36 @@ async def test_POST_MultiDict(aiohttp_client: AiohttpClient) -> None:
         assert 200 == resp.status
 
 
+@pytest.mark.parametrize("data", (None, b""))
+async def test_GET_DEFLATE(aiohttp_client: AiohttpClient, data: Optional[bytes]) -> None:
+    async def handler(request: web.Request) -> web.Response:
+        return web.json_response({"ok": True})
+
+    write_mock = None
+    original_write_bytes = ClientRequest.write_bytes
+
+    async def write_bytes(self: ClientRequest, writer: StreamWriter, conn: Connection) -> None:
+        nonlocal write_mock
+        original_write = writer._write
+
+        with mock.patch.object(writer, "_write", autospec=True, spec_set=True, side_effect=original_write) as write_mock:
+            await original_write_bytes(self, writer, conn)
+
+    with mock.patch.object(ClientRequest, "write_bytes", write_bytes):
+        app = web.Application()
+        app.router.add_get("/", handler)
+        client = await aiohttp_client(app)
+
+        async with client.get("/", data=data, compress=True) as resp:
+            assert resp.status == 200
+            content = await resp.json()
+            assert content == {"ok": True}
+
+    assert write_mock is not None
+    # No chunks should have been sent for an empty body.
+    write_mock.assert_not_called()
+
+
 async def test_POST_DATA_DEFLATE(aiohttp_client: AiohttpClient) -> None:
     async def handler(request: web.Request) -> web.Response:
         data = await request.post()
@@ -1546,7 +1579,7 @@ async def test_POST_DATA_DEFLATE(aiohttp_client: AiohttpClient) -> None:
     client = await aiohttp_client(app)
 
     # True is not a valid type, but still tested for backwards compatibility.
-    resp = await client.post("/", data={"some": "data"}, compress=True)  # type: ignore[arg-type]
+    resp = await client.post("/", data={"some": "data"}, compress=True)
     assert 200 == resp.status
     content = await resp.json()
     assert content == {"some": "data"}


### PR DESCRIPTION
Overrule the compress setting if the body is empty, as the user is unlikely to have wanted to send a compressed body.

Fixes #3413.
Closes #8928.