### PR TITLE
Document exceptions raised by send_frame et al.

### DIFF
--- a/CHANGES/11234.doc.rst
+++ b/CHANGES/11234.doc.rst
@@ -1,0 +1,2 @@
+Clarified exceptions raised by ``WebSocketResponse.send_frame`` at al.
+-- by :user:`DoctorJohn`.

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -1087,7 +1087,9 @@ and :ref:`aiohttp-web-signals` handlers::
                       :class:`str` (converted to *UTF-8* encoded bytes)
                       or :class:`bytes`.
 
-      :raise RuntimeError: if connections is not started or closing.
+      :raise RuntimeError: if the connections is not started.
+
+      :raise aiohttp.ClientConnectionResetError: if the connection is closing.
 
       .. versionchanged:: 3.0
 
@@ -1102,7 +1104,9 @@ and :ref:`aiohttp-web-signals` handlers::
                       :class:`str` (converted to *UTF-8* encoded bytes)
                       or :class:`bytes`.
 
-      :raise RuntimeError: if connections is not started or closing.
+      :raise RuntimeError: if the connections is not started.
+
+      :raise aiohttp.ClientConnectionResetError: if the connection is closing.
 
       .. versionchanged:: 3.0
 
@@ -1119,9 +1123,11 @@ and :ref:`aiohttp-web-signals` handlers::
                            single message,
                            ``None`` for not overriding per-socket setting.
 
-      :raise RuntimeError: if connection is not started or closing
+      :raise RuntimeError: if the connection is not started.
 
       :raise TypeError: if data is not :class:`str`
+
+      :raise aiohttp.ClientConnectionResetError: if the connection is closing.
 
       .. versionchanged:: 3.0
 
@@ -1139,10 +1145,12 @@ and :ref:`aiohttp-web-signals` handlers::
                            single message,
                            ``None`` for not overriding per-socket setting.
 
-      :raise RuntimeError: if connection is not started or closing
+      :raise RuntimeError: if the connection is not started.
 
       :raise TypeError: if data is not :class:`bytes`,
                         :class:`bytearray` or :class:`memoryview`.
+
+      :raise aiohttp.ClientConnectionResetError: if the connection is closing.
 
       .. versionchanged:: 3.0
 
@@ -1164,11 +1172,13 @@ and :ref:`aiohttp-web-signals` handlers::
                              returns a JSON string
                              (:func:`json.dumps` by default).
 
-      :raise RuntimeError: if connection is not started or closing
+      :raise RuntimeError: if the connection is not started.
 
       :raise ValueError: if data is not serializable object
 
       :raise TypeError: if value returned by ``dumps`` param is not :class:`str`
+
+      :raise aiohttp.ClientConnectionResetError: if the connection is closing.
 
       .. versionchanged:: 3.0
 
@@ -1198,6 +1208,10 @@ and :ref:`aiohttp-web-signals` handlers::
       :param int compress: sets specific level of compression for
                            single message,
                            ``None`` for not overriding per-socket setting.
+
+      :raise RuntimeError: if the connection is not started.
+
+      :raise aiohttp.ClientConnectionResetError: if the connection is closing.
 
       .. versionadded:: 3.11
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
This PR updates the web reference docs of `aiohttp.web.WebSocketResponse.send_frame` et al. with previously missing `:raise` declarations.

Most notably, `send_frame`, `send_str`, `send_bytes`, and `send_json` all raise `aiohttp.ClientConnectionResetError`, which was previously undocumented. Additionally, it was not documented that `send_frame` may raise a `RuntimeError` if the connection is not started yet.

<details>
<summary>For reference, here are the relevant code snippets:</summary>

- `send_frame` raising `RuntimeError` if the connection is not started yet: https://github.com/aio-libs/aiohttp/blob/7c3afd2211aeacd077e7f11a3e1bf9b9234a7610/aiohttp/web_ws.py#L405-L411
- `send_frame` et al. raising `aiohttp.ClientConnectionResetError` if the connection is closing:
    https://github.com/aio-libs/aiohttp/blob/7c3afd2211aeacd077e7f11a3e1bf9b9234a7610/aiohttp/_websocket/writer.py#L71-L72
    https://github.com/aio-libs/aiohttp/blob/7c3afd2211aeacd077e7f11a3e1bf9b9234a7610/aiohttp/_websocket/writer.py#L125-L126

</details>

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->
No

## Is it a substantial burden for the maintainers to support this?

<!--
Stop right there! Pause. Just for a minute... Can you think of anything
obvious that would complicate the ongoing development of this project?

Try to consider if you'd be able to maintain it throughout the next
5 years. Does it seem viable? Tell us your thoughts! We'd very much
love to hear what the consequences of merging this patch might be...

This will help us assess if your change is something we'd want to
entertain early in the review process. Thank you in advance!
-->
*pause*

No

## Related issue number

<!-- Will this resolve any open issues? -->
<!-- Remember to prefix with 'Fixes' if it closes an issue (e.g. 'Fixes #123'). -->
n/a

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES/` folder
  * name it `<issue_or_pr_num>.<type>.rst` (e.g. `588.bugfix.rst`)
  * if you don't have an issue number, change it to the pull request
    number after creating the PR
    * `.bugfix`: A bug fix for something the maintainers deemed an
      improper undesired behavior that got corrected to match
      pre-agreed expectations.
    * `.feature`: A new behavior, public APIs. That sort of stuff.
    * `.deprecation`: A declaration of future API removals and breaking
      changes in behavior.
    * `.breaking`: When something public is removed in a breaking way.
      Could be deprecated in an earlier release.
    * `.doc`: Notable updates to the documentation structure or build
      process.
    * `.packaging`: Notes for downstreams about unobvious side effects
      and tooling. Changes in the test invocation considerations and
      runtime assumptions.
    * `.contrib`: Stuff that affects the contributor experience. e.g.
      Running tests, building the docs, setting up the development
      environment.
    * `.misc`: Changes that are hard to assign to any of the above
      categories.
  * Make sure to use full sentences with correct case and punctuation,
    for example:
    ```rst
    Fixed issue with non-ascii contents in doctest text files
    -- by :user:`contributor-gh-handle`.
    ```

    Use the past tense or the present tense a non-imperative mood,
    referring to what's changed compared to the last released version
    of this project.
