### PR TITLE
Prevent blockbuster False Positives from coverage.py Locking

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -84,7 +84,7 @@ def blockbuster(request: pytest.FixtureRequest) -> Iterator[None]:
         # Note: coverage.py uses locking internally which can cause false positives
         # in blockbuster when it instruments code. This is particularly problematic
         # on Windows where it can lead to flaky test failures.
-        # Additionally, we're not particularly worried about lock.acquire happening
+        # Additionally, we're not particularly worried about threading.Lock.acquire happening
         # by accident in this codebase as we primarily use asyncio.Lock for
         # synchronization in async code.
         # Allow lock.acquire calls to prevent these false positives

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -88,7 +88,7 @@ def blockbuster(request: pytest.FixtureRequest) -> Iterator[None]:
         # by accident in this codebase as we primarily use asyncio.Lock for
         # synchronization in async code.
         # Allow lock.acquire calls to prevent these false positives
-        bb.functions["lock.acquire"].deactivate()
+        bb.functions["threading.Lock.acquire"].deactivate()
         yield
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -88,7 +88,7 @@ def blockbuster(request: pytest.FixtureRequest) -> Iterator[None]:
         # by accident in this codebase as we primarily use asyncio.Lock for
         # synchronization in async code.
         # Allow lock.acquire calls to prevent these false positives
-        bb.functions["lock.acquire"].can_block = True
+        bb.functions["lock.acquire"].deactivate()
         yield
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -81,6 +81,14 @@ def blockbuster(request: pytest.FixtureRequest) -> Iterator[None]:
             bb.functions[func].can_block_in(
                 "aiohttp/web_urldispatcher.py", "add_static"
             )
+        # Note: coverage.py uses locking internally which can cause false positives
+        # in blockbuster when it instruments code. This is particularly problematic
+        # on Windows where it can lead to flaky test failures.
+        # Additionally, we're not particularly worried about lock.acquire happening
+        # by accident in this codebase as we primarily use asyncio.Lock for
+        # synchronization in async code.
+        # Allow lock.acquire calls to prevent these false positives
+        bb.functions["lock.acquire"].can_block = True
         yield
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

This change marks `threading.Lock.acquire` as a potentially blocking function in Blockbuster to avoid false positives during instrumentation.

**Details**

- `coverage.py` uses internal locking which can interfere with Blockbuster’s instrumentation.
- On Windows, this has led to flaky test failures due to false positives.
- Our codebase mainly uses `asyncio.Lock`, so real usage of `threading.Lock.acquire` is minimal and not a concern.
