### PR TITLE
Add tests for static route resolution with trailing slash

### DIFF
--- a/tests/test_web_urldispatcher.py
+++ b/tests/test_web_urldispatcher.py
@@ -49,6 +49,26 @@ from aiohttp.web_urldispatcher import Resource, SystemRoute
             b"my_file_in_dir</a></li>\n</ul>\n</body>\n</html>",
             id="index_subdir",
         ),
+        pytest.param(
+            True,
+            200,
+            "/static",
+            "/static/",
+            b"<html>\n<head>\n<title>Index of /.</title>\n</head>\n<body>\n<h1>Index of"
+            b' /.</h1>\n<ul>\n<li><a href="/static/my_dir">my_dir/</a></li>\n<li><a href="'
+            b'/static/my_file">my_file</a></li>\n</ul>\n</body>\n</html>',
+            id="index_static_trailing_slash",
+        ),
+        pytest.param(
+            True,
+            200,
+            "/static",
+            "/static/my_dir/",
+            b"<html>\n<head>\n<title>Index of /my_dir</title>\n</head>\n<body>\n<h1>"
+            b'Index of /my_dir</h1>\n<ul>\n<li><a href="/static/my_dir/my_file_in_dir">'
+            b"my_file_in_dir</a></li>\n</ul>\n</body>\n</html>",
+            id="index_subdir_trailing_slash",
+        ),
     ],
 )
 async def test_access_root_of_static_handler(


### PR DESCRIPTION
## What do these changes do?

Add test coverage for static route resolution when URLs include trailing slashes (e.g., `/static/` and `/static/my_dir/`).

## Are there changes in behavior for the user?

No. Tests only.

## Is it a substantial burden for the maintainers to support this?

No. Simple test additions to existing parametrized test.

## Related issue number

Related to #11888 - ensures trailing slash behavior is preserved.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
- [ ] Add a new news fragment into the `CHANGES/` folder
