### PR TITLE
Make web logs timestamps DST aware

### DIFF
--- a/CHANGES/11283.bugfix.rst
+++ b/CHANGES/11283.bugfix.rst
@@ -1,3 +1,3 @@
-Made ``AccessLogger`` use ``tm_gmtoff`` for timestamps to be aware of DST.
+Made ``AccessLogger`` timestamps aware of DST.
 
 -- by :user:`sgaist`

--- a/CHANGES/11283.bugfix.rst
+++ b/CHANGES/11283.bugfix.rst
@@ -1,3 +1,3 @@
-Made ``AccessLogger`` use ``tm_gmtoff` for timestamps to be aware of DST.
+Made ``AccessLogger`` use ``tm_gmtoff`` for timestamps to be aware of DST.
 
 -- by :user:`sgaist`

--- a/CHANGES/11283.bugfix.rst
+++ b/CHANGES/11283.bugfix.rst
@@ -1,0 +1,2 @@
+Made `AccessLogger` use `tm_gmtoff` for timestamps to be aware of DST.
+-- by :user:`sgaist`

--- a/CHANGES/11283.bugfix.rst
+++ b/CHANGES/11283.bugfix.rst
@@ -1,3 +1,3 @@
-Made `AccessLogger` use `tm_gmtoff` for timestamps to be aware of DST.
+Made ``AccessLogger`` use ``tm_gmtoff` for timestamps to be aware of DST.
 
 -- by :user:`sgaist`

--- a/CHANGES/11283.bugfix.rst
+++ b/CHANGES/11283.bugfix.rst
@@ -1,2 +1,3 @@
 Made `AccessLogger` use `tm_gmtoff` for timestamps to be aware of DST.
+
 -- by :user:`sgaist`

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -317,6 +317,7 @@ Roman Postnov
 Rong Zhang
 Samir Akarioh
 Samuel Colvin
+Samuel Gaist
 Sean Hunt
 Sebastian Acuna
 Sebastian Hanula

--- a/aiohttp/web_log.py
+++ b/aiohttp/web_log.py
@@ -139,7 +139,7 @@ class AccessLogger(AbstractAccessLogger):
     @staticmethod
     def _format_t(request: BaseRequest, response: StreamResponse, time: float) -> str:
         tz = datetime.timezone(
-            datetime.timedelta(seconds=time_mod.localtime().tm_gmtoff)
+            datetime.timedelta(seconds=-time_mod.localtime().tm_gmtoff)
         )
         now = datetime.datetime.now(tz)
         start_time = now - datetime.timedelta(seconds=time)

--- a/aiohttp/web_log.py
+++ b/aiohttp/web_log.py
@@ -3,7 +3,6 @@ import functools
 import logging
 import os
 import re
-import time as time_mod
 from collections import namedtuple
 from typing import Any, Callable, Dict, Iterable, List, Tuple  # noqa
 
@@ -138,10 +137,8 @@ class AccessLogger(AbstractAccessLogger):
 
     @staticmethod
     def _format_t(request: BaseRequest, response: StreamResponse, time: float) -> str:
-        tz = datetime.timezone(
-            datetime.timedelta(seconds=-time_mod.localtime().tm_gmtoff)
-        )
-        now = datetime.datetime.now(tz)
+        tz = datetime.datetime.now(datetime.timezone.utc).astimezone()
+        now = datetime.datetime.now(tz.tzinfo)
         start_time = now - datetime.timedelta(seconds=time)
         return start_time.strftime("[%d/%b/%Y:%H:%M:%S %z]")
 

--- a/aiohttp/web_log.py
+++ b/aiohttp/web_log.py
@@ -137,8 +137,7 @@ class AccessLogger(AbstractAccessLogger):
 
     @staticmethod
     def _format_t(request: BaseRequest, response: StreamResponse, time: float) -> str:
-        tz = datetime.datetime.now(datetime.timezone.utc).astimezone()
-        now = datetime.datetime.now(tz.tzinfo)
+        now = datetime.datetime.now(datetime.timezone.utc).astimezone()
         start_time = now - datetime.timedelta(seconds=time)
         return start_time.strftime("[%d/%b/%Y:%H:%M:%S %z]")
 

--- a/aiohttp/web_log.py
+++ b/aiohttp/web_log.py
@@ -138,7 +138,9 @@ class AccessLogger(AbstractAccessLogger):
 
     @staticmethod
     def _format_t(request: BaseRequest, response: StreamResponse, time: float) -> str:
-        tz = datetime.timezone(datetime.timedelta(seconds=-time_mod.timezone))
+        tz = datetime.timezone(
+            datetime.timedelta(seconds=time_mod.localtime().tm_gmtoff)
+        )
         now = datetime.datetime.now(tz)
         start_time = now - datetime.timedelta(seconds=time)
         return start_time.strftime("[%d/%b/%Y:%H:%M:%S %z]")

--- a/tests/test_web_log.py
+++ b/tests/test_web_log.py
@@ -93,14 +93,17 @@ def test_access_logger_atoms(
     extra: Dict[str, object],
 ) -> None:
     class TestTimeZone(datetime.tzinfo):
-        def __init__(self):
+        def __init__(self) -> None:
             self.stdoffset = datetime.timedelta(hours=8)
 
-        def utcoffset(self, dt):
+        def utcoffset(self, dt: datetime.datetime | None) -> datetime.timedelta:
             return self.stdoffset
 
-        def dst(self, dt):
+        def dst(self, dt: datetime.datetime | None) -> datetime.timedelta:
             return datetime.timedelta(0)
+
+        def tzname(self, dt: datetime.datetime | None) -> str:
+            return "test-tz"
 
     class PatchedDatetime(datetime.datetime):
         @classmethod
@@ -219,17 +222,23 @@ def test_access_logger_atoms_dst(
 ) -> None:
 
     class TestTimeZone(datetime.tzinfo):
-        def __init__(self):
+        def __init__(self) -> None:
             self.std_offset = datetime.timedelta(hours=1)
 
-        def utcoffset(self, dt):
+        def utcoffset(self, dt: datetime.datetime | None) -> datetime.timedelta:
             return self.std_offset + self.dst(dt)
 
-        def dst(self, dt):
+        def dst(self, dt: datetime.datetime | None) -> datetime.timedelta:
             if is_dst:
                 return datetime.timedelta(hours=1)
             else:
                 return datetime.timedelta(0)
+
+        def tzname(self, dt: datetime.datetime | None) -> str:
+            if is_dst:
+                return "test-dst"
+            else:
+                return "test-std"
 
     class PatchedDatetime(datetime.datetime):
         @classmethod

--- a/tests/test_web_log.py
+++ b/tests/test_web_log.py
@@ -2,6 +2,7 @@ import datetime
 import logging
 import platform
 import sys
+import time
 from contextvars import ContextVar
 from typing import Dict, NoReturn, Optional
 from unittest import mock
@@ -96,8 +97,11 @@ def test_access_logger_atoms(
         def now(cls, tz: Optional[datetime.tzinfo] = None) -> Self:
             return cls(1843, 1, 1, 0, 30, tzinfo=tz)
 
+    def patched_localtime(sec: int = None):
+        return time.struct_time((0, 0, 0, 0, 0, 0, 0, 0, 0, "test-tz", 28800))
+
     monkeypatch.setattr("datetime.datetime", PatchedDatetime)
-    monkeypatch.setattr("time.timezone", -28800)
+    monkeypatch.setattr("time.localtime", patched_localtime)
     monkeypatch.setattr("os.getpid", lambda: 42)
     mock_logger = mock.Mock()
     access_logger = AccessLogger(mock_logger, log_format)

--- a/tests/test_web_log.py
+++ b/tests/test_web_log.py
@@ -97,7 +97,7 @@ def test_access_logger_atoms(
         def now(cls, tz: Optional[datetime.tzinfo] = None) -> Self:
             return cls(1843, 1, 1, 0, 30, tzinfo=tz)
 
-    def patched_localtime(sec: int = None):
+    def patched_localtime(sec: Optional[int] = None) -> time.struct_time:
         return time.struct_time((0, 0, 0, 0, 0, 0, 0, 0, 0, "test-tz", 28800))
 
     monkeypatch.setattr("datetime.datetime", PatchedDatetime)

--- a/tests/test_web_log.py
+++ b/tests/test_web_log.py
@@ -2,12 +2,12 @@ import datetime
 import logging
 import platform
 import sys
-import time
 from contextvars import ContextVar
 from typing import Dict, NoReturn, Optional
 from unittest import mock
 
 import pytest
+from freezegun import freeze_time
 
 import aiohttp
 from aiohttp import web
@@ -92,16 +92,22 @@ def test_access_logger_atoms(
     expected: str,
     extra: Dict[str, object],
 ) -> None:
+    class TestTimeZone(datetime.tzinfo):
+        def __init__(self):
+            self.stdoffset = datetime.timedelta(hours=8)
+
+        def utcoffset(self, dt):
+            return self.stdoffset
+
+        def dst(self, dt):
+            return datetime.timedelta(0)
+
     class PatchedDatetime(datetime.datetime):
         @classmethod
         def now(cls, tz: Optional[datetime.tzinfo] = None) -> Self:
-            return cls(1843, 1, 1, 0, 30, tzinfo=tz)
-
-    def patched_localtime(sec: Optional[int] = None) -> time.struct_time:
-        return time.struct_time((0, 0, 0, 0, 0, 0, 0, 0, 0, "test-tz", -28800))
+            return cls(1843, 1, 1, 0, 30, tzinfo=TestTimeZone())
 
     monkeypatch.setattr("datetime.datetime", PatchedDatetime)
-    monkeypatch.setattr("time.localtime", patched_localtime)
     monkeypatch.setattr("os.getpid", lambda: 42)
     mock_logger = mock.Mock()
     access_logger = AccessLogger(mock_logger, log_format)
@@ -117,6 +123,144 @@ def test_access_logger_atoms(
     assert not mock_logger.exception.called, mock_logger.exception.call_args
 
     mock_logger.info.assert_called_with(expected, extra=extra)
+
+
+@pytest.mark.skipif(
+    IS_PYPY,
+    reason="""
+    Because of patching :py:class:`datetime.datetime`, under PyPy it
+    fails in :py:func:`isinstance` call in
+    :py:meth:`datetime.datetime.__sub__` (called from
+    :py:meth:`aiohttp.AccessLogger._format_t`):
+
+    *** TypeError: isinstance() arg 2 must be a class, type, or tuple of classes and types
+
+    (Pdb) from datetime import datetime
+    (Pdb) isinstance(now, datetime)
+    *** TypeError: isinstance() arg 2 must be a class, type, or tuple of classes and types
+    (Pdb) datetime.__class__
+    <class 'unittest.mock.MagicMock'>
+    (Pdb) isinstance(now, datetime.__class__)
+    False
+
+    Ref: https://bitbucket.org/pypy/pypy/issues/1187/call-to-isinstance-in-__sub__-self-other
+    Ref: https://github.com/celery/celery/issues/811
+    Ref: https://stackoverflow.com/a/46102240/595220
+    """,
+)
+@pytest.mark.parametrize(
+    "input_date,is_dst,log_format,expected,extra",
+    [
+        (
+            "2011-09-19 02:30:00",
+            True,
+            "%t",
+            "[19/Sep/2011:02:29:56 +0200]",
+            {"request_start_time": "[19/Sep/2011:02:29:56 +0200]"},
+        ),
+        (
+            "2011-12-19 02:30:00",
+            False,
+            "%t",
+            "[19/Dec/2011:02:29:56 +0100]",
+            {"request_start_time": "[19/Dec/2011:02:29:56 +0100]"},
+        ),
+        (
+            "2011-09-19 02:30:00",
+            True,
+            '%a %t %P %r %s %b %T %Tf %D "%{H1}i" "%{H2}i"',
+            (
+                "127.0.0.2 [19/Sep/2011:02:29:56 +0200] <42> "
+                'GET /path HTTP/1.1 200 42 3 3.141593 3141593 "a" "b"'
+            ),
+            {
+                "first_request_line": "GET /path HTTP/1.1",
+                "process_id": "<42>",
+                "remote_address": "127.0.0.2",
+                "request_start_time": "[19/Sep/2011:02:29:56 +0200]",
+                "request_time": "3",
+                "request_time_frac": "3.141593",
+                "request_time_micro": "3141593",
+                "response_size": 42,
+                "response_status": 200,
+                "request_header": {"H1": "a", "H2": "b"},
+            },
+        ),
+        (
+            "2011-12-19 02:30:00",
+            False,
+            '%a %t %P %r %s %b %T %Tf %D "%{H1}i" "%{H2}i"',
+            (
+                "127.0.0.2 [19/Dec/2011:02:29:56 +0100] <42> "
+                'GET /path HTTP/1.1 200 42 3 3.141593 3141593 "a" "b"'
+            ),
+            {
+                "first_request_line": "GET /path HTTP/1.1",
+                "process_id": "<42>",
+                "remote_address": "127.0.0.2",
+                "request_start_time": "[19/Dec/2011:02:29:56 +0100]",
+                "request_time": "3",
+                "request_time_frac": "3.141593",
+                "request_time_micro": "3141593",
+                "response_size": 42,
+                "response_status": 200,
+                "request_header": {"H1": "a", "H2": "b"},
+            },
+        ),
+    ],
+)
+def test_access_logger_atoms_dst(
+    monkeypatch: pytest.MonkeyPatch,
+    input_date: str,
+    is_dst: int,
+    log_format: str,
+    expected: str,
+    extra: Dict[str, object],
+) -> None:
+
+    class TestTimeZone(datetime.tzinfo):
+        def __init__(self):
+            self.std_offset = datetime.timedelta(hours=1)
+
+        def utcoffset(self, dt):
+            return self.std_offset + self.dst(dt)
+
+        def dst(self, dt):
+            if is_dst:
+                return datetime.timedelta(hours=1)
+            else:
+                return datetime.timedelta(0)
+
+    class PatchedDatetime(datetime.datetime):
+        @classmethod
+        def now(cls, tz: Optional[datetime.tzinfo] = None) -> Self:
+            dt = datetime.datetime.strptime(input_date, "%Y-%m-%d %H:%M:%S")
+            hour = dt.hour + 1
+            if is_dst:
+                hour = dt.hour + 2
+            return cls(
+                dt.year, dt.month, dt.day, hour, dt.minute, tzinfo=TestTimeZone()
+            )
+
+    monkeypatch.setattr("datetime.datetime", PatchedDatetime)
+    monkeypatch.setattr("os.getpid", lambda: 42)
+
+    mock_logger = mock.Mock()
+    access_logger = AccessLogger(mock_logger, log_format)
+    request = mock.Mock(
+        headers={"H1": "a", "H2": "b"},
+        method="GET",
+        path_qs="/path",
+        version=aiohttp.HttpVersion(1, 1),
+        remote="127.0.0.2",
+    )
+    response = mock.Mock(headers={}, body_length=42, status=200)
+
+    with freeze_time(input_date):
+        access_logger.log(request, response, 3.1415926)
+        assert not mock_logger.exception.called, mock_logger.exception.call_args
+
+        mock_logger.info.assert_called_with(expected, extra=extra)
 
 
 def test_access_logger_dicts() -> None:

--- a/tests/test_web_log.py
+++ b/tests/test_web_log.py
@@ -110,6 +110,9 @@ def test_access_logger_atoms(
         def now(cls, tz: Optional[datetime.tzinfo] = None) -> Self:
             return cls(1843, 1, 1, 0, 30, tzinfo=TestTimeZone())
 
+        def astimezone(self, tz: datetime.tzinfo | None = None) -> Self:
+            return self
+
     monkeypatch.setattr("datetime.datetime", PatchedDatetime)
     monkeypatch.setattr("os.getpid", lambda: 42)
     mock_logger = mock.Mock()
@@ -239,6 +242,9 @@ def test_access_logger_atoms_dst(
                 return "test-dst"
             else:
                 return "test-std"
+
+        def astimezone(self, tz: datetime.tzinfo | None = None) -> Self:
+            return self
 
     class PatchedDatetime(datetime.datetime):
         @classmethod

--- a/tests/test_web_log.py
+++ b/tests/test_web_log.py
@@ -98,7 +98,7 @@ def test_access_logger_atoms(
             return cls(1843, 1, 1, 0, 30, tzinfo=tz)
 
     def patched_localtime(sec: Optional[int] = None) -> time.struct_time:
-        return time.struct_time((0, 0, 0, 0, 0, 0, 0, 0, 0, "test-tz", 28800))
+        return time.struct_time((0, 0, 0, 0, 0, 0, 0, 0, 0, "test-tz", -28800))
 
     monkeypatch.setattr("datetime.datetime", PatchedDatetime)
     monkeypatch.setattr("time.localtime", patched_localtime)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

Make web logs timestamps DST aware using the tm_gmtoff value rather than the static timezone information.

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->

There might be a jump in timestamps where DST changes

## Is it a substantial burden for the maintainers to support this?

<!--
Stop right there! Pause. Just for a minute... Can you think of anything
obvious that would complicate the ongoing development of this project?

Try to consider if you'd be able to maintain it throughout the next
5 years. Does it seem viable? Tell us your thoughts! We'd very much
love to hear what the consequences of merging this patch might be...

This will help us assess if your change is something we'd want to
entertain early in the review process. Thank you in advance!
-->

There should be no burden for maintainers as there is no new code.

## Related issue number

<!-- Will this resolve any open issues? -->
<!-- Remember to prefix with 'Fixes' if it closes an issue (e.g. 'Fixes #123'). -->

Fixes #11283

## Checklist

- [X] I think the code is well written
- [X] Unit tests for the changes exist
- [X] Documentation reflects the changes
- [X] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [X] Add a new news fragment into the `CHANGES/` folder
  * name it `<issue_or_pr_num>.<type>.rst` (e.g. `588.bugfix.rst`)
  * if you don't have an issue number, change it to the pull request
    number after creating the PR
    * `.bugfix`: A bug fix for something the maintainers deemed an
      improper undesired behavior that got corrected to match
      pre-agreed expectations.
    * `.feature`: A new behavior, public APIs. That sort of stuff.
    * `.deprecation`: A declaration of future API removals and breaking
      changes in behavior.
    * `.breaking`: When something public is removed in a breaking way.
      Could be deprecated in an earlier release.
    * `.doc`: Notable updates to the documentation structure or build
      process.
    * `.packaging`: Notes for downstreams about unobvious side effects
      and tooling. Changes in the test invocation considerations and
      runtime assumptions.
    * `.contrib`: Stuff that affects the contributor experience. e.g.
      Running tests, building the docs, setting up the development
      environment.
    * `.misc`: Changes that are hard to assign to any of the above
      categories.
  * Make sure to use full sentences with correct case and punctuation,
    for example:
    ```rst
    Fixed issue with non-ascii contents in doctest text files
    -- by :user:`contributor-gh-handle`.
    ```

    Use the past tense or the present tense a non-imperative mood,
    referring to what's changed compared to the last released version
    of this project.
