### PR TITLE
[3.13] Fix auto-created TCPConnector not using session's event loop

### DIFF
--- a/CHANGES/11147.bugfix.rst
+++ b/CHANGES/11147.bugfix.rst
@@ -1,1 +1,1 @@
-Fixed auto-created TCPConnector not using the session's event loop when ClientSession is created without an explicit connector -- by :user:`bdraco`.
+Fixed auto-created :py:class:`~aiohttp.TCPConnector` not using the session's event loop when :py:class:`~aiohttp.ClientSession` is created without an explicit connector -- by :user:`bdraco`.

--- a/CHANGES/11147.bugfix.rst
+++ b/CHANGES/11147.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed auto-created TCPConnector not using the session's event loop when ClientSession is created without an explicit connector -- by :user:`bdraco`.

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -369,7 +369,9 @@ class ClientSession:
             )
 
         if connector is None:
-            connector = TCPConnector(ssl_shutdown_timeout=ssl_shutdown_timeout)
+            connector = TCPConnector(
+                loop=loop, ssl_shutdown_timeout=ssl_shutdown_timeout
+            )
 
         if connector._loop is not loop:
             raise RuntimeError("Session and connector has to use same event loop")

--- a/tests/test_client_session.py
+++ b/tests/test_client_session.py
@@ -422,6 +422,26 @@ def test_connector_loop(loop: asyncio.AbstractEventLoop) -> None:
         another_loop.run_until_complete(connector.close())
 
 
+def test_auto_created_connector_uses_session_loop(
+    loop: asyncio.AbstractEventLoop,
+) -> None:
+    """Test that auto-created TCPConnector uses the session's loop."""
+    # Create a ClientSession without providing a connector
+    # The session should auto-create a TCPConnector with the provided loop
+    session = ClientSession(loop=loop)
+
+    # Verify the connector was created
+    assert session.connector is not None
+    assert isinstance(session.connector, TCPConnector)
+
+    # Verify the connector uses the same loop as the session
+    assert session.connector._loop is loop
+    assert session.connector._loop is session._loop
+
+    # Clean up
+    loop.run_until_complete(session.close())
+
+
 def test_detach(loop, session) -> None:
     conn = session.connector
     try:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

This PR restores the `loop` parameter that was accidentally removed from the TCPConnector instantiation in ClientSession when PR #11095 was merged. When a ClientSession is created without an explicit connector, it auto-creates a TCPConnector. This connector should use the same event loop as the session to maintain consistency.

## Are there changes in behavior for the user?

No behavior changes for users. This is a bug fix that restores the previous correct behavior where the auto-created TCPConnector uses the same event loop as the ClientSession.

## Is it a substantial burden for the maintainers to support this?

No, this is a simple one-line fix that restores a parameter that was accidentally removed. The pattern of passing the loop parameter to connectors is well-established throughout the codebase and is already tested. This change adds minimal maintenance burden and includes a test to prevent regression.

## Related issue number

Fixes #11147

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES/` folder
  * name it `<issue_or_pr_num>.<type>.rst` (e.g. `588.bugfix.rst`)
  * if you don't have an issue number, change it to the pull request
    number after creating the PR
    * `.bugfix`: A bug fix for something the maintainers deemed an
      improper undesired behavior that got corrected to match
      pre-agreed expectations.
    * `.feature`: A new behavior, public APIs. That sort of stuff.
    * `.deprecation`: A declaration of future API removals and breaking
      changes in behavior.
    * `.breaking`: When something public is removed in a breaking way.
      Could be deprecated in an earlier release.
    * `.doc`: Notable updates to the documentation structure or build
      process.
    * `.packaging`: Notes for downstreams about unobvious side effects
      and tooling. Changes in the test invocation considerations and
      runtime assumptions.
    * `.contrib`: Stuff that affects the contributor experience. e.g.
      Running tests, building the docs, setting up the development
      environment.
    * `.misc`: Changes that are hard to assign to any of the above
      categories.
  * Make sure to use full sentences with correct case and punctuation,
    for example:
    ```rst
    Fixed issue with non-ascii contents in doctest text files
    -- by :user:`contributor-gh-handle`.
    ```

    Use the past tense or the present tense a non-imperative mood,
    referring to what's changed compared to the last released version
    of this project.