### PR TITLE
Fix algorithm case preservation in DigestAuthMiddleware

### DIFF
--- a/CHANGES/11352.bugfix.rst
+++ b/CHANGES/11352.bugfix.rst
@@ -1,2 +1,2 @@
-Fixed ``DigestAuthMiddleware`` to preserve the algorithm case from the server's challenge in the authorization response. This improves compatibility with servers that perform case-sensitive algorithm matching (e.g., servers expecting ``algorithm=MD5-sess`` instead of ``algorithm=MD5-SESS``)
+Fixed :class:`~aiohttp.DigestAuthMiddleware` to preserve the algorithm case from the server's challenge in the authorization response. This improves compatibility with servers that perform case-sensitive algorithm matching (e.g., servers expecting ``algorithm=MD5-sess`` instead of ``algorithm=MD5-SESS``)
 -- by :user:`bdraco`.

--- a/CHANGES/11352.bugfix.rst
+++ b/CHANGES/11352.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed ``DigestAuthMiddleware`` to preserve the algorithm case from the server's challenge in the authorization response. This improves compatibility with servers that perform case-sensitive algorithm matching (e.g., servers expecting ``algorithm=MD5-sess`` instead of ``algorithm=MD5-SESS``)
+-- by :user:`bdraco`.

--- a/aiohttp/client_middleware_digest_auth.py
+++ b/aiohttp/client_middleware_digest_auth.py
@@ -245,7 +245,9 @@ class DigestAuthMiddleware:
             )
 
         qop_raw = challenge.get("qop", "")
-        algorithm = challenge.get("algorithm", "MD5").upper()
+        # Preserve original algorithm case for response while using uppercase for processing
+        algorithm_original = challenge.get("algorithm", "MD5")
+        algorithm = algorithm_original.upper()
         opaque = challenge.get("opaque", "")
 
         # Convert string values to bytes once
@@ -342,7 +344,7 @@ class DigestAuthMiddleware:
             "nonce": escape_quotes(nonce),
             "uri": path,
             "response": response_digest.decode(),
-            "algorithm": algorithm,
+            "algorithm": algorithm_original,
         }
 
         # Optional fields

--- a/tests/test_client_middleware_digest_auth.py
+++ b/tests/test_client_middleware_digest_auth.py
@@ -1302,8 +1302,9 @@ async def test_case_sensitive_algorithm_server(
             )
 
         # Extract algorithm from auth response
-        if algo_match := re.search(r"algorithm=([^,\s]+)", auth_header):
-            auth_algorithms.append(algo_match.group(1))
+        algo_match = re.search(r"algorithm=([^,\s]+)", auth_header)
+        assert algo_match is not None
+        auth_algorithms.append(algo_match.group(1))
 
         # Case-sensitive server: only accept exact case match
         assert "algorithm=MD5-sess" in auth_header


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

This PR fixes a case sensitivity issue in `DigestAuthMiddleware` where the algorithm name from the server's challenge was being converted to uppercase in the Authorization header response. Some servers (like Prusa printers) are case-sensitive and expect the exact algorithm case to be preserved.

The fix preserves the original algorithm case from the WWW-Authenticate challenge while still using uppercase internally for hash function lookups and algorithm type checking.

## Are there changes in behavior for the user?

Yes, but only for users connecting to case-sensitive digest auth servers. The middleware will now preserve the exact algorithm case from the server's challenge instead of converting it to uppercase. This improves compatibility with servers that expect exact case matching (e.g., servers sending `algorithm="MD5-sess"` will now receive `algorithm=MD5-sess` instead of `algorithm=MD5-SESS`).

## Is it a substantial burden for the maintainers to support this?

No. This is a minimal change that adds one variable to store the original algorithm case. The fix is backward compatible and doesn't change the API. The implementation is straightforward and includes comprehensive tests to prevent regression.

## Related issue number

Fixes home-assistant/core#149196

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES/` folder
  * name it `<issue_or_pr_num>.<type>.rst` (e.g. `588.bugfix.rst`)
  * if you don't have an issue number, change it to the pull request
    number after creating the PR
    * `.bugfix`: A bug fix for something the maintainers deemed an
      improper undesired behavior that got corrected to match
      pre-agreed expectations.
    * `.feature`: A new behavior, public APIs. That sort of stuff.
    * `.deprecation`: A declaration of future API removals and breaking
      changes in behavior.
    * `.breaking`: When something public is removed in a breaking way.
      Could be deprecated in an earlier release.
    * `.doc`: Notable updates to the documentation structure or build
      process.
    * `.packaging`: Notes for downstreams about unobvious side effects
      and tooling. Changes in the test invocation considerations and
      runtime assumptions.
    * `.contrib`: Stuff that affects the contributor experience. e.g.
      Running tests, building the docs, setting up the development
      environment.
    * `.misc`: Changes that are hard to assign to any of the above
      categories.
  * Make sure to use full sentences with correct case and punctuation,
    for example:
    ```rst
    Fixed issue with non-ascii contents in doctest text files
    -- by :user:`contributor-gh-handle`.
    ```

    Use the past tense or the present tense a non-imperative mood,
    referring to what's changed compared to the last released version
    of this project.