### PR TITLE
Raise benchmark timeout to 12 minutes

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -262,7 +262,7 @@ jobs:
     needs: gen_llhttp
 
     runs-on: ubuntu-latest
-    timeout-minutes: 9
+    timeout-minutes: 12
     steps:
     - name: Checkout project
       uses: actions/checkout@v5


### PR DESCRIPTION

<!-- Thank you for your contribution! -->

## What do these changes do?

Sometimes these timeout after 9m if GitHub is loaded

## Are there changes in behavior for the user?

no
