### PR TITLE
Make AppRunner's configuration options available in run_app()

### DIFF
--- a/CHANGES/11633.feature.rst
+++ b/CHANGES/11633.feature.rst
@@ -1,0 +1,2 @@
+Make configuration options in ``AppRunner`` also available in ``run_app()``
+-- by :user:`Cycloctane`.

--- a/aiohttp/web.py
+++ b/aiohttp/web.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING, Any, cast
 
 from .abc import AbstractAccessLogger
 from .helpers import AppKey
-from .log import access_logger
+from .log import access_logger, server_logger
 from .typedefs import PathLike
 from .web_app import Application, CleanupError
 from .web_exceptions import (
@@ -277,18 +277,12 @@ async def _run_app(
     port: int | None = None,
     path: PathLike | TypingIterable[PathLike] | None = None,
     sock: socket.socket | TypingIterable[socket.socket] | None = None,
-    shutdown_timeout: float = 60.0,
-    keepalive_timeout: float = 75.0,
     ssl_context: SSLContext | None = None,
     print: Callable[..., None] | None = print,
     backlog: int = 128,
-    access_log_class: type[AbstractAccessLogger] = AccessLogger,
-    access_log_format: str = AccessLogger.LOG_FORMAT,
-    access_log: logging.Logger | None = access_logger,
-    handle_signals: bool = True,
     reuse_address: bool | None = None,
     reuse_port: bool | None = None,
-    handler_cancellation: bool = False,
+    **kwargs: Any,
 ) -> None:
     # An internal function to actually do all dirty job for application running
     if asyncio.iscoroutine(app):
@@ -296,16 +290,7 @@ async def _run_app(
 
     app = cast(Application, app)
 
-    runner = AppRunner(
-        app,
-        handle_signals=handle_signals,
-        access_log_class=access_log_class,
-        access_log_format=access_log_format,
-        access_log=access_log,
-        keepalive_timeout=keepalive_timeout,
-        shutdown_timeout=shutdown_timeout,
-        handler_cancellation=handler_cancellation,
-    )
+    runner = AppRunner(app, **kwargs)
 
     await runner.setup()
 
@@ -453,6 +438,7 @@ def run_app(
     reuse_port: bool | None = None,
     handler_cancellation: bool = False,
     loop: asyncio.AbstractEventLoop | None = None,
+    **kwargs: Any,
 ) -> None:
     """Run an app locally"""
     if loop is None:
@@ -485,6 +471,7 @@ def run_app(
             reuse_address=reuse_address,
             reuse_port=reuse_port,
             handler_cancellation=handler_cancellation,
+            **kwargs,
         )
     )
 

--- a/aiohttp/web.py
+++ b/aiohttp/web.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING, Any, cast
 
 from .abc import AbstractAccessLogger
 from .helpers import AppKey
-from .log import access_logger, server_logger
+from .log import access_logger
 from .typedefs import PathLike
 from .web_app import Application, CleanupError
 from .web_exceptions import (

--- a/aiohttp/web.py
+++ b/aiohttp/web.py
@@ -282,7 +282,7 @@ async def _run_app(
     backlog: int = 128,
     reuse_address: bool | None = None,
     reuse_port: bool | None = None,
-    **kwargs: Any,
+    **kwargs: Any,  # TODO(PY311): Use Unpack
 ) -> None:
     # An internal function to actually do all dirty job for application running
     if asyncio.iscoroutine(app):

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -3032,6 +3032,9 @@ Utilities
                                      scalability is a concern.
                                      :ref:`aiohttp-web-peer-disconnection`
 
+   :param kwargs: additional named parameters to pass into
+                  :class:`AppRunner` constructor.
+
    .. versionadded:: 3.0
 
       Support *access_log_class* parameter.

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -2920,7 +2920,8 @@ Utilities
                       handle_signals=True, \
                       reuse_address=None, \
                       reuse_port=None, \
-                      handler_cancellation=False)
+                      handler_cancellation=False, \
+					  **kwargs)
 
    A high-level function for running an application, serving it until
    keyboard interrupt and performing a

--- a/tests/test_run_app.py
+++ b/tests/test_run_app.py
@@ -954,12 +954,7 @@ def test_run_app_pass_apprunner_kwargs(
 
     app = web.Application()
     monkeypatch.setattr(BaseRunner, "__init__", base_runner_init_spy)
-    web.run_app(
-        app,
-        print=stopper(patched_loop),
-        loop=patched_loop,
-        **{param: m},  # type: ignore[arg-type]
-    )
+    web.run_app(app, print=stopper(patched_loop), loop=patched_loop, **{param: m})
 
 
 def test_run_app_context_vars(patched_loop: asyncio.AbstractEventLoop) -> None:

--- a/tests/test_run_app.py
+++ b/tests/test_run_app.py
@@ -926,27 +926,39 @@ def test_run_app_cancels_failed_tasks(patched_loop: asyncio.AbstractEventLoop) -
     exc_handler.assert_called_with(patched_loop, msg)
 
 
-def test_run_app_keepalive_timeout(
+@pytest.mark.parametrize(
+    "param",
+    (
+        "keepalive_timeout",
+        "max_line_size",
+        "max_headers",
+        "max_field_size",
+        "lingering_time",
+        "read_bufsize",
+        "auto_decompress",
+    ),
+)
+def test_run_app_pass_apprunner_kwargs(
+    param: str,
     patched_loop: asyncio.AbstractEventLoop,
-    mocker: MockerFixture,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    new_timeout = 1234
+    m = mock.Mock()
     base_runner_init_orig = BaseRunner.__init__
 
     def base_runner_init_spy(
         self: BaseRunner[web.Request], *args: Any, **kwargs: Any
     ) -> None:
-        assert kwargs["keepalive_timeout"] == new_timeout
+        assert kwargs[param] is m
         base_runner_init_orig(self, *args, **kwargs)
 
     app = web.Application()
     monkeypatch.setattr(BaseRunner, "__init__", base_runner_init_spy)
     web.run_app(
         app,
-        keepalive_timeout=new_timeout,
         print=stopper(patched_loop),
         loop=patched_loop,
+        **{param: m},  # type: ignore[arg-type]
     )
 
 


### PR DESCRIPTION
## What do these changes do?

Some configuration flags are only available in `AppRunner`. This pr makes them also configurable in `run_app()`.

## Are there changes in behavior for the user?

Users can now set more configuration options in `run_app()` to serve aiohttp web application without creating custom `AppRunner` instances.

## Is it a substantial burden for the maintainers to support this?

## Related issue number

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
- [ ] Add a new news fragment into the `CHANGES/` folder
