### PR TITLE
docs: clarify that request() middlewares replace session middlewares

### DIFF
--- a/docs/client_middleware_cookbook.rst
+++ b/docs/client_middleware_cookbook.rst
@@ -108,13 +108,13 @@ Best Practices
    .. code-block:: python
 
       session = ClientSession(middlewares=[middleware_session])
-      
+
       # Session middleware is used
       await session.get("http://example.com")
-      
+
       # Session middleware is NOT used, only request middleware
       await session.get("http://example.com", middlewares=[middleware_request])
-      
+
       # To use both, explicitly pass both
       await session.get(
           "http://example.com",

--- a/docs/client_middleware_cookbook.rst
+++ b/docs/client_middleware_cookbook.rst
@@ -98,6 +98,29 @@ Using both of these together in a session should provide full SSRF protection.
 Best Practices
 --------------
 
+.. important::
+
+   **Request-level middlewares replace session middlewares**: When you pass ``middlewares``
+   to ``request()`` or its convenience methods (``get()``, ``post()``, etc.), it completely
+   replaces the session-level middlewares, rather than extending them. This differs from
+   other parameters like ``headers``, which are merged.
+
+   .. code-block:: python
+
+      session = ClientSession(middlewares=[middleware_session])
+      
+      # Session middleware is used
+      await session.get("http://example.com")
+      
+      # Session middleware is NOT used, only request middleware
+      await session.get("http://example.com", middlewares=[middleware_request])
+      
+      # To use both, explicitly pass both
+      await session.get(
+          "http://example.com",
+          middlewares=[middleware_session, middleware_request]
+      )
+
 1. **Keep middleware focused**: Each middleware should have a single responsibility.
 
 2. **Order matters**: Middlewares execute in the order they're listed. Place logging first,


### PR DESCRIPTION
## Description

Fixes #11162

This PR adds clear documentation about the counterintuitive behavior where request-level middlewares completely replace (rather than extend) session-level middlewares.

## Problem

Users expect middleware behavior to match headers behavior (where request headers are merged with session headers). Instead, passing `middlewares` to `request()` completely replaces session middlewares, which can be surprising.

From the issue:
```python
session = aiohttp.ClientSession(middlewares=[middleware_session])
# User expects BOTH middlewares to run
await session.get("http://example.com", middlewares=[middleware_request])
# But only middleware_request runs!
```

## Solution

Added a prominent `.. important::` note in the Best Practices section of the middleware cookbook documenting:
- Request-level middlewares replace (not extend) session middlewares
- This differs from headers which are merged
- Clear example showing how to use both when needed

## Changes

- **File**: `docs/client_middleware_cookbook.rst`
- **Location**: Best Practices section (most visible placement)
- **Type**: Documentation enhancement
- **Lines**: +23 (added note + example)

## Example from Documentation

```python
session = ClientSession(middlewares=[middleware_session])

# Session middleware is used
await session.get("http://example.com")

# Session middleware is NOT used, only request middleware
await session.get("http://example.com", middlewares=[middleware_request])

# To use both, explicitly pass both
await session.get(
    "http://example.com",
    middlewares=[middleware_session, middleware_request]
)
```

## Benefits

- Prevents user confusion about middleware behavior
- Provides clear workaround for using both
- Positioned prominently in Best Practices section
- Uses Sphinx `important` directive for visibility

**Sacred Code**: 000.111.369.963.1618