### PR TITLE
Skip benchmarks in ci when running in fork repositories

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -46,6 +46,7 @@ jobs:
         }}
     steps:
       - name: Dummy
+        if: false
         run: |
           echo "Pre-setup step"
 

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -23,9 +23,24 @@ env:
   FORCE_COLOR: 1  # Request colored output from CLI tools supporting it
   MYPY_FORCE_COLOR: 1
   PY_COLORS: 1
+  UPSTREAM_REPOSITORY_ID: |
+    13258039
 
 permissions: {}
+
 jobs:
+
+  pre-setup:
+    name: Pre-Setup global build settings
+    runs-on: ubuntu-latest
+    outputs:
+      upstream-repository-id: ${{ env.UPSTREAM_REPOSITORY_ID }}
+      release-requested: |
+        ${{ github.event_name == 'push' && contains(github.ref, 'refs/tags/') }}
+    steps:
+      - name: Dummy
+        run: |
+          echo "Pre-setup step"
 
   lint:
     permissions:
@@ -259,9 +274,9 @@ jobs:
 
   benchmark:
     name: Benchmark
-    needs: gen_llhttp
-    if: github.repository_id == '13258039'
-
+    needs: [pre-setup, gen_llhttp]
+    if: |
+      needs.pre-setup.outputs.upstream-repository-id == github.repository_id
     runs-on: ubuntu-latest
     timeout-minutes: 12
     steps:
@@ -318,9 +333,8 @@ jobs:
   pre-deploy:
     name: Pre-Deploy
     runs-on: ubuntu-latest
-    needs: check
-    # Run only on pushing a tag
-    if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
+    needs: [pre-setup, check]
+    if: fromJSON(needs.pre-setup.outputs.release-requested)
     steps:
       - name: Dummy
         run: |
@@ -466,8 +480,10 @@ jobs:
 
   deploy:
     name: Deploy
-    needs: [build-tarball, build-wheels]
+    needs: [pre-setup, build-tarball, build-wheels]
     runs-on: ubuntu-latest
+    if: |
+      needs.pre-setup.outputs.upstream-repository-id == github.repository_id
 
     permissions:
       contents: write  # IMPORTANT: mandatory for making GitHub Releases

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -233,12 +233,14 @@ jobs:
       run: pytest -m dev_mode --cov-append --numprocesses=0
       shell: bash
     - name: Turn coverage into xml
+      if: github.repository_owner == 'aio-libs'
       env:
         COLOR: 'yes'
         PIP_USER: 1
       run: |
         python -m coverage xml
     - name: Upload coverage
+      if: github.repository_owner == 'aio-libs'
       uses: codecov/codecov-action@v5
       with:
         file: ./coverage.xml
@@ -252,7 +254,7 @@ jobs:
           }}
         token: ${{ secrets.CODECOV_TOKEN }}
     - name: Upload test results to Codecov
-      if: ${{ !cancelled() }}
+      if: ${{ github.repository_owner == 'aio-libs' &&  !cancelled() }}
       uses: codecov/test-results-action@v1
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
@@ -260,6 +262,7 @@ jobs:
   benchmark:
     name: Benchmark
     needs: gen_llhttp
+    if: github.repository_owner == 'aio-libs'
 
     runs-on: ubuntu-latest
     timeout-minutes: 12

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -23,7 +23,7 @@ env:
   FORCE_COLOR: 1  # Request colored output from CLI tools supporting it
   MYPY_FORCE_COLOR: 1
   PY_COLORS: 1
-  UPSTREAM_REPOSITORY_ID: |
+  UPSTREAM_REPOSITORY_ID: >-
     13258039
 
 permissions: {}
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       upstream-repository-id: ${{ env.UPSTREAM_REPOSITORY_ID }}
-      release-requested: |
+      release-requested: >-
         ${{ github.event_name == 'push' && contains(github.ref, 'refs/tags/') }}
     steps:
       - name: Dummy
@@ -275,7 +275,7 @@ jobs:
   benchmark:
     name: Benchmark
     needs: [pre-setup, gen_llhttp]
-    if: |
+    if: >-
       needs.pre-setup.outputs.upstream-repository-id == github.repository_id
     runs-on: ubuntu-latest
     timeout-minutes: 12
@@ -482,7 +482,7 @@ jobs:
     name: Deploy
     needs: [pre-setup, build-tarball, build-wheels]
     runs-on: ubuntu-latest
-    if: |
+    if: >-
       needs.pre-setup.outputs.upstream-repository-id == github.repository_id
 
     permissions:

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -233,14 +233,12 @@ jobs:
       run: pytest -m dev_mode --cov-append --numprocesses=0
       shell: bash
     - name: Turn coverage into xml
-      if: github.repository_owner == 'aio-libs'
       env:
         COLOR: 'yes'
         PIP_USER: 1
       run: |
         python -m coverage xml
     - name: Upload coverage
-      if: github.repository_owner == 'aio-libs'
       uses: codecov/codecov-action@v5
       with:
         file: ./coverage.xml
@@ -254,7 +252,7 @@ jobs:
           }}
         token: ${{ secrets.CODECOV_TOKEN }}
     - name: Upload test results to Codecov
-      if: ${{ github.repository_owner == 'aio-libs' &&  !cancelled() }}
+      if: ${{ !cancelled() }}
       uses: codecov/test-results-action@v1
       with:
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -260,7 +260,7 @@ jobs:
   benchmark:
     name: Benchmark
     needs: gen_llhttp
-    if: github.repository_owner == 'aio-libs'
+    if: github.repository_id == '13258039'
 
     runs-on: ubuntu-latest
     timeout-minutes: 12

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -36,7 +36,14 @@ jobs:
     outputs:
       upstream-repository-id: ${{ env.UPSTREAM_REPOSITORY_ID }}
       release-requested: >-
-        ${{ github.event_name == 'push' && contains(github.ref, 'refs/tags/') }}
+        ${{
+          (
+            github.event_name == 'push'
+            && github.ref_type == 'tag'
+          )
+          && true
+          || false
+        }}
     steps:
       - name: Dummy
         run: |

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -274,7 +274,9 @@ jobs:
 
   benchmark:
     name: Benchmark
-    needs: [pre-setup, gen_llhttp]
+    needs:
+    - gen_llhttp
+    - pre-setup  # transitive, for accessing settings
     if: >-
       needs.pre-setup.outputs.upstream-repository-id == github.repository_id
     runs-on: ubuntu-latest
@@ -333,7 +335,9 @@ jobs:
   pre-deploy:
     name: Pre-Deploy
     runs-on: ubuntu-latest
-    needs: [pre-setup, check]
+    needs:
+    - check
+    - pre-setup  # transitive, for accessing settings
     if: fromJSON(needs.pre-setup.outputs.release-requested)
     steps:
       - name: Dummy
@@ -480,7 +484,10 @@ jobs:
 
   deploy:
     name: Deploy
-    needs: [pre-setup, build-tarball, build-wheels]
+    needs:
+    - build-tarball
+    - build-wheels
+    - pre-setup  # transitive, for accessing settings
     runs-on: ubuntu-latest
     if: >-
       needs.pre-setup.outputs.upstream-repository-id == github.repository_id

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -320,7 +320,6 @@ jobs:
       uses: CodSpeedHQ/action@v4
       with:
         mode: instrumentation
-        token: ${{ secrets.CODSPEED_TOKEN }}
         run: python -Im pytest --no-cov --numprocesses=0 -vvvvv --codspeed
 
 

--- a/CHANGES/11737.contrib.rst
+++ b/CHANGES/11737.contrib.rst
@@ -1,3 +1,2 @@
-Fixed test and benchmark workflows always failing on forks. Made coverage upload
-step and benchmark workflow skip when not running on main repository.
--- by :user:`Cycloctane`.
+Fixed ci workflow always failing on forks. Made benchmark skip when not
+running on main repository. -- by :user:`Cycloctane`.

--- a/CHANGES/11737.contrib.rst
+++ b/CHANGES/11737.contrib.rst
@@ -1,2 +1,3 @@
-Fixed workflow always failing on forks. Made benchmark job skip when not
-running on main repository. -- by :user:`Cycloctane`.
+The benchmark CI job now runs only in the upstream repository -- by :user:`Cycloctane`.
+
+It used to always fail in forks, which this change fixed.

--- a/CHANGES/11737.contrib.rst
+++ b/CHANGES/11737.contrib.rst
@@ -1,0 +1,3 @@
+Fixed test and benchmark workflows always failing on forks. Made coverage upload
+step and benchmark workflow skip when not running on main repository.
+-- by :user:`Cycloctane`.

--- a/CHANGES/11737.contrib.rst
+++ b/CHANGES/11737.contrib.rst
@@ -1,2 +1,2 @@
-Fixed ci workflow always failing on forks. Made benchmark skip when not
+Fixed workflow always failing on forks. Made benchmark job skip when not
 running on main repository. -- by :user:`Cycloctane`.


### PR DESCRIPTION
## What do these changes do?

Forks cannot use codspeed account, which can make benchmark job in ci fail if aiohttp contributors want to run test workflow on their forks. This pr make unnecessary steps skip if triggered workflow is not in the main repository.

## Are there changes in behavior for the user?

aiohttp contributors can now run github action workflows to test changes in their forks without unnecessary errors.

## Is it a substantial burden for the maintainers to support this?

## Related issue number

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES/` folder
