### PR TITLE
fix(connector): propagate proxy headers on connection reuse (#11777)

### DIFF
--- a/CHANGES/2596.bugfix.rst
+++ b/CHANGES/2596.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed proxy authorization headers not being passed when reusing a connection, which caused 407 (Proxy authentication required) errors
+-- by :user:`GLeurquin`.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -144,6 +144,7 @@ Georges Dubus
 Greg Holt
 Gregory Haynes
 Grigoriy Soldatov
+Guillaume Leurquin
 Gus Goulart
 Gustavo Carneiro
 Günther Jena

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -598,7 +598,7 @@ class BaseConnector:
         """Set Proxy-Authorization header for non-SSL proxy requests and builds the proxy request for SSL proxy requests."""
         url = req.proxy
         assert url is not None
-        headers: Dict[str, str] = {}
+        headers: dict[str, str] = {}
         if req.proxy_headers is not None:
             headers = req.proxy_headers  # type: ignore[assignment]
         headers[hdrs.HOST] = req.headers[hdrs.HOST]

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -594,13 +594,15 @@ class BaseConnector:
 
     def _update_proxy_auth_header_and_build_proxy_req(
         self, req: ClientRequest
-    ) -> ClientRequestBase:
+    ) -> ClientRequest:
         """Set Proxy-Authorization header for non-SSL proxy requests and builds the proxy request for SSL proxy requests."""
         url = req.proxy
         assert url is not None
-        headers = req.proxy_headers or CIMultiDict[str]()
+        headers: Dict[str, str] = {}
+        if req.proxy_headers is not None:
+            headers = req.proxy_headers  # type: ignore[assignment]
         headers[hdrs.HOST] = req.headers[hdrs.HOST]
-        proxy_req = ClientRequestBase(
+        proxy_req = ClientRequest(
             hdrs.METH_GET,
             url,
             headers=headers,

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -1592,28 +1592,9 @@ class TCPConnector(BaseConnector):
     async def _create_proxy_connection(
         self, req: ClientRequest, traces: list["Trace"], timeout: "ClientTimeout"
     ) -> tuple[asyncio.BaseTransport, ResponseHandler]:
-<<<<<<< HEAD
         self._fail_on_no_start_tls(req)
         runtime_has_start_tls = self._loop_supports_start_tls()
-
-        headers: dict[str, str] = {}
-        if req.proxy_headers is not None:
-            headers = req.proxy_headers  # type: ignore[assignment]
-        headers[hdrs.HOST] = req.headers[hdrs.HOST]
-
-        url = req.proxy
-        assert url is not None
-        proxy_req = ClientRequest(
-            hdrs.METH_GET,
-            url,
-            headers=headers,
-            auth=req.proxy_auth,
-            loop=self._loop,
-            ssl=req.ssl,
-        )
-=======
         proxy_req = self._update_proxy_auth_header_and_build_proxy_req(req)
->>>>>>> 7bbf17d09 (fix(connector): propagate proxy headers on connection reuse (#11777))
 
         # create connection to proxy server
         transport, proto = await self._create_direct_connection(

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -3194,7 +3194,6 @@ async def test_connect_reuseconn_tracing(loop, key) -> None:
 )
 async def test_connect_reuse_proxy_headers(  # type: ignore[misc]
     loop: asyncio.AbstractEventLoop,
-    make_client_request: _RequestMaker,
     test_case: str,
     wait_for_con: bool,
     expect_proxy_auth_header: bool,
@@ -3225,7 +3224,7 @@ async def test_connect_reuse_proxy_headers(  # type: ignore[misc]
         None,
         hash(tuple(proxy_headers.items())) if proxy_headers else None,
     )
-    req = make_client_request(
+    req = ClientRequest(
         "GET",
         URL("http://localhost:80"),
         loop=loop,


### PR DESCRIPTION
(cherry picked from commit 7bbf17d09d5f87b93022d340e39d53f386d5d485)