### PR TITLE
Add warning to release notes about the quote_cookie fix

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -153,6 +153,14 @@ Features
 3.12.7 (2025-06-02)
 ===================
 
+.. warning::
+
+   This release fixes an issue where the ``quote_cookie`` parameter was not being properly
+   respected for shared cookies (domain="", path=""). If your server does not handle quoted
+   cookies correctly, you may need to disable cookie quoting by setting ``quote_cookie=False``
+   when creating your :class:`~aiohttp.ClientSession` or :class:`~aiohttp.CookieJar`.
+   See :ref:`aiohttp-client-cookies-quoting` for details.
+
 Bug fixes
 ---------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -159,7 +159,7 @@ Features
    respected for shared cookies (domain="", path=""). If your server does not handle quoted
    cookies correctly, you may need to disable cookie quoting by setting ``quote_cookie=False``
    when creating your :class:`~aiohttp.ClientSession` or :class:`~aiohttp.CookieJar`.
-   See :ref:`aiohttp-client-cookies-quoting` for details.
+   See :ref:`aiohttp-client-cookie-quoting-routine` for details.
 
 Bug fixes
 ---------


### PR DESCRIPTION
This caused a bit of trouble for Home Assistant devs. Let's warn about it.

Note Windows CI is broken due to python 3.13.4 being broken on windows
windows CI started failing 8 hour ago. I think its the python 3.13.4 update : https://github.com/aio-libs/aiohttp/actions/runs/15608488223?pr=11189 -- https://github.com/actions/setup-python/issues/1123#issuecomment-2967884782