### PR TITLE
[PR #9951 backport][3.13] Move metadata to pyproject.toml

### DIFF
--- a/CHANGES/9951.packaging.rst
+++ b/CHANGES/9951.packaging.rst
@@ -1,0 +1,2 @@
+Moved core packaging metadata from :file:`setup.cfg` to :file:`pyproject.toml` per :pep:`621`
+-- by :user:`cdce8p`.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -9,8 +9,7 @@ graft examples
 graft tests
 graft tools
 graft requirements
-recursive-include vendor *
-global-include aiohttp *.pyi
+graft vendor
 global-exclude *.pyc
 global-exclude *.pyd
 global-exclude *.so

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
   "Operating System :: Microsoft :: Windows",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
@@ -31,7 +32,7 @@ classifiers = [
   "Programming Language :: Python :: 3.14",
   "Topic :: Internet :: WWW/HTTP",
 ]
-requires-python = ">= 3.10"
+requires-python = ">= 3.9"
 dynamic = [
   "dependencies",
   "optional-dependencies",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,76 @@
 [build-system]
 requires = [
     "pkgconfig",
-    "setuptools >= 46.4.0",
+    # setuptools >= 67.0 required for Python 3.12+ support
+    # Next step should be >= 77.0 for PEP 639 support
+    # Don't bump too early to give distributors time to update
+    # their setuptools version.
+    "setuptools >= 67.0",
 ]
 build-backend = "setuptools.build_meta"
+
+[project]
+name        = "aiohttp"
+# TODO: Update to just 'license = "..."' once setuptools is bumped to >=77
+license     = {text = "Apache-2.0 AND MIT"}
+description = "Async http client/server framework (asyncio)"
+readme      = "README.rst"
+classifiers = [
+  "Development Status :: 5 - Production/Stable",
+  "Framework :: AsyncIO",
+  "Intended Audience :: Developers",
+  "Operating System :: POSIX",
+  "Operating System :: MacOS :: MacOS X",
+  "Operating System :: Microsoft :: Windows",
+  "Programming Language :: Python",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
+  "Topic :: Internet :: WWW/HTTP",
+]
+requires-python = ">= 3.10"
+dynamic = [
+  "dependencies",
+  "optional-dependencies",
+  "version",
+]
+
+[[project.maintainers]]
+name = "aiohttp team"
+email = "team@aiohttp.org"
+
+[project.urls]
+"Homepage"           = "https://github.com/aio-libs/aiohttp"
+"Chat: Matrix"       = "https://matrix.to/#/#aio-libs:matrix.org"
+"Chat: Matrix Space" = "https://matrix.to/#/#aio-libs-space:matrix.org"
+"CI: GitHub Actions" = "https://github.com/aio-libs/aiohttp/actions?query=workflow%3ACI"
+"Coverage: codecov"  = "https://codecov.io/github/aio-libs/aiohttp"
+"Docs: Changelog"    = "https://docs.aiohttp.org/en/stable/changes.html"
+"Docs: RTD"          = "https://docs.aiohttp.org"
+"GitHub: issues"     = "https://github.com/aio-libs/aiohttp/issues"
+"GitHub: repo"       = "https://github.com/aio-libs/aiohttp"
+
+[tool.setuptools]
+license-files = [
+  # TODO: Use 'project.license-files' instead once setuptools is bumped to >=77
+  "LICENSE.txt",
+  "vendor/llhttp/LICENSE",
+]
+
+[tool.setuptools.dynamic]
+version = {attr = "aiohttp.__version__"}
+
+[tool.setuptools.packages.find]
+include = [
+  "aiohttp",
+  "aiohttp.*",
+]
+
+[tool.setuptools.exclude-package-data]
+"*" = ["*.c", "*.h"]
 
 [tool.towncrier]
   package = "aiohttp"
@@ -88,8 +155,3 @@ ignore-words-list = 'te,ue'
 # TODO(3.13): Remove aiohttp.helpers once https://github.com/python/cpython/pull/106771
 # is available in all supported cpython versions
 exclude-modules = "(^aiohttp\\.helpers)"
-
-[tool.black]
-# TODO: Remove when project metadata is moved here.
-# Black can read the value from [project.requires-python].
-target-version = ["py39", "py310", "py311", "py312"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,56 +1,4 @@
-[metadata]
-name = aiohttp
-version = attr: aiohttp.__version__
-url = https://github.com/aio-libs/aiohttp
-project_urls =
-  Chat: Matrix = https://matrix.to/#/#aio-libs:matrix.org
-  Chat: Matrix Space = https://matrix.to/#/#aio-libs-space:matrix.org
-  CI: GitHub Actions = https://github.com/aio-libs/aiohttp/actions?query=workflow%%3ACI
-  Coverage: codecov = https://codecov.io/github/aio-libs/aiohttp
-  Docs: Changelog = https://docs.aiohttp.org/en/stable/changes.html
-  Docs: RTD = https://docs.aiohttp.org
-  GitHub: issues = https://github.com/aio-libs/aiohttp/issues
-  GitHub: repo = https://github.com/aio-libs/aiohttp
-description = Async http client/server framework (asyncio)
-long_description = file: README.rst
-long_description_content_type = text/x-rst
-maintainer = aiohttp team <team@aiohttp.org>
-maintainer_email = team@aiohttp.org
-license = Apache-2.0 AND MIT
-license_files =
-    LICENSE.txt
-    vendor/llhttp/LICENSE
-classifiers =
-  Development Status :: 5 - Production/Stable
-
-  Framework :: AsyncIO
-
-  Intended Audience :: Developers
-
-  Operating System :: POSIX
-  Operating System :: MacOS :: MacOS X
-  Operating System :: Microsoft :: Windows
-
-  Programming Language :: Python
-  Programming Language :: Python :: 3
-  Programming Language :: Python :: 3.9
-  Programming Language :: Python :: 3.10
-  Programming Language :: Python :: 3.11
-  Programming Language :: Python :: 3.12
-  Programming Language :: Python :: 3.13
-  Programming Language :: Python :: 3.14
-
-  Topic :: Internet :: WWW/HTTP
-
 [options]
-python_requires = >=3.9
-packages =
-  aiohttp
-  aiohttp._websocket
-# https://setuptools.readthedocs.io/en/latest/setuptools.html#setting-the-zip-safe-flag
-zip_safe = False
-include_package_data = True
-
 install_requires =
   aiohappyeyeballs >= 2.5.0
   aiosignal >= 1.4.0
@@ -61,28 +9,12 @@ install_requires =
   propcache >= 0.2.0
   yarl >= 1.17.0, < 2.0
 
-[options.exclude_package_data]
-* =
-    *.c
-    *.h
-
 [options.extras_require]
 speedups =
   aiodns >= 3.3.0
   Brotli; platform_python_implementation == 'CPython'
   brotlicffi; platform_python_implementation != 'CPython'
   backports.zstd; platform_python_implementation == 'CPython' and python_version < "3.14"
-
-[options.packages.find]
-exclude =
-  examples
-
-[options.package_data]
-# Ref:
-# https://setuptools.readthedocs.io/en/latest/setuptools.html#options
-# (see notes for the asterisk/`*` meaning)
-* =
-    *.so
 
 [pep8]
 max-line-length=79


### PR DESCRIPTION
This is a backport of PR https://github.com/aio-libs/aiohttp/pull/9951 as merged into master (https://github.com/aio-libs/aiohttp/commit/6b5d8e7f6b92fe944930b12e16d4884d01d14323).

Modified the backport to include Python `3.9` in the classifier list again as well as updated `requires-python` to `>= 3.9`.