### PR TITLE
Add python-proxy-headers to third_party.rst

### DIFF
--- a/docs/third_party.rst
+++ b/docs/third_party.rst
@@ -149,6 +149,9 @@ ask to raise the status.
 - `pytest-aiohttp-client <https://github.com/sivakov512/pytest-aiohttp-client>`_
   Pytest fixture with simpler api, payload decoding and status code assertions.
 
+- `python-proxy-headers <https://github.com/proxymesh/python-proxy-headers>`_
+  provides ``aiohttp_proxy`` extension for receiving custom response headers from a proxy server
+
 - `octomachinery <https://octomachinery.dev>`_ A framework for developing
   GitHub Apps and GitHub Actions.
 


### PR DESCRIPTION
for aiohttp_proxy extension

<!-- Thank you for your contribution! -->

## What do these changes do?

Add `python-proxy-headers` to third party library list

## Are there changes in behavior for the user?

No

## Is it a substantial burden for the maintainers to support this?

No

## Checklist

- [x] Documentation reflects the changes