### PR TITLE
Remove cherry-picker from requirements

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -47,11 +47,8 @@ cfgv==3.4.0
     # via pre-commit
 charset-normalizer==3.4.4
     # via requests
-cherry-picker==2.6.0
-    # via -r requirements/dev.in
 click==8.3.0
     # via
-    #   cherry-picker
     #   pip-tools
     #   slotscheck
     #   towncrier
@@ -86,8 +83,6 @@ frozenlist==1.8.0
     # via
     #   -r requirements/runtime-deps.in
     #   aiosignal
-gidgethub==5.4.0
-    # via cherry-picker
 gunicorn==23.0.0
     # via -r requirements/base.in
 identify==2.6.15
@@ -174,7 +169,6 @@ pygments==2.19.2
     #   sphinx
 pyjwt==2.8.0
     # via
-    #   gidgethub
     #   pyjwt
 pyproject-hooks==1.2.0
     # via
@@ -210,7 +204,6 @@ pyyaml==6.0.3
     # via pre-commit
 requests==2.32.5
     # via
-    #   cherry-picker
     #   sphinx
     #   sphinxcontrib-spelling
 rich==14.2.0
@@ -244,14 +237,9 @@ sphinxcontrib-spelling==8.0.1 ; platform_system != "Windows"
     # via -r requirements/doc-spelling.in
 sphinxcontrib-towncrier==0.5.0a0
     # via -r requirements/doc.in
-stamina==25.1.0
-    # via cherry-picker
-tenacity==9.1.2
-    # via stamina
 tomli==2.3.0
     # via
     #   build
-    #   cherry-picker
     #   coverage
     #   mypy
     #   pip-tools
@@ -281,8 +269,6 @@ typing-extensions==4.15.0
     #   virtualenv
 typing-inspection==0.4.2
     # via pydantic
-uritemplate==4.2.0
-    # via gidgethub
 urllib3==2.5.0
     # via requests
 uvloop==0.21.0 ; platform_system != "Windows"

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -2,5 +2,4 @@
 -r test.in
 -r doc.in
 
-cherry_picker
 pip-tools

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -47,11 +47,8 @@ cfgv==3.4.0
     # via pre-commit
 charset-normalizer==3.4.4
     # via requests
-cherry-picker==2.6.0
-    # via -r requirements/dev.in
 click==8.3.0
     # via
-    #   cherry-picker
     #   pip-tools
     #   slotscheck
     #   towncrier
@@ -84,8 +81,6 @@ frozenlist==1.8.0
     # via
     #   -r requirements/runtime-deps.in
     #   aiosignal
-gidgethub==5.4.0
-    # via cherry-picker
 gunicorn==23.0.0
     # via -r requirements/base.in
 identify==2.6.15
@@ -169,7 +164,6 @@ pygments==2.19.2
     #   sphinx
 pyjwt==2.8.0
     # via
-    #   gidgethub
     #   pyjwt
 pyproject-hooks==1.2.0
     # via
@@ -205,7 +199,6 @@ pyyaml==6.0.3
     # via pre-commit
 requests==2.32.5
     # via
-    #   cherry-picker
     #   sphinx
 rich==14.2.0
     # via pytest-codspeed
@@ -235,14 +228,9 @@ sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
 sphinxcontrib-towncrier==0.5.0a0
     # via -r requirements/doc.in
-stamina==25.1.0
-    # via cherry-picker
-tenacity==9.1.2
-    # via stamina
 tomli==2.3.0
     # via
     #   build
-    #   cherry-picker
     #   coverage
     #   mypy
     #   pip-tools
@@ -272,8 +260,6 @@ typing-extensions==4.15.0
     #   virtualenv
 typing-inspection==0.4.2
     # via pydantic
-uritemplate==4.2.0
-    # via gidgethub
 urllib3==2.5.0
     # via requests
 uvloop==0.21.0 ; platform_system != "Windows" and implementation_name == "cpython"


### PR DESCRIPTION
This module doesn't seem to be used anywhere in our CI, nor does it even appear in our docs. It simply ends up creating some extra noise and maintenance overhead via Dependabot.