### PR TITLE
[PR #11940/a47740c backport][3.14] Restore BodyPartReader.decode() as sync method, add decode_async() for non-blocking decompression

### DIFF
--- a/CHANGES/11898.bugfix.rst
+++ b/CHANGES/11898.bugfix.rst
@@ -1,0 +1,6 @@
+Restored :py:meth:`~aiohttp.BodyPartReader.decode` as a synchronous method
+for backward compatibility. The method was inadvertently changed to async
+in 3.13.3 as part of the decompression bomb security fix. A new
+:py:meth:`~aiohttp.BodyPartReader.decode_async` method is now available
+for non-blocking decompression of large payloads. Internal aiohttp code
+uses the async variant to maintain security protections -- by :user:`bdraco`.

--- a/aiohttp/multipart.py
+++ b/aiohttp/multipart.py
@@ -312,8 +312,7 @@ class BodyPartReader:
         data = bytearray()
         while not self._at_eof:
             data.extend(await self.read_chunk(self.chunk_size))
-        # https://github.com/python/mypy/issues/17537
-        if decode:  # type: ignore[unreachable]
+        if decode:
             return await self.decode_async(data)
         return data
 

--- a/aiohttp/web_request.py
+++ b/aiohttp/web_request.py
@@ -749,7 +749,7 @@ class BaseRequest(MutableMapping[str | RequestKey[Any], Any], HeadersMixin):
                         )
                         chunk = await field.read_chunk(size=2**16)
                         while chunk:
-                            chunk = await field.decode(chunk)
+                            chunk = await field.decode_async(chunk)
                             await self._loop.run_in_executor(None, tmp.write, chunk)
                             size += len(chunk)
                             if 0 < max_size < size:

--- a/docs/multipart_reference.rst
+++ b/docs/multipart_reference.rst
@@ -102,7 +102,7 @@ Multipart reference
 
    .. method:: decode(data)
 
-      Decodes data according the specified ``Content-Encoding``
+      Decodes data synchronously according the specified ``Content-Encoding``
       or ``Content-Transfer-Encoding`` headers value.
 
       Supports ``gzip``, ``deflate`` and ``identity`` encodings for
@@ -116,6 +116,34 @@ Multipart reference
       :raises: :exc:`RuntimeError` - if encoding is unknown.
 
       :rtype: bytes
+
+      .. note::
+
+         For large payloads, consider using :meth:`decode_async` instead
+         to avoid blocking the event loop during decompression.
+
+   .. method:: decode_async(data)
+      :async:
+
+      Decodes data asynchronously according the specified ``Content-Encoding``
+      or ``Content-Transfer-Encoding`` headers value.
+
+      This method offloads decompression to an executor for large payloads
+      to avoid blocking the event loop.
+
+      Supports ``gzip``, ``deflate`` and ``identity`` encodings for
+      ``Content-Encoding`` header.
+
+      Supports ``base64``, ``quoted-printable``, ``binary`` encodings for
+      ``Content-Transfer-Encoding`` header.
+
+      :param bytearray data: Data to decode.
+
+      :raises: :exc:`RuntimeError` - if encoding is unknown.
+
+      :rtype: bytes
+
+      .. versionadded:: 3.13.4
 
    .. method:: get_charset(default=None)
 

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -391,6 +391,53 @@ class TestPartReader:
             result = await obj.read(decode=True)
         assert b"Time to Relax!" == result
 
+    async def test_decode_with_content_transfer_encoding_base64(self) -> None:
+        h = CIMultiDictProxy(CIMultiDict({CONTENT_TRANSFER_ENCODING: "base64"}))
+        with Stream(b"VG\r\r\nltZSB0byBSZ\r\nWxheCE=\r\n--:--") as stream:
+            obj = aiohttp.BodyPartReader(BOUNDARY, h, stream)
+            result = b""
+            while not obj.at_eof():
+                chunk = await obj.read_chunk(size=6)
+                result += obj.decode(chunk)
+        assert b"Time to Relax!" == result
+
+    async def test_decode_async_with_content_transfer_encoding_base64(self) -> None:
+        h = CIMultiDictProxy(CIMultiDict({CONTENT_TRANSFER_ENCODING: "base64"}))
+        with Stream(b"VG\r\r\nltZSB0byBSZ\r\nWxheCE=\r\n--:--") as stream:
+            obj = aiohttp.BodyPartReader(BOUNDARY, h, stream)
+            result = b""
+            while not obj.at_eof():
+                chunk = await obj.read_chunk(size=6)
+                result += await obj.decode_async(chunk)
+        assert b"Time to Relax!" == result
+
+    async def test_decode_with_content_encoding_deflate(self) -> None:
+        h = CIMultiDictProxy(CIMultiDict({CONTENT_ENCODING: "deflate"}))
+        data = b"\x0b\xc9\xccMU(\xc9W\x08J\xcdI\xacP\x04\x00"
+        with Stream(data + b"\r\n--:--") as stream:
+            obj = aiohttp.BodyPartReader(BOUNDARY, h, stream)
+            chunk = await obj.read_chunk(size=len(data))
+            result = obj.decode(chunk)
+        assert b"Time to Relax!" == result
+
+    async def test_decode_with_content_encoding_identity(self) -> None:
+        h = CIMultiDictProxy(CIMultiDict({CONTENT_ENCODING: "identity"}))
+        data = b"Time to Relax!"
+        with Stream(data + b"\r\n--:--") as stream:
+            obj = aiohttp.BodyPartReader(BOUNDARY, h, stream)
+            chunk = await obj.read_chunk(size=len(data))
+            result = obj.decode(chunk)
+        assert data == result
+
+    async def test_decode_with_content_encoding_unknown(self) -> None:
+        h = CIMultiDictProxy(CIMultiDict({CONTENT_ENCODING: "snappy"}))
+        data = b"Time to Relax!"
+        with Stream(data + b"\r\n--:--") as stream:
+            obj = aiohttp.BodyPartReader(BOUNDARY, h, stream)
+            chunk = await obj.read_chunk(size=len(data))
+            with pytest.raises(RuntimeError, match="unknown content encoding"):
+                obj.decode(chunk)
+
     async def test_read_with_content_transfer_encoding_quoted_printable(self) -> None:
         with Stream(
             b"=D0=9F=D1=80=D0=B8=D0=B2=D0=B5=D1=82,"
@@ -407,17 +454,6 @@ class TestPartReader:
             b" \xd0\xbc\xd0\xb8\xd1\x80!"
         )
         assert result == expected
-
-    async def test_decode_with_content_transfer_encoding_base64(self) -> None:
-        with Stream(b"VG\r\r\nltZSB0byBSZ\r\nWxheCE=\r\n--:--") as stream:
-            obj = aiohttp.BodyPartReader(
-                BOUNDARY, {CONTENT_TRANSFER_ENCODING: "base64"}, stream
-            )
-            result = b""
-            while not obj.at_eof():
-                chunk = await obj.read_chunk(size=6)
-                result += await obj.decode(chunk)
-        assert b"Time to Relax!" == result
 
     @pytest.mark.parametrize("encoding", ("binary", "8bit", "7bit"))
     async def test_read_with_content_transfer_encoding_binary(


### PR DESCRIPTION
(cherry picked from commit a47740c093dcc5291fb7e43788a9432b20093834)
