### PR TITLE
Fix file uploads failing with HTTP 422 on 307/308 redirects

### DIFF
--- a/CHANGES/11270.bugfix.rst
+++ b/CHANGES/11270.bugfix.rst
@@ -1,1 +1,1 @@
-Fixed file uploads failing with HTTP 422 errors when encountering 307/308 redirects by ensuring correct Content-Length calculation after payload reuse -- by :user:`bdraco`.
+Fixed file uploads failing with HTTP 422 errors when encountering 307/308 redirects, and 301/302 redirects for non-POST methods, by preserving the request body when appropriate per :rfc:`9110#section-15.4.3-3.1` -- by :user:`bdraco`.

--- a/CHANGES/11270.bugfix.rst
+++ b/CHANGES/11270.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed file uploads failing with HTTP 422 errors when encountering 307/308 redirects by ensuring correct Content-Length calculation after payload reuse -- by :user:`bdraco`.

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -761,13 +761,7 @@ class ClientSession:
                             data = None
                             if headers.get(hdrs.CONTENT_LENGTH):
                                 headers.pop(hdrs.CONTENT_LENGTH)
-                        elif (
-                            resp.status in (307, 308)
-                            or (
-                                resp.status in (301, 302)
-                                and resp.method != hdrs.METH_POST
-                            )
-                        ) and req._body is not None:
+                        else:
                             # For 307/308, always preserve the request body
                             # For 301/302 with non-POST methods, preserve the request body
                             # https://www.rfc-editor.org/rfc/rfc9110#section-15.4.3-3.1

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -761,6 +761,10 @@ class ClientSession:
                             data = None
                             if headers.get(hdrs.CONTENT_LENGTH):
                                 headers.pop(hdrs.CONTENT_LENGTH)
+                        elif resp.status in (307, 308) and req._body is not None:
+                            # For 307/308, preserve the request body
+                            # Use the existing payload to avoid recreating it from a potentially consumed file
+                            data = req._body
 
                         r_url = resp.headers.get(hdrs.LOCATION) or resp.headers.get(
                             hdrs.URI

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -761,8 +761,16 @@ class ClientSession:
                             data = None
                             if headers.get(hdrs.CONTENT_LENGTH):
                                 headers.pop(hdrs.CONTENT_LENGTH)
-                        elif resp.status in (307, 308) and req._body is not None:
-                            # For 307/308, preserve the request body
+                        elif (
+                            resp.status in (307, 308)
+                            or (
+                                resp.status in (301, 302)
+                                and resp.method != hdrs.METH_POST
+                            )
+                        ) and req._body is not None:
+                            # For 307/308, always preserve the request body
+                            # For 301/302 with non-POST methods, preserve the request body
+                            # https://www.rfc-editor.org/rfc/rfc9110#section-15.4.3-3.1
                             # Use the existing payload to avoid recreating it from a potentially consumed file
                             data = req._body
 

--- a/aiohttp/payload.py
+++ b/aiohttp/payload.py
@@ -539,7 +539,8 @@ class IOBasePayload(Payload):
 
     @property
     def size(self) -> Optional[int]:
-        """Size of the payload in bytes.
+        """
+        Size of the payload in bytes.
 
         Returns the total size of the payload content from the initial position.
         This ensures consistent Content-Length for requests, including 307/308 redirects

--- a/aiohttp/payload.py
+++ b/aiohttp/payload.py
@@ -542,7 +542,14 @@ class IOBasePayload(Payload):
         """
         Size of the payload in bytes.
 
-        Returns the total size of the payload content.
+        This is the remaining size of the file-like object that can be read.
+
+        This property stores the start position on first access
+        to ensure that subsequent calls to size return the correct
+        number of bytes remaining to be read, even after some data has been consumed.
+
+        Returns the number of bytes remaining to be read from the file.
+
         Returns None if the size cannot be determined (e.g., for unseekable streams).
         """
         try:

--- a/aiohttp/payload.py
+++ b/aiohttp/payload.py
@@ -550,12 +550,12 @@ class IOBasePayload(Payload):
         """
         try:
             # Store the start position on first access.
-            # This is critical for 307/308 redirects where the same payload instance
-            # is reused. Without storing the initial position, after the first request
-            # reads the file, the file position would be at EOF, which would cause the
+            # This is critical when the same payload instance is reused (e.g., 307/308
+            # redirects). Without storing the initial position, after the payload is
+            # read once, the file position would be at EOF, which would cause the
             # size calculation to return 0 (file_size - EOF position).
             # By storing the start position, we ensure the size calculation always
-            # returns the correct total size for subsequent redirect requests.
+            # returns the correct total size for any subsequent use.
             if self._start_position is None:
                 try:
                     self._start_position = self._value.tell()

--- a/aiohttp/payload.py
+++ b/aiohttp/payload.py
@@ -551,10 +551,11 @@ class IOBasePayload(Payload):
         try:
             # Store the start position on first access.
             # This is critical for 307/308 redirects where the same payload instance
-            # is reused. After the first request reads the file, the position is at EOF,
-            # causing size calculation to return 0 (file_size - EOF position).
-            # By storing the start position on first access, we ensure the size calculation
-            # returns the correct total size for the subsequent redirect request.
+            # is reused. Without storing the initial position, after the first request
+            # reads the file, the file position would be at EOF, which would cause the
+            # size calculation to return 0 (file_size - EOF position).
+            # By storing the start position, we ensure the size calculation always
+            # returns the correct total size for subsequent redirect requests.
             if self._start_position is None:
                 try:
                     self._start_position = self._value.tell()

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -5359,9 +5359,9 @@ async def test_amazon_like_cookie_scenario(aiohttp_client: AiohttpClient) -> Non
         ), "All raw headers should be preserved"
 
 
-@pytest.mark.parametrize("status", [307, 308])
+@pytest.mark.parametrize("status", (307, 308))
 async def test_file_upload_307_308_redirect(
-    aiohttp_client: Any, tmp_path: pathlib.Path, status: int
+    aiohttp_client: AiohttpClient, tmp_path: pathlib.Path, status: int
 ) -> None:
     """Test that file uploads work correctly with 307/308 redirects.
 
@@ -5426,7 +5426,7 @@ async def test_file_upload_307_308_redirect(
 @pytest.mark.parametrize("status", [301, 302])
 @pytest.mark.parametrize("method", ["PUT", "PATCH", "DELETE"])
 async def test_file_upload_301_302_redirect_non_post(
-    aiohttp_client: Any, tmp_path: pathlib.Path, status: int, method: str
+    aiohttp_client: AiohttpClient, tmp_path: pathlib.Path, status: int, method: str
 ) -> None:
     """Test that file uploads work correctly with 301/302 redirects for non-POST methods.
 
@@ -5490,7 +5490,7 @@ async def test_file_upload_301_302_redirect_non_post(
 
 
 async def test_file_upload_307_302_redirect_chain(
-    aiohttp_client: Any, tmp_path: pathlib.Path
+    aiohttp_client: AiohttpClient, tmp_path: pathlib.Path
 ) -> None:
     """Test that file uploads work correctly with 307->302->200 redirect chain.
 

--- a/tests/test_payload.py
+++ b/tests/test_payload.py
@@ -1276,3 +1276,85 @@ async def test_text_io_payload_size_utf16(tmp_path: Path) -> None:
         assert len(writer.buffer) == utf16_file_size
     finally:
         await loop.run_in_executor(None, f.close)
+
+
+async def test_iobase_payload_size_after_reading(tmp_path: Path) -> None:
+    """Test that IOBasePayload.size returns correct size after file has been read.
+
+    This demonstrates the bug where size calculation doesn't account for
+    the current file position, causing issues with 307/308 redirects.
+    """
+    # Create a test file with known content
+    test_file = tmp_path / "test.txt"
+    content = b"Hello, World! This is test content."
+    await asyncio.to_thread(test_file.write_bytes, content)
+    expected_size = len(content)
+
+    # Open the file and create payload
+    f = await asyncio.to_thread(open, test_file, "rb")
+    try:
+        p = payload.BufferedReaderPayload(f)
+
+        # First size check - should return full file size
+        assert p.size == expected_size
+
+        # Read the file (simulating first request)
+        writer = BufferWriter()
+        await p.write(writer)
+        assert len(writer.buffer) == expected_size
+
+        # Second size check - should still return full file size
+        # but currently returns 0 because file position is at EOF
+        assert p.size == expected_size  # This assertion fails!
+
+        # Attempting to write again should write the full content
+        # but currently writes nothing because file is at EOF
+        writer2 = BufferWriter()
+        await p.write(writer2)
+        assert len(writer2.buffer) == expected_size  # This also fails!
+    finally:
+        await asyncio.to_thread(f.close)
+
+
+async def test_iobase_payload_size_unseekable() -> None:
+    """Test that IOBasePayload.size returns None for unseekable files."""
+
+    class UnseekableFile:
+        """Mock file object that doesn't support seeking."""
+
+        def __init__(self, content: bytes) -> None:
+            self.content = content
+            self.pos = 0
+
+        def read(self, size: int = -1) -> bytes:
+            if size == -1:
+                result = self.content[self.pos :]
+                self.pos = len(self.content)
+            else:
+                result = self.content[self.pos : self.pos + size]
+                self.pos += len(result)
+            return result
+
+        def tell(self) -> int:
+            raise OSError("Unseekable file")
+
+        def seek(self, offset: int, whence: int = 0) -> int:
+            raise OSError("Unseekable file")
+
+        def fileno(self) -> int:
+            raise AttributeError("No file descriptor")
+
+    content = b"Unseekable content"
+    f = UnseekableFile(content)
+    p = payload.IOBasePayload(f)
+
+    # Size should return None for unseekable files
+    assert p.size is None
+
+    # Writing should still work
+    writer = BufferWriter()
+    await p.write(writer)
+    assert writer.buffer == content
+
+    # After reading, the payload should be marked as consumed
+    assert p.consumed is True

--- a/tests/test_payload.py
+++ b/tests/test_payload.py
@@ -1346,7 +1346,7 @@ async def test_iobase_payload_size_unseekable() -> None:
 
     content = b"Unseekable content"
     f = UnseekableFile(content)
-    p = payload.IOBasePayload(f)
+    p = payload.IOBasePayload(f)  # type: ignore[arg-type]
 
     # Size should return None for unseekable files
     assert p.size is None

--- a/tests/test_payload.py
+++ b/tests/test_payload.py
@@ -1326,23 +1326,13 @@ async def test_iobase_payload_size_unseekable() -> None:
             self.content = content
             self.pos = 0
 
-        def read(self, size: int = -1) -> bytes:
-            if size == -1:
-                result = self.content[self.pos :]
-                self.pos = len(self.content)
-            else:
-                result = self.content[self.pos : self.pos + size]
-                self.pos += len(result)
+        def read(self, size: int) -> bytes:
+            result = self.content[self.pos : self.pos + size]
+            self.pos += len(result)
             return result
 
         def tell(self) -> int:
             raise OSError("Unseekable file")
-
-        def seek(self, offset: int, whence: int = 0) -> int:
-            raise OSError("Unseekable file")
-
-        def fileno(self) -> int:
-            raise AttributeError("No file descriptor")
 
     content = b"Unseekable content"
     f = UnseekableFile(content)

--- a/tests/test_payload.py
+++ b/tests/test_payload.py
@@ -1351,6 +1351,9 @@ async def test_iobase_payload_size_unseekable() -> None:
     # Size should return None for unseekable files
     assert p.size is None
 
+    # Payload should not be consumed before writing
+    assert p.consumed is False
+
     # Writing should still work
     writer = BufferWriter()
     await p.write(writer)

--- a/tests/test_payload.py
+++ b/tests/test_payload.py
@@ -1356,5 +1356,6 @@ async def test_iobase_payload_size_unseekable() -> None:
     await p.write(writer)
     assert writer.buffer == content
 
-    # After reading, the payload should be marked as consumed
+    # For unseekable files that can't tell() or seek(),
+    # they are marked as consumed after the first write
     assert p.consumed is True


### PR DESCRIPTION
## What do these changes do?

These changes fix a bug where file uploads fail with HTTP 422 errors when encountering 307/308 redirects. The issue occurs because:

1. HTTP 307/308 redirects preserve the request body (unlike 301/302/303)
2. When aiohttp reuses the same file payload for the redirect, the file position is at EOF after the first request
3. This causes the Content-Length calculation to return 0 for the second request, leading to server rejection

The fix includes:
- **Client change**: Preserve the payload instance (not raw data) for 307/308 redirects to prevent recreation of consumed payloads
- **Payload change**: Store initial file position on first access and calculate size from that position, ensuring correct Content-Length for reused payloads

## Are there changes in behavior for the user?

File uploads that encounter 307/308 redirects will now work correctly instead of failing with HTTP 422 errors. This is a bug fix that restores expected behavior - no breaking changes.

## Is it a substantial burden for the maintainers to support this?

No. The changes are minimal and focused:
- Simple logic to preserve payload instances for specific redirect types
- File position management that's already part of the payload lifecycle
- Well-tested with both unit and integration tests
- No new APIs or complex abstractions

## Related issue number

Fixes #11270

## Implementation Details

### Changes Made

1. **aiohttp/client.py**
   - Modified redirect handling to preserve payload instance for 307/308 redirects
   - Changed from `data = req.data` to `data = req._body` to avoid payload recreation

2. **aiohttp/payload.py**
   - Modified `size` property to store start position on first access
   - Returns total size from start position instead of remaining bytes
   - Added AttributeError handling for tarfile streams
   - Properly handles unseekable files by returning None for size

3. **tests/test_payload.py**
   - Added test for payload size calculation after reading
   - Added test for unseekable file handling

4. **tests/test_client_functional.py**
   - Added integration test for file upload with 307 redirect

### Technical Explanation

The root cause identified by Cycloctane in the issue: "Two requests share the same BufferedReaderPayload instance, while the second request get zero Content-Length."

This happens because:
1. First request reads the file, moving position to EOF
2. For 307/308 redirects, the same payload is reused
3. Size calculation was `file_size - current_position`, which equals 0 at EOF
4. Server receives Content-Length: 0 and returns 422 Unprocessable Entity

The fix stores the initial file position when size is first accessed, then always calculates size from that position. This ensures consistent Content-Length across multiple uses of the same payload instance.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes (no user-facing API changes)
- [ ] Add yourself to `CONTRIBUTORS.txt`
- [x] Add a new news fragment `11270.bugfix.rst` into the `CHANGES/` folder