### PR TITLE
enforce rfc6455 section 4.2.1 requirement to refuse malformed Websocket handshake

### DIFF
--- a/CHANGES/10729.breaking.rst
+++ b/CHANGES/10729.breaking.rst
@@ -1,0 +1,1 @@
+Stopped processing non-``GET`` method in WebSocket connection handshake (this might confuse proxies) as demanded by :rfc:`6455#section-4.2.1` -- by :user:`pajod`.

--- a/aiohttp/web_ws.py
+++ b/aiohttp/web_ws.py
@@ -36,7 +36,7 @@ from .http_websocket import _INTERNAL_RECEIVE_TYPES, WSMessageError
 from .log import ws_logger
 from .streams import EofStream
 from .typedefs import JSONDecoder, JSONEncoder
-from .web_exceptions import HTTPBadRequest, HTTPException
+from .web_exceptions import HTTPBadRequest, HTTPException, HTTPMethodNotAllowed
 from .web_request import BaseRequest
 from .web_response import StreamResponse
 
@@ -226,6 +226,9 @@ class WebSocketResponse(StreamResponse):
         self, request: BaseRequest
     ) -> Tuple["CIMultiDict[str]", Optional[str], int, bool]:
         headers = request.headers
+        if request.method != hdrs.METH_GET:
+            raise HTTPMethodNotAllowed(request.method, {hdrs.METH_GET})
+
         if "websocket" != headers.get(hdrs.UPGRADE, "").lower().strip():
             raise HTTPBadRequest(
                 text=(

--- a/tests/test_web_websocket.py
+++ b/tests/test_web_websocket.py
@@ -215,6 +215,12 @@ def test_can_prepare_unknown_protocol(make_request: _RequestMaker) -> None:
     assert WebSocketReady(True, None) == ws.can_prepare(req)
 
 
+def test_can_prepare_invalid_method(make_request: _RequestMaker) -> None:
+    req = make_request("POST", "/")
+    ws = web.WebSocketResponse()
+    assert WebSocketReady(False, None) == ws.can_prepare(req)
+
+
 def test_can_prepare_without_upgrade(make_request: _RequestMaker) -> None:
     req = make_request("GET", "/", headers=CIMultiDict({}))
     ws = web.WebSocketResponse()
@@ -369,11 +375,11 @@ async def test_close_idempotent(make_request: _RequestMaker) -> None:
     assert close_code == 0
 
 
-async def test_prepare_post_method_ok(make_request: _RequestMaker) -> None:
+async def test_prepare_invalid_method(make_request: _RequestMaker) -> None:
     req = make_request("POST", "/")
     ws = web.WebSocketResponse()
-    await ws.prepare(req)
-    assert ws.prepared
+    with pytest.raises(web.HTTPMethodNotAllowed):
+        await ws.prepare(req)
 
 
 async def test_prepare_without_upgrade(make_request: _RequestMaker) -> None:


### PR DESCRIPTION
## What do these changes do?

* refuse HTTP/1.1 WebSocket handshake when method != "GET"
* there is precedent for [being careful](https://github.com/aio-libs/aiohttp/blob/c8e14b15f5ad68a2cedaf263e6f7796387f8e175/aiohttp/web_urldispatcher.py#L312-L325) about emitting 1xx informational responses that could confuse a proxy

I only noticed this was previously in place and had been *removed* in #3980 after writing this. I do not believe it should have been, given that proxies may depend on the clear language in the spec.

## Are there changes in behavior for the user?

* Not for users that follow the instructions in documentation:
> The handler should be registered as HTTP GET processor
* Possibly for users that extend [examples/web_ws.py](https://github.com/aio-libs/aiohttp/blob/master/examples/web_ws.py) and end up registering such dual-use handler to non-GET routes.
* Possibly for other users having legitimate use cases that I am simply not aware of.

## Is it a substantial burden for the maintainers to support this?

* adds single branch which can probably stay untouched forever
  * but will break BADLY in backwards-incompatible manner, in case I missed something
* by submitting a draft I am potentially dumping related work (HTTP version check, allow_head=True docs, ..) on others

## References

* https://datatracker.ietf.org/doc/html/rfc6455#section-4.2.1
> If the server, while reading the handshake, finds that the client did
   not send a handshake that matches the description below [..] the server MUST stop
   processing the client's handshake and return an HTTP response with an
   appropriate error code (such as 400 Bad Request).
>
>   1.   An HTTP/1.1 or higher GET request [..]
* https://websockets.spec.whatwg.org/
* https://datatracker.ietf.org/doc/html/rfc9110#field.upgrade
* https://docs.aiohttp.org/en/stable/web_quickstart.html#websockets

* I have failed to identify which *client* issue motivated supporting non-rfc6455 websocket handshake, but recent docker versions are clearly expecting GET for [the relevant API endpoint](https://github.com/moby/moby/blob/master/docs/api/v1.24.md#attach-to-a-container-websocket).

## Related issue number

* Reverts: https://github.com/aio-libs/aiohttp/pull/3980

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
  - already did.. with this patch no further warning about the footgun is needed
- [x] Add a new news fragment into the `CHANGES/` folder
<!--
  * name it `<issue_or_pr_num>.<type>.rst` (e.g. `588.bugfix.rst`)
  * if you don't have an issue number, change it to the pull request
    number after creating the PR
    * `.bugfix`: A bug fix for something the maintainers deemed an
      improper undesired behavior that got corrected to match
      pre-agreed expectations.
    * `.feature`: A new behavior, public APIs. That sort of stuff.
    * `.deprecation`: A declaration of future API removals and breaking
      changes in behavior.
    * `.breaking`: When something public is removed in a breaking way.
      Could be deprecated in an earlier release.
    * `.doc`: Notable updates to the documentation structure or build
      process.
    * `.packaging`: Notes for downstreams about unobvious side effects
      and tooling. Changes in the test invocation considerations and
      runtime assumptions.
    * `.contrib`: Stuff that affects the contributor experience. e.g.
      Running tests, building the docs, setting up the development
      environment.
    * `.misc`: Changes that are hard to assign to any of the above
      categories.
  * Make sure to use full sentences with correct case and punctuation,
    for example:
    ```rst
    Fixed issue with non-ascii contents in doctest text files
    -- by :user:`contributor-gh-handle`.
    ```

    Use the past tense or the present tense a non-imperative mood,
    referring to what's changed compared to the last released version
    of this project.
-->