### PR TITLE
Ensure cookies are still parsed after a malformed cookie

### DIFF
--- a/CHANGES/11632.bugfix.rst
+++ b/CHANGES/11632.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed cookie parser to continue parsing subsequent cookies when encountering a malformed cookie that fails regex validation, such as Google's ``g_state`` cookie with unescaped quotes -- by :user:`bdraco`.

--- a/aiohttp/_cookie_helpers.py
+++ b/aiohttp/_cookie_helpers.py
@@ -200,12 +200,11 @@ def parse_cookie_header(header: str) -> list[tuple[str, Morsel[str]]]:
                 value = header[eq_pos + 1 : end_pos].strip()
 
                 # Validate the name (same as regex path)
-                if not key or not _COOKIE_NAME_RE.match(key):
-                    if key:  # Only warn if there was a key to validate
-                        internal_logger.warning(
-                            "Can not load cookie: Illegal cookie name %r", key
-                        )
-                else:
+                if not _COOKIE_NAME_RE.match(key):
+                    internal_logger.warning(
+                        "Can not load cookie: Illegal cookie name %r", key
+                    )
+                elif key:
                     morsel = Morsel()
                     morsel.__setstate__(  # type: ignore[attr-defined]
                         {"key": key, "value": _unquote(value), "coded_value": value}

--- a/aiohttp/_cookie_helpers.py
+++ b/aiohttp/_cookie_helpers.py
@@ -168,7 +168,8 @@ def parse_cookie_header(header: str) -> list[tuple[str, Morsel[str]]]:
     This parser uses the same regex-based approach as parse_set_cookie_headers
     to properly handle quoted values that may contain semicolons. When the
     regex fails to match a malformed cookie, it falls back to simple parsing
-    to ensure subsequent cookies are not lost (issue #11632).
+    to ensure subsequent cookies are not lost
+    https://github.com/aio-libs/aiohttp/issues/11632
 
     Args:
         header: The Cookie header value to parse
@@ -188,7 +189,7 @@ def parse_cookie_header(header: str) -> list[tuple[str, Morsel[str]]]:
         # Use the same pattern as parse_set_cookie_headers to find cookies
         match = _COOKIE_PATTERN.match(header, i)
         if not match:
-            # Fallback for malformed cookies (issue #11632)
+            # Fallback for malformed cookies https://github.com/aio-libs/aiohttp/issues/11632
             # Find next semicolon to skip or attempt simple key=value parsing
             next_semi = header.find(";", i)
             eq_pos = header.find("=", i)

--- a/aiohttp/_cookie_helpers.py
+++ b/aiohttp/_cookie_helpers.py
@@ -219,7 +219,7 @@ def parse_cookie_header(header: str) -> list[tuple[str, Morsel[str]]]:
             continue
 
         # Create new morsel
-        morsel: Morsel[str] = Morsel()
+        morsel = Morsel()
         # Preserve the original value as coded_value (with quotes if present)
         # We use __setstate__ instead of the public set() API because it allows us to
         # bypass validation and set already validated state. This is more stable than

--- a/aiohttp/_cookie_helpers.py
+++ b/aiohttp/_cookie_helpers.py
@@ -199,7 +199,13 @@ def parse_cookie_header(header: str) -> list[tuple[str, Morsel[str]]]:
                 key = header[i:eq_pos].strip()
                 value = header[eq_pos + 1 : end_pos].strip()
 
-                if key and _COOKIE_NAME_RE.match(key):
+                # Validate the name (same as regex path)
+                if not key or not _COOKIE_NAME_RE.match(key):
+                    if key:  # Only warn if there was a key to validate
+                        internal_logger.warning(
+                            "Can not load cookie: Illegal cookie name %r", key
+                        )
+                else:
                     morsel = Morsel()
                     morsel.__setstate__(  # type: ignore[attr-defined]
                         {"key": key, "value": _unquote(value), "coded_value": value}

--- a/aiohttp/_cookie_helpers.py
+++ b/aiohttp/_cookie_helpers.py
@@ -179,6 +179,7 @@ def parse_cookie_header(header: str) -> list[tuple[str, Morsel[str]]]:
     if not header:
         return []
 
+    morsel: Morsel[str]
     cookies: list[tuple[str, Morsel[str]]] = []
     i = 0
     n = len(header)
@@ -199,7 +200,7 @@ def parse_cookie_header(header: str) -> list[tuple[str, Morsel[str]]]:
                 value = header[eq_pos + 1 : end_pos].strip()
 
                 if key and _COOKIE_NAME_RE.match(key):
-                    morsel: Morsel[str] = Morsel()
+                    morsel = Morsel()
                     morsel.__setstate__(  # type: ignore[attr-defined]
                         {"key": key, "value": _unquote(value), "coded_value": value}
                     )

--- a/aiohttp/_cookie_helpers.py
+++ b/aiohttp/_cookie_helpers.py
@@ -205,7 +205,7 @@ def parse_cookie_header(header: str) -> list[tuple[str, Morsel[str]]]:
                     internal_logger.warning(
                         "Can not load cookie: Illegal cookie name %r", key
                     )
-                elif key:
+                else:
                     morsel = Morsel()
                     morsel.__setstate__(  # type: ignore[attr-defined]
                         {"key": key, "value": _unquote(value), "coded_value": value}

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -341,8 +341,9 @@ tuples
 UI
 un
 unawaited
-undercounting
 unclosed
+undercounting
+unescaped
 unhandled
 unicode
 unittest

--- a/tests/test_cookie_helpers.py
+++ b/tests/test_cookie_helpers.py
@@ -1561,7 +1561,7 @@ def test_parse_cookie_header_invalid_name_in_fallback(
 def test_parse_cookie_header_empty_key_in_fallback(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """Test that fallback parser handles empty cookie names without warning."""
+    """Test that fallback parser logs warning for empty cookie names."""
     header = 'normal=value; ={"malformed":"json"}; another=test'
 
     result = parse_cookie_header(header)
@@ -1576,7 +1576,7 @@ def test_parse_cookie_header_empty_key_in_fallback(
     assert name2 == "another"
     assert morsel2.value == "test"
 
-    assert "Illegal cookie name" not in caplog.text
+    assert "Can not load cookie: Illegal cookie name ''" in caplog.text
 
 
 @pytest.mark.parametrize(

--- a/tests/test_cookie_helpers.py
+++ b/tests/test_cookie_helpers.py
@@ -1558,6 +1558,27 @@ def test_parse_cookie_header_invalid_name_in_fallback(
     assert "Can not load cookie: Illegal cookie name 'invalid,name'" in caplog.text
 
 
+def test_parse_cookie_header_empty_key_in_fallback(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Test that fallback parser handles empty cookie names without warning."""
+    header = 'normal=value; ={"malformed":"json"}; another=test'
+
+    result = parse_cookie_header(header)
+
+    assert len(result) == 2
+
+    name1, morsel1 = result[0]
+    assert name1 == "normal"
+    assert morsel1.value == "value"
+
+    name2, morsel2 = result[1]
+    assert name2 == "another"
+    assert morsel2.value == "test"
+
+    assert "Illegal cookie name" not in caplog.text
+
+
 @pytest.mark.parametrize(
     ("input_str", "expected"),
     [

--- a/tests/test_cookie_helpers.py
+++ b/tests/test_cookie_helpers.py
@@ -1137,7 +1137,6 @@ def test_parse_cookie_header_empty() -> None:
     assert parse_cookie_header("   ") == []
 
 
-@pytest.mark.xfail(reason="https://github.com/aio-libs/aiohttp/issues/11632")
 def test_parse_cookie_gstate_header() -> None:
     header = (
         "_ga=ga; "

--- a/tests/test_cookie_helpers.py
+++ b/tests/test_cookie_helpers.py
@@ -1518,7 +1518,6 @@ def test_parse_cookie_header_whitespace_in_fallback() -> None:
 
 def test_parse_cookie_header_empty_value_in_fallback() -> None:
     """Test that fallback handles empty values correctly."""
-    # Empty values are valid and should be preserved
     header = "normal=value; empty=; another=test"
 
     result = parse_cookie_header(header)
@@ -1542,13 +1541,10 @@ def test_parse_cookie_header_invalid_name_in_fallback(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Test that fallback parser rejects cookies with invalid names."""
-    # Create a malformed cookie value that triggers fallback (unescaped quotes in JSON),
-    # but with an invalid cookie name (comma not allowed per _COOKIE_NAME_RE)
     header = 'normal=value; invalid,name={"x":"y"}; another=test'
 
     result = parse_cookie_header(header)
 
-    # Should only get 'normal' and 'another', skipping 'invalid,name'
     assert len(result) == 2
 
     name1, morsel1 = result[0]
@@ -1559,7 +1555,6 @@ def test_parse_cookie_header_invalid_name_in_fallback(
     assert name2 == "another"
     assert morsel2.value == "test"
 
-    # Should log a warning about the illegal cookie name (same as regex path)
     assert "Can not load cookie: Illegal cookie name 'invalid,name'" in caplog.text
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Ensure cookies are still parsed after a malformed cookie
Browsers and nodejs cookie parser are a lot more permissive so
we should handle similar cases.

## Are there changes in behavior for the user?

we can handle more real world cookies

## Is it a substantial burden for the maintainers to support this?

<!--
Stop right there! Pause. Just for a minute... Can you think of anything
obvious that would complicate the ongoing development of this project?

Try to consider if you'd be able to maintain it throughout the next
5 years. Does it seem viable? Tell us your thoughts! We'd very much
love to hear what the consequences of merging this patch might be...

This will help us assess if your change is something we'd want to
entertain early in the review process. Thank you in advance!
-->

Its pretty similar to how node.js does it and they haven't substantively changed it in a while so probably not going to require much maint burden

## Related issue number

fixes #11632
