### PR TITLE
Fixed zstd decompression if no content size header is available

### DIFF
--- a/CHANGES/11604.bugfix.rst
+++ b/CHANGES/11604.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed zstd decompression if no content size header is available -- by :user:`AlbertoJimenezRuiz`.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -11,6 +11,7 @@ Adrián Chaves
 Ahmed Tahri
 Alan Bogarin
 Alan Tse
+Alberto Jiménez-Ruiz
 Alec Hanefeld
 Alejandro Gómez
 Aleksandr Danshyn

--- a/aiohttp/compression_utils.py
+++ b/aiohttp/compression_utils.py
@@ -35,9 +35,7 @@ except ImportError:
         from zstandard import ZstdDecompressor
 
         def create_zstd_decompressor():
-            return ZstdDecompressor().decompressobj(
-                read_across_frames=True
-            )
+            return ZstdDecompressor().decompressobj(read_across_frames=True)
 
         HAS_ZSTD = True
     except ImportError:

--- a/aiohttp/compression_utils.py
+++ b/aiohttp/compression_utils.py
@@ -300,7 +300,7 @@ class ZSTDDecompressor:
         if sys.version_info >= (3, 14):
             self._obj = compression.zstd.ZstdDecompressor()
         else:
-            self._obj = zstandard.ZstdDecompressor()
+            self._obj = zstandard.ZstdDecompressor().decompressobj(read_across_frames=True)
 
     def decompress_sync(self, data: bytes) -> bytes:
         return self._obj.decompress(data)

--- a/aiohttp/compression_utils.py
+++ b/aiohttp/compression_utils.py
@@ -300,7 +300,9 @@ class ZSTDDecompressor:
         if sys.version_info >= (3, 14):
             self._obj = compression.zstd.ZstdDecompressor()
         else:
-            self._obj = zstandard.ZstdDecompressor().decompressobj(read_across_frames=True)
+            self._obj = zstandard.ZstdDecompressor().decompressobj(
+                read_across_frames=True
+            )
 
     def decompress_sync(self, data: bytes) -> bytes:
         return self._obj.decompress(data)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

This change fixes the decompression of zstd streams where the content size field is not included in the compressed data. 

## Are there changes in behavior for the user?

Previously, on some streams, aiohttp would crash in a similar way as indygreg/python-zstandard#196. 

Now it doesn't.

<!-- Outline any notable behaviour for the end users. -->

## Related issue number

<!-- Will this resolve any open issues? -->
<!-- Remember to prefix with 'Fixes' if it closes an issue (e.g. 'Fixes #123'). -->

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES/` folder
  * name it `<issue_or_pr_num>.<type>.rst` (e.g. `588.bugfix.rst`)
  * if you don't have an issue number, change it to the pull request
    number after creating the PR
    * `.bugfix`: A bug fix for something the maintainers deemed an
      improper undesired behavior that got corrected to match
      pre-agreed expectations.
    * `.feature`: A new behavior, public APIs. That sort of stuff.
    * `.deprecation`: A declaration of future API removals and breaking
      changes in behavior.
    * `.breaking`: When something public is removed in a breaking way.
      Could be deprecated in an earlier release.
    * `.doc`: Notable updates to the documentation structure or build
      process.
    * `.packaging`: Notes for downstreams about unobvious side effects
      and tooling. Changes in the test invocation considerations and
      runtime assumptions.
    * `.contrib`: Stuff that affects the contributor experience. e.g.
      Running tests, building the docs, setting up the development
      environment.
    * `.misc`: Changes that are hard to assign to any of the above
      categories.
  * Make sure to use full sentences with correct case and punctuation,
    for example:
    ```rst
    Fixed issue with non-ascii contents in doctest text files
    -- by :user:`contributor-gh-handle`.
    ```

    Use the past tense or the present tense a non-imperative mood,
    referring to what's changed compared to the last released version
    of this project.
