### PR TITLE
Introducing aiohttp Guru on Gurubase.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -41,6 +41,10 @@ Async http client/server framework
    :target: https://matrix.to/#/%23aio-libs-space:matrix.org
    :alt: Matrix Space — #aio-libs-space:matrix.org
 
+.. image:: https://img.shields.io/badge/Gurubase-Ask%20aiohttp%20Guru-006BFF
+   :target: https://gurubase.io/g/aiohttp
+   :alt: Gurubase - Ask aiohttp Guru
+
 
 Key Features
 ============


### PR DESCRIPTION
Hello team,

We are the maintainers of [Anteon](https://github.com/getanteon/anteon). Recently, we created Gurubase.io with the mission of building a centralized, open-source, tool-focused knowledge base. Each "guru" in Gurubase is equipped with custom knowledge to answer user questions based on data related to the respective tool.

We’re excited to let you know that [aiohttp Guru](https://gurubase.io/g/aiohttp) has been manually added to Gurubase. aiohttp Guru uses the data from this repo and data from the [docs](https://aiohttp.readthedocs.io/) to answer questions by leveraging the LLM.

This PR introduces the "aiohttp Guru", showcasing that aiohttp now has an AI assistant available to help users with their questions. We’d love to hear your feedback on this contribution.

You also have the option to maintain the "aiohttp Guru" by following the instructions in the [Gurubase Repo](https://github.com/getanteon/gurubase?tab=readme-ov-file#how-to-claim-a-guru) and to add an ASK AI widget to the aiohttp documentation website as detailed [here](https://github.com/getanteon/gurubase?tab=readme-ov-file#widget).

If you’d prefer us to disable aiohttp Guru in Gurubase, just let us know that's totally fine.
