### PR TITLE
Docs/unify contrib docs

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,18 +1,25 @@
-Contributing
-============
-
 Instructions for contributors
 -----------------------------
 
+In order to make a clone of the `GitHub <https://github.com/aio-libs/aiohttp>`_ repo: open the link and press the "Fork" button on the upper-right menu of the web page.
 
-In order to make a clone of the GitHub_ repo: open the link and press the
-"Fork" button on the upper-right menu of the web page.
-
-I hope everybody knows how to work with git and github nowadays :)
+If you'd like to learn more about Git and GitHub, `check out GitHub's helpful introduction
+<https://docs.github.com/en/get-started/using-git/about-git>`_.
 
 Workflow is pretty straightforward:
 
-  1. Clone the GitHub_ repo using the ``--recurse-submodules`` argument
+  0. Make sure you are reading the latest version of this document.
+     It can be found in the GitHub_ repo in the ``docs`` subdirectory.
+
+  1. Clone your forked GitHub_ repo with the ``--recurse-submodules`` flag as shown in the command below,
+     ensuring to replace the placeholder with your github username:
+
+      .. code-block:: shell
+
+         $ git clone \
+            https://github.com/<your_github_username>/aiohttp.git \
+            --recurse-submodules
+
 
   2. Setup your machine with the required development environment
 
@@ -20,7 +27,7 @@ Workflow is pretty straightforward:
 
   4. Make sure all tests passed
 
-  5. Add a file into the ``CHANGES`` folder, named after the ticket or PR number
+  5. Add a file into the ``CHANGES`` folder (see `Changelog update <CHANGES>`_ for how).
 
   6. Commit changes to your own aiohttp clone
 
@@ -28,9 +35,22 @@ Workflow is pretty straightforward:
 
   8. Optionally make backport Pull Request(s) for landing a bug fix into released aiohttp versions.
 
-.. important::
+.. note::
 
-    Please open the "`contributing <https://docs.aiohttp.org/en/stable/contributing.html>`_"
-    documentation page to get detailed information about all steps.
+   The project uses *Squash-and-Merge* strategy for *GitHub Merge* button.
 
-.. _GitHub: https://github.com/aio-libs/aiohttp
+   Basically it means that there is **no need to rebase** a Pull Request against
+   *master* branch. Just ``git merge`` *master* into your working copy (a fork) if
+   needed. The Pull Request is automatically squashed into the single commit
+   once the PR is accepted.
+
+.. note::
+
+   GitHub issue and pull request threads are automatically locked when there has
+   not been any recent activity for one year.  Please open a `new issue
+   <https://github.com/aio-libs/aiohttp/issues/new>`_ for related bugs.
+
+   If you feel like there are important points in the locked discussions,
+   please include those excerpts into that new issue.
+
+.. export-point-instructions-for-contributors

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -329,6 +329,7 @@ Sunit Deshpande
 Sviatoslav Bulbakha
 Sviatoslav Sydorenko
 Taha Jahangir
+Tambe Tabitha Achere
 Taras Voinarovskyi
 Terence Honles
 Thanos Lefteris

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -1,65 +1,9 @@
 .. _aiohttp-contributing:
 
-Contributing
-============
+.. include:: ../CONTRIBUTING.rst
+   :end-before: export-point-instructions-for-contributors
 
 (:doc:`contributing-admins`)
-
-Instructions for contributors
------------------------------
-
-In order to make a clone of the GitHub_ repo: open the link and press the "Fork" button on the upper-right menu of the web page.
-
-If you'd like to learn more about Git and GitHub, `check out GitHub's helpful introduction
-<https://docs.github.com/en/get-started/using-git/about-git>`_.
-
-Workflow is pretty straightforward:
-
-  0. Make sure you are reading the latest version of this document.
-     It can be found in the GitHub_ repo in the ``docs`` subdirectory.
-
-  1. Clone your forked GitHub_ repo with the ``--recurse-submodules`` flag as shown in the command below,
-     ensuring to replace the placeholder with your github username:
-
-      .. code-block:: shell
-
-         $ git clone \
-            https://github.com/<your_github_username>/aiohttp.git \
-            --recurse-submodules
-
-
-  2. Setup your machine with the required development environment
-
-  3. Make a change
-
-  4. Make sure all tests passed
-
-  5. Add a file into the ``CHANGES`` folder (see `Changelog update`_ for how).
-
-  6. Commit changes to your own aiohttp clone
-
-  7. Make a pull request from the github page of your clone against the master branch
-
-  8. Optionally make backport Pull Request(s) for landing a bug fix into released aiohttp versions.
-
-.. note::
-
-   The project uses *Squash-and-Merge* strategy for *GitHub Merge* button.
-
-   Basically it means that there is **no need to rebase** a Pull Request against
-   *master* branch. Just ``git merge`` *master* into your working copy (a fork) if
-   needed. The Pull Request is automatically squashed into the single commit
-   once the PR is accepted.
-
-.. note::
-
-   GitHub issue and pull request threads are automatically locked when there has
-   not been any recent activity for one year.  Please open a `new issue
-   <https://github.com/aio-libs/aiohttp/issues/new>`_ for related bugs.
-
-   If you feel like there are important points in the locked discussions,
-   please include those excerpts into that new issue.
-
 
 Preconditions for running aiohttp test suite
 --------------------------------------------

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -10,14 +10,23 @@ Instructions for contributors
 
 In order to make a clone of the GitHub_ repo: open the link and press the "Fork" button on the upper-right menu of the web page.
 
-I hope everybody knows how to work with git and github nowadays :)
+If you'd like to learn more about Git and GitHub, `check out GitHub's helpful introduction
+<https://docs.github.com/en/get-started/using-git/about-git>`_.
 
 Workflow is pretty straightforward:
 
   0. Make sure you are reading the latest version of this document.
      It can be found in the GitHub_ repo in the ``docs`` subdirectory.
 
-  1. Clone the GitHub_ repo using the ``--recurse-submodules`` argument
+  1. Clone your forked GitHub_ repo with the ``--recurse-submodules`` flag as shown in the command below,
+     ensuring to replace the placeholder with your github username:
+
+      .. code-block:: shell
+
+         $ git clone \
+            https://github.com/<your_github_username>/aiohttp.git \
+            --recurse-submodules
+
 
   2. Setup your machine with the required development environment
 
@@ -56,6 +65,8 @@ Preconditions for running aiohttp test suite
 --------------------------------------------
 
 We expect you to use a python virtual environment to run our tests.
+Also, ensure that you have `npm
+<https://docs.npmjs.com/downloading-and-installing-node-js-and-npm>`_ installed.
 
 There are several ways to make a virtual environment.
 
@@ -237,9 +248,22 @@ Please before making a Pull Request about documentation changes run:
    $ make doc
 
 Once it finishes it will output the index html page
+
 ``open file:///.../aiohttp/docs/_build/html/index.html``.
 
 Go to the link and make sure your doc changes looks good.
+
+Note that this page doesn't automatically refresh itself. So, if you make more changes, build the docs again to see how they look on the page.
+
+.. note::
+   If you are on MacOS, you might need to install `graphviz <https://graphviz.org/>`_ first.
+   Use
+
+   .. code-block:: shell
+
+      $ brew install graphviz
+
+   and then run the command above to build the docs.
 
 Spell checking
 --------------


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Edit onboarding documentation to 

- emphasize the need for npm as a pre-requisite to run tests,
- make the git clone link explicit like the rest of the commands,
- point to GitHub docs if user isn't familiar yet,
- inform macOS users about the possible need for graphviz if `make doc` doesn't work.

It also goes ahead to unify `CONTRIBUTING.rst` in root and `docs/contributing.rst` such that there is now one source of truth. The preliminary documentation is housed in the github-rendered outward-facing `CONTRIBUTING.rst` and the extended documentation is housed in `docs/contributing.rst` which is rendered on readthedocs.

The changes in this pull requests remove the previous duplication of preliminary documentation such that further changes to it will be done in one place (`CONTRIBUTING.rst`) and imported to the other locations as needed.

## Are there changes in behavior for the user?

None

## Is it a substantial burden for the maintainers to support this?

None. This makes future maintenance easier.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- Remember to prefix with 'Fixes' if it should close the issue (e.g. 'Fixes #123'). -->

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES/` folder
  * name it `<issue_or_pr_num>.<type>.rst` (e.g. `588.bugfix.rst`)
  * if you don't have an issue number, change it to the pull request
    number after creating the PR
    * `.bugfix`: A bug fix for something the maintainers deemed an
      improper undesired behavior that got corrected to match
      pre-agreed expectations.
    * `.feature`: A new behavior, public APIs. That sort of stuff.
    * `.deprecation`: A declaration of future API removals and breaking
      changes in behavior.
    * `.breaking`: When something public is removed in a breaking way.
      Could be deprecated in an earlier release.
    * `.doc`: Notable updates to the documentation structure or build
      process.
    * `.packaging`: Notes for downstreams about unobvious side effects
      and tooling. Changes in the test invocation considerations and
      runtime assumptions.
    * `.contrib`: Stuff that affects the contributor experience. e.g.
      Running tests, building the docs, setting up the development
      environment.
    * `.misc`: Changes that are hard to assign to any of the above
      categories.
  * Make sure to use full sentences with correct case and punctuation,
    for example:
    ```rst
    Fixed issue with non-ascii contents in doctest text files
    -- by :user:`contributor-gh-handle`.
    ```

    Use the past tense or the present tense a non-imperative mood,
    referring to what's changed compared to the last released version
    of this project.
