### PR TITLE
Ignore partitioned attributes in cookies if it is not supported by http.cookie

### DIFF
--- a/CHANGES/11523.bugfix.rst
+++ b/CHANGES/11523.bugfix.rst
@@ -1,2 +1,2 @@
-Fix saved cookiejars fail to be loaded if cookies have ``partitioned`` flag when
+Fix saved ``CookieJar`` fail to be loaded if cookies have ``partitioned`` flag when
 ``http.cookie`` does not have partitioned cookies supports. -- by :user:`Cycloctane`.

--- a/CHANGES/11523.bugfix.rst
+++ b/CHANGES/11523.bugfix.rst
@@ -1,0 +1,2 @@
+Fix saved cookiejars fail to be loaded if cookies have ``partitioned`` flag when
+``http.cookie`` does not have partitioned cookies supports. -- by :user:`Cycloctane`.

--- a/aiohttp/_cookie_helpers.py
+++ b/aiohttp/_cookie_helpers.py
@@ -6,7 +6,6 @@ These are not part of the public API and may change without notice.
 """
 
 import re
-import sys
 from http.cookies import Morsel
 from typing import List, Optional, Sequence, Tuple, cast
 
@@ -270,11 +269,8 @@ def parse_set_cookie_headers(headers: Sequence[str]) -> List[Tuple[str, Morsel[s
                     break
                 if lower_key in _COOKIE_BOOL_ATTRS:
                     # Boolean attribute with any value should be True
-                    if current_morsel is not None:
-                        if lower_key == "partitioned" and sys.version_info < (3, 14):
-                            dict.__setitem__(current_morsel, lower_key, True)
-                        else:
-                            current_morsel[lower_key] = True
+                    if current_morsel is not None and current_morsel.isReservedKey(key):
+                        current_morsel[lower_key] = True
                 elif value is None:
                     # Invalid cookie string - non-boolean attribute without value
                     break

--- a/tests/test_cookie_helpers.py
+++ b/tests/test_cookie_helpers.py
@@ -568,6 +568,26 @@ def test_parse_set_cookie_headers_partitioned_not_set() -> None:
 
 
 # Tests that don't require partitioned support in SimpleCookie
+@pytest.mark.skipif(
+    sys.version_info >= (3, 14),
+    reason="Python 3.14+ has built-in partitioned cookie support",
+)
+def test_parse_set_cookie_headers_partitioned_not_set_if_no_support() -> None:
+    headers = [
+        "cookie1=value1; Partitioned",
+        "cookie2=value2; Partitioned=",
+        "cookie3=value3; Partitioned=true",
+    ]
+
+    result = parse_set_cookie_headers(headers)
+
+    assert len(result) == 5
+    for i, (_, morsel) in enumerate(result):
+        assert (
+            morsel.get("partitioned") is None
+        ), f"Cookie {i+1} should not have partitioned flag"
+
+
 def test_parse_set_cookie_headers_partitioned_with_other_attrs_manual() -> None:
     """
     Test parsing logic for partitioned cookies combined with all other attributes.

--- a/tests/test_cookie_helpers.py
+++ b/tests/test_cookie_helpers.py
@@ -6,6 +6,7 @@ from http.cookies import (
     SimpleCookie,
     _unquote as simplecookie_unquote,
 )
+import sys
 
 import pytest
 
@@ -427,6 +428,10 @@ def test_parse_set_cookie_headers_boolean_attrs() -> None:
         assert morsel.get("httponly") is True, f"{name} should have httponly=True"
 
 
+@pytest.mark.skipif(
+    sys.version_info < (3, 14),
+    reason="Partitioned cookies support requires Python 3.14+",
+)
 def test_parse_set_cookie_headers_boolean_attrs_with_partitioned() -> None:
     """Test that boolean attributes including partitioned work correctly."""
     # Test secure attribute variations
@@ -482,6 +487,10 @@ def test_parse_set_cookie_headers_encoded_values() -> None:
     assert result[2][1].value == "%21%40%23%24%25%5E%26*%28%29"
 
 
+@pytest.mark.skipif(
+    sys.version_info < (3, 14),
+    reason="Partitioned cookies support requires Python 3.14+",
+)
 def test_parse_set_cookie_headers_partitioned() -> None:
     """
     Test that parse_set_cookie_headers handles partitioned attribute correctly.
@@ -518,6 +527,10 @@ def test_parse_set_cookie_headers_partitioned() -> None:
     assert result[4][1].get("path") == "/"
 
 
+@pytest.mark.skipif(
+    sys.version_info < (3, 14),
+    reason="Partitioned cookies support requires Python 3.14+",
+)
 def test_parse_set_cookie_headers_partitioned_case_insensitive() -> None:
     """Test that partitioned attribute is recognized case-insensitively."""
     headers = [

--- a/tests/test_cookie_helpers.py
+++ b/tests/test_cookie_helpers.py
@@ -581,7 +581,7 @@ def test_parse_set_cookie_headers_partitioned_not_set_if_no_support() -> None:
 
     result = parse_set_cookie_headers(headers)
 
-    assert len(result) == 5
+    assert len(result) == 3
     for i, (_, morsel) in enumerate(result):
         assert (
             morsel.get("partitioned") is None

--- a/tests/test_cookie_helpers.py
+++ b/tests/test_cookie_helpers.py
@@ -1,12 +1,12 @@
 """Tests for internal cookie helper functions."""
 
+import sys
 from http.cookies import (
     CookieError,
     Morsel,
     SimpleCookie,
     _unquote as simplecookie_unquote,
 )
-import sys
 
 import pytest
 

--- a/tests/test_cookiejar.py
+++ b/tests/test_cookiejar.py
@@ -14,7 +14,6 @@ from freezegun import freeze_time
 from yarl import URL
 
 from aiohttp import CookieJar, DummyCookieJar
-from aiohttp._cookie_helpers import parse_set_cookie_headers
 from aiohttp.typedefs import LooseCookies
 
 

--- a/tests/test_cookiejar.py
+++ b/tests/test_cookiejar.py
@@ -14,6 +14,7 @@ from freezegun import freeze_time
 from yarl import URL
 
 from aiohttp import CookieJar, DummyCookieJar
+from aiohttp._cookie_helpers import parse_set_cookie_headers
 from aiohttp.typedefs import LooseCookies
 
 
@@ -204,6 +205,19 @@ def test_save_load(
         jar_test[cookie.key] = cookie
 
     assert jar_test == cookies_to_receive
+
+
+def test_save_load_partitioned_cookies(tmp_path: Path) -> None:
+    file_path = Path(str(tmp_path)) / "aiohttp.test2.cookie"
+    # export cookie jar
+    jar_save = CookieJar()
+    jar_save.update_cookies_from_headers(
+        ["session=cookie; Partitioned"], URL("https://example.com/")
+    )
+    jar_save.save(file_path=file_path)
+    jar_load = CookieJar()
+    jar_load.load(file_path=file_path)
+    assert jar_save._cookies == jar_load._cookies
 
 
 async def test_update_cookie_with_unicode_domain() -> None:


### PR DESCRIPTION
## What do these changes do?

Only set `partitioned` flag if it is supported by http.cookie (in python >= 3.14 or monkey-patched). Fix issue where saved cookiejars fail to be unpickled due to unsupported attribute. (At least clients without partitioned cookies supports can load cookiejars created by themselves.)

## Are there changes in behavior for the user?

## Is it a substantial burden for the maintainers to support this?

## Related issue number

Fixes #11523 

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
- [x] Add a new news fragment into the `CHANGES/` folder
