### PR TITLE
Bump blockbuster to 1.5.26

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -28,7 +28,7 @@ backports-zstd==1.1.0 ; implementation_name == "cpython"
     # via
     #   -r requirements/lint.in
     #   -r requirements/runtime-deps.in
-blockbuster==1.5.25
+blockbuster==1.5.26
     # via
     #   -r requirements/lint.in
     #   -r requirements/test-common.in

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -28,7 +28,7 @@ backports-zstd==1.1.0 ; platform_python_implementation == "CPython" and python_v
     # via
     #   -r requirements/lint.in
     #   -r requirements/runtime-deps.in
-blockbuster==1.5.25
+blockbuster==1.5.26
     # via
     #   -r requirements/lint.in
     #   -r requirements/test-common.in

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -12,7 +12,7 @@ async-timeout==5.0.1
     # via valkey
 backports-zstd==1.1.0 ; implementation_name == "cpython"
     # via -r requirements/lint.in
-blockbuster==1.5.25
+blockbuster==1.5.26
     # via -r requirements/lint.in
 cffi==2.0.0
     # via

--- a/requirements/test-common.txt
+++ b/requirements/test-common.txt
@@ -6,7 +6,7 @@
 #
 annotated-types==0.7.0
     # via pydantic
-blockbuster==1.5.25
+blockbuster==1.5.26
     # via -r requirements/test-common.in
 cffi==2.0.0
     # via

--- a/requirements/test-ft.txt
+++ b/requirements/test-ft.txt
@@ -16,7 +16,7 @@ async-timeout==5.0.1 ; python_version < "3.11"
     # via -r requirements/runtime-deps.in
 backports-zstd==1.1.0 ; platform_python_implementation == "CPython" and python_version < "3.14"
     # via -r requirements/runtime-deps.in
-blockbuster==1.5.25
+blockbuster==1.5.26
     # via -r requirements/test-common.in
 brotli==1.2.0 ; platform_python_implementation == "CPython"
     # via -r requirements/runtime-deps.in

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -16,7 +16,7 @@ async-timeout==5.0.1 ; python_version < "3.11"
     # via -r requirements/runtime-deps.in
 backports-zstd==1.1.0 ; platform_python_implementation == "CPython" and python_version < "3.14"
     # via -r requirements/runtime-deps.in
-blockbuster==1.5.25
+blockbuster==1.5.26
     # via -r requirements/test-common.in
 brotli==1.2.0 ; platform_python_implementation == "CPython"
     # via -r requirements/runtime-deps.in


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
Bump blockbuster to 1.5.26.
Needed because of false positives with Python 3.14.1t

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->
No

