### PR TITLE
Add Windows 11 ARM64 to CI/CD workflow matrix

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -372,7 +372,7 @@ jobs:
     needs: pre-deploy
     strategy:
       matrix:
-        os: ["ubuntu-latest", "windows-latest", "macos-latest", "ubuntu-24.04-arm"]
+        os: ["ubuntu-latest", "windows-latest", "windows-11-arm", "macos-latest", "ubuntu-24.04-arm"]
         qemu: ['']
         musl: [""]
         include:

--- a/CHANGES/11937.misc.rst
+++ b/CHANGES/11937.misc.rst
@@ -1,0 +1,2 @@
+Added win_arm64 to the wheels that gets pushed to PyPI
+-- by :user:`AraHaan`.


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
This adds the Windows 11 arm64 runner image for github actions to the CI/CD workflow matrix to ensure that the win_arm64 wheel gets built. Without this I cannot use ``--platform`` that passes in ``win_arm64`` into pip to install all of the packages in my ``requirements.txt`` which include ``discord.py``, ``asqlite``, and ``aiohttp``. With this change there is a chance that aiohttp could get a win_arm64 wheel published to pypi just like with ``yarl`` and ``multidict`` to name a few binary packages that are dependencies of aiohttp.

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->
No changes, other than allowing one to pip install aiohttp using it's ``--platform`` argument which forces install from wheels as the only valid option, without arm64 wheels it will try to install version ``0.13.1`` of aiohttp which is not supported in many packages (many packages supports ``aiohttp<4,>=3.7.4,`` only).

## Is it a substantial burden for the maintainers to support this?

<!--
Stop right there! Pause. Just for a minute... Can you think of anything
obvious that would complicate the ongoing development of this project?

Try to consider if you'd be able to maintain it throughout the next
5 years. Does it seem viable? Tell us your thoughts! We'd very much
love to hear what the consequences of merging this patch might be...

This will help us assess if your change is something we'd want to
entertain early in the review process. Thank you in advance!
-->
Nope, all this does is adds the new arm64 windows github actions runner to build the win_arm64 wheel for publish to pypi.

## Related issue number

<!-- Will this resolve any open issues? -->
<!-- Remember to prefix with 'Fixes' if it closes an issue (e.g. 'Fixes #123'). -->
Fixes #11937

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist (I doubt unit tests are needed for a minor CI change)
- [x] Documentation reflects the changes (No doc changes are needed)
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt` (No code changes are provided.)
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES/` folder
  * name it `<issue_or_pr_num>.<type>.rst` (e.g. `588.bugfix.rst`)
  * if you don't have an issue number, change it to the pull request
    number after creating the PR
    * `.bugfix`: A bug fix for something the maintainers deemed an
      improper undesired behavior that got corrected to match
      pre-agreed expectations.
    * `.feature`: A new behavior, public APIs. That sort of stuff.
    * `.deprecation`: A declaration of future API removals and breaking
      changes in behavior.
    * `.breaking`: When something public is removed in a breaking way.
      Could be deprecated in an earlier release.
    * `.doc`: Notable updates to the documentation structure or build
      process.
    * `.packaging`: Notes for downstreams about unobvious side effects
      and tooling. Changes in the test invocation considerations and
      runtime assumptions.
    * `.contrib`: Stuff that affects the contributor experience. e.g.
      Running tests, building the docs, setting up the development
      environment.
    * `.misc`: Changes that are hard to assign to any of the above
      categories.
  * Make sure to use full sentences with correct case and punctuation,
    for example:
    ```rst
    Fixed issue with non-ascii contents in doctest text files
    -- by :user:`contributor-gh-handle`.
    ```

    Use the past tense or the present tense a non-imperative mood,
    referring to what's changed compared to the last released version
    of this project.
