### PR TITLE
Add Second Generic Value to _TracingSignal for Custom Context Variables

### DIFF
--- a/CHANGES/11268.feature.rst
+++ b/CHANGES/11268.feature.rst
@@ -1,2 +1,2 @@
-Updated `_TracingSignal` to utilize a secondary generic variable for type hinting custom context variables.
+Updated ``_TracingSignal`` to utilize a secondary generic variable for type hinting custom context variables
 -- by :user:`Vizonex`.

--- a/CHANGES/11268.feature.rst
+++ b/CHANGES/11268.feature.rst
@@ -1,0 +1,2 @@
+Updated `_TracingSignal` to utilize a secondary generic variable for typehinting custom context variables.
+-- by :user:`Vizonex`.

--- a/CHANGES/11268.feature.rst
+++ b/CHANGES/11268.feature.rst
@@ -1,2 +1,2 @@
-Updated `_TracingSignal` to utilize a secondary generic variable for typehinting custom context variables.
+Updated `_TracingSignal` to utilize a secondary generic variable for type hinting custom context variables.
 -- by :user:`Vizonex`.

--- a/aiohttp/tracing.py
+++ b/aiohttp/tracing.py
@@ -75,7 +75,7 @@ class TraceConfig(Generic[_T]):
             _T, TraceConnectionQueuedEndParams
         ] = Signal(self)
         self._on_connection_create_start: _TracingSignal[
-            TraceConnectionCreateStartParams
+            _T, TraceConnectionCreateStartParams
         ] = Signal(self)
         self._on_connection_create_end: _TracingSignal[
             _T, TraceConnectionCreateEndParams

--- a/aiohttp/tracing.py
+++ b/aiohttp/tracing.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:
     from .client import ClientSession
 
     _ParamT_contra = TypeVar("_ParamT_contra", contravariant=True)
-    _TracingSignal = Signal[ClientSession, SimpleNamespace, _ParamT_contra]
+    _TracingSignal = Signal[ClientSession, "_T", _ParamT_contra]
 
 
 __all__ = (
@@ -52,46 +52,52 @@ class TraceConfig(Generic[_T]):
     def __init__(
         self, trace_config_ctx_factory: _Factory[Any] = SimpleNamespace
     ) -> None:
-        self._on_request_start: _TracingSignal[TraceRequestStartParams] = Signal(self)
-        self._on_request_chunk_sent: _TracingSignal[TraceRequestChunkSentParams] = (
+        self._on_request_start: _TracingSignal[_T, TraceRequestStartParams] = Signal(
+            self
+        )
+        self._on_request_chunk_sent: _TracingSignal[_T, TraceRequestChunkSentParams] = (
             Signal(self)
         )
         self._on_response_chunk_received: _TracingSignal[
-            TraceResponseChunkReceivedParams
+            _T, TraceResponseChunkReceivedParams
         ] = Signal(self)
-        self._on_request_end: _TracingSignal[TraceRequestEndParams] = Signal(self)
-        self._on_request_exception: _TracingSignal[TraceRequestExceptionParams] = (
+        self._on_request_end: _TracingSignal[_T, TraceRequestEndParams] = Signal(self)
+        self._on_request_exception: _TracingSignal[_T, TraceRequestExceptionParams] = (
             Signal(self)
         )
-        self._on_request_redirect: _TracingSignal[TraceRequestRedirectParams] = Signal(
-            self
+        self._on_request_redirect: _TracingSignal[_T, TraceRequestRedirectParams] = (
+            Signal(self)
         )
         self._on_connection_queued_start: _TracingSignal[
-            TraceConnectionQueuedStartParams
+            _T, TraceConnectionQueuedStartParams
         ] = Signal(self)
         self._on_connection_queued_end: _TracingSignal[
-            TraceConnectionQueuedEndParams
+            _T, TraceConnectionQueuedEndParams
         ] = Signal(self)
         self._on_connection_create_start: _TracingSignal[
             TraceConnectionCreateStartParams
         ] = Signal(self)
         self._on_connection_create_end: _TracingSignal[
-            TraceConnectionCreateEndParams
+            _T, TraceConnectionCreateEndParams
         ] = Signal(self)
         self._on_connection_reuseconn: _TracingSignal[
-            TraceConnectionReuseconnParams
+            _T, TraceConnectionReuseconnParams
         ] = Signal(self)
         self._on_dns_resolvehost_start: _TracingSignal[
-            TraceDnsResolveHostStartParams
+            _T, TraceDnsResolveHostStartParams
         ] = Signal(self)
-        self._on_dns_resolvehost_end: _TracingSignal[TraceDnsResolveHostEndParams] = (
-            Signal(self)
+        self._on_dns_resolvehost_end: _TracingSignal[
+            _T, TraceDnsResolveHostEndParams
+        ] = Signal(self)
+        self._on_dns_cache_hit: _TracingSignal[_T, TraceDnsCacheHitParams] = Signal(
+            self
         )
-        self._on_dns_cache_hit: _TracingSignal[TraceDnsCacheHitParams] = Signal(self)
-        self._on_dns_cache_miss: _TracingSignal[TraceDnsCacheMissParams] = Signal(self)
-        self._on_request_headers_sent: _TracingSignal[TraceRequestHeadersSentParams] = (
-            Signal(self)
+        self._on_dns_cache_miss: _TracingSignal[_T, TraceDnsCacheMissParams] = Signal(
+            self
         )
+        self._on_request_headers_sent: _TracingSignal[
+            _T, TraceRequestHeadersSentParams
+        ] = Signal(self)
 
         self._trace_config_ctx_factory: _Factory[_T] = trace_config_ctx_factory
 
@@ -118,89 +124,91 @@ class TraceConfig(Generic[_T]):
         self._on_request_headers_sent.freeze()
 
     @property
-    def on_request_start(self) -> "_TracingSignal[TraceRequestStartParams]":
+    def on_request_start(self) -> "_TracingSignal[_T, TraceRequestStartParams]":
         return self._on_request_start
 
     @property
-    def on_request_chunk_sent(self) -> "_TracingSignal[TraceRequestChunkSentParams]":
+    def on_request_chunk_sent(
+        self,
+    ) -> "_TracingSignal[_T, TraceRequestChunkSentParams]":
         return self._on_request_chunk_sent
 
     @property
     def on_response_chunk_received(
         self,
-    ) -> "_TracingSignal[TraceResponseChunkReceivedParams]":
+    ) -> "_TracingSignal[_T, TraceResponseChunkReceivedParams]":
         return self._on_response_chunk_received
 
     @property
-    def on_request_end(self) -> "_TracingSignal[TraceRequestEndParams]":
+    def on_request_end(self) -> "_TracingSignal[_T, TraceRequestEndParams]":
         return self._on_request_end
 
     @property
     def on_request_exception(
         self,
-    ) -> "_TracingSignal[TraceRequestExceptionParams]":
+    ) -> "_TracingSignal[_T, TraceRequestExceptionParams]":
         return self._on_request_exception
 
     @property
     def on_request_redirect(
         self,
-    ) -> "_TracingSignal[TraceRequestRedirectParams]":
+    ) -> "_TracingSignal[_T, TraceRequestRedirectParams]":
         return self._on_request_redirect
 
     @property
     def on_connection_queued_start(
         self,
-    ) -> "_TracingSignal[TraceConnectionQueuedStartParams]":
+    ) -> "_TracingSignal[_T, TraceConnectionQueuedStartParams]":
         return self._on_connection_queued_start
 
     @property
     def on_connection_queued_end(
         self,
-    ) -> "_TracingSignal[TraceConnectionQueuedEndParams]":
+    ) -> "_TracingSignal[_T, TraceConnectionQueuedEndParams]":
         return self._on_connection_queued_end
 
     @property
     def on_connection_create_start(
         self,
-    ) -> "_TracingSignal[TraceConnectionCreateStartParams]":
+    ) -> "_TracingSignal[_T, TraceConnectionCreateStartParams]":
         return self._on_connection_create_start
 
     @property
     def on_connection_create_end(
         self,
-    ) -> "_TracingSignal[TraceConnectionCreateEndParams]":
+    ) -> "_TracingSignal[_T, TraceConnectionCreateEndParams]":
         return self._on_connection_create_end
 
     @property
     def on_connection_reuseconn(
         self,
-    ) -> "_TracingSignal[TraceConnectionReuseconnParams]":
+    ) -> "_TracingSignal[_T, TraceConnectionReuseconnParams]":
         return self._on_connection_reuseconn
 
     @property
     def on_dns_resolvehost_start(
         self,
-    ) -> "_TracingSignal[TraceDnsResolveHostStartParams]":
+    ) -> "_TracingSignal[_T, TraceDnsResolveHostStartParams]":
         return self._on_dns_resolvehost_start
 
     @property
     def on_dns_resolvehost_end(
         self,
-    ) -> "_TracingSignal[TraceDnsResolveHostEndParams]":
+    ) -> "_TracingSignal[_T, TraceDnsResolveHostEndParams]":
         return self._on_dns_resolvehost_end
 
     @property
-    def on_dns_cache_hit(self) -> "_TracingSignal[TraceDnsCacheHitParams]":
+    def on_dns_cache_hit(self) -> "_TracingSignal[_T, TraceDnsCacheHitParams]":
         return self._on_dns_cache_hit
 
     @property
-    def on_dns_cache_miss(self) -> "_TracingSignal[TraceDnsCacheMissParams]":
+    def on_dns_cache_miss(self) -> "_TracingSignal[_T, TraceDnsCacheMissParams]":
         return self._on_dns_cache_miss
 
     @property
     def on_request_headers_sent(
         self,
-    ) -> "_TracingSignal[TraceRequestHeadersSentParams]":
+    ) -> "_TracingSignal[_T, TraceRequestHeadersSentParams]":
         return self._on_request_headers_sent
 
 

--- a/aiohttp/tracing.py
+++ b/aiohttp/tracing.py
@@ -11,9 +11,6 @@ from .helpers import frozen_dataclass_decorator
 if TYPE_CHECKING:
     from .client import ClientSession
 
-    _ParamT_contra = TypeVar("_ParamT_contra", contravariant=True)
-    _TracingSignal = Signal[ClientSession, "_T", _ParamT_contra]
-
 
 __all__ = (
     "TraceConfig",
@@ -36,6 +33,8 @@ __all__ = (
 )
 
 _T = TypeVar("_T", covariant=True)
+_ParamT_contra = TypeVar("_ParamT_contra", contravariant=True)
+_TracingSignal = Signal["ClientSession", _T, _ParamT_contra]
 
 
 class _Factory(Protocol[_T]):

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -15,6 +15,5 @@ pytest_codspeed
 python-on-whales
 setuptools-git
 trustme; platform_machine != "i686"  # no 32-bit wheels
-typing-extensions
 wait-for-it
 zlib_ng

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -14,7 +14,7 @@ pytest-xdist
 pytest_codspeed
 python-on-whales
 setuptools-git
-typing-extensions
 trustme; platform_machine != "i686"  # no 32-bit wheels
+typing-extensions
 wait-for-it
 zlib_ng

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -14,6 +14,7 @@ pytest-xdist
 pytest_codspeed
 python-on-whales
 setuptools-git
+typing-extensions
 trustme; platform_machine != "i686"  # no 32-bit wheels
 wait-for-it
 zlib_ng

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -37,10 +37,13 @@ class TestTraceConfig:
     def test_trace_config_ctx_factory(self) -> None:
         trace_config = TraceConfig(trace_config_ctx_factory=dict)
         assert isinstance(trace_config.trace_config_ctx(), dict)
-    
+
     def test_trace_config_signal_typehint(self):
         trace_config = TraceConfig(dict)
-        assert_type(trace_config.on_request_start, Signal[ClientSession, dict[str, Any], TraceRequestStartParams])
+        assert_type(
+            trace_config.on_request_start,
+            Signal[ClientSession, dict[str, Any], TraceRequestStartParams],
+        )
 
     def test_trace_config_ctx_request_ctx(self) -> None:
         trace_request_ctx = Mock()

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -33,6 +33,10 @@ class TestTraceConfig:
     def test_trace_config_ctx_default(self) -> None:
         trace_config = TraceConfig()
         assert isinstance(trace_config.trace_config_ctx(), SimpleNamespace)
+        assert_type(
+            trace_config.on_request_chunk_sent,
+            Signal[ClientSession, SimpleNamespace, TraceRequestChunkSentParams]
+        )
 
     def test_trace_config_ctx_factory(self) -> None:
         trace_config = TraceConfig(trace_config_ctx_factory=dict)

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -37,9 +37,6 @@ class TestTraceConfig:
     def test_trace_config_ctx_factory(self) -> None:
         trace_config = TraceConfig(trace_config_ctx_factory=dict)
         assert isinstance(trace_config.trace_config_ctx(), dict)
-
-    def test_trace_config_signal_typehint(self):
-        trace_config = TraceConfig(dict)
         assert_type(
             trace_config.on_request_start,
             Signal[ClientSession, dict[str, Any], TraceRequestStartParams],

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -35,7 +35,7 @@ class TestTraceConfig:
         assert isinstance(trace_config.trace_config_ctx(), SimpleNamespace)
         assert_type(
             trace_config.on_request_chunk_sent,
-            Signal[ClientSession, SimpleNamespace, TraceRequestChunkSentParams]
+            Signal[ClientSession, SimpleNamespace, TraceRequestChunkSentParams],
         )
 
     def test_trace_config_ctx_factory(self) -> None:

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -4,7 +4,10 @@ from unittest import mock
 from unittest.mock import Mock
 
 import pytest
+from aiosignal import Signal
+from typing_extensions import assert_type
 
+from aiohttp import ClientSession
 from aiohttp.tracing import (
     Trace,
     TraceConfig,
@@ -34,6 +37,10 @@ class TestTraceConfig:
     def test_trace_config_ctx_factory(self) -> None:
         trace_config = TraceConfig(trace_config_ctx_factory=dict)
         assert isinstance(trace_config.trace_config_ctx(), dict)
+    
+    def test_trace_config_signal_typehint(self):
+        trace_config = TraceConfig(dict)
+        assert_type(trace_config.on_request_start, Signal[ClientSession, dict[str, Any], TraceRequestStartParams])
 
     def test_trace_config_ctx_request_ctx(self) -> None:
         trace_request_ctx = Mock()

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -1,3 +1,4 @@
+import sys
 from types import SimpleNamespace
 from typing import Any, Tuple
 from unittest import mock
@@ -5,7 +6,6 @@ from unittest.mock import Mock
 
 import pytest
 from aiosignal import Signal
-from typing_extensions import assert_type
 
 from aiohttp import ClientSession
 from aiohttp.tracing import (
@@ -28,23 +28,28 @@ from aiohttp.tracing import (
     TraceResponseChunkReceivedParams,
 )
 
+if sys.version_info >= (3, 11):
+    from typing import assert_type
+
 
 class TestTraceConfig:
     def test_trace_config_ctx_default(self) -> None:
         trace_config = TraceConfig()
         assert isinstance(trace_config.trace_config_ctx(), SimpleNamespace)
-        assert_type(
-            trace_config.on_request_chunk_sent,
-            Signal[ClientSession, SimpleNamespace, TraceRequestChunkSentParams],
-        )
+        if sys.version_info >= (3, 11):
+            assert_type(
+                trace_config.on_request_chunk_sent,
+                Signal[ClientSession, SimpleNamespace, TraceRequestChunkSentParams],
+            )
 
     def test_trace_config_ctx_factory(self) -> None:
         trace_config = TraceConfig(trace_config_ctx_factory=dict)
         assert isinstance(trace_config.trace_config_ctx(), dict)
-        assert_type(
-            trace_config.on_request_start,
-            Signal[ClientSession, dict[str, Any], TraceRequestStartParams],
-        )
+        if sys.version_info >= (3, 11):
+            assert_type(
+                trace_config.on_request_start,
+                Signal[ClientSession, dict[str, Any], TraceRequestStartParams],
+            )
 
     def test_trace_config_ctx_request_ctx(self) -> None:
         trace_request_ctx = Mock()


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

First of all, thank you for helping me accomplish my wishes of reviving aiosignal and improving type hinting it's going to help a lot of people figure out how to use TraceConfig better. Let me extend my thanks by ensuring that the generic variable is being properly hinted at across all callbacks so that if a custom items are utilized users will be able to typehint that item without failure. 

## Are there changes in behavior for the user?

Typehinting the Generic Variable in replacement for a custom variable has it's own benefits such as allowing a user to visually see what custom variables need to be passed & for what callback it will be done with.

### Here's a small creative example to illustrates this new generic variable

```python
from aiohttp import TraceConfig, ClientSession, TraceRequestRedirectParams
from attrs import define, field
from yarl import URL

# Hypothetically lets say we wanted to write a tool that blocks shady websites
# from being requested

class ShadyLinkDetected(Exception):
    pass

# This will be our context to investigate shady links...
@define
class URLRedirects:
    urls: list[URL] = field(factory=list)


# TraceConfig is now typehinted as TraceConfig[URLRedirects]
tc = TraceConfig(URLRedirects([URL("http://shady-url.com")]))


# on_request_redirect is hinted as _TracingSignal[URLRedirects, TraceRequestRedirectParams] which should match
# to this callback being made...
@tc.on_request_redirect
async def on_request_redirect(
    client: ClientSession, ctx: URLRedirects, params: TraceRequestRedirectParams
):
    if params.url in ctx.urls:
        raise ShadyLinkDetected("Found a Malicous Link, will not continue to request")

```

<!--
Stop right there! Pause. Just for a minute... Can you think of anything
obvious that would complicate the ongoing development of this project?

Try to consider if you'd be able to maintain it throughout the next
5 years. Does it seem viable? Tell us your thoughts! We'd very much
love to hear what the consequences of merging this patch might be...

This will help us assess if your change is something we'd want to
entertain early in the review process. Thank you in advance!
-->

## Related issue number

- Fixes #11160

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES/` folder
  * name it `<issue_or_pr_num>.<type>.rst` (e.g. `588.bugfix.rst`)
  * if you don't have an issue number, change it to the pull request
    number after creating the PR
    * `.bugfix`: A bug fix for something the maintainers deemed an
      improper undesired behavior that got corrected to match
      pre-agreed expectations.
    * `.feature`: A new behavior, public APIs. That sort of stuff.
    * `.deprecation`: A declaration of future API removals and breaking
      changes in behavior.
    * `.breaking`: When something public is removed in a breaking way.
      Could be deprecated in an earlier release.
    * `.doc`: Notable updates to the documentation structure or build
      process.
    * `.packaging`: Notes for downstreams about unobvious side effects
      and tooling. Changes in the test invocation considerations and
      runtime assumptions.
    * `.contrib`: Stuff that affects the contributor experience. e.g.
      Running tests, building the docs, setting up the development
      environment.
    * `.misc`: Changes that are hard to assign to any of the above
      categories.
  * Make sure to use full sentences with correct case and punctuation,
    for example:
    ```rst
    Fixed issue with non-ascii contents in doctest text files
    -- by :user:`contributor-gh-handle`.
    ```

    Use the past tense or the present tense a non-imperative mood,
    referring to what's changed compared to the last released version
    of this project.
