### PR TITLE
Request/Response storage typing (backport to v3.14)

### DIFF
--- a/CHANGES/11766.feature.rst
+++ b/CHANGES/11766.feature.rst
@@ -1,0 +1,4 @@
+Added ``RequestKey`` and ``ResponseKey`` classes,
+which enable static type checking for request & response
+context storages in the same way that ``AppKey`` does for ``Application``
+-- by :user:`gsoldatov`.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -143,6 +143,7 @@ Gennady Andreyev
 Georges Dubus
 Greg Holt
 Gregory Haynes
+Grigoriy Soldatov
 Gus Goulart
 Gustavo Carneiro
 Günther Jena

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -417,7 +417,7 @@ class ClientSession:
 
     def __init_subclass__(cls: type["ClientSession"]) -> None:
         warnings.warn(
-            f"Inheritance class {cls.__name__} from ClientSession " "is discouraged",
+            f"Inheritance class {cls.__name__} from ClientSession is discouraged",
             DeprecationWarning,
             stacklevel=2,
         )
@@ -427,7 +427,7 @@ class ClientSession:
         def __setattr__(self, name: str, val: Any) -> None:
             if name not in self.ATTRS:
                 warnings.warn(
-                    f"Setting custom ClientSession.{name} attribute " "is discouraged",
+                    f"Setting custom ClientSession.{name} attribute is discouraged",
                     DeprecationWarning,
                     stacklevel=2,
                 )

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -812,8 +812,11 @@ def set_exception(
 
 
 @functools.total_ordering
-class AppKey(Generic[_T]):
-    """Keys for static typing support in Application."""
+class BaseKey(Generic[_T]):
+    """Base for concrete context storage key classes.
+
+    Each storage is provided with its own sub-class for the sake of some additional type safety.
+    """
 
     __slots__ = ("_name", "_t", "__orig_class__")
 
@@ -835,9 +838,9 @@ class AppKey(Generic[_T]):
         self._t = t
 
     def __lt__(self, other: object) -> bool:
-        if isinstance(other, AppKey):
+        if isinstance(other, BaseKey):
             return self._name < other._name
-        return True  # Order AppKey above other types.
+        return True  # Order BaseKey above other types.
 
     def __repr__(self) -> str:
         t = self._t
@@ -855,7 +858,19 @@ class AppKey(Generic[_T]):
                 t_repr = f"{t.__module__}.{t.__qualname__}"
         else:
             t_repr = repr(t)
-        return f"<AppKey({self._name}, type={t_repr})>"
+        return f"<{self.__class__.__name__}({self._name}, type={t_repr})>"
+
+
+class AppKey(BaseKey[_T]):
+    """Keys for static typing support in Application."""
+
+
+class RequestKey(BaseKey[_T]):
+    """Keys for static typing support in Request."""
+
+
+class ResponseKey(BaseKey[_T]):
+    """Keys for static typing support in Response."""
 
 
 class ChainMapProxy(Mapping[str | AppKey[Any], Any]):
@@ -866,7 +881,7 @@ class ChainMapProxy(Mapping[str | AppKey[Any], Any]):
 
     def __init_subclass__(cls) -> None:
         raise TypeError(
-            f"Inheritance class {cls.__name__} from ChainMapProxy " "is forbidden"
+            f"Inheritance class {cls.__name__} from ChainMapProxy is forbidden"
         )
 
     @overload  # type: ignore[override]

--- a/aiohttp/web.py
+++ b/aiohttp/web.py
@@ -11,7 +11,7 @@ from importlib import import_module
 from typing import TYPE_CHECKING, Any, cast
 
 from .abc import AbstractAccessLogger
-from .helpers import AppKey as AppKey
+from .helpers import AppKey, RequestKey, ResponseKey
 from .log import access_logger
 from .typedefs import PathLike
 from .web_app import Application as Application, CleanupError as CleanupError
@@ -223,11 +223,13 @@ __all__ = (
     "BaseRequest",
     "FileField",
     "Request",
+    "RequestKey",
     # web_response
     "ContentCoding",
     "Response",
     "StreamResponse",
     "json_response",
+    "ResponseKey",
     # web_routedef
     "AbstractRouteDef",
     "RouteDef",

--- a/aiohttp/web_app.py
+++ b/aiohttp/web_app.py
@@ -166,7 +166,7 @@ class Application(MutableMapping[str | AppKey[Any], Any]):
 
     def __init_subclass__(cls: type["Application"]) -> None:
         warnings.warn(
-            f"Inheritance class {cls.__name__} from web.Application " "is discouraged",
+            f"Inheritance class {cls.__name__} from web.Application is discouraged",
             DeprecationWarning,
             stacklevel=3,
         )

--- a/aiohttp/web_protocol.py
+++ b/aiohttp/web_protocol.py
@@ -690,7 +690,7 @@ class RequestHandler(BaseProtocol):
                 self.log_exception("Missing return statement on request handler")
             else:
                 self.log_exception(
-                    "Web-handler should return a response instance, " f"got {resp!r}"
+                    f"Web-handler should return a response instance, got {resp!r}"
                 )
             exc = HTTPInternalServerError()
             resp = Response(

--- a/aiohttp/web_request.py
+++ b/aiohttp/web_request.py
@@ -10,7 +10,7 @@ import warnings
 from collections.abc import Iterator, Mapping, MutableMapping
 from re import Pattern
 from types import MappingProxyType
-from typing import TYPE_CHECKING, Any, Final, Optional, cast
+from typing import TYPE_CHECKING, Any, Final, Optional, TypeVar, cast, overload
 from urllib.parse import parse_qsl
 
 import attr
@@ -34,6 +34,7 @@ from .helpers import (
     ChainMapProxy,
     ETag,
     HeadersMixin,
+    RequestKey,
     parse_http_date,
     reify,
     sentinel,
@@ -50,7 +51,7 @@ from .typedefs import (
     RawHeaders,
     StrOrURL,
 )
-from .web_exceptions import HTTPRequestEntityTooLarge
+from .web_exceptions import HTTPRequestEntityTooLarge, NotAppKeyWarning
 from .web_response import StreamResponse
 
 __all__ = ("BaseRequest", "FileField", "Request")
@@ -60,6 +61,9 @@ if TYPE_CHECKING:
     from .web_app import Application
     from .web_protocol import RequestHandler
     from .web_urldispatcher import UrlMappingMatchInfo
+
+
+_T = TypeVar("_T")
 
 
 @attr.s(auto_attribs=True, frozen=True, slots=True)
@@ -98,8 +102,7 @@ _FORWARDED_PAIR_RE: Final[Pattern[str]] = re.compile(_FORWARDED_PAIR)
 ############################################################
 
 
-class BaseRequest(MutableMapping[str, Any], HeadersMixin):
-
+class BaseRequest(MutableMapping[str | RequestKey[Any], Any], HeadersMixin):
     POST_METHODS = {
         hdrs.METH_PATCH,
         hdrs.METH_POST,
@@ -131,6 +134,7 @@ class BaseRequest(MutableMapping[str, Any], HeadersMixin):
     )
     _post: MultiDictProxy[str | bytes | FileField] | None = None
     _read_bytes: bytes | None = None
+    _seen_str_keys: set[str] = set()
 
     def __init__(
         self,
@@ -142,7 +146,7 @@ class BaseRequest(MutableMapping[str, Any], HeadersMixin):
         loop: asyncio.AbstractEventLoop,
         *,
         client_max_size: int = 1024**2,
-        state: dict[str, Any] | None = None,
+        state: dict[RequestKey[Any] | str, Any] | None = None,
         scheme: str | None = None,
         host: str | None = None,
         remote: str | None = None,
@@ -286,19 +290,40 @@ class BaseRequest(MutableMapping[str, Any], HeadersMixin):
 
     # MutableMapping API
 
-    def __getitem__(self, key: str) -> Any:
+    @overload  # type: ignore[override]
+    def __getitem__(self, key: RequestKey[_T]) -> _T: ...
+
+    @overload
+    def __getitem__(self, key: str) -> Any: ...
+
+    def __getitem__(self, key: str | RequestKey[_T]) -> Any:
         return self._state[key]
 
-    def __setitem__(self, key: str, value: Any) -> None:
+    @overload  # type: ignore[override]
+    def __setitem__(self, key: RequestKey[_T], value: _T) -> None: ...
+
+    @overload
+    def __setitem__(self, key: str, value: Any) -> None: ...
+
+    def __setitem__(self, key: str | RequestKey[_T], value: Any) -> None:
+        if not isinstance(key, RequestKey) and key not in BaseRequest._seen_str_keys:
+            BaseRequest._seen_str_keys.add(key)
+            warnings.warn(
+                "It is recommended to use web.RequestKey instances for keys.\n"
+                + "https://docs.aiohttp.org/en/stable/web_advanced.html"
+                + "#request-s-storage",
+                category=NotAppKeyWarning,
+                stacklevel=2,
+            )
         self._state[key] = value
 
-    def __delitem__(self, key: str) -> None:
+    def __delitem__(self, key: str | RequestKey[_T]) -> None:
         del self._state[key]
 
     def __len__(self) -> int:
         return len(self._state)
 
-    def __iter__(self) -> Iterator[str]:
+    def __iter__(self) -> Iterator[str | RequestKey[Any]]:
         return iter(self._state)
 
     ########

--- a/aiohttp/web_runner.py
+++ b/aiohttp/web_runner.py
@@ -374,7 +374,7 @@ class AppRunner(BaseRunner):
         super().__init__(handle_signals=handle_signals, **kwargs)
         if not isinstance(app, Application):
             raise TypeError(
-                "The first argument should be web.Application " f"instance, got {app!r}"
+                f"The first argument should be web.Application instance, got {app!r}"
             )
         self._app = app
 

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -87,8 +87,15 @@ support the :class:`dict` interface.
 
 Therefore, data may be stored inside a request object. ::
 
-   async def handler(request):
-       request['unique_key'] = data
+    request_id_key = web.RequestKey("request_id_key", str)
+
+    @web.middleware
+    async def request_id_middleware(request, handler):
+        request[request_id_key] = "some_request_id"
+        return await handler(request)
+
+    async def handler(request):
+        request_id = request[request_id_key]
 
 See https://github.com/aio-libs/aiohttp_session code for an example.
 The ``aiohttp_session.get_session(request)`` method uses ``SESSION_KEY``

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -6,6 +6,7 @@ aiohttp
 aiohttpdemo
 aiohttp’s
 aiopg
+al
 alives
 api
 api’s
@@ -119,6 +120,7 @@ env
 environ
 eof
 epoll
+et
 etag
 ETag
 expirations
@@ -166,6 +168,7 @@ iterable
 iterables
 javascript
 Jinja
+jitter
 json
 keepalive
 keepalived
@@ -293,6 +296,7 @@ runtime
 runtimes
 sa
 Satisfiable
+scalability
 schemas
 sendfile
 serializable
@@ -305,6 +309,7 @@ ssl
 SSLContext
 startup
 stateful
+storages
 subapplication
 subclassed
 subclasses
@@ -350,6 +355,7 @@ unicode
 unittest
 Unittest
 unix
+unobvious
 unsets
 unstripped
 untyped

--- a/docs/web_advanced.rst
+++ b/docs/web_advanced.rst
@@ -447,10 +447,13 @@ Request's storage
 ^^^^^^^^^^^^^^^^^
 
 Variables that are only needed for the lifetime of a :class:`Request`, can be
-stored in a :class:`Request`::
+stored in a :class:`Request`. Similarly to :class:`Application`, :class:`RequestKey`
+instances or strings can be used as keys::
+
+    my_private_key = web.RequestKey("my_private_key", str)
 
     async def handler(request):
-      request['my_private_key'] = "data"
+      request[my_private_key] = "data"
       ...
 
 This is mostly useful for :ref:`aiohttp-web-middlewares` and
@@ -465,9 +468,11 @@ also support :class:`collections.abc.MutableMapping` interface. This is useful
 when you want to share data with signals and middlewares once all the work in
 the handler is done::
 
+    my_metric_key = web.ResponseKey("my_metric_key", int)
+
     async def handler(request):
       [ do all the work ]
-      response['my_metric'] = 123
+      response[my_metric_key] = 123
       return response
 
 
@@ -719,18 +724,20 @@ In contrast, when accessing the stream directly (not recommended in middleware):
 
 When working with raw stream data that needs to be shared between middleware and handlers::
 
+    raw_body_key = web.RequestKey("raw_body_key", bytes)
+
     async def stream_parsing_middleware(
         request: web.Request,
         handler: Callable[[web.Request], Awaitable[web.StreamResponse]]
     ) -> web.StreamResponse:
         # Read stream once and store the data
         raw_data = await request.content.read()
-        request['raw_body'] = raw_data
+        request[raw_body_key] = raw_data
         return await handler(request)
 
     async def handler(request: web.Request) -> web.Response:
         # Access the stored data instead of reading the stream again
-        raw_data = request.get('raw_body', b'')
+        raw_data = request.get(raw_body_key, b'')
         return web.Response(body=raw_data)
 
 Example

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -554,6 +554,13 @@ and :ref:`aiohttp-web-signals` handlers.
       request copy with changed *path*, *method* etc.
 
 
+.. class:: RequestKey(name, t)
+
+   Keys for use in :class:`Request`.
+
+   See :class:`AppKey` for more details.
+
+
 
 
 .. _aiohttp-web-response:
@@ -1422,6 +1429,15 @@ the handler.
       :class:`Response` initializer.
 
 
+.. class:: ResponseKey(name, t)
+
+   Keys for use in :class:`Response`.
+
+   See :class:`AppKey` for more details.
+
+
+
+
 .. _aiohttp-web-app-and-router:
 
 Application and Router
@@ -1769,6 +1785,7 @@ Application and Router
 
    :param t: The type that should be used for the value in the dict (e.g.
              `str`, `Iterator[int]` etc.)
+
 
 .. class:: Server
 

--- a/tests/test_web_exceptions.py
+++ b/tests/test_web_exceptions.py
@@ -238,6 +238,7 @@ def test_HTTPException_retains_cause() -> None:
     assert "direct cause" in tb
 
 
+@pytest.mark.filterwarnings(r"ignore:.*web\.RequestKey:UserWarning")
 async def test_HTTPException_retains_cookie(aiohttp_client: AiohttpClient) -> None:
     @web.middleware
     async def middleware(request, handler):


### PR DESCRIPTION
(cherry picked from commit 30055104aeda525303e1eb93d3fa9e3eee0f6dfc)

<!-- Thank you for your contribution! -->

## What do these changes do?

Backport of #11766 to v3.14.

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->

## Is it a substantial burden for the maintainers to support this?

<!--
Stop right there! Pause. Just for a minute... Can you think of anything
obvious that would complicate the ongoing development of this project?

Try to consider if you'd be able to maintain it throughout the next
5 years. Does it seem viable? Tell us your thoughts! We'd very much
love to hear what the consequences of merging this patch might be...

This will help us assess if your change is something we'd want to
entertain early in the review process. Thank you in advance!
-->

## Related issue number

<!-- Will this resolve any open issues? -->
<!-- Remember to prefix with 'Fixes' if it closes an issue (e.g. 'Fixes #123'). -->

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES/` folder
  * name it `<issue_or_pr_num>.<type>.rst` (e.g. `588.bugfix.rst`)
  * if you don't have an issue number, change it to the pull request
    number after creating the PR
    * `.bugfix`: A bug fix for something the maintainers deemed an
      improper undesired behavior that got corrected to match
      pre-agreed expectations.
    * `.feature`: A new behavior, public APIs. That sort of stuff.
    * `.deprecation`: A declaration of future API removals and breaking
      changes in behavior.
    * `.breaking`: When something public is removed in a breaking way.
      Could be deprecated in an earlier release.
    * `.doc`: Notable updates to the documentation structure or build
      process.
    * `.packaging`: Notes for downstreams about unobvious side effects
      and tooling. Changes in the test invocation considerations and
      runtime assumptions.
    * `.contrib`: Stuff that affects the contributor experience. e.g.
      Running tests, building the docs, setting up the development
      environment.
    * `.misc`: Changes that are hard to assign to any of the above
      categories.
  * Make sure to use full sentences with correct case and punctuation,
    for example:
    ```rst
    Fixed issue with non-ascii contents in doctest text files
    -- by :user:`contributor-gh-handle`.
    ```

    Use the past tense or the present tense a non-imperative mood,
    referring to what's changed compared to the last released version
    of this project.
