### PR TITLE
setup.cfg: include llhttp LICENSE in license-files

### DIFF
--- a/CHANGES/11226.packaging.rst
+++ b/CHANGES/11226.packaging.rst
@@ -1,0 +1,1 @@
+Started including the ``llhttp`` :file:`LICENSE` file in wheels by adding ``vendor/llhttp/LICENSE`` to ``license-files`` in :file:`setup.cfg` -- by :user:`threexc`.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -354,6 +354,7 @@ Tim Menninger
 Tolga Tezel
 Tomasz Trebski
 Toshiaki Tanaka
+Trevor Gamblin
 Trinh Hoang Nhu
 Tymofii Tsiapa
 Vadim Suharnikov

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,8 +16,10 @@ long_description = file: README.rst
 long_description_content_type = text/x-rst
 maintainer = aiohttp team <team@aiohttp.org>
 maintainer_email = team@aiohttp.org
-license = Apache-2.0
-license_files = LICENSE.txt
+license = Apache-2.0 AND MIT
+license_files =
+    LICENSE.txt
+    vendor/llhttp/LICENSE
 classifiers =
   Development Status :: 5 - Production/Stable
 


### PR DESCRIPTION
## What do these changes do?

Make sure that the `llhttp` `LICENSE` file is included in the wheel by modifying `setup.cfg`'s license-files field to be a list according to the Python Packaging User Guide.

## Are there changes in behavior for the user?

No.

## Is it a substantial burden for the maintainers to support this?

The main difference is that the maintainers will have to further update the `license-files` field in `setup.cfg` (or possibly modify `pyproject.toml` if that config content moves there) should `llhttp`'s LICENSE file change name, etc.

## Related issue number

Fixes: #11225

## Checklist

- [X] I think the code is well written
- [X] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES/` folder
  * name it `<issue_or_pr_num>.<type>.rst` (e.g. `588.bugfix.rst`)
  * if you don't have an issue number, change it to the pull request
    number after creating the PR
    * `.bugfix`: A bug fix for something the maintainers deemed an
      improper undesired behavior that got corrected to match
      pre-agreed expectations.
    * `.feature`: A new behavior, public APIs. That sort of stuff.
    * `.deprecation`: A declaration of future API removals and breaking
      changes in behavior.
    * `.breaking`: When something public is removed in a breaking way.
      Could be deprecated in an earlier release.
    * `.doc`: Notable updates to the documentation structure or build
      process.
    * `.packaging`: Notes for downstreams about unobvious side effects
      and tooling. Changes in the test invocation considerations and
      runtime assumptions.
    * `.contrib`: Stuff that affects the contributor experience. e.g.
      Running tests, building the docs, setting up the development
      environment.
    * `.misc`: Changes that are hard to assign to any of the above
      categories.
  * Make sure to use full sentences with correct case and punctuation,
    for example:
    ```rst
    Fixed issue with non-ascii contents in doctest text files
    -- by :user:`contributor-gh-handle`.
    ```

## Testing:

From master branch (building with `python3 -m build` in a venv):

```
(venv) tgamblin@megalith ~/workspace/git/pythonsrc/aiohttp (master)$ unzip -l dist/aiohttp-4.0.0a2.dev0-cp313-cp313-linux_x86_64.whl | grep LICEN
      588  06-17-2025 20:08   aiohttp-4.0.0a2.dev0.dist-info/licenses/LICENSE.txt
```

and from my patch branch:

```
(venv) tgamblin@megalith ~/workspace/git/pythonsrc/aiohttp (tgamblin/llhttp-license-fix)$ unzip -l dist/aiohttp-4.0.0a2.dev0-cp313-cp313-linux_x86_64.whl | grep LICEN
      588  06-17-2025 20:16   aiohttp-4.0.0a2.dev0.dist-info/licenses/LICENSE.txt
     1105  06-17-2025 20:16   aiohttp-4.0.0a2.dev0.dist-info/licenses/vendor/llhttp/LICENSE
```

