### PR TITLE
Restore BodyPartReader.decode() as sync method, add decode_async() for non-blocking decompression

### DIFF
--- a/CHANGES/11898.bugfix.rst
+++ b/CHANGES/11898.bugfix.rst
@@ -1,0 +1,6 @@
+Restored :py:meth:`~aiohttp.BodyPartReader.decode` as a synchronous method
+for backward compatibility. The method was inadvertently changed to async
+in 3.13.3 as part of the decompression bomb security fix. A new
+:py:meth:`~aiohttp.BodyPartReader.decode_async` method is now available
+for non-blocking decompression of large payloads. Internal aiohttp code
+uses the async variant to maintain security protections -- by :user:`bdraco`.

--- a/aiohttp/multipart.py
+++ b/aiohttp/multipart.py
@@ -314,7 +314,7 @@ class BodyPartReader:
             data.extend(await self.read_chunk(self.chunk_size))
         # https://github.com/python/mypy/issues/17537
         if decode:  # type: ignore[unreachable]
-            return await self.decode(data)
+            return await self.decode_async(data)
         return data
 
     async def read_chunk(self, size: int = chunk_size) -> bytes:
@@ -492,20 +492,51 @@ class BodyPartReader:
         """Returns True if the boundary was reached or False otherwise."""
         return self._at_eof
 
-    async def decode(self, data: bytes) -> bytes:
-        """Decodes data.
+    def decode(self, data: bytes) -> bytes:
+        """Decodes data synchronously.
 
-        Decoding is done according the specified Content-Encoding
+        Decodes data according the specified Content-Encoding
         or Content-Transfer-Encoding headers value.
+
+        Note: For large payloads, consider using decode_async() instead
+        to avoid blocking the event loop during decompression.
         """
         if CONTENT_TRANSFER_ENCODING in self.headers:
             data = self._decode_content_transfer(data)
         # https://datatracker.ietf.org/doc/html/rfc7578#section-4.8
         if not self._is_form_data and CONTENT_ENCODING in self.headers:
-            return await self._decode_content(data)
+            return self._decode_content(data)
         return data
 
-    async def _decode_content(self, data: bytes) -> bytes:
+    async def decode_async(self, data: bytes) -> bytes:
+        """Decodes data asynchronously.
+
+        Decodes data according the specified Content-Encoding
+        or Content-Transfer-Encoding headers value.
+
+        This method offloads decompression to an executor for large payloads
+        to avoid blocking the event loop.
+        """
+        if CONTENT_TRANSFER_ENCODING in self.headers:
+            data = self._decode_content_transfer(data)
+        # https://datatracker.ietf.org/doc/html/rfc7578#section-4.8
+        if not self._is_form_data and CONTENT_ENCODING in self.headers:
+            return await self._decode_content_async(data)
+        return data
+
+    def _decode_content(self, data: bytes) -> bytes:
+        encoding = self.headers.get(CONTENT_ENCODING, "").lower()
+        if encoding == "identity":
+            return data
+        if encoding in {"deflate", "gzip"}:
+            return ZLibDecompressor(
+                encoding=encoding,
+                suppress_deflate_header=True,
+            ).decompress_sync(data, max_length=self._max_decompress_size)
+
+        raise RuntimeError(f"unknown content encoding: {encoding}")
+
+    async def _decode_content_async(self, data: bytes) -> bytes:
         encoding = self.headers.get(CONTENT_ENCODING, "").lower()
         if encoding == "identity":
             return data
@@ -588,7 +619,7 @@ class BodyPartReaderPayload(Payload):
         field = self._value
         chunk = await field.read_chunk(size=2**16)
         while chunk:
-            await writer.write(await field.decode(chunk))
+            await writer.write(await field.decode_async(chunk))
             chunk = await field.read_chunk(size=2**16)
 
 

--- a/aiohttp/web_request.py
+++ b/aiohttp/web_request.py
@@ -716,7 +716,7 @@ class BaseRequest(MutableMapping[str | RequestKey[Any], Any], HeadersMixin):
                         )
                         chunk = await field.read_chunk(size=2**16)
                         while chunk:
-                            chunk = await field.decode(chunk)
+                            chunk = await field.decode_async(chunk)
                             await self._loop.run_in_executor(None, tmp.write, chunk)
                             size += len(chunk)
                             if 0 < max_size < size:

--- a/docs/multipart_reference.rst
+++ b/docs/multipart_reference.rst
@@ -102,7 +102,7 @@ Multipart reference
 
    .. method:: decode(data)
 
-      Decodes data according the specified ``Content-Encoding``
+      Decodes data synchronously according the specified ``Content-Encoding``
       or ``Content-Transfer-Encoding`` headers value.
 
       Supports ``gzip``, ``deflate`` and ``identity`` encodings for
@@ -116,6 +116,34 @@ Multipart reference
       :raises: :exc:`RuntimeError` - if encoding is unknown.
 
       :rtype: bytes
+
+      .. note::
+
+         For large payloads, consider using :meth:`decode_async` instead
+         to avoid blocking the event loop during decompression.
+
+   .. method:: decode_async(data)
+      :async:
+
+      Decodes data asynchronously according the specified ``Content-Encoding``
+      or ``Content-Transfer-Encoding`` headers value.
+
+      This method offloads decompression to an executor for large payloads
+      to avoid blocking the event loop.
+
+      Supports ``gzip``, ``deflate`` and ``identity`` encodings for
+      ``Content-Encoding`` header.
+
+      Supports ``base64``, ``quoted-printable``, ``binary`` encodings for
+      ``Content-Transfer-Encoding`` header.
+
+      :param bytearray data: Data to decode.
+
+      :raises: :exc:`RuntimeError` - if encoding is unknown.
+
+      :rtype: bytes
+
+      .. versionadded:: 3.13.4
 
    .. method:: get_charset(default=None)
 

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -394,7 +394,17 @@ class TestPartReader:
             result = b""
             while not obj.at_eof():
                 chunk = await obj.read_chunk(size=6)
-                result += await obj.decode(chunk)
+                result += obj.decode(chunk)
+        assert b"Time to Relax!" == result
+
+    async def test_decode_async_with_content_transfer_encoding_base64(self) -> None:
+        h = CIMultiDictProxy(CIMultiDict({CONTENT_TRANSFER_ENCODING: "base64"}))
+        with Stream(b"VG\r\r\nltZSB0byBSZ\r\nWxheCE=\r\n--:--") as stream:
+            obj = aiohttp.BodyPartReader(BOUNDARY, h, stream)
+            result = b""
+            while not obj.at_eof():
+                chunk = await obj.read_chunk(size=6)
+                result += await obj.decode_async(chunk)
         assert b"Time to Relax!" == result
 
     async def test_read_with_content_transfer_encoding_quoted_printable(self) -> None:


### PR DESCRIPTION
## What do these changes do?

This PR fixes an unintentional breaking API change introduced in 3.13.3 where `BodyPartReader.decode()` was changed from a synchronous method to an async method as a side effect of the decompression bomb security fix (GHSA-6mq8-rvhq-8wgg).

The fix:
1. Restores `decode()` as a synchronous method for backward compatibility
2. Adds a new `decode_async()` method that offloads decompression to an executor for large payloads
3. Updates internal aiohttp code to use `decode_async()` to maintain security protections

Both methods include the `max_length` parameter for decompression bomb protection.

## Are there changes in behavior for the user?

- Users who upgraded to 3.13.3 and were broken by the async `decode()` change can now use the sync `decode()` method again
- Users who want non-blocking decompression for large payloads can use the new `decode_async()` method
- Internal aiohttp methods like `read(decode=True)` continue to use the secure async path

## Is it a substantial burden for the maintainers to support this?

No. This is a minimal change that adds one new public method (`decode_async`) while restoring the original behavior of `decode()`. The two methods share the same logic with the only difference being sync vs async decompression. The maintenance burden is low as both code paths are simple and well-tested.

## Related issue number

Fixes the regression introduced in #11898 (decompression bomb security fix)

Related to GHSA-6mq8-rvhq-8wgg

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
- [x] Add a new news fragment into the `CHANGES/` folder
