### PR TITLE
Changed the default values and static annotations according to static annotated types and values passed

### DIFF
--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -270,7 +270,7 @@ class BaseConnector:
         limit: int = 100,
         limit_per_host: int = 0,
         enable_cleanup_closed: bool = False,
-        timeout_ceil_threshold: float = 5,
+        timeout_ceil_threshold: float = 5.0,
     ) -> None:
         if force_close:
             if keepalive_timeout is not None and keepalive_timeout is not sentinel:
@@ -782,7 +782,7 @@ class BaseConnector:
 
 
 class _DNSCacheTable:
-    def __init__(self, ttl: Optional[float] = None) -> None:
+    def __init__(self, ttl: float | int | None = None) -> None:
         self._addrs_rr: Dict[Tuple[str, int], Tuple[Iterator[ResolveResult], int]] = {}
         self._timestamps: Dict[Tuple[str, int], float] = {}
         self._ttl = ttl
@@ -906,7 +906,7 @@ class TCPConnector(BaseConnector):
         limit: int = 100,
         limit_per_host: int = 0,
         enable_cleanup_closed: bool = False,
-        timeout_ceil_threshold: float = 5,
+        timeout_ceil_threshold: float = 5.0,
         happy_eyeballs_delay: Optional[float] = 0.25,
         interleave: Optional[int] = None,
         socket_factory: Optional[SocketFactoryType] = None,


### PR DESCRIPTION
There are in total 3 changes proposed.

For the first change, updation of default value 5 passed to `timeout_ceil_threshold` was done to 5.0 since the static annotation is present as `float` but a `int` default value is being passed at runtime, if no values are passed as arguments to that parameter. This particular change happens at 2 place i.e. in two methods.

Another code change is done i.e. at static annotation of ttl parameter of `__init__` method of `_DNSCacheTable` is changed from `Optional[float]` to `float | int | None` since at runtime a int value is sometimes passed to this parameter. This particular class was called from another place where the value is by default being passed 10.

Link to the __init__ method invocation where the int 10 value is being passed :
https://github.com/aio-libs/aiohttp/blob/8767e9e042f2588b738c7364bc8705aa9510b0d0/aiohttp/connector.py#L899
https://github.com/aio-libs/aiohttp/blob/8767e9e042f2588b738c7364bc8705aa9510b0d0/aiohttp/connector.py#L940