### PR TITLE
[PR #11643 backport][3.14] Move dependency metadata from `setup.cfg` to `pyproject.toml`

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -37,7 +37,7 @@ jobs:
         submodules: true
     - name: >-
         Verify that `requirements/runtime-deps.in`
-        is in sync with `setup.cfg`
+        is in sync with `pyproject.toml`
       run: |
         set -eEuo pipefail
         make sync-direct-runtime-deps

--- a/CHANGES/11643.packaging.rst
+++ b/CHANGES/11643.packaging.rst
@@ -1,0 +1,2 @@
+Moved dependency metadata from :file:`setup.cfg` to :file:`pyproject.toml` per :pep:`621`
+-- by :user:`cdce8p`.

--- a/Makefile
+++ b/Makefile
@@ -179,5 +179,5 @@ install-dev: .develop
 
 .PHONY: sync-direct-runtime-deps
 sync-direct-runtime-deps:
-	@echo Updating 'requirements/runtime-deps.in' from 'setup.cfg'... >&2
+	@echo Updating 'requirements/runtime-deps.in' from 'pyproject.toml'... >&2
 	@python requirements/sync-direct-runtime-deps.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,10 +32,26 @@ classifiers = [
   "Topic :: Internet :: WWW/HTTP",
 ]
 requires-python = ">= 3.10"
+dependencies = [
+  "aiohappyeyeballs >= 2.5.0",
+  "aiosignal >= 1.4.0",
+  "async-timeout >= 4.0, < 6.0 ; python_version < '3.11'",
+  "attrs >= 17.3.0",
+  "frozenlist >= 1.1.1",
+  "multidict >=4.5, < 7.0",
+  "propcache >= 0.2.0",
+  "yarl >= 1.17.0, < 2.0",
+]
 dynamic = [
-  "dependencies",
-  "optional-dependencies",
   "version",
+]
+
+[project.optional-dependencies]
+speedups = [
+  "aiodns >= 3.3.0",
+  "Brotli; platform_python_implementation == 'CPython'",
+  "brotlicffi; platform_python_implementation != 'CPython'",
+  "backports.zstd; platform_python_implementation == 'CPython' and python_version < '3.14'",
 ]
 
 [[project.maintainers]]

--- a/requirements/runtime-deps.in
+++ b/requirements/runtime-deps.in
@@ -1,11 +1,11 @@
-# Extracted from `setup.cfg` via `make sync-direct-runtime-deps`
+# Extracted from `pyproject.toml` via `make sync-direct-runtime-deps`
 
 aiodns >= 3.3.0
 aiohappyeyeballs >= 2.5.0
 aiosignal >= 1.4.0
-async-timeout >= 4.0, < 6.0 ; python_version < "3.11"
+async-timeout >= 4.0, < 6.0 ; python_version < '3.11'
 attrs >= 17.3.0
-backports.zstd; platform_python_implementation == 'CPython' and python_version < "3.14"
+backports.zstd; platform_python_implementation == 'CPython' and python_version < '3.14'
 Brotli; platform_python_implementation == 'CPython'
 brotlicffi; platform_python_implementation != 'CPython'
 frozenlist >= 1.1.1

--- a/requirements/sync-direct-runtime-deps.py
+++ b/requirements/sync-direct-runtime-deps.py
@@ -1,16 +1,22 @@
 #!/usr/bin/env python
-"""Sync direct runtime dependencies from setup.cfg to runtime-deps.in."""
+"""Sync direct runtime dependencies from pyproject.toml to runtime-deps.in."""
 
-from configparser import ConfigParser
+import sys
 from pathlib import Path
 
-cfg = ConfigParser()
-cfg.read(Path("setup.cfg"))
-reqs = cfg["options"]["install_requires"] + cfg.items("options.extras_require")[0][1]
-reqs = sorted(reqs.split("\n"), key=str.casefold)
-reqs.remove("")
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    raise RuntimeError("Use Python 3.11+ to run 'make sync-direct-runtime-deps'")
+
+data = tomllib.loads(Path("pyproject.toml").read_text())
+reqs = (
+    data["project"]["dependencies"]
+    + data["project"]["optional-dependencies"]["speedups"]
+)
+reqs = sorted(reqs, key=str.casefold)
 
 with open(Path("requirements", "runtime-deps.in"), "w") as outfile:
-    header = "# Extracted from `setup.cfg` via `make sync-direct-runtime-deps`\n\n"
+    header = "# Extracted from `pyproject.toml` via `make sync-direct-runtime-deps`\n\n"
     outfile.write(header)
     outfile.write("\n".join(reqs) + "\n")

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,21 +1,3 @@
-[options]
-install_requires =
-  aiohappyeyeballs >= 2.5.0
-  aiosignal >= 1.4.0
-  async-timeout >= 4.0, < 6.0 ; python_version < "3.11"
-  attrs >= 17.3.0
-  frozenlist >= 1.1.1
-  multidict >=4.5, < 7.0
-  propcache >= 0.2.0
-  yarl >= 1.17.0, < 2.0
-
-[options.extras_require]
-speedups =
-  aiodns >= 3.3.0
-  Brotli; platform_python_implementation == 'CPython'
-  brotlicffi; platform_python_implementation != 'CPython'
-  backports.zstd; platform_python_implementation == 'CPython' and python_version < "3.14"
-
 [pep8]
 max-line-length=79
 


### PR DESCRIPTION
This is a backport of PR https://github.com/aio-libs/aiohttp/pull/11643 as merged into master (https://github.com/aio-libs/aiohttp/commit/e1aec0ac94277a8b67092293aeac3c19e17fdd86).

Modified the backport to include `attrs` again as present on the 3.14 branch.