### PR TITLE
docs: Add exception handling guidance for background tasks

### DIFF
--- a/CHANGES/1870.doc.rst
+++ b/CHANGES/1870.doc.rst
@@ -1,0 +1,1 @@
+Added documentation and examples for exception handling in background tasks created with ``asyncio.create_task()``, addressing silent failure patterns in high-throughput async systems -- by :user:`tsayin4`.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -165,6 +165,7 @@ Hugh Young
 Hugo Herter
 Hugo Hromic
 Hugo van Kemenade
+Hilmi Tuna Sayın
 Hynek Schlawack
 Igor Alexandrov
 Igor Bolshakov

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -158,6 +158,7 @@ Günther Jena
 Hans Adema
 Harmon Y.
 Harry Liu
+Hilmi Tuna Sayın
 Hiroshi Ogawa
 Hrishikesh Paranjape
 Hu Bo
@@ -165,7 +166,6 @@ Hugh Young
 Hugo Herter
 Hugo Hromic
 Hugo van Kemenade
-Hilmi Tuna Sayın
 Hynek Schlawack
 Igor Alexandrov
 Igor Bolshakov

--- a/docs/client_advanced.rst
+++ b/docs/client_advanced.rst
@@ -851,7 +851,7 @@ raised during the request will not propagate to the spawning context:
         async with aiohttp.ClientSession() as session:
             # This exception will be logged but not propagated
             resp = await session.get('http://invalid-url')
-    
+
     # Caller is unaware of the failure
     asyncio.create_task(fetch_in_background())
 
@@ -878,7 +878,7 @@ exceptions without blocking:
             task.result()
         except aiohttp.ClientError as e:
             logger.error(f"Request failed: {e}")
-    
+
     task = asyncio.create_task(session.get('http://example.com'))
     task.add_done_callback(handle_response)
 

--- a/docs/client_quickstart.rst
+++ b/docs/client_quickstart.rst
@@ -89,6 +89,10 @@ should be called in this case, e.g.::
         # ...
     await session.close()
 
+.. warning::
+   When spawning requests as background tasks using ``asyncio.create_task()``,
+   exceptions must be explicitly handled. See :ref:`aiohttp-client-advanced`
+   for details on background task exception handling.
 
 Passing Parameters In URLs
 ==========================

--- a/examples/client_background_tasks.py
+++ b/examples/client_background_tasks.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""
+Background Task Exception Handling
+===================================
+
+Demonstrates proper exception handling for background HTTP requests.
+"""
+
+import asyncio
+import logging
+
+import aiohttp
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+async def unsafe_pattern():
+    """Fire-and-forget without exception handling (unsafe)."""
+    async with aiohttp.ClientSession() as session:
+        # This will fail, but exception only logged to event loop
+        asyncio.create_task(session.get("http://invalid-nonexistent-domain-12345.com"))
+        logger.info("Task spawned, continuing without waiting...")
+
+
+async def safe_pattern_callback():
+    """Fire-and-forget with callback exception handling (safe)."""
+
+    def handle_result(task: asyncio.Task) -> None:
+        try:
+            resp = task.result()
+            logger.info(f"Background request completed with status {resp.status}")
+            resp.release()  # Critical: release connection
+        except aiohttp.ClientError as e:
+            logger.error(f"Background request failed: {e}")
+
+    async with aiohttp.ClientSession() as session:
+        task = asyncio.create_task(session.get("http://httpbin.org/status/500"))
+        task.add_done_callback(handle_result)
+        await asyncio.sleep(2)  # Wait for task to complete
+
+
+async def safe_pattern_gather():
+    """Multiple background tasks using asyncio.gather()."""
+    async with aiohttp.ClientSession() as session:
+        tasks = [
+            session.get("http://httpbin.org/status/200"),
+            session.get("http://httpbin.org/status/500"),
+            session.get("http://invalid-domain-12345.com"),
+        ]
+        
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+        
+        for i, result in enumerate(results):
+            if isinstance(result, Exception):
+                logger.error(f"Task {i} failed: {result}")
+            else:
+                logger.info(f"Task {i} succeeded: {result.status}")
+                result.release()  # Critical: release connection
+
+
+async def main():
+    logger.info("=== UNSAFE PATTERN ===")
+    await unsafe_pattern()
+    await asyncio.sleep(3)  # Wait to see exception logged
+    
+    logger.info("\n=== SAFE PATTERN (CALLBACK) ===")
+    await safe_pattern_callback()
+    
+    logger.info("\n=== SAFE PATTERN (GATHER) ===")
+    await safe_pattern_gather()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/client_background_tasks.py
+++ b/examples/client_background_tasks.py
@@ -48,9 +48,9 @@ async def safe_pattern_gather():
             session.get("http://httpbin.org/status/500"),
             session.get("http://invalid-domain-12345.com"),
         ]
-        
+
         results = await asyncio.gather(*tasks, return_exceptions=True)
-        
+
         for i, result in enumerate(results):
             if isinstance(result, Exception):
                 logger.error(f"Task {i} failed: {result}")
@@ -63,10 +63,10 @@ async def main():
     logger.info("=== UNSAFE PATTERN ===")
     await unsafe_pattern()
     await asyncio.sleep(3)  # Wait to see exception logged
-    
+
     logger.info("\n=== SAFE PATTERN (CALLBACK) ===")
     await safe_pattern_callback()
-    
+
     logger.info("\n=== SAFE PATTERN (GATHER) ===")
     await safe_pattern_gather()
 


### PR DESCRIPTION


## What do these changes do?

Adds documentation and runnable examples explaining how to handle exceptions in background tasks created with asyncio.create_task().

The changes address a common pitfall where developers use fire-and-forget task patterns with aiohttp requests, unaware that exceptions raised in background tasks do not propagate to the spawning context. This can lead to silent failures in production systems.

## Are there changes in behavior for the user?

No behavioral changes to the library. This is documentation-only.

Users will now find:

- A clear warning in the quickstart guide about background task exception handling
- A dedicated section in the advanced guide explaining the semantics
- A runnable example demonstrating both unsafe and safe patterns

## Is it a substantial burden for the maintainers to support this?

No. This is purely additive documentation with no code changes.

- No new APIs or features to maintain
- The example follows existing aiohttp patterns (proper response release, standard ClientSession usage)
- The documented patterns are already recommended best practices in the asyncio ecosystem
- Future maintenance burden is minimal: updates would only be needed if asyncio exception semantics or aiohttp background task guidance changes

## Related issue number

No existing issue. This addresses a documentation gap identified through production experience.

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist (N/A - documentation only)
- [x] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * Will add after PR number is assigned
- [ ] Add a new news fragment into the `CHANGES/` folder
 * Will add after PR number is assigned