### PR TITLE
Remove unnecessary assertion in test_when_timeout_smaller_second

### DIFF
--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -297,7 +297,6 @@ def test_when_timeout_smaller_second(loop: asyncio.AbstractEventLoop) -> None:
     timer = loop.time() + timeout
 
     handle = helpers.TimeoutHandle(loop, timeout)
-    assert handle is not None
     start_handle = handle.start()
     assert start_handle is not None
     when = start_handle.when()


### PR DESCRIPTION
## What do these changes do?

That assertion somehow takes 50~ ms in python 3.14 (I guess it is because pytest's assert rewrite?). And it is also not necessary for mypy static check. Simply remove that line should make python 3.14's failing `test_when_timeout_smaller_second()` test pass.

## Are there changes in behavior for the user?

## Is it a substantial burden for the maintainers to support this?

## Related issue number

#11503 

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
- [ ] Add a new news fragment into the `CHANGES/` folder
