### PR TITLE
Add dynamic port binding

### DIFF
--- a/CHANGES/10665.feature.rst
+++ b/CHANGES/10665.feature.rst
@@ -1,0 +1,1 @@
+Added `port` accessor for dynamic port allocations in `TCPSite` -- by :user:`twhittock-disguise`.

--- a/CHANGES/10665.feature.rst
+++ b/CHANGES/10665.feature.rst
@@ -1,1 +1,1 @@
-Added `port` accessor for dynamic port allocations in `TCPSite` -- by :user:`twhittock-disguise`.
+Added :py:attr:`~aiohttp.web.TCPSite.port` accessor for dynamic port allocations in :class:`~aiohttp.web.TCPSite` -- by :user:`twhittock-disguise`.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -344,6 +344,7 @@ Thomas Forbes
 Thomas Grainger
 Tim Menninger
 Tolga Tezel
+Tom Whittock
 Tomasz Trebski
 Toshiaki Tanaka
 Trinh Hoang Nhu

--- a/aiohttp/web_runner.py
+++ b/aiohttp/web_runner.py
@@ -113,6 +113,11 @@ class TCPSite(BaseSite):
         host = "0.0.0.0" if not self._host else self._host
         return str(URL.build(scheme=scheme, host=host, port=self._port))
 
+    @property
+    def port(self) -> int:
+        """Return the port number the server is bound to, useful for the dynamically allocated port (0)."""
+        return self._port
+
     async def start(self) -> None:
         await super().start()
         loop = asyncio.get_event_loop()
@@ -127,6 +132,10 @@ class TCPSite(BaseSite):
             reuse_address=self._reuse_address,
             reuse_port=self._reuse_port,
         )
+        if self._port == 0:
+            # Port 0 means bind to any port, so we need to set the attribute
+            # to the port the server was actually bound to.
+            self._port = self._server.sockets[0].getsockname()[1]
 
 
 class UnixSite(BaseSite):

--- a/docs/web_advanced.rst
+++ b/docs/web_advanced.rst
@@ -1181,6 +1181,28 @@ the middleware might use :meth:`BaseRequest.clone`.
    for modifying *scheme*, *host* and *remote* attributes according
    to ``Forwarded`` and ``X-Forwarded-*`` HTTP headers.
 
+Deploying with a dynamic port
+-----------------------------
+
+When deploying aiohttp in a zeroconf environment, it may be useful
+to have the server bind to a dynamic port. This can be done by
+using the ``0`` port number. This will cause the OS to assign a
+free port to the server. The assigned port can be retrieved
+using the :attr:`TCPSite.port` property after the server has started.
+
+For example::
+
+    app = web.Application()
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.TCPSite(runner, 'localhost', 0)
+    await site.start()
+
+    print(f"Server started on port {site.port}")
+    while True:
+        await asyncio.sleep(3600)  # sleep forever
+
+
 Swagger support
 ---------------
 

--- a/docs/web_advanced.rst
+++ b/docs/web_advanced.rst
@@ -1184,7 +1184,7 @@ the middleware might use :meth:`BaseRequest.clone`.
 Deploying with a dynamic port
 -----------------------------
 
-When deploying aiohttp in a zeroconf environment, it may be useful
+When deploying aiohttp with zero-configuration networking, it may be useful
 to have the server bind to a dynamic port. This can be done by
 using the ``0`` port number. This will cause the OS to assign a
 free port to the server. The assigned port can be retrieved

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -2788,6 +2788,17 @@ application on specific TCP or Unix socket, e.g.::
                            this flag when being created. This option is not
                            supported on Windows.
 
+   .. attribute:: port
+
+      The port number the server is bound to. This is useful when the port
+      number is not known in advance, such as when constructing with
+      port 0 to request an ephemeral port or when not supplying the port
+      to the constructor.
+      This attribute is read-only and should not be modified.
+      This attribute is only guaranteed to be correct after the server has
+      been started.
+
+
 .. class:: UnixSite(runner, path, *, \
                    shutdown_timeout=60.0, ssl_context=None, \
                    backlog=128)

--- a/tests/test_web_runner.py
+++ b/tests/test_web_runner.py
@@ -256,7 +256,19 @@ async def test_tcpsite_empty_str_host(make_runner: _RunnerMaker) -> None:
     runner = make_runner()
     await runner.setup()
     site = web.TCPSite(runner, host="")
+    assert site.port == 8080
     assert site.name == "http://0.0.0.0:8080"
+
+
+async def test_tcpsite_ephemeral_port(make_runner: _RunnerMaker) -> None:
+    runner = make_runner()
+    await runner.setup()
+    site = web.TCPSite(runner, port=0)
+
+    await site.start()
+    assert site.port != 0
+    assert site.name.startswith("http://0.0.0.0:")
+    await site.stop()
 
 
 def test_run_after_asyncio_run() -> None:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

As per #10665 the TCPSite has a public `port` property which is updated with the bound port number if it was dynamically allocated

## Are there changes in behavior for the user?

Users are now able to rely on the port property and name property on TCPSite having the correct port number if they were relying on port `0` dynamic allocation.

## Is it a substantial burden for the maintainers to support this?

Port 0 is a standard feature in all supported OSs, and leverages the OS capabilities, rather than any specific logic in aiohttp, so the burden should be small.

## Related issue number

Fixes #10665

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES/` folder
  * name it `<issue_or_pr_num>.<type>.rst` (e.g. `588.bugfix.rst`)
  * if you don't have an issue number, change it to the pull request
    number after creating the PR
    * `.bugfix`: A bug fix for something the maintainers deemed an
      improper undesired behavior that got corrected to match
      pre-agreed expectations.
    * `.feature`: A new behavior, public APIs. That sort of stuff.
    * `.deprecation`: A declaration of future API removals and breaking
      changes in behavior.
    * `.breaking`: When something public is removed in a breaking way.
      Could be deprecated in an earlier release.
    * `.doc`: Notable updates to the documentation structure or build
      process.
    * `.packaging`: Notes for downstreams about unobvious side effects
      and tooling. Changes in the test invocation considerations and
      runtime assumptions.
    * `.contrib`: Stuff that affects the contributor experience. e.g.
      Running tests, building the docs, setting up the development
      environment.
    * `.misc`: Changes that are hard to assign to any of the above
      categories.
  * Make sure to use full sentences with correct case and punctuation,
    for example:
    ```rst
    Fixed issue with non-ascii contents in doctest text files
    -- by :user:`contributor-gh-handle`.
    ```

    Use the past tense or the present tense a non-imperative mood,
    referring to what's changed compared to the last released version
    of this project.
