### PR TITLE
Reject non-ascii characters in some headers (#11886)

### DIFF
--- a/aiohttp/_http_parser.pyx
+++ b/aiohttp/_http_parser.pyx
@@ -419,7 +419,8 @@ cdef class HttpParser:
         headers = CIMultiDictProxy(CIMultiDict(self._headers))
 
         if self._cparser.type == cparser.HTTP_REQUEST:
-            allowed = upgrade and headers.get("upgrade", "").lower() in ALLOWED_UPGRADES
+            h_upg = headers.get("upgrade", "")
+            allowed = upgrade and h_upg.isascii() and h_upg.lower() in ALLOWED_UPGRADES
             if allowed or self._cparser.method == cparser.HTTP_CONNECT:
                 self._upgraded = True
         else:
@@ -434,8 +435,7 @@ cdef class HttpParser:
         enc = self._content_encoding
         if enc is not None:
             self._content_encoding = None
-            enc = enc.lower()
-            if enc in ('gzip', 'deflate', 'br', 'zstd'):
+            if enc.isascii() and enc.lower() in {"gzip", "deflate", "br", "zstd"}:
                 encoding = enc
 
         if self._cparser.type == cparser.HTTP_REQUEST:


### PR DESCRIPTION
(cherry picked from commit 5affd64f86d28a16a8f8e6fea2d217c99bf7831f)