### PR TITLE
add xfail test for https://github.com/aio-libs/aiohttp/issues/11665

### DIFF
--- a/tests/test_web_urldispatcher.py
+++ b/tests/test_web_urldispatcher.py
@@ -951,7 +951,7 @@ async def test_url_with_many_slashes(aiohttp_client: AiohttpClient) -> None:
         assert r.status == 200
 
 
-#@pytest.mark.xfail(reason="https://github.com/aio-libs/aiohttp/issues/11665")
+# @pytest.mark.xfail(reason="https://github.com/aio-libs/aiohttp/issues/11665")
 async def test_subapp_domain_routing_same_path(aiohttp_client: AiohttpClient) -> None:
     app = web.Application()
     sub_app = web.Application()

--- a/tests/test_web_urldispatcher.py
+++ b/tests/test_web_urldispatcher.py
@@ -950,6 +950,7 @@ async def test_url_with_many_slashes(aiohttp_client: AiohttpClient) -> None:
     async with client.get("///a") as r:
         assert r.status == 200
 
+
 @pytest.mark.xfail(reason="https://github.com/aio-libs/aiohttp/issues/11665")
 async def test_subapp_domain_routing(aiohttp_client: AiohttpClient) -> None:
     app = web.Application()
@@ -958,20 +959,21 @@ async def test_subapp_domain_routing(aiohttp_client: AiohttpClient) -> None:
     class MyViewWrong(web.View):
         async def get(self) -> web.Response:
             return web.Response(status=404)
-    
+
     class MyViewCorrect(web.View):
         async def get(self) -> web.Response:
             return web.Response()
 
     app.router.add_routes([web.view("/", MyViewWrong)])
     subApp.router.add_routes([web.view("/", MyViewCorrect)])
-    
-    app.add_domain('different.example.com', subApp)
+
+    app.add_domain("different.example.com", subApp)
 
     client = await aiohttp_client(app)
-    headers = {'Host': 'different.example.com'}
+    headers = {"Host": "different.example.com"}
     async with client.get("/", headers=headers) as r:
         assert r.status == 200
+
 
 async def test_route_with_regex(aiohttp_client: AiohttpClient) -> None:
     """Test a route with a regex preceded by a fixed string."""

--- a/tests/test_web_urldispatcher.py
+++ b/tests/test_web_urldispatcher.py
@@ -952,15 +952,18 @@ async def test_url_with_many_slashes(aiohttp_client: AiohttpClient) -> None:
 
 
 @pytest.mark.xfail(reason="https://github.com/aio-libs/aiohttp/issues/11665")
-async def test_subapp_domain_routing(aiohttp_client: AiohttpClient) -> None:
+async def test_subapp_domain_routing_same_path(aiohttp_client: AiohttpClient) -> None:
     app = web.Application()
     sub_app = web.Application()
 
-    class MyViewCorrect(web.View):
-        async def get(self) -> web.Response:
-            return web.Response(text="SUBAPP")
+    async def mainapp_handler(request: web.Request) -> web.Response:
+        assert False
 
-    sub_app.router.add_view("/", MyViewCorrect)
+    async def subapp_handler(request: web.Request) -> web.Response:
+        return web.Response(text="SUBAPP")
+
+    app.router.add_get("/", mainapp_handler)
+    sub_app.router.add_get("/", subapp_handler)
     app.add_domain("different.example.com", sub_app)
 
     client = await aiohttp_client(app)

--- a/tests/test_web_urldispatcher.py
+++ b/tests/test_web_urldispatcher.py
@@ -951,7 +951,7 @@ async def test_url_with_many_slashes(aiohttp_client: AiohttpClient) -> None:
         assert r.status == 200
 
 
-@pytest.mark.xfail(reason="https://github.com/aio-libs/aiohttp/issues/11665")
+#@pytest.mark.xfail(reason="https://github.com/aio-libs/aiohttp/issues/11665")
 async def test_subapp_domain_routing_same_path(aiohttp_client: AiohttpClient) -> None:
     app = web.Application()
     sub_app = web.Application()

--- a/tests/test_web_urldispatcher.py
+++ b/tests/test_web_urldispatcher.py
@@ -966,7 +966,7 @@ async def test_subapp_domain_routing(aiohttp_client: AiohttpClient) -> None:
     client = await aiohttp_client(app)
     async with client.get("/", headers={"Host": "different.example.com"}) as r:
         assert r.status == 200
-        result = await resp.text()
+        result = await r.text()
         assert result == "SUBAPP"
 
 

--- a/tests/test_web_urldispatcher.py
+++ b/tests/test_web_urldispatcher.py
@@ -951,7 +951,7 @@ async def test_url_with_many_slashes(aiohttp_client: AiohttpClient) -> None:
         assert r.status == 200
 
 
-# @pytest.mark.xfail(reason="https://github.com/aio-libs/aiohttp/issues/11665")
+@pytest.mark.xfail(reason="https://github.com/aio-libs/aiohttp/issues/11665")
 async def test_subapp_domain_routing_same_path(aiohttp_client: AiohttpClient) -> None:
     app = web.Application()
     sub_app = web.Application()

--- a/tests/test_web_urldispatcher.py
+++ b/tests/test_web_urldispatcher.py
@@ -950,6 +950,28 @@ async def test_url_with_many_slashes(aiohttp_client: AiohttpClient) -> None:
     async with client.get("///a") as r:
         assert r.status == 200
 
+@pytest.mark.xfail(reason="https://github.com/aio-libs/aiohttp/issues/11665")
+async def test_subapp_domain_routing(aiohttp_client: AiohttpClient) -> None:
+    app = web.Application()
+    subApp = web.Application()
+
+    class MyViewWrong(web.View):
+        async def get(self) -> web.Response:
+            return web.Response(status=404)
+    
+    class MyViewCorrect(web.View):
+        async def get(self) -> web.Response:
+            return web.Response()
+
+    app.router.add_routes([web.view("/", MyViewWrong)])
+    subApp.router.add_routes([web.view("/", MyViewCorrect)])
+    
+    app.add_domain('different.example.com', subApp)
+
+    client = await aiohttp_client(app)
+    headers = {'Host': 'different.example.com'}
+    async with client.get("/", headers=headers) as r:
+        assert r.status == 200
 
 async def test_route_with_regex(aiohttp_client: AiohttpClient) -> None:
     """Test a route with a regex preceded by a fixed string."""


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?
This is only a test for the linked issue: https://github.com/aio-libs/aiohttp/issues/11665
<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?
No
<!-- Outline any notable behaviour for the end users. -->

## Is it a substantial burden for the maintainers to support this?

<!--
Stop right there! Pause. Just for a minute... Can you think of anything
obvious that would complicate the ongoing development of this project?

Try to consider if you'd be able to maintain it throughout the next
5 years. Does it seem viable? Tell us your thoughts! We'd very much
love to hear what the consequences of merging this patch might be...

This will help us assess if your change is something we'd want to
entertain early in the review process. Thank you in advance!
-->

## Related issue number
https://github.com/aio-libs/aiohttp/issues/11665
<!-- Will this resolve any open issues? -->
<!-- Remember to prefix with 'Fixes' if it closes an issue (e.g. 'Fixes #123'). -->

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES/` folder
  * name it `<issue_or_pr_num>.<type>.rst` (e.g. `588.bugfix.rst`)
  * if you don't have an issue number, change it to the pull request
    number after creating the PR
    * `.bugfix`: A bug fix for something the maintainers deemed an
      improper undesired behavior that got corrected to match
      pre-agreed expectations.
    * `.feature`: A new behavior, public APIs. That sort of stuff.
    * `.deprecation`: A declaration of future API removals and breaking
      changes in behavior.
    * `.breaking`: When something public is removed in a breaking way.
      Could be deprecated in an earlier release.
    * `.doc`: Notable updates to the documentation structure or build
      process.
    * `.packaging`: Notes for downstreams about unobvious side effects
      and tooling. Changes in the test invocation considerations and
      runtime assumptions.
    * `.contrib`: Stuff that affects the contributor experience. e.g.
      Running tests, building the docs, setting up the development
      environment.
    * `.misc`: Changes that are hard to assign to any of the above
      categories.
  * Make sure to use full sentences with correct case and punctuation,
    for example:
    ```rst
    Fixed issue with non-ascii contents in doctest text files
    -- by :user:`contributor-gh-handle`.
    ```

    Use the past tense or the present tense a non-imperative mood,
    referring to what's changed compared to the last released version
    of this project.
