### PR TITLE
SSLObject made available through exceptions

### DIFF
--- a/CHANGES/10028.feature.rst
+++ b/CHANGES/10028.feature.rst
@@ -1,0 +1,3 @@
+Added ``ssl_object`` attribute to ``ClientResponseError`` and its subclasses
+to provide access to SSL certificate information even after connection closure
+-- by :user:`fed239`.

--- a/CHANGES/10028.feature.rst
+++ b/CHANGES/10028.feature.rst
@@ -1,3 +1,3 @@
 Added ``ssl_object`` attribute to ``ClientResponseError`` and its subclasses
-to provide access to SSL certificate information even after connection closure
--- by :user:`fed239`.
+(including ``ServerFingerprintMismatch``) to provide access to SSL certificate
+information even after connection closure -- by :user:`fed239`.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -139,6 +139,7 @@ Eugene Nikolaiev
 Eugene Tolmachev
 Evan Kepner
 Evert Lammerts
+Fedor Tyurin
 Felix Yan
 Fernanda Guimarães
 FichteFoll

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -76,7 +76,6 @@ from .client_reqrep import (
     ClientResponse,
     Fingerprint,
     RequestInfo,
-    _extract_ssl_object,
 )
 from .client_ws import (
     DEFAULT_WS_CLIENT_TIMEOUT,
@@ -1112,7 +1111,7 @@ class ClientSession:
                     message="Invalid response status",
                     status=resp.status,
                     headers=resp.headers,
-                    ssl_object=_extract_ssl_object(resp._connection),
+                    ssl_object=resp._ssl_object,
                 )
 
             if resp.headers.get(hdrs.UPGRADE, "").lower() != "websocket":
@@ -1122,7 +1121,7 @@ class ClientSession:
                     message="Invalid upgrade header",
                     status=resp.status,
                     headers=resp.headers,
-                    ssl_object=_extract_ssl_object(resp._connection),
+                    ssl_object=resp._ssl_object,
                 )
 
             if not resp._upgraded:
@@ -1132,7 +1131,7 @@ class ClientSession:
                     message="Invalid connection header",
                     status=resp.status,
                     headers=resp.headers,
-                    ssl_object=_extract_ssl_object(resp._connection),
+                    ssl_object=resp._ssl_object,
                 )
 
             # key calculation
@@ -1145,7 +1144,7 @@ class ClientSession:
                     message="Invalid challenge response",
                     status=resp.status,
                     headers=resp.headers,
-                    ssl_object=_extract_ssl_object(resp._connection),
+                    ssl_object=resp._ssl_object,
                 )
 
             # websocket protocol
@@ -1175,7 +1174,7 @@ class ClientSession:
                             message=exc.args[0],
                             status=resp.status,
                             headers=resp.headers,
-                            ssl_object=_extract_ssl_object(resp._connection),
+                            ssl_object=resp._ssl_object,
                         ) from exc
                 else:
                     compress = 0

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -76,6 +76,7 @@ from .client_reqrep import (
     ClientResponse,
     Fingerprint,
     RequestInfo,
+    _extract_ssl_object,
 )
 from .client_ws import (
     DEFAULT_WS_CLIENT_TIMEOUT,
@@ -779,7 +780,9 @@ class ClientSession:
                                 await req._body.close()
                             resp.close()
                             raise TooManyRedirects(
-                                history[0].request_info, tuple(history)
+                                history[0].request_info,
+                                tuple(history),
+                                ssl_object=_extract_ssl_object(resp._connection),
                             )
 
                         # For 301 and 302, mimic IE, now changed in RFC
@@ -1108,6 +1111,7 @@ class ClientSession:
                     message="Invalid response status",
                     status=resp.status,
                     headers=resp.headers,
+                    ssl_object=_extract_ssl_object(resp._connection),
                 )
 
             if resp.headers.get(hdrs.UPGRADE, "").lower() != "websocket":
@@ -1117,6 +1121,7 @@ class ClientSession:
                     message="Invalid upgrade header",
                     status=resp.status,
                     headers=resp.headers,
+                    ssl_object=_extract_ssl_object(resp._connection),
                 )
 
             if not resp._upgraded:
@@ -1126,6 +1131,7 @@ class ClientSession:
                     message="Invalid connection header",
                     status=resp.status,
                     headers=resp.headers,
+                    ssl_object=_extract_ssl_object(resp._connection),
                 )
 
             # key calculation
@@ -1138,6 +1144,7 @@ class ClientSession:
                     message="Invalid challenge response",
                     status=resp.status,
                     headers=resp.headers,
+                    ssl_object=_extract_ssl_object(resp._connection),
                 )
 
             # websocket protocol
@@ -1167,6 +1174,7 @@ class ClientSession:
                             message=exc.args[0],
                             status=resp.status,
                             headers=resp.headers,
+                            ssl_object=_extract_ssl_object(resp._connection),
                         ) from exc
                 else:
                     compress = 0

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -778,11 +778,12 @@ class ClientSession:
                         if max_redirects and redirects >= max_redirects:
                             if req._body is not None:
                                 await req._body.close()
+                            ssl_object = resp._ssl_object
                             resp.close()
                             raise TooManyRedirects(
                                 history[0].request_info,
                                 tuple(history),
-                                ssl_object=_extract_ssl_object(resp._connection),
+                                ssl_object=ssl_object,
                             )
 
                         # For 301 and 302, mimic IE, now changed in RFC

--- a/aiohttp/client_exceptions.py
+++ b/aiohttp/client_exceptions.py
@@ -2,7 +2,7 @@
 
 import asyncio
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING
 
 from .typedefs import StrOrURL
 
@@ -10,8 +10,9 @@ try:
     import ssl
 
     SSLContext = ssl.SSLContext
+    SSLObject = ssl.SSLObject
 except ImportError:  # pragma: no cover
-    ssl = SSLContext = None  # type: ignore[assignment]
+    ssl = SSLContext = SSLObject = None  # type: ignore[assignment]
 
 if TYPE_CHECKING:
     from .client_reqrep import ClientResponse, ConnectionKey, Fingerprint, RequestInfo
@@ -76,7 +77,7 @@ class ClientResponseError(ClientError):
         status: int | None = None,
         message: str = "",
         headers: Mapping[str, str] | None = None,
-        ssl_object: object | None = None,
+        ssl_object: "SSLObject | None" = None,
     ) -> None:
         self.request_info = request_info
         if status is not None:
@@ -86,8 +87,21 @@ class ClientResponseError(ClientError):
         self.message = message
         self.headers = headers
         self.history = history
-        self.ssl_object = ssl_object
+        self._ssl_object = ssl_object
         self.args = (request_info, history)
+
+    @property
+    def ssl_object(self) -> "SSLObject | None":
+        return self._ssl_object
+
+    def __getstate__(self) -> dict:
+        state = self.__dict__.copy()
+        state.pop("_ssl_object", None)
+        return state
+
+    def __setstate__(self, state: dict) -> None:
+        self.__dict__.update(state)
+        self._ssl_object = None
 
     def __str__(self) -> str:
         return f"{self.status}, message={self.message!r}, url={str(self.request_info.real_url)!r}"
@@ -166,7 +180,7 @@ class ClientConnectorError(ClientOSError):
         return self._conn_key.port
 
     @property
-    def ssl(self) -> Union[SSLContext, bool, "Fingerprint"]:
+    def ssl(self) -> "SSLContext | bool | Fingerprint":
         return self._conn_key.ssl
 
     def __str__(self) -> str:

--- a/aiohttp/client_exceptions.py
+++ b/aiohttp/client_exceptions.py
@@ -1,8 +1,9 @@
 """HTTP related errors."""
 
 import asyncio
+import weakref
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING
 
 from .typedefs import StrOrURL
 
@@ -10,8 +11,9 @@ try:
     import ssl
 
     SSLContext = ssl.SSLContext
+    SSLObject = ssl.SSLObject
 except ImportError:  # pragma: no cover
-    ssl = SSLContext = None  # type: ignore[assignment]
+    ssl = SSLContext = SSLObject = None  # type: ignore[assignment]
 
 if TYPE_CHECKING:
     from .client_reqrep import ClientResponse, ConnectionKey, Fingerprint, RequestInfo
@@ -76,7 +78,7 @@ class ClientResponseError(ClientError):
         status: int | None = None,
         message: str = "",
         headers: Mapping[str, str] | None = None,
-        ssl_object: object | None = None,
+        ssl_object: "SSLObject | None" = None,
     ) -> None:
         self.request_info = request_info
         if status is not None:
@@ -86,8 +88,14 @@ class ClientResponseError(ClientError):
         self.message = message
         self.headers = headers
         self.history = history
-        self.ssl_object = ssl_object
+        self._ssl_object = weakref.ref(ssl_object) if ssl_object is not None else None
         self.args = (request_info, history)
+
+    @property
+    def ssl_object(self) -> "SSLObject | None":
+        if self._ssl_object is None:
+            return None
+        return self._ssl_object()
 
     def __str__(self) -> str:
         return f"{self.status}, message={self.message!r}, url={str(self.request_info.real_url)!r}"
@@ -166,7 +174,7 @@ class ClientConnectorError(ClientOSError):
         return self._conn_key.port
 
     @property
-    def ssl(self) -> Union[SSLContext, bool, "Fingerprint"]:
+    def ssl(self) -> "SSLContext | bool | Fingerprint":
         return self._conn_key.ssl
 
     def __str__(self) -> str:

--- a/aiohttp/client_exceptions.py
+++ b/aiohttp/client_exceptions.py
@@ -2,7 +2,7 @@
 
 import asyncio
 from collections.abc import Mapping
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from .typedefs import StrOrURL
 
@@ -94,13 +94,14 @@ class ClientResponseError(ClientError):
     def ssl_object(self) -> "SSLObject | None":
         return self._ssl_object
 
-    def __getstate__(self) -> dict:
+    def __getstate__(self) -> dict[str, Any]:
         state = self.__dict__.copy()
         state.pop("_ssl_object", None)
         return state
 
-    def __setstate__(self, state: dict) -> None:
-        self.__dict__.update(state)
+    def __setstate__(self, state: dict[str, Any] | None) -> None:
+        if state:
+            self.__dict__.update(state)
         self._ssl_object = None
 
     def __str__(self) -> str:

--- a/aiohttp/client_exceptions.py
+++ b/aiohttp/client_exceptions.py
@@ -265,15 +265,30 @@ class ServerFingerprintMismatch(ServerConnectionError):
 
     args: tuple[bytes, bytes, str, int]
 
-    def __init__(self, expected: bytes, got: bytes, host: str, port: int) -> None:
+    def __init__(
+        self,
+        expected: bytes,
+        got: bytes,
+        host: str,
+        port: int,
+        *,
+        ssl_object: "SSLObject | None" = None,
+    ) -> None:
         self.expected = expected
         self.got = got
         self.host = host
         self.port = port
+        self.ssl_object = ssl_object
         self.args = (expected, got, host, port)
 
     def __repr__(self) -> str:
-        return f"<{self.__class__.__name__} expected={self.expected!r} got={self.got!r} host={self.host!r} port={self.port!r}>"
+        result = (
+            f"<{self.__class__.__name__} expected={self.expected!r} got={self.got!r}"
+            f" host={self.host!r} port={self.port!r}"
+        )
+        if self.ssl_object is not None:
+            result += f" ssl_object={self.ssl_object!r}"
+        return result + ">"
 
 
 class ClientPayloadError(ClientError):

--- a/aiohttp/client_exceptions.py
+++ b/aiohttp/client_exceptions.py
@@ -63,6 +63,7 @@ class ClientResponseError(ClientError):
     status: HTTP status code.
     message: Error message.
     headers: Response headers.
+    ssl_object: SSL object from the connection, if available.
     """
 
     args: tuple[RequestInfo, tuple[ClientResponse, ...]]
@@ -75,6 +76,7 @@ class ClientResponseError(ClientError):
         status: int | None = None,
         message: str = "",
         headers: Mapping[str, str] | None = None,
+        ssl_object: object | None = None,
     ) -> None:
         self.request_info = request_info
         if status is not None:
@@ -84,6 +86,7 @@ class ClientResponseError(ClientError):
         self.message = message
         self.headers = headers
         self.history = history
+        self.ssl_object = ssl_object
         self.args = (request_info, history)
 
     def __str__(self) -> str:
@@ -97,6 +100,8 @@ class ClientResponseError(ClientError):
             args += f", message={self.message!r}"
         if self.headers is not None:
             args += f", headers={self.headers!r}"
+        if self.ssl_object is not None:
+            args += f", ssl_object={self.ssl_object!r}"
         return f"{type(self).__name__}({args})"
 
 

--- a/aiohttp/client_exceptions.py
+++ b/aiohttp/client_exceptions.py
@@ -1,9 +1,8 @@
 """HTTP related errors."""
 
 import asyncio
-import weakref
 from collections.abc import Mapping
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Union
 
 from .typedefs import StrOrURL
 
@@ -11,9 +10,8 @@ try:
     import ssl
 
     SSLContext = ssl.SSLContext
-    SSLObject = ssl.SSLObject
 except ImportError:  # pragma: no cover
-    ssl = SSLContext = SSLObject = None  # type: ignore[assignment]
+    ssl = SSLContext = None  # type: ignore[assignment]
 
 if TYPE_CHECKING:
     from .client_reqrep import ClientResponse, ConnectionKey, Fingerprint, RequestInfo
@@ -78,7 +76,7 @@ class ClientResponseError(ClientError):
         status: int | None = None,
         message: str = "",
         headers: Mapping[str, str] | None = None,
-        ssl_object: "SSLObject | None" = None,
+        ssl_object: object | None = None,
     ) -> None:
         self.request_info = request_info
         if status is not None:
@@ -88,14 +86,8 @@ class ClientResponseError(ClientError):
         self.message = message
         self.headers = headers
         self.history = history
-        self._ssl_object = weakref.ref(ssl_object) if ssl_object is not None else None
+        self.ssl_object = ssl_object
         self.args = (request_info, history)
-
-    @property
-    def ssl_object(self) -> "SSLObject | None":
-        if self._ssl_object is None:
-            return None
-        return self._ssl_object()
 
     def __str__(self) -> str:
         return f"{self.status}, message={self.message!r}, url={str(self.request_info.real_url)!r}"
@@ -174,7 +166,7 @@ class ClientConnectorError(ClientOSError):
         return self._conn_key.port
 
     @property
-    def ssl(self) -> "SSLContext | bool | Fingerprint":
+    def ssl(self) -> Union[SSLContext, bool, "Fingerprint"]:
         return self._conn_key.ssl
 
     def __str__(self) -> str:

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -11,7 +11,7 @@ from collections.abc import Callable, Iterable, Sequence
 from hashlib import md5, sha1, sha256
 from http.cookies import BaseCookie, SimpleCookie
 from types import MappingProxyType, TracebackType
-from typing import TYPE_CHECKING, Any, Literal, NamedTuple, TypedDict
+from typing import TYPE_CHECKING, Any, Literal, NamedTuple, TypedDict, cast
 
 from multidict import CIMultiDict, CIMultiDictProxy, MultiDict, MultiDictProxy
 from yarl import URL, Query
@@ -102,7 +102,7 @@ def _extract_ssl_object(
         return None
 
     try:
-        return transport.get_extra_info("ssl_object")
+        return cast("SSLObject | None", transport.get_extra_info("ssl_object"))
     except Exception:
         return None
 

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -11,7 +11,7 @@ from collections.abc import Callable, Iterable, Sequence
 from hashlib import md5, sha1, sha256
 from http.cookies import BaseCookie, SimpleCookie
 from types import MappingProxyType, TracebackType
-from typing import TYPE_CHECKING, Any, Literal, NamedTuple, Optional, TypedDict
+from typing import TYPE_CHECKING, Any, Literal, NamedTuple, Optional, TypedDict, Union
 
 from multidict import CIMultiDict, CIMultiDictProxy, MultiDict, MultiDictProxy
 from yarl import URL, Query
@@ -83,12 +83,23 @@ _CONTAINS_CONTROL_CHAR_RE = re.compile(r"[^-!#$%&'*+.^_`|~0-9a-zA-Z]")
 _DIGITS_RE = re.compile(r"\d+", re.ASCII)
 
 
-def _extract_ssl_object(connection: Optional["Connection"]) -> Optional[object]:
-    """Extract SSL object from connection if available."""
+def _extract_ssl_object(
+    connection: Optional[Union["Connection", object]],
+) -> Optional[object]:
+    """Extract SSL object from connection or transport if available."""
     if connection is None:
         return None
 
-    transport = connection.transport
+    # Handle both Connection objects and Transport objects
+    if hasattr(connection, "transport"):
+        # This is a Connection object
+        transport = connection.transport
+    elif hasattr(connection, "get_extra_info"):
+        # This is a Transport object
+        transport = connection
+    else:
+        return None
+
     if transport is None:
         return None
 

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -63,10 +63,11 @@ from .typedefs import DEFAULT_JSON_DECODER, JSONDecoder, RawHeaders
 
 try:
     import ssl
-    from ssl import SSLContext
+    from ssl import SSLContext, SSLObject
 except ImportError:  # pragma: no cover
     ssl = None  # type: ignore[assignment]
     SSLContext = object  # type: ignore[misc,assignment]
+    SSLObject = object  # type: ignore[misc,assignment]
 
 
 __all__ = ("ClientRequest", "ClientResponse", "RequestInfo", "Fingerprint")
@@ -84,8 +85,8 @@ _DIGITS_RE = re.compile(r"\d+", re.ASCII)
 
 
 def _extract_ssl_object(
-    connection: Optional[Union["Connection", object]],
-) -> Optional[object]:
+    connection: Union["Connection", asyncio.BaseTransport, None],
+) -> SSLObject | None:
     """Extract SSL object from connection or transport if available."""
     if connection is None:
         return None
@@ -103,11 +104,7 @@ def _extract_ssl_object(
     if transport is None:
         return None
 
-    try:
-        return transport.get_extra_info("ssl_object")
-    except Exception:
-        # If we can't get the SSL object for any reason, return None
-        return None
+    return transport.get_extra_info("ssl_object")
 
 
 def _gen_default_accept_encoding() -> str:

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -11,7 +11,7 @@ from collections.abc import Callable, Iterable, Sequence
 from hashlib import md5, sha1, sha256
 from http.cookies import BaseCookie, SimpleCookie
 from types import MappingProxyType, TracebackType
-from typing import TYPE_CHECKING, Any, Literal, NamedTuple, Optional, TypedDict, Union
+from typing import TYPE_CHECKING, Any, Literal, NamedTuple, TypedDict
 
 from multidict import CIMultiDict, CIMultiDictProxy, MultiDict, MultiDictProxy
 from yarl import URL, Query
@@ -63,10 +63,11 @@ from .typedefs import DEFAULT_JSON_DECODER, JSONDecoder, RawHeaders
 
 try:
     import ssl
-    from ssl import SSLContext
+    from ssl import SSLContext, SSLObject
 except ImportError:  # pragma: no cover
     ssl = None  # type: ignore[assignment]
     SSLContext = object  # type: ignore[misc,assignment]
+    SSLObject = object  # type: ignore[misc,assignment]
 
 
 __all__ = ("ClientRequest", "ClientResponse", "RequestInfo", "Fingerprint")
@@ -84,18 +85,15 @@ _DIGITS_RE = re.compile(r"\d+", re.ASCII)
 
 
 def _extract_ssl_object(
-    connection: Optional[Union["Connection", object]],
-) -> Optional[object]:
+    connection: "Connection | asyncio.BaseTransport | None",
+) -> SSLObject | None:
     """Extract SSL object from connection or transport if available."""
     if connection is None:
         return None
 
-    # Handle both Connection objects and Transport objects
     if hasattr(connection, "transport"):
-        # This is a Connection object
         transport = connection.transport
     elif hasattr(connection, "get_extra_info"):
-        # This is a Transport object
         transport = connection
     else:
         return None
@@ -106,7 +104,6 @@ def _extract_ssl_object(
     try:
         return transport.get_extra_info("ssl_object")
     except Exception:
-        # If we can't get the SSL object for any reason, return None
         return None
 
 
@@ -228,6 +225,7 @@ class ClientResponse(HeadersMixin):
     _upgraded: bool = False  # parser saw a Connection: upgrade token
 
     _connection: "Connection | None" = None  # current connection
+    _ssl_object: SSLObject | None = None
     _cookies: SimpleCookie | None = None
     _raw_cookie_headers: tuple[str, ...] | None = None
     _continue: asyncio.Future[bool] | None = None
@@ -485,6 +483,7 @@ class ClientResponse(HeadersMixin):
         self._closed = False
         self._protocol = connection.protocol
         self._connection = connection
+        self._ssl_object = _extract_ssl_object(connection)
 
         with self._timer:
             while True:
@@ -595,7 +594,7 @@ class ClientResponse(HeadersMixin):
                 status=self.status,
                 message=self.reason,
                 headers=self.headers,
-                ssl_object=_extract_ssl_object(self._connection),
+                ssl_object=self._ssl_object,
             )
 
     def _release_connection(self) -> None:
@@ -720,7 +719,7 @@ class ClientResponse(HeadersMixin):
                         "unexpected mimetype: %s" % self.content_type
                     ),
                     headers=self.headers,
-                    ssl_object=_extract_ssl_object(self._connection),
+                    ssl_object=self._ssl_object,
                 )
 
         if encoding is None:

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -63,11 +63,10 @@ from .typedefs import DEFAULT_JSON_DECODER, JSONDecoder, RawHeaders
 
 try:
     import ssl
-    from ssl import SSLContext, SSLObject
+    from ssl import SSLContext
 except ImportError:  # pragma: no cover
     ssl = None  # type: ignore[assignment]
     SSLContext = object  # type: ignore[misc,assignment]
-    SSLObject = object  # type: ignore[misc,assignment]
 
 
 __all__ = ("ClientRequest", "ClientResponse", "RequestInfo", "Fingerprint")
@@ -85,8 +84,8 @@ _DIGITS_RE = re.compile(r"\d+", re.ASCII)
 
 
 def _extract_ssl_object(
-    connection: Union["Connection", asyncio.BaseTransport, None],
-) -> SSLObject | None:
+    connection: Optional[Union["Connection", object]],
+) -> Optional[object]:
     """Extract SSL object from connection or transport if available."""
     if connection is None:
         return None
@@ -104,7 +103,11 @@ def _extract_ssl_object(
     if transport is None:
         return None
 
-    return transport.get_extra_info("ssl_object")
+    try:
+        return transport.get_extra_info("ssl_object")
+    except Exception:
+        # If we can't get the SSL object for any reason, return None
+        return None
 
 
 def _gen_default_accept_encoding() -> str:

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -180,7 +180,13 @@ class Fingerprint:
         got = self._hashfunc(cert).digest()
         if got != self._fingerprint:
             host, port, *_ = transport.get_extra_info("peername")
-            raise ServerFingerprintMismatch(self._fingerprint, got, host, port)
+            try:
+                ssl_object: SSLObject | None = transport.get_extra_info("ssl_object")
+            except Exception:
+                ssl_object = None
+            raise ServerFingerprintMismatch(
+                self._fingerprint, got, host, port, ssl_object=ssl_object
+            )
 
 
 if ssl is not None:

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -11,7 +11,7 @@ from collections.abc import Callable, Iterable, Sequence
 from hashlib import md5, sha1, sha256
 from http.cookies import BaseCookie, SimpleCookie
 from types import MappingProxyType, TracebackType
-from typing import TYPE_CHECKING, Any, Literal, NamedTuple, TypedDict
+from typing import TYPE_CHECKING, Any, Literal, NamedTuple, Optional, TypedDict
 
 from multidict import CIMultiDict, CIMultiDictProxy, MultiDict, MultiDictProxy
 from yarl import URL, Query
@@ -81,6 +81,22 @@ if TYPE_CHECKING:
 _CONNECTION_CLOSED_EXCEPTION = ClientConnectionError("Connection closed")
 _CONTAINS_CONTROL_CHAR_RE = re.compile(r"[^-!#$%&'*+.^_`|~0-9a-zA-Z]")
 _DIGITS_RE = re.compile(r"\d+", re.ASCII)
+
+
+def _extract_ssl_object(connection: Optional["Connection"]) -> Optional[object]:
+    """Extract SSL object from connection if available."""
+    if connection is None:
+        return None
+
+    transport = connection.transport
+    if transport is None:
+        return None
+
+    try:
+        return transport.get_extra_info("ssl_object")
+    except Exception:
+        # If we can't get the SSL object for any reason, return None
+        return None
 
 
 def _gen_default_accept_encoding() -> str:
@@ -472,6 +488,7 @@ class ClientResponse(HeadersMixin):
                         status=exc.code,
                         message=exc.message,
                         headers=exc.headers,
+                        ssl_object=_extract_ssl_object(connection),
                     ) from exc
 
                 if message.code < 100 or message.code > 199 or message.code == 101:
@@ -567,6 +584,7 @@ class ClientResponse(HeadersMixin):
                 status=self.status,
                 message=self.reason,
                 headers=self.headers,
+                ssl_object=_extract_ssl_object(self._connection),
             )
 
     def _release_connection(self) -> None:
@@ -691,6 +709,7 @@ class ClientResponse(HeadersMixin):
                         "unexpected mimetype: %s" % self.content_type
                     ),
                     headers=self.headers,
+                    ssl_object=_extract_ssl_object(self._connection),
                 )
 
         if encoding is None:

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -38,6 +38,7 @@ from .client_proto import ResponseHandler
 from .client_reqrep import (
     SSL_ALLOWED_TYPES,
     ClientRequest,
+    ClientRequestBase,
     Fingerprint,
     _extract_ssl_object,
 )

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -38,7 +38,6 @@ from .client_proto import ResponseHandler
 from .client_reqrep import (
     SSL_ALLOWED_TYPES,
     ClientRequest,
-    ClientRequestBase,
     Fingerprint,
     _extract_ssl_object,
 )

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -40,6 +40,7 @@ from .client_reqrep import (
     ClientRequest,
     ClientRequestBase,
     Fingerprint,
+    _extract_ssl_object,
 )
 from .helpers import (
     _SENTINEL,
@@ -1556,6 +1557,7 @@ class TCPConnector(BaseConnector):
                             status=resp.status,
                             message=message,
                             headers=resp.headers,
+                            ssl_object=_extract_ssl_object(transport),
                         )
                 except BaseException:
                     # It shouldn't be closed in `finally` because it's fed to

--- a/docs/client_advanced.rst
+++ b/docs/client_advanced.rst
@@ -701,6 +701,38 @@ DER with e.g::
    to :class:`TCPConnector` as default, the value from
    :meth:`ClientSession.get` and others override default.
 
+Example: Access SSL certificate information from exceptions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. versionadded:: 3.13
+
+When :class:`ClientResponseError` or its subclasses are raised, you can access
+SSL certificate information even after the connection has been closed using
+the :attr:`~ClientResponseError.ssl_object` attribute::
+
+  try:
+      async with session.get('https://example.com') as resp:
+          resp.raise_for_status()
+  except aiohttp.ClientResponseError as e:
+      if e.ssl_object:
+          # Access peer certificate information
+          peer_cert = e.ssl_object.getpeercert()
+          print(f"Certificate subject: {peer_cert.get('subject')}")
+          print(f"Certificate issuer: {peer_cert.get('issuer')}")
+
+          # Check certificate validity dates
+          not_before = peer_cert.get('notBefore')
+          not_after = peer_cert.get('notAfter')
+          print(f"Valid from {not_before} to {not_after}")
+
+          # Access cipher information
+          cipher = e.ssl_object.cipher()
+          if cipher:
+              print(f"Cipher: {cipher[0]}, Protocol: {cipher[1]}")
+
+This is particularly useful for advanced certificate validation, debugging
+SSL-related issues, or implementing custom certificate verification logic.
+
 .. _aiohttp-client-proxy-support:
 
 Proxy support

--- a/docs/client_advanced.rst
+++ b/docs/client_advanced.rst
@@ -704,7 +704,7 @@ DER with e.g::
 Example: Access SSL certificate information from exceptions
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. versionadded:: 3.13
+.. versionadded:: 4.0
 
 When :class:`ClientResponseError` or its subclasses are raised, you can access
 SSL certificate information even after the connection has been closed using

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -2782,6 +2782,27 @@ Response errors
 
       .. deprecated:: 3.1
 
+   .. attribute:: ssl_object
+
+      SSL object from the connection transport, if available
+      (:class:`ssl.SSLSocket` or ``None``).
+
+      This attribute provides access to SSL certificate information even after
+      the connection has been closed. Useful for advanced certificate
+      validation and debugging SSL-related issues.
+
+      Example usage::
+
+          try:
+              async with session.get('https://example.com') as resp:
+                  resp.raise_for_status()
+          except aiohttp.ClientResponseError as e:
+              if e.ssl_object:
+                  peer_cert = e.ssl_object.getpeercert()
+                  print(f"Certificate subject: {peer_cert.get('subject')}")
+
+      .. versionadded:: 3.13
+
 
 .. class:: ContentTypeError
    :canonical: aiohttp.client_exceptions.ContentTypeError

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -2785,7 +2785,7 @@ Response errors
    .. attribute:: ssl_object
 
       SSL object from the connection transport, if available
-      (:class:`ssl.SSLSocket` or ``None``).
+      (:class:`ssl.SSLObject` or ``None``).
 
       This attribute provides access to SSL certificate information even after
       the connection has been closed. Useful for advanced certificate
@@ -2801,7 +2801,7 @@ Response errors
                   peer_cert = e.ssl_object.getpeercert()
                   print(f"Certificate subject: {peer_cert.get('subject')}")
 
-      .. versionadded:: 3.13
+      .. versionadded:: 4.0
 
 
 .. class:: ContentTypeError

--- a/tests/test_client_exceptions.py
+++ b/tests/test_client_exceptions.py
@@ -111,7 +111,7 @@ class TestClientResponseError:
 
     def test_repr_with_ssl_object(self) -> None:
         mock_ssl_object = Mock(spec=ssl.SSLObject)
-        mock_ssl_object.__repr__ = Mock(return_value="<MockSSLObject>")
+        type(mock_ssl_object).__repr__ = Mock(return_value="<MockSSLObject>")  # type: ignore[method-assign]
         err = client.ClientResponseError(
             request_info=self.request_info,
             history=(),
@@ -128,10 +128,7 @@ class TestClientResponseError:
         assert repr(err) == expected_repr
 
     def test_ssl_object_strong_ref_persists(self) -> None:
-        class FakeSSLObject:
-            pass
-
-        obj = FakeSSLObject()
+        obj = Mock(spec=ssl.SSLObject)
         err = client.ClientResponseError(
             request_info=self.request_info, history=(), ssl_object=obj
         )
@@ -349,7 +346,7 @@ class TestServerFingerprintMismatch:
 
     def test_repr_with_ssl_object(self) -> None:
         mock_ssl_object = Mock(spec=ssl.SSLObject)
-        mock_ssl_object.__repr__ = Mock(return_value="<MockSSLObject>")
+        type(mock_ssl_object).__repr__ = Mock(return_value="<MockSSLObject>")  # type: ignore[method-assign]
         err = client.ServerFingerprintMismatch(
             b"exp", b"got", "example.com", 8080, ssl_object=mock_ssl_object
         )

--- a/tests/test_client_exceptions.py
+++ b/tests/test_client_exceptions.py
@@ -336,6 +336,32 @@ class TestServerFingerprintMismatch:
             "got=b'got' host='example.com' port=8080>"
         )
 
+    def test_ssl_object_none_by_default(self) -> None:
+        err = client.ServerFingerprintMismatch(b"exp", b"got", "example.com", 8080)
+        assert err.ssl_object is None
+
+    def test_ssl_object_stored(self) -> None:
+        mock_ssl_object = Mock(spec=ssl.SSLObject)
+        err = client.ServerFingerprintMismatch(
+            b"exp", b"got", "example.com", 8080, ssl_object=mock_ssl_object
+        )
+        assert err.ssl_object is mock_ssl_object
+
+    def test_repr_with_ssl_object(self) -> None:
+        mock_ssl_object = Mock(spec=ssl.SSLObject)
+        mock_ssl_object.__repr__ = Mock(return_value="<MockSSLObject>")
+        err = client.ServerFingerprintMismatch(
+            b"exp", b"got", "example.com", 8080, ssl_object=mock_ssl_object
+        )
+        assert repr(err) == (
+            "<ServerFingerprintMismatch expected=b'exp' "
+            "got=b'got' host='example.com' port=8080 ssl_object=<MockSSLObject>>"
+        )
+
+    def test_repr_without_ssl_object(self) -> None:
+        err = client.ServerFingerprintMismatch(b"exp", b"got", "example.com", 8080)
+        assert "ssl_object" not in repr(err)
+
 
 class TestInvalidURL:
     def test_ctor(self) -> None:

--- a/tests/test_client_exceptions.py
+++ b/tests/test_client_exceptions.py
@@ -127,18 +127,6 @@ class TestClientResponseError:
         )
         assert repr(err) == expected_repr
 
-    def test_ssl_object_weakref(self) -> None:
-        class SSLObject:
-            pass
-
-        obj = SSLObject()
-        err = client.ClientResponseError(
-            request_info=self.request_info, history=(), ssl_object=obj
-        )
-        assert err.ssl_object is obj
-        del obj
-        assert err.ssl_object is None
-
 
 class TestClientConnectorError:
     connection_key = client_reqrep.ConnectionKey(
@@ -403,11 +391,12 @@ class TestExtractSSLObject:
         assert result is mock_ssl_object
         mock_transport.get_extra_info.assert_called_once_with("ssl_object")
 
-    def test_extract_ssl_object_no_exception_suppression(self) -> None:
+    def test_extract_ssl_object_exception_handling(self) -> None:
         mock_transport = Mock()
         mock_transport.get_extra_info.side_effect = Exception("Transport error")
         mock_connection = Mock()
         mock_connection.transport = mock_transport
 
-        with pytest.raises(Exception, match="Transport error"):
-            _extract_ssl_object(mock_connection)
+        result = _extract_ssl_object(mock_connection)
+
+        assert result is None

--- a/tests/test_client_exceptions.py
+++ b/tests/test_client_exceptions.py
@@ -127,6 +127,18 @@ class TestClientResponseError:
         )
         assert repr(err) == expected_repr
 
+    def test_ssl_object_weakref(self) -> None:
+        class SSLObject:
+            pass
+
+        obj = SSLObject()
+        err = client.ClientResponseError(
+            request_info=self.request_info, history=(), ssl_object=obj
+        )
+        assert err.ssl_object is obj
+        del obj
+        assert err.ssl_object is None
+
 
 class TestClientConnectorError:
     connection_key = client_reqrep.ConnectionKey(
@@ -391,12 +403,11 @@ class TestExtractSSLObject:
         assert result is mock_ssl_object
         mock_transport.get_extra_info.assert_called_once_with("ssl_object")
 
-    def test_extract_ssl_object_exception_handling(self) -> None:
+    def test_extract_ssl_object_no_exception_suppression(self) -> None:
         mock_transport = Mock()
         mock_transport.get_extra_info.side_effect = Exception("Transport error")
         mock_connection = Mock()
         mock_connection.transport = mock_transport
 
-        result = _extract_ssl_object(mock_connection)
-
-        assert result is None
+        with pytest.raises(Exception, match="Transport error"):
+            _extract_ssl_object(mock_connection)

--- a/tests/test_client_exceptions.py
+++ b/tests/test_client_exceptions.py
@@ -136,6 +136,29 @@ class TestClientResponseError:
         del obj
         assert err.ssl_object is not None
 
+    def test_getstate_excludes_ssl_object(self) -> None:
+        mock_ssl_object = Mock(spec=ssl.SSLObject)
+        err = client.ClientResponseError(
+            request_info=self.request_info, history=(), ssl_object=mock_ssl_object
+        )
+        state = err.__getstate__()
+        assert "_ssl_object" not in state
+        assert "status" in state
+
+    def test_setstate_clears_ssl_object(self) -> None:
+        mock_ssl_object = Mock(spec=ssl.SSLObject)
+        err = client.ClientResponseError(
+            request_info=self.request_info, history=(), ssl_object=mock_ssl_object
+        )
+        state = err.__getstate__()
+        err.__setstate__(state)
+        assert err.ssl_object is None
+
+    def test_setstate_with_none_state(self) -> None:
+        err = client.ClientResponseError(request_info=self.request_info, history=())
+        err.__setstate__(None)
+        assert err.ssl_object is None
+
 
 class TestClientConnectorError:
     connection_key = client_reqrep.ConnectionKey(
@@ -433,6 +456,25 @@ class TestExtractSSLObject:
         mock_connection.transport = mock_transport
 
         result = _extract_ssl_object(mock_connection)
+
+        assert result is None
+
+    def test_extract_ssl_object_transport_passed_directly(self) -> None:
+        mock_ssl_object = Mock(spec=ssl.SSLObject)
+
+        class DirectTransport:
+            def get_extra_info(self, key: str, default: object = None) -> object:
+                return mock_ssl_object if key == "ssl_object" else default
+
+        result = _extract_ssl_object(DirectTransport())  # type: ignore[arg-type]
+
+        assert result is mock_ssl_object
+
+    def test_extract_ssl_object_no_matching_attribute(self) -> None:
+        class UnknownConnection:
+            pass
+
+        result = _extract_ssl_object(UnknownConnection())  # type: ignore[arg-type]
 
         assert result is None
 

--- a/tests/test_client_exceptions.py
+++ b/tests/test_client_exceptions.py
@@ -1,12 +1,15 @@
 import errno
 import pickle
+import ssl
 import sys
+from unittest.mock import Mock
 
 import pytest
 from multidict import CIMultiDict, CIMultiDictProxy
 from yarl import URL
 
 from aiohttp import client, client_reqrep
+from aiohttp.client_reqrep import _extract_ssl_object
 from aiohttp.helpers import HeadersDictProxy
 from aiohttp.http_parser import RawResponseMessage
 from aiohttp.typedefs import StrOrURL
@@ -94,6 +97,35 @@ class TestClientResponseError:
             headers=HeadersDictProxy(CIMultiDict()),
         )
         assert str(err) == ("400, message='Something wrong', url='http://example.com'")
+
+    def test_ssl_object_none_by_default(self) -> None:
+        err = client.ClientResponseError(request_info=self.request_info, history=())
+        assert err.ssl_object is None
+
+    def test_ssl_object_stored(self) -> None:
+        mock_ssl_object = Mock(spec=ssl.SSLObject)
+        err = client.ClientResponseError(
+            request_info=self.request_info, history=(), ssl_object=mock_ssl_object
+        )
+        assert err.ssl_object is mock_ssl_object
+
+    def test_repr_with_ssl_object(self) -> None:
+        mock_ssl_object = Mock(spec=ssl.SSLObject)
+        mock_ssl_object.__repr__ = Mock(return_value="<MockSSLObject>")
+        err = client.ClientResponseError(
+            request_info=self.request_info,
+            history=(),
+            status=400,
+            message="Something wrong",
+            headers=CIMultiDict(),
+            ssl_object=mock_ssl_object,
+        )
+        expected_repr = (
+            "ClientResponseError(%r, (), status=400, "
+            "message='Something wrong', headers=<CIMultiDict()>, ssl_object=<MockSSLObject>)"
+            % (self.request_info,)
+        )
+        assert repr(err) == expected_repr
 
 
 class TestClientConnectorError:
@@ -334,3 +366,37 @@ class TestInvalidURL:
     def test_str_with_description(self) -> None:
         err = client.InvalidURL(url=":wrong:url:", description=":description:")
         assert str(err) == ":wrong:url: - :description:"
+
+
+class TestExtractSSLObject:
+    def test_extract_ssl_object_none_connection(self) -> None:
+        result = _extract_ssl_object(None)
+        assert result is None
+
+    def test_extract_ssl_object_no_transport(self) -> None:
+        mock_connection = Mock()
+        mock_connection.transport = None
+        result = _extract_ssl_object(mock_connection)
+        assert result is None
+
+    def test_extract_ssl_object_success(self) -> None:
+        mock_ssl_object = Mock(spec=ssl.SSLObject)
+        mock_transport = Mock()
+        mock_transport.get_extra_info.return_value = mock_ssl_object
+        mock_connection = Mock()
+        mock_connection.transport = mock_transport
+
+        result = _extract_ssl_object(mock_connection)
+
+        assert result is mock_ssl_object
+        mock_transport.get_extra_info.assert_called_once_with("ssl_object")
+
+    def test_extract_ssl_object_exception_handling(self) -> None:
+        mock_transport = Mock()
+        mock_transport.get_extra_info.side_effect = Exception("Transport error")
+        mock_connection = Mock()
+        mock_connection.transport = mock_transport
+
+        result = _extract_ssl_object(mock_connection)
+
+        assert result is None

--- a/tests/test_client_exceptions.py
+++ b/tests/test_client_exceptions.py
@@ -127,6 +127,18 @@ class TestClientResponseError:
         )
         assert repr(err) == expected_repr
 
+    def test_ssl_object_strong_ref_persists(self) -> None:
+        class FakeSSLObject:
+            pass
+
+        obj = FakeSSLObject()
+        err = client.ClientResponseError(
+            request_info=self.request_info, history=(), ssl_object=obj
+        )
+        assert err.ssl_object is obj
+        del obj
+        assert err.ssl_object is not None
+
 
 class TestClientConnectorError:
     connection_key = client_reqrep.ConnectionKey(
@@ -391,7 +403,7 @@ class TestExtractSSLObject:
         assert result is mock_ssl_object
         mock_transport.get_extra_info.assert_called_once_with("ssl_object")
 
-    def test_extract_ssl_object_exception_handling(self) -> None:
+    def test_extract_ssl_object_suppresses_exception(self) -> None:
         mock_transport = Mock()
         mock_transport.get_extra_info.side_effect = Exception("Transport error")
         mock_connection = Mock()
@@ -400,3 +412,41 @@ class TestExtractSSLObject:
         result = _extract_ssl_object(mock_connection)
 
         assert result is None
+
+
+class TestSSLObjectTimingCapture:
+    """Tests that ssl_object is captured early so it survives connection release."""
+
+    request_info = client.RequestInfo(
+        url=URL("http://example.com"),
+        method="GET",
+        headers=CIMultiDictProxy(CIMultiDict()),
+        real_url=URL("http://example.com"),
+    )
+
+    def test_client_response_error_ssl_object_available_after_connection_cleared(
+        self,
+    ) -> None:
+        mock_ssl_object = Mock(spec=ssl.SSLObject)
+        err = client.ClientResponseError(
+            request_info=self.request_info,
+            history=(),
+            ssl_object=mock_ssl_object,
+        )
+        assert err.ssl_object is mock_ssl_object
+
+    def test_too_many_redirects_ssl_object_stored(self) -> None:
+        mock_ssl_object = Mock(spec=ssl.SSLObject)
+        err = client.TooManyRedirects(
+            request_info=self.request_info,
+            history=(),
+            ssl_object=mock_ssl_object,
+        )
+        assert err.ssl_object is mock_ssl_object
+
+    def test_too_many_redirects_ssl_object_none_by_default(self) -> None:
+        err = client.TooManyRedirects(
+            request_info=self.request_info,
+            history=(),
+        )
+        assert err.ssl_object is None

--- a/tests/test_client_fingerprint.py
+++ b/tests/test_client_fingerprint.py
@@ -56,7 +56,7 @@ def test_fingerprint_check_passes_ssl_object_on_mismatch() -> None:
             return mock_ssl_object
         if key == "peername":
             return ("127.0.0.1", 443)
-        return default
+        return default  # pragma: no cover
 
     transport.get_extra_info.side_effect = get_extra_info
 
@@ -87,7 +87,7 @@ def test_fingerprint_check_ssl_object_none_when_get_extra_info_raises() -> None:
             raise RuntimeError("transport closed")
         if key == "peername":
             return ("127.0.0.1", 443)
-        return default
+        return default  # pragma: no cover
 
     transport = mock.Mock()
     transport.get_extra_info.side_effect = get_extra_info
@@ -104,8 +104,8 @@ async def test_ssl_object_on_server_fingerprint_mismatch(
     aiohttp_client: AiohttpClient,
     tls_certificate_fingerprint_sha256: bytes,
 ) -> None:
-    async def handler(request: web.Request) -> NoReturn:
-        assert False
+    async def handler(request: web.Request) -> NoReturn:  # pragma: no cover
+        assert False  # pragma: no cover
 
     bad_fingerprint = b"\x00" * len(tls_certificate_fingerprint_sha256)
     connector = aiohttp.TCPConnector(ssl=aiohttp.Fingerprint(bad_fingerprint))

--- a/tests/test_client_fingerprint.py
+++ b/tests/test_client_fingerprint.py
@@ -1,10 +1,13 @@
 import hashlib
+from typing import NoReturn
 from unittest import mock
 
 import pytest
+from pytest_aiohttp import AiohttpClient, AiohttpServer
 
 import aiohttp
 from aiohttp.client_exceptions import ServerFingerprintMismatch
+from aiohttp import web
 
 ssl = pytest.importorskip("ssl")
 
@@ -92,3 +95,26 @@ def test_fingerprint_check_ssl_object_none_when_get_extra_info_raises() -> None:
         fp.check(transport)
 
     assert exc_info.value.ssl_object is None
+
+
+async def test_ssl_object_on_server_fingerprint_mismatch(
+    aiohttp_server: AiohttpServer,
+    ssl_ctx: ssl.SSLContext,
+    aiohttp_client: AiohttpClient,
+    tls_certificate_fingerprint_sha256: bytes,
+) -> None:
+    async def handler(request: web.Request) -> NoReturn:
+        assert False
+
+    bad_fingerprint = b"\x00" * len(tls_certificate_fingerprint_sha256)
+    connector = aiohttp.TCPConnector(ssl=aiohttp.Fingerprint(bad_fingerprint))
+
+    app = web.Application()
+    app.router.add_get("/", handler)
+    server = await aiohttp_server(app, ssl=ssl_ctx)
+    client = await aiohttp_client(server, connector=connector)  # type: ignore[var-annotated]
+
+    with pytest.raises(ServerFingerprintMismatch) as exc_info:
+        await client.get("/")
+
+    assert isinstance(exc_info.value.ssl_object, ssl.SSLObject)

--- a/tests/test_client_fingerprint.py
+++ b/tests/test_client_fingerprint.py
@@ -4,6 +4,7 @@ from unittest import mock
 import pytest
 
 import aiohttp
+from aiohttp.client_exceptions import ServerFingerprintMismatch
 
 ssl = pytest.importorskip("ssl")
 
@@ -32,3 +33,62 @@ def test_fingerprint_check_no_ssl() -> None:
     transport = mock.Mock()
     transport.get_extra_info.return_value = None
     fp.check(transport)
+
+
+def test_fingerprint_check_passes_ssl_object_on_mismatch() -> None:
+    sha256 = hashlib.sha256(b"12345678" * 64).digest()
+    fp = aiohttp.Fingerprint(sha256)
+
+    mock_ssl_object = mock.Mock(spec=ssl.SSLObject)
+    bad_cert = b"bad_cert_data"
+    mock_ssl_object.getpeercert.return_value = bad_cert
+
+    transport = mock.Mock()
+
+    def get_extra_info(key: str, default: object = None) -> object:
+        if key == "sslcontext":
+            return mock.Mock()
+        if key == "ssl_object":
+            return mock_ssl_object
+        if key == "peername":
+            return ("127.0.0.1", 443)
+        return default
+
+    transport.get_extra_info.side_effect = get_extra_info
+
+    with pytest.raises(ServerFingerprintMismatch) as exc_info:
+        fp.check(transport)
+
+    assert exc_info.value.ssl_object is mock_ssl_object
+
+
+def test_fingerprint_check_ssl_object_none_when_get_extra_info_raises() -> None:
+    sha256 = hashlib.sha256(b"12345678" * 64).digest()
+    fp = aiohttp.Fingerprint(sha256)
+
+    mock_ssl_object = mock.Mock(spec=ssl.SSLObject)
+    bad_cert = b"bad_cert_data"
+    mock_ssl_object.getpeercert.return_value = bad_cert
+
+    call_count = 0
+
+    def get_extra_info(key: str, default: object = None) -> object:
+        nonlocal call_count
+        if key == "sslcontext":
+            return mock.Mock()
+        if key == "ssl_object":
+            call_count += 1
+            if call_count == 1:
+                return mock_ssl_object
+            raise RuntimeError("transport closed")
+        if key == "peername":
+            return ("127.0.0.1", 443)
+        return default
+
+    transport = mock.Mock()
+    transport.get_extra_info.side_effect = get_extra_info
+
+    with pytest.raises(ServerFingerprintMismatch) as exc_info:
+        fp.check(transport)
+
+    assert exc_info.value.ssl_object is None

--- a/tests/test_client_fingerprint.py
+++ b/tests/test_client_fingerprint.py
@@ -6,8 +6,8 @@ import pytest
 from pytest_aiohttp import AiohttpClient, AiohttpServer
 
 import aiohttp
-from aiohttp.client_exceptions import ServerFingerprintMismatch
 from aiohttp import web
+from aiohttp.client_exceptions import ServerFingerprintMismatch
 
 ssl = pytest.importorskip("ssl")
 

--- a/tests/test_client_fingerprint.py
+++ b/tests/test_client_fingerprint.py
@@ -1,4 +1,5 @@
 import hashlib
+import ssl
 from typing import NoReturn
 from unittest import mock
 
@@ -9,7 +10,7 @@ import aiohttp
 from aiohttp import web
 from aiohttp.client_exceptions import ServerFingerprintMismatch
 
-ssl = pytest.importorskip("ssl")
+pytest.importorskip("ssl")
 
 
 def test_fingerprint_sha256() -> None:

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -43,10 +43,18 @@ from pytest_mock import MockerFixture
 from yarl import URL, Query
 
 import aiohttp
-from aiohttp import Fingerprint, ServerFingerprintMismatch, hdrs, payload, web
+from aiohttp import (
+    Fingerprint,
+    ServerFingerprintMismatch,
+    WSServerHandshakeError,
+    hdrs,
+    payload,
+    web,
+)
 from aiohttp.abc import AbstractResolver, ResolveResult
 from aiohttp.client_exceptions import (
     ClientResponseError,
+    ContentTypeError,
     InvalidURL,
     InvalidUrlClientError,
     InvalidUrlRedirectClientError,
@@ -5950,3 +5958,131 @@ async def test_upload_complete_late_access(aiohttp_client: AiohttpClient) -> Non
         # Writer task is done; future is created lazily on this first access.
         assert resp._upload_complete is None
         assert resp.upload_complete.done()
+
+
+async def test_ssl_object_on_raise_for_status_inside_context(
+    aiohttp_server: AiohttpServer,
+    ssl_ctx: ssl.SSLContext,
+    aiohttp_client: AiohttpClient,
+    client_ssl_ctx: ssl.SSLContext,
+) -> None:
+    async def handler(request: web.Request) -> web.Response:
+        return web.Response(status=404, text="Not found")
+
+    app = web.Application()
+    app.router.add_get("/", handler)
+    server = await aiohttp_server(app, ssl=ssl_ctx)
+    connector = aiohttp.TCPConnector(ssl=client_ssl_ctx)
+    client = await aiohttp_client(server, connector=connector)  # type: ignore[var-annotated]
+
+    with pytest.raises(ClientResponseError) as exc_info:
+        async with client.get("/") as resp:
+            resp.raise_for_status()
+
+    assert isinstance(exc_info.value.ssl_object, ssl.SSLObject)
+    assert exc_info.value.ssl_object.getpeercert() is not None
+
+
+async def test_ssl_object_on_raise_for_status_outside_context(
+    aiohttp_server: AiohttpServer,
+    ssl_ctx: ssl.SSLContext,
+    aiohttp_client: AiohttpClient,
+    client_ssl_ctx: ssl.SSLContext,
+) -> None:
+    async def handler(request: web.Request) -> web.Response:
+        return web.Response(status=404, text="Not found")
+
+    app = web.Application()
+    app.router.add_get("/", handler)
+    server = await aiohttp_server(app, ssl=ssl_ctx)
+    connector = aiohttp.TCPConnector(ssl=client_ssl_ctx)
+    client = await aiohttp_client(server, connector=connector)  # type: ignore[var-annotated]
+
+    async with client.get("/") as resp:
+        await resp.read()
+
+    with pytest.raises(ClientResponseError) as exc_info:
+        resp.raise_for_status()
+
+    assert isinstance(exc_info.value.ssl_object, ssl.SSLObject)
+
+
+async def test_ssl_object_on_content_type_error(
+    aiohttp_server: AiohttpServer,
+    ssl_ctx: ssl.SSLContext,
+    aiohttp_client: AiohttpClient,
+    client_ssl_ctx: ssl.SSLContext,
+) -> None:
+    async def handler(request: web.Request) -> web.Response:
+        return web.Response(status=200, text="plain text", content_type="text/plain")
+
+    app = web.Application()
+    app.router.add_get("/", handler)
+    server = await aiohttp_server(app, ssl=ssl_ctx)
+    connector = aiohttp.TCPConnector(ssl=client_ssl_ctx)
+    client = await aiohttp_client(server, connector=connector)  # type: ignore[var-annotated]
+
+    with pytest.raises(ContentTypeError) as exc_info:
+        async with client.get("/") as resp:
+            await resp.json()
+
+    assert isinstance(exc_info.value.ssl_object, ssl.SSLObject)
+
+
+async def test_ssl_object_none_on_plain_http(aiohttp_client: AiohttpClient) -> None:
+    async def handler(request: web.Request) -> web.Response:
+        return web.Response(status=404, text="Not found")
+
+    app = web.Application()
+    app.router.add_get("/", handler)
+    client = await aiohttp_client(app)
+
+    with pytest.raises(ClientResponseError) as exc_info:
+        async with client.get("/") as resp:
+            resp.raise_for_status()
+
+    assert exc_info.value.ssl_object is None
+
+
+async def test_ssl_object_on_too_many_redirects(
+    aiohttp_server: AiohttpServer,
+    ssl_ctx: ssl.SSLContext,
+    aiohttp_client: AiohttpClient,
+    client_ssl_ctx: ssl.SSLContext,
+) -> None:
+    async def redirect(request: web.Request) -> NoReturn:
+        count = int(request.match_info["count"])
+        assert count
+        raise web.HTTPFound(location=f"/redirect/{count - 1}")
+
+    app = web.Application()
+    app.router.add_get(r"/redirect/{count:\d+}", redirect)
+    server = await aiohttp_server(app, ssl=ssl_ctx)
+    connector = aiohttp.TCPConnector(ssl=client_ssl_ctx)
+    client = await aiohttp_client(server, connector=connector)  # type: ignore[var-annotated]
+
+    with pytest.raises(TooManyRedirects) as exc_info:
+        await client.get("/redirect/5", max_redirects=2)
+
+    assert isinstance(exc_info.value.ssl_object, ssl.SSLObject)
+
+
+async def test_ssl_object_on_ws_handshake_error(
+    aiohttp_server: AiohttpServer,
+    ssl_ctx: ssl.SSLContext,
+    aiohttp_client: AiohttpClient,
+    client_ssl_ctx: ssl.SSLContext,
+) -> None:
+    async def handler(request: web.Request) -> web.Response:
+        return web.Response(status=200, text="not a websocket upgrade")
+
+    app = web.Application()
+    app.router.add_get("/", handler)
+    server = await aiohttp_server(app, ssl=ssl_ctx)
+    connector = aiohttp.TCPConnector(ssl=client_ssl_ctx)
+    client = await aiohttp_client(server, connector=connector)  # type: ignore[var-annotated]
+
+    with pytest.raises(WSServerHandshakeError) as exc_info:
+        await client.ws_connect("/")
+
+    assert isinstance(exc_info.value.ssl_object, ssl.SSLObject)

--- a/tests/test_client_response.py
+++ b/tests/test_client_response.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import gc
+import ssl
 import sys
 from http.cookies import SimpleCookie
 from json import JSONDecodeError
@@ -991,6 +992,62 @@ def test_raise_for_status_4xx_without_reason() -> None:
     assert str(cm.value.status) == "404"
     assert str(cm.value.message) == ""
     assert response.closed
+
+
+def test_raise_for_status_ssl_object_captured_before_connection_release() -> None:
+    url = URL("http://def-cl-resp.org")
+    response = ClientResponse(
+        "get",
+        url,
+        writer=WriterMock(),
+        continue100=None,
+        timer=TimerNoop(),
+        traces=[],
+        loop=mock.Mock(),
+        session=mock.Mock(),
+        request_headers=CIMultiDict[str](),
+        original_url=url,
+        stream_writer=mock.create_autospec(
+            AbstractStreamWriter, spec_set=True, instance=True
+        ),
+    )
+    mock_ssl_object = mock.Mock(spec=ssl.SSLObject)
+    response._ssl_object = mock_ssl_object
+    response._connection = None
+    response.status = 403
+    response.reason = "FORBIDDEN"
+    with pytest.raises(aiohttp.ClientResponseError) as cm:
+        response.raise_for_status()
+    assert cm.value.ssl_object is mock_ssl_object
+
+
+async def test_json_content_type_error_ssl_object_captured_before_release() -> None:
+    url = URL("http://def-cl-resp.org")
+    response = ClientResponse(
+        "get",
+        url,
+        writer=WriterMock(),
+        continue100=None,
+        timer=TimerNoop(),
+        traces=[],
+        loop=mock.Mock(),
+        session=mock.Mock(),
+        request_headers=CIMultiDict[str](),
+        original_url=url,
+        stream_writer=mock.create_autospec(
+            AbstractStreamWriter, spec_set=True, instance=True
+        ),
+    )
+    mock_ssl_object = mock.Mock(spec=ssl.SSLObject)
+    response._ssl_object = mock_ssl_object
+    response._connection = None
+    response.status = 200
+    response.reason = "OK"
+    response._body = b"plain text"
+    response._headers = HeadersDictProxy(CIMultiDict({"Content-Type": "text/plain"}))
+    with pytest.raises(aiohttp.ContentTypeError) as cm:
+        await response.json(content_type="application/json")
+    assert cm.value.ssl_object is mock_ssl_object
 
 
 def test_resp_host() -> None:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Adds an `ssl_object` attribute (`ssl.SSLObject | None`) to `ClientResponseError` and its subclasses, giving users access to SSL/TLS certificate information when an HTTP exception is raised — even after the connection has been closed.

**Key design decisions and fixes (addresses all review feedback from Dreamsorcerer, bdraco, webknjaz):**

- **Strong reference (not weakref):** `ssl_object` is stored as a plain strong reference. A weakref would be GC'd once the connection closes — the exact moment the user needs the data — making the feature non-functional. The strong reference is the right trade-off for the typical short lifetime of an exception.
- **Early capture in `ClientResponse.start()`:** The SSL object is extracted from the transport immediately when the response starts, before any connection-release can happen. This solves the "always None" timing problem for `raise_for_status()`, `json()`, and `TooManyRedirects` that existed in the initial implementation.
- **Exception-safe extraction:** `_extract_ssl_object()` wraps `transport.get_extra_info("ssl_object")` in a narrow `try/except Exception: return None` guard so that a transport error never masks the primary exception being raised.
- **`ServerFingerprintMismatch` wired up:** The most SSL-relevant exception now carries `ssl_object` too, extracted at fingerprint-check time while the transport is still live.
- **Pickling preserved:** `__getstate__`/`__setstate__` exclude `_ssl_object` from the pickle payload (ssl objects are not serializable), so existing pickle behaviour is maintained.

**Exceptions covered:**

| Exception | `ssl_object` source |
|---|---|
| `ClientResponseError` / `ClientResponseError` subclasses | `ClientResponse._ssl_object` (captured in `start()`) |
| `ContentTypeError` (from `.json()`) | same |
| `TooManyRedirects` | captured from `resp._ssl_object` before `resp.close()` |
| `WSServerHandshakeError` | `resp._ssl_object` |
| `ServerFingerprintMismatch` | transport at fingerprint-check time |
| `ClientHttpProxyError` | transport at CONNECT time (proxy TLS, not end-to-end) |
| HTTP (non-TLS) requests | `None` |

## Are there changes in behavior for the user?

No breaking changes. The `ssl_object` parameter on `ClientResponseError.__init__` and `ServerFingerprintMismatch.__init__` is keyword-only with a default of `None`, so all existing call sites continue to work unchanged. Users can now optionally access `exception.ssl_object` to inspect the peer certificate, cipher suite, TLS version, etc.

Example usage:
```python
try:
    async with session.get("https://example.com/api") as resp:
        resp.raise_for_status()
except aiohttp.ClientResponseError as exc:
    if exc.ssl_object is not None:
        print(exc.ssl_object.getpeercert())
        print(exc.ssl_object.cipher())
```

## Is it a substantial burden for the maintainers to support this?

Minimal. The attribute is a simple property backed by a stored reference. The extraction logic is isolated in `_extract_ssl_object()`. Pickling is handled transparently. No new dependencies are introduced.

## Related issue number

Fixes #10028

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is <Name> <Surname>.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES/` folder
  * name it `<issue_or_pr_num>.<type>.rst` (e.g. `588.bugfix.rst`)
  * if you don't have an issue number, change it to the pull request
    number after creating the PR
    * `.bugfix`: A bug fix for something the maintainers deemed an
      improper undesired behavior that got corrected to match
      pre-agreed expectations.
    * `.feature`: A new behavior, public APIs. That sort of stuff.
    * `.deprecation`: A declaration of future API removals and breaking
      changes in behavior.
    * `.breaking`: When something public is removed in a breaking way.
      Could be deprecated in an earlier release.
    * `.doc`: Notable updates to the documentation structure or build
      process.
    * `.packaging`: Notes for downstreams about unobvious side effects
      and tooling. Changes in the test invocation considerations and
      runtime assumptions.
    * `.contrib`: Stuff that affects the contributor experience. e.g.
      Running tests, building the docs, setting up the development
      environment.
    * `.misc`: Changes that are hard to assign to any of the above
      categories.
  * Make sure to use full sentences with correct case and punctuation,
    for example:
    ```rst
    Fixed issue with non-ascii contents in doctest text files
    -- by :user:`contributor-gh-handle`.
    ```

    Use the past tense or the present tense a non-imperative mood,
    referring to what's changed compared to the last released version
    of this project.
