### PR TITLE
Re-backport 10713 - add regression test

### DIFF
--- a/CHANGES/10713.misc.rst
+++ b/CHANGES/10713.misc.rst
@@ -1,0 +1,1 @@
+Optimized web server performance when access logging is disabled by reducing time syscalls -- by :user:`bdraco`.

--- a/aiohttp/web_protocol.py
+++ b/aiohttp/web_protocol.py
@@ -457,7 +457,7 @@ class RequestHandler(BaseProtocol):
     def log_access(
         self, request: BaseRequest, response: StreamResponse, time: float | None
     ) -> None:
-        if self.access_logger is not None and self.access_logger.enabled:
+        if self._logging_enabled and self.access_logger is not None:
             if TYPE_CHECKING:
                 assert time is not None
             self.access_logger.log(request, response, self._loop.time() - time)

--- a/tests/test_web_log.py
+++ b/tests/test_web_log.py
@@ -283,7 +283,6 @@ async def test_logger_set_to_none(
     assert "This should not be logged" not in caplog.text
 
 
-@pytest.mark.xfail(reason="#11778")
 async def test_logger_does_not_log_when_enabled_post_init(
     aiohttp_server: AiohttpServer,
     aiohttp_client: AiohttpClient,


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

https://github.com/aio-libs/aiohttp/pull/10713 resolved bug https://github.com/aio-libs/aiohttp/issues/11778, but the backports missed the key change. This PR adjusts that backport and marks a regression test as no longer expected to fail

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?
Just the fix for 11778

## Is it a substantial burden for the maintainers to support this?
No
<!--
Stop right there! Pause. Just for a minute... Can you think of anything
obvious that would complicate the ongoing development of this project?

Try to consider if you'd be able to maintain it throughout the next
5 years. Does it seem viable? Tell us your thoughts! We'd very much
love to hear what the consequences of merging this patch might be...

This will help us assess if your change is something we'd want to
entertain early in the review process. Thank you in advance!
-->

## Related issue number
https://github.com/aio-libs/aiohttp/issues/11778
<!-- Will this resolve any open issues? -->
<!-- Remember to prefix with 'Fixes' if it closes an issue (e.g. 'Fixes #123'). -->

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES/` folder
  * name it `<issue_or_pr_num>.<type>.rst` (e.g. `588.bugfix.rst`)
  * if you don't have an issue number, change it to the pull request
    number after creating the PR
    * `.bugfix`: A bug fix for something the maintainers deemed an
      improper undesired behavior that got corrected to match
      pre-agreed expectations.
    * `.feature`: A new behavior, public APIs. That sort of stuff.
    * `.deprecation`: A declaration of future API removals and breaking
      changes in behavior.
    * `.breaking`: When something public is removed in a breaking way.
      Could be deprecated in an earlier release.
    * `.doc`: Notable updates to the documentation structure or build
      process.
    * `.packaging`: Notes for downstreams about unobvious side effects
      and tooling. Changes in the test invocation considerations and
      runtime assumptions.
    * `.contrib`: Stuff that affects the contributor experience. e.g.
      Running tests, building the docs, setting up the development
      environment.
    * `.misc`: Changes that are hard to assign to any of the above
      categories.
  * Make sure to use full sentences with correct case and punctuation,
    for example:
    ```rst
    Fixed issue with non-ascii contents in doctest text files
    -- by :user:`contributor-gh-handle`.
    ```

    Use the past tense or the present tense a non-imperative mood,
    referring to what's changed compared to the last released version
    of this project.
