### PR TITLE
[PR #11623/df8ad83 backport][3.13] Fix zstd decompression for chunked zstd response

### DIFF
--- a/CHANGES/11623.bugfix
+++ b/CHANGES/11623.bugfix
@@ -1,0 +1,1 @@
+Switched to `backports.zstd` for Python <3.14 and fixed zstd decompression for chunked zstd streams -- by :user:`ZhaoMJ`.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -263,6 +263,7 @@ Mikhail Burshteyn
 Mikhail Kashkin
 Mikhail Lukyanchenko
 Mikhail Nacharov
+Mingjie Zhao
 Misha Behersky
 Mitchell Ferree
 Morgan Delahaye-Prat

--- a/aiohttp/compression_utils.py
+++ b/aiohttp/compression_utils.py
@@ -22,18 +22,14 @@ except ImportError:  # pragma: no cover
     HAS_BROTLI = False
 
 try:
-    from compression.zstd import (  # type: ignore[import-not-found]  # noqa: I900
-        ZstdDecompressor,
-    )
+    if sys.version_info >= (3, 14):
+        from compression.zstd import ZstdDecompressor  # noqa: I900
+    else:  # TODO(PY314): Remove mentions of backports.zstd across codebase
+        from backports.zstd import ZstdDecompressor
 
     HAS_ZSTD = True
 except ImportError:
-    try:
-        from zstandard import ZstdDecompressor
-
-        HAS_ZSTD = True
-    except ImportError:
-        HAS_ZSTD = False
+    HAS_ZSTD = False
 
 
 MAX_SYNC_CHUNK_SIZE = 1024
@@ -298,12 +294,12 @@ class ZSTDDecompressor:
         if not HAS_ZSTD:
             raise RuntimeError(
                 "The zstd decompression is not available. "
-                "Please install `zstandard` module"
+                "Please install `backports.zstd` module"
             )
         self._obj = ZstdDecompressor()
 
     def decompress_sync(self, data: bytes) -> bytes:
-        return self._obj.decompress(data)  # type: ignore[no-any-return]
+        return self._obj.decompress(data)
 
     def flush(self) -> bytes:
         return b""

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -980,7 +980,7 @@ class DeflateBuffer:
             if not HAS_ZSTD:
                 raise ContentEncodingError(
                     "Can not decode content-encoding: zstandard (zstd). "
-                    "Please install `zstandard`"
+                    "Please install `backports.zstd`"
                 )
             self.decompressor = ZSTDDecompressor()
         else:

--- a/docs/client_quickstart.rst
+++ b/docs/client_quickstart.rst
@@ -188,7 +188,7 @@ just install `Brotli <https://pypi.org/project/Brotli/>`_
 or `brotlicffi <https://pypi.org/project/brotlicffi/>`_.
 
 You can enable ``zstd`` transfer-encodings support,
-install `zstandard <https://pypi.org/project/zstandard/>`_.
+install `backports.zstd <https://pypi.org/project/backports.zstd/>`_.
 If you are using Python >= 3.14, no dependency should be required.
 
 JSON Request

--- a/requirements/base-ft.txt
+++ b/requirements/base-ft.txt
@@ -46,5 +46,5 @@ typing-extensions==4.15.0
     #   multidict
 yarl==1.21.0
     # via -r requirements/runtime-deps.in
-zstandard==0.25.0 ; platform_python_implementation == "CPython" and python_version < "3.14"
+backports.zstd==0.5.0 ; platform_python_implementation == "CPython" and python_version < "3.14"
     # via -r requirements/runtime-deps.in

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -48,5 +48,5 @@ uvloop==0.21.0 ; platform_system != "Windows" and implementation_name == "cpytho
     # via -r requirements/base.in
 yarl==1.21.0
     # via -r requirements/runtime-deps.in
-zstandard==0.25.0 ; platform_python_implementation == "CPython" and python_version < "3.14"
+backports.zstd==0.5.0 ; platform_python_implementation == "CPython" and python_version < "3.14"
     # via -r requirements/runtime-deps.in

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -302,7 +302,7 @@ zlib-ng==1.0.0
     # via
     #   -r requirements/lint.in
     #   -r requirements/test-common.in
-zstandard==0.25.0 ; implementation_name == "cpython"
+backports.zstd==0.5.0 ; implementation_name == "cpython"
     # via
     #   -r requirements/lint.in
     #   -r requirements/runtime-deps.in

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -293,7 +293,7 @@ zlib-ng==1.0.0
     # via
     #   -r requirements/lint.in
     #   -r requirements/test-common.in
-zstandard==0.25.0 ; platform_python_implementation == "CPython" and python_version < "3.14"
+backports.zstd==0.5.0 ; platform_python_implementation == "CPython" and python_version < "3.14"
     # via
     #   -r requirements/lint.in
     #   -r requirements/runtime-deps.in

--- a/requirements/lint.in
+++ b/requirements/lint.in
@@ -1,4 +1,5 @@
 aiodns
+backports.zstd; implementation_name == "cpython"
 blockbuster
 freezegun
 isal
@@ -13,4 +14,3 @@ trustme
 uvloop; platform_system != "Windows"
 valkey
 zlib_ng
-zstandard; implementation_name == "cpython"

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -121,5 +121,5 @@ virtualenv==20.34.0
     # via pre-commit
 zlib-ng==1.0.0
     # via -r requirements/lint.in
-zstandard==0.25.0 ; implementation_name == "cpython"
+backports.zstd==0.5.0 ; implementation_name == "cpython"
     # via -r requirements/lint.in

--- a/requirements/runtime-deps.in
+++ b/requirements/runtime-deps.in
@@ -5,10 +5,10 @@ aiohappyeyeballs >= 2.5.0
 aiosignal >= 1.4.0
 async-timeout >= 4.0, < 6.0 ; python_version < "3.11"
 attrs >= 17.3.0
+backports.zstd; platform_python_implementation == 'CPython' and python_version < "3.14"
 Brotli; platform_python_implementation == 'CPython'
 brotlicffi; platform_python_implementation != 'CPython'
 frozenlist >= 1.1.1
 multidict >=4.5, < 7.0
 propcache >= 0.2.0
 yarl >= 1.17.0, < 2.0
-zstandard; platform_python_implementation == 'CPython' and python_version < "3.14"

--- a/requirements/runtime-deps.txt
+++ b/requirements/runtime-deps.txt
@@ -42,5 +42,5 @@ typing-extensions==4.15.0
     #   multidict
 yarl==1.21.0
     # via -r requirements/runtime-deps.in
-zstandard==0.25.0 ; platform_python_implementation == "CPython" and python_version < "3.14"
+backports.zstd==0.5.0 ; platform_python_implementation == "CPython" and python_version < "3.14"
     # via -r requirements/runtime-deps.in

--- a/requirements/test-ft.txt
+++ b/requirements/test-ft.txt
@@ -152,5 +152,5 @@ yarl==1.21.0
     # via -r requirements/runtime-deps.in
 zlib-ng==1.0.0
     # via -r requirements/test-common.in
-zstandard==0.25.0 ; platform_python_implementation == "CPython" and python_version < "3.14"
+backports.zstd==0.5.0 ; platform_python_implementation == "CPython" and python_version < "3.14"
     # via -r requirements/runtime-deps.in

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -154,5 +154,5 @@ yarl==1.21.0
     # via -r requirements/runtime-deps.in
 zlib-ng==1.0.0
     # via -r requirements/test-common.in
-zstandard==0.25.0 ; platform_python_implementation == "CPython" and python_version < "3.14"
+backports.zstd==0.5.0 ; platform_python_implementation == "CPython" and python_version < "3.14"
     # via -r requirements/runtime-deps.in

--- a/setup.cfg
+++ b/setup.cfg
@@ -71,7 +71,7 @@ speedups =
   aiodns >= 3.3.0
   Brotli; platform_python_implementation == 'CPython'
   brotlicffi; platform_python_implementation != 'CPython'
-  zstandard; platform_python_implementation == 'CPython' and python_version < "3.14"
+  backports.zstd; platform_python_implementation == 'CPython' and python_version < "3.14"
 
 [options.packages.find]
 exclude =

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -34,13 +34,13 @@ try:
 except ImportError:
     brotli = None
 
-if sys.version_info >= (3, 14):
-    import compression.zstd as zstandard  # noqa: I900
-else:
-    try:
-        import zstandard
-    except ImportError:
-        zstandard = None  # type: ignore[assignment]
+try:
+    if sys.version_info >= (3, 14):
+        import compression.zstd as zstandard  # noqa: I900
+    else:
+        import backports.zstd as zstandard
+except ImportError:
+    zstandard = None  # type: ignore[assignment]
 
 REQUEST_PARSERS = [HttpRequestParserPy]
 RESPONSE_PARSERS = [HttpResponseParserPy]


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

This is a backport of PR https://github.com/aio-libs/aiohttp/pull/11623 as merged into master (https://github.com/aio-libs/aiohttp/commit/df8ad83efdd33408db2803cbd4a50be45422b74f).

## What do these changes do?

The changes fix the decompression of chunked zstd streams.

## Are there changes in behavior for the user?

Previously, on chunked zstd streams, aiohttp would crash with `zstandard.backend_c.ZstdError: could not determine content size in frame header` or `zstd.ZstdError: decompression error: did not decompress full frame`. 
Now it doesn't.

## Related issue number

https://github.com/aio-libs/aiohttp/pull/11604 tries to fix the same issue, but there's no corresponding GitHub issue opened yet.

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES/` folder
  * name it `<issue_or_pr_num>.<type>.rst` (e.g. `588.bugfix.rst`)
  * if you don't have an issue number, change it to the pull request
    number after creating the PR
    * `.bugfix`: A bug fix for something the maintainers deemed an
      improper undesired behavior that got corrected to match
      pre-agreed expectations.
    * `.feature`: A new behavior, public APIs. That sort of stuff.
    * `.deprecation`: A declaration of future API removals and breaking
      changes in behavior.
    * `.breaking`: When something public is removed in a breaking way.
      Could be deprecated in an earlier release.
    * `.doc`: Notable updates to the documentation structure or build
      process.
    * `.packaging`: Notes for downstreams about unobvious side effects
      and tooling. Changes in the test invocation considerations and
      runtime assumptions.
    * `.contrib`: Stuff that affects the contributor experience. e.g.
      Running tests, building the docs, setting up the development
      environment.
    * `.misc`: Changes that are hard to assign to any of the above
      categories.
  * Make sure to use full sentences with correct case and punctuation,
    for example:
    ```rst
    Fixed issue with non-ascii contents in doctest text files
    -- by :user:`contributor-gh-handle`.
    ```

    Use the past tense or the present tense a non-imperative mood,
    referring to what's changed compared to the last released version
    of this project.
