### PR TITLE
Add distinction between error cases in TimerContext

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -140,6 +140,7 @@ Frederik Peter Aalund
 Gabriel Tremblay
 Gang Ji
 Gary Wilson Jr.
+Gary Yendell
 Gennady Andreyev
 Georges Dubus
 Greg Holt

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -658,7 +658,16 @@ class TimerContext(BaseTimerContext):
     def __enter__(self) -> BaseTimerContext:
         task = asyncio.current_task(loop=self._loop)
         if task is None:
-            raise RuntimeError("Timeout context manager should be used inside a task")
+            try:
+                asyncio.current_task()
+            except RuntimeError:
+                raise RuntimeError(
+                    "Timeout context manager should be used inside a task"
+                )
+            else:
+                raise RuntimeError(
+                    "Timeout context manager used in a task on a different event loop"
+                )
 
         if sys.version_info >= (3, 11):
             # Remember if the task was already cancelling


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?
This adds a distinct error message in the case that `TimerContext` is used within a task, but the task is on a different event loop.

## Are there changes in behavior for the user?
The user will get a slightly different - and hopefully more useful - error message in the above case.

## Is it a substantial burden for the maintainers to support this?
No.

## Related issue number
Fixes #10153 

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES/` folder
  * name it `<issue_or_pr_num>.<type>.rst` (e.g. `588.bugfix.rst`)
  * if you don't have an issue number, change it to the pull request
    number after creating the PR
    * `.bugfix`: A bug fix for something the maintainers deemed an
      improper undesired behavior that got corrected to match
      pre-agreed expectations.
    * `.feature`: A new behavior, public APIs. That sort of stuff.
    * `.deprecation`: A declaration of future API removals and breaking
      changes in behavior.
    * `.breaking`: When something public is removed in a breaking way.
      Could be deprecated in an earlier release.
    * `.doc`: Notable updates to the documentation structure or build
      process.
    * `.packaging`: Notes for downstreams about unobvious side effects
      and tooling. Changes in the test invocation considerations and
      runtime assumptions.
    * `.contrib`: Stuff that affects the contributor experience. e.g.
      Running tests, building the docs, setting up the development
      environment.
    * `.misc`: Changes that are hard to assign to any of the above
      categories.
  * Make sure to use full sentences with correct case and punctuation,
    for example:
    ```rst
    Fixed issue with non-ascii contents in doctest text files
    -- by :user:`contributor-gh-handle`.
    ```

    Use the past tense or the present tense a non-imperative mood,
    referring to what's changed compared to the last released version
    of this project.
