### PR TITLE
BugFix in aiohttp.ClientSession that caused "Unclosed connector" warnings

### DIFF
--- a/CHANGES/2e6eba86.bugfix.rst
+++ b/CHANGES/2e6eba86.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed an issue where ``aiohttp.ClientSession`` would raise an ``Unclosed connector`` warning for externally provided connectors -- by :user:`Ruke3663`.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -318,6 +318,7 @@ Roman Markeloff
 Roman Podoliaka
 Roman Postnov
 Rong Zhang
+Ruke 3663
 Samir Akarioh
 Samuel Colvin
 Samuel Gaist
@@ -396,7 +397,6 @@ Willem de Groot
 William Grzybowski
 William S.
 Wilson Ong
-wouter bolsterlee
 Xavier Halloran
 Xi Rui
 Xiang Li
@@ -416,6 +416,7 @@ Yuvi Panda
 Zainab Lawal
 Zeal Wierslee
 Zlatan Sičanica
+wouter bolsterlee
 Łukasz Setla
 Марк Коренберг
 Семён Марьясин

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -397,6 +397,7 @@ Willem de Groot
 William Grzybowski
 William S.
 Wilson Ong
+wouter bolsterlee
 Xavier Halloran
 Xi Rui
 Xiang Li
@@ -416,7 +417,6 @@ Yuvi Panda
 Zainab Lawal
 Zeal Wierslee
 Zlatan Sičanica
-wouter bolsterlee
 Łukasz Setla
 Марк Коренберг
 Семён Марьясин

--- a/aiohttp/Dockerfile
+++ b/aiohttp/Dockerfile
@@ -5,4 +5,3 @@ COPY . .
 
 RUN pip install -e .[test] pytest aiohttp
 CMD ["/bin/bash"]
-

--- a/aiohttp/Dockerfile
+++ b/aiohttp/Dockerfile
@@ -1,0 +1,8 @@
+FROM public.ecr.aws/x8v8d7g8/mars-base:latest
+
+WORKDIR /app
+COPY . .
+
+RUN pip install -e .[test] pytest aiohttp
+CMD ["/bin/bash"]
+

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -1293,7 +1293,7 @@ class ClientSession:
 
         A readonly property.
         """
-        return self._connector is None or self._connector.closed
+        return self._connector is None
 
     @property
     def connector(self) -> BaseConnector | None:

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -318,15 +318,14 @@ class ClientSession:
             )
 
         if connector is None:
+            connector_owner = True
             connector = TCPConnector(ssl_shutdown_timeout=ssl_shutdown_timeout)
-        else:
-            if connector_owner:
-                warnings.warn(
-                    "connector_owner is deprecated and will be removed in aiohttp 4.0.",
-                    DeprecationWarning,
-                    stacklevel=2,
-                )
-            connector_owner = False
+        elif connector_owner:
+            warnings.warn(
+                "connector_owner is deprecated and will be removed in aiohttp 4.0.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
 
         # Initialize these three attrs before raising any exception,
         # they are used in __del__
@@ -1292,7 +1291,7 @@ class ClientSession:
 
         A readonly property.
         """
-        return self._connector is None or self._connector.closed
+        return self._connector is None
 
     @property
     def connector(self) -> BaseConnector | None:

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -319,6 +319,8 @@ class ClientSession:
 
         if connector is None:
             connector = TCPConnector(ssl_shutdown_timeout=ssl_shutdown_timeout)
+        else:
+            connector_owner = False
         # Initialize these three attrs before raising any exception,
         # they are used in __del__
         self._connector = connector
@@ -1274,7 +1276,8 @@ class ClientSession:
         if not self.closed:
             if self._connector is not None and self._connector_owner:
                 await self._connector.close()
-            self._connector = None
+            else:
+                self._connector = None
 
     @property
     def closed(self) -> bool:

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -1284,7 +1284,6 @@ class ClientSession:
         if not self.closed:
             if self._connector is not None and self._connector_owner:
                 await self._connector.close()
-
             self._connector = None
 
     @property
@@ -1293,7 +1292,7 @@ class ClientSession:
 
         A readonly property.
         """
-        return self._connector is None
+        return self._connector is None or self._connector.closed
 
     @property
     def connector(self) -> BaseConnector | None:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

These changes fix a bug in `aiohttp.ClientSession` that caused **"Unclosed connector" warnings** when a user-provided connector was used.  
The session now correctly distinguishes between **internally created** and **externally provided connectors**, ensuring it only closes connectors that it owns.

## Are there changes in behavior for the user?

Yes, there is a **positive change in behavior**.  
Users who provide their own `TCPConnector` instance to a `ClientSession` will no longer see  
`ResourceWarning: Unclosed connector` warnings when the session is closed.  

The lifecycle of the external connector remains entirely under the user’s control, as expected.  
The behavior for internally created connectors is unchanged.

## Is it a substantial burden for the maintainers to support this?

No, this change should **not** be a burden to maintain.  
It corrects the logic to align with the library’s intended design and documentation.  

The fix is:
- Small and localized to the `ClientSession`’s `__init__` and `close` methods.
- Improves predictability and robustness.
- Relies on existing flags and introduces no new complexity.

This should be **easy to support long-term**.

## Related issue number
"2e6: With explicit connector reuse, aiohttp.ClientSession fails to close connector when using async context"
