### PR TITLE
Fix infinite `iter_chunks()` on empty response

### DIFF
--- a/aiohttp/__init__.py
+++ b/aiohttp/__init__.py
@@ -88,7 +88,7 @@ from .payload import (
     payload_type,
 )
 from .resolver import AsyncResolver, DefaultResolver, ThreadedResolver
-from .streams import EMPTY_PAYLOAD, DataQueue, EofStream, StreamReader
+from .streams import EMPTY_PAYLOAD, DataQueue, EofStream, StreamReader, empty_stream_reader
 from .tracing import (
     TraceConfig,
     TraceConnectionCreateEndParams,
@@ -212,6 +212,7 @@ __all__: Tuple[str, ...] = (
     "EMPTY_PAYLOAD",
     "EofStream",
     "StreamReader",
+    "empty_stream_reader",
     # tracing
     "TraceConfig",
     "TraceConnectionCreateEndParams",

--- a/aiohttp/__init__.py
+++ b/aiohttp/__init__.py
@@ -88,7 +88,13 @@ from .payload import (
     payload_type,
 )
 from .resolver import AsyncResolver, DefaultResolver, ThreadedResolver
-from .streams import EMPTY_PAYLOAD, DataQueue, EofStream, StreamReader, empty_stream_reader
+from .streams import (
+    EMPTY_PAYLOAD,
+    DataQueue,
+    EofStream,
+    StreamReader,
+    empty_stream_reader,
+)
 from .tracing import (
     TraceConfig,
     TraceConnectionCreateEndParams,

--- a/aiohttp/_http_parser.pyx
+++ b/aiohttp/_http_parser.pyx
@@ -38,7 +38,11 @@ from .http_writer import (
     HttpVersion10 as _HttpVersion10,
     HttpVersion11 as _HttpVersion11,
 )
-from .streams import EMPTY_PAYLOAD as _EMPTY_PAYLOAD, StreamReader as _StreamReader, empty_stream_reader as _empty_stream_reader
+from .streams import (
+    EMPTY_PAYLOAD as _EMPTY_PAYLOAD,
+    StreamReader as _StreamReader,
+    empty_stream_reader as _empty_stream_reader,
+)
 
 cimport cython
 

--- a/aiohttp/_http_parser.pyx
+++ b/aiohttp/_http_parser.pyx
@@ -38,7 +38,7 @@ from .http_writer import (
     HttpVersion10 as _HttpVersion10,
     HttpVersion11 as _HttpVersion11,
 )
-from .streams import EMPTY_PAYLOAD as _EMPTY_PAYLOAD, StreamReader as _StreamReader
+from .streams import EMPTY_PAYLOAD as _EMPTY_PAYLOAD, StreamReader as _StreamReader, empty_stream_reader as _empty_stream_reader
 
 cimport cython
 
@@ -70,6 +70,7 @@ cdef object SEC_WEBSOCKET_KEY1 = hdrs.SEC_WEBSOCKET_KEY1
 cdef object CONTENT_ENCODING = hdrs.CONTENT_ENCODING
 cdef object EMPTY_PAYLOAD = _EMPTY_PAYLOAD
 cdef object StreamReader = _StreamReader
+cdef object empty_stream_reader = _empty_stream_reader
 cdef object DeflateBuffer = _DeflateBuffer
 cdef bytes EMPTY_BYTES = b""
 
@@ -463,14 +464,14 @@ cdef class HttpParser:
                 self._protocol, timer=self._timer, loop=self._loop,
                 limit=self._limit)
         else:
-            payload = EMPTY_PAYLOAD
+            payload = empty_stream_reader()
 
         self._payload = payload
         if encoding is not None and self._auto_decompress:
             self._payload = DeflateBuffer(payload, encoding)
 
         if not self._response_with_body:
-            payload = EMPTY_PAYLOAD
+            payload = empty_stream_reader()
 
         self._messages.append((msg, payload))
 

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -54,7 +54,7 @@ from .http_exceptions import (
     TransferEncodingError,
 )
 from .http_writer import HttpVersion, HttpVersion10
-from .streams import EMPTY_PAYLOAD, StreamReader
+from .streams import EMPTY_PAYLOAD, StreamReader, empty_stream_reader
 from .typedefs import RawHeaders
 
 __all__ = (
@@ -436,7 +436,7 @@ class HttpParser(abc.ABC, Generic[_MsgT]):
                             if not payload_parser.done:
                                 self._payload_parser = payload_parser
                         else:
-                            payload = EMPTY_PAYLOAD
+                            payload = empty_stream_reader()
 
                         messages.append((msg, payload))
                         should_close = msg.should_close

--- a/aiohttp/streams.py
+++ b/aiohttp/streams.py
@@ -30,6 +30,7 @@ __all__ = (
     "EofStream",
     "StreamReader",
     "DataQueue",
+    "empty_stream_reader",
 )
 
 _T = TypeVar("_T")
@@ -602,6 +603,18 @@ class EmptyStreamReader(StreamReader):  # lgtm [py/missing-call-to-init]
 
 
 EMPTY_PAYLOAD: Final[StreamReader] = EmptyStreamReader()
+
+
+def empty_stream_reader() -> "EmptyStreamReader":
+    """Create a fresh EmptyStreamReader instance.
+
+    This function should be used instead of the global EMPTY_PAYLOAD
+    to avoid state sharing issues between requests.
+
+    Returns:
+        A new EmptyStreamReader instance.
+    """
+    return EmptyStreamReader()
 
 
 class DataQueue(Generic[_T]):


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?
When aiohttp returns an empty reader, the first time the `iter_chunks()` iterator stops after the first read as expected. However, on the second empty reader return, `iter_chunks()` loops forever.

This is due to state sharing caused by the global `EmptyStreamReader` instance. It has been noticed during review in #7645, but so far hasn't been addressed.

This PR attempts to address the issue by returning a new instance.

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?
The change makes it safe to read content of empty responses using `iter_chunks()`.
<!-- Outline any notable behaviour for the end users. -->

## Is it a substantial burden for the maintainers to support this?

<!--
Stop right there! Pause. Just for a minute... Can you think of anything
obvious that would complicate the ongoing development of this project?

Try to consider if you'd be able to maintain it throughout the next
5 years. Does it seem viable? Tell us your thoughts! We'd very much
love to hear what the consequences of merging this patch might be...

This will help us assess if your change is something we'd want to
entertain early in the review process. Thank you in advance!
-->

## Related issue number

<!-- Will this resolve any open issues? -->
<!-- Remember to prefix with 'Fixes' if it closes an issue (e.g. 'Fixes #123'). -->

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES/` folder
  * name it `<issue_or_pr_num>.<type>.rst` (e.g. `588.bugfix.rst`)
  * if you don't have an issue number, change it to the pull request
    number after creating the PR
    * `.bugfix`: A bug fix for something the maintainers deemed an
      improper undesired behavior that got corrected to match
      pre-agreed expectations.
    * `.feature`: A new behavior, public APIs. That sort of stuff.
    * `.deprecation`: A declaration of future API removals and breaking
      changes in behavior.
    * `.breaking`: When something public is removed in a breaking way.
      Could be deprecated in an earlier release.
    * `.doc`: Notable updates to the documentation structure or build
      process.
    * `.packaging`: Notes for downstreams about unobvious side effects
      and tooling. Changes in the test invocation considerations and
      runtime assumptions.
    * `.contrib`: Stuff that affects the contributor experience. e.g.
      Running tests, building the docs, setting up the development
      environment.
    * `.misc`: Changes that are hard to assign to any of the above
      categories.
  * Make sure to use full sentences with correct case and punctuation,
    for example:
    ```rst
    Fixed issue with non-ascii contents in doctest text files
    -- by :user:`contributor-gh-handle`.
    ```

    Use the past tense or the present tense a non-imperative mood,
    referring to what's changed compared to the last released version
    of this project.
