### PR TITLE
[PR #11940/a47740c backport][3.13] Restore BodyPartReader.decode() as sync method, add decode_async() for non-blocking decompression

### DIFF
--- a/CHANGES/11898.bugfix.rst
+++ b/CHANGES/11898.bugfix.rst
@@ -1,0 +1,6 @@
+Restored :py:meth:`~aiohttp.BodyPartReader.decode` as a synchronous method
+for backward compatibility. The method was inadvertently changed to async
+in 3.13.3 as part of the decompression bomb security fix. A new
+:py:meth:`~aiohttp.BodyPartReader.decode_async` method is now available
+for non-blocking decompression of large payloads. Internal aiohttp code
+uses the async variant to maintain security protections -- by :user:`bdraco`.

--- a/aiohttp/multipart.py
+++ b/aiohttp/multipart.py
@@ -324,8 +324,9 @@ class BodyPartReader:
         data = bytearray()
         while not self._at_eof:
             data.extend(await self.read_chunk(self.chunk_size))
-        if decode:
-            return await self.decode(data)
+        # https://github.com/python/mypy/issues/17537
+        if decode:  # type: ignore[unreachable]
+            return await self.decode_async(data)
         return data
 
     async def read_chunk(self, size: int = chunk_size) -> bytes:
@@ -503,20 +504,58 @@ class BodyPartReader:
         """Returns True if the boundary was reached or False otherwise."""
         return self._at_eof
 
-    async def decode(self, data: bytes) -> bytes:
-        """Decodes data.
-
-        Decoding is done according the specified Content-Encoding
-        or Content-Transfer-Encoding headers value.
-        """
+    def _apply_content_transfer_decoding(self, data: bytes) -> bytes:
+        """Apply Content-Transfer-Encoding decoding if header is present."""
         if CONTENT_TRANSFER_ENCODING in self.headers:
-            data = self._decode_content_transfer(data)
-        # https://datatracker.ietf.org/doc/html/rfc7578#section-4.8
-        if not self._is_form_data and CONTENT_ENCODING in self.headers:
-            return await self._decode_content(data)
+            return self._decode_content_transfer(data)
         return data
 
-    async def _decode_content(self, data: bytes) -> bytes:
+    def _needs_content_decoding(self) -> bool:
+        """Check if Content-Encoding decoding should be applied."""
+        # https://datatracker.ietf.org/doc/html/rfc7578#section-4.8
+        return not self._is_form_data and CONTENT_ENCODING in self.headers
+
+    def decode(self, data: bytes) -> bytes:
+        """Decodes data synchronously.
+
+        Decodes data according the specified Content-Encoding
+        or Content-Transfer-Encoding headers value.
+
+        Note: For large payloads, consider using decode_async() instead
+        to avoid blocking the event loop during decompression.
+        """
+        data = self._apply_content_transfer_decoding(data)
+        if self._needs_content_decoding():
+            return self._decode_content(data)
+        return data
+
+    async def decode_async(self, data: bytes) -> bytes:
+        """Decodes data asynchronously.
+
+        Decodes data according the specified Content-Encoding
+        or Content-Transfer-Encoding headers value.
+
+        This method offloads decompression to an executor for large payloads
+        to avoid blocking the event loop.
+        """
+        data = self._apply_content_transfer_decoding(data)
+        if self._needs_content_decoding():
+            return await self._decode_content_async(data)
+        return data
+
+    def _decode_content(self, data: bytes) -> bytes:
+        encoding = self.headers.get(CONTENT_ENCODING, "").lower()
+        if encoding == "identity":
+            return data
+        if encoding in {"deflate", "gzip"}:
+            return ZLibDecompressor(
+                encoding=encoding,
+                suppress_deflate_header=True,
+            ).decompress_sync(data, max_length=self._max_decompress_size)
+
+        raise RuntimeError(f"unknown content encoding: {encoding}")
+
+    async def _decode_content_async(self, data: bytes) -> bytes:
         encoding = self.headers.get(CONTENT_ENCODING, "").lower()
         if encoding == "identity":
             return data
@@ -599,7 +638,7 @@ class BodyPartReaderPayload(Payload):
         field = self._value
         chunk = await field.read_chunk(size=2**16)
         while chunk:
-            await writer.write(await field.decode(chunk))
+            await writer.write(await field.decode_async(chunk))
             chunk = await field.read_chunk(size=2**16)
 
 

--- a/aiohttp/multipart.py
+++ b/aiohttp/multipart.py
@@ -324,8 +324,7 @@ class BodyPartReader:
         data = bytearray()
         while not self._at_eof:
             data.extend(await self.read_chunk(self.chunk_size))
-        # https://github.com/python/mypy/issues/17537
-        if decode:  # type: ignore[unreachable]
+        if decode:
             return await self.decode_async(data)
         return data
 

--- a/aiohttp/web_request.py
+++ b/aiohttp/web_request.py
@@ -740,7 +740,7 @@ class BaseRequest(MutableMapping[str, Any], HeadersMixin):
                         )
                         chunk = await field.read_chunk(size=2**16)
                         while chunk:
-                            chunk = await field.decode(chunk)
+                            chunk = await field.decode_async(chunk)
                             await self._loop.run_in_executor(None, tmp.write, chunk)
                             size += len(chunk)
                             if 0 < max_size < size:

--- a/docs/multipart_reference.rst
+++ b/docs/multipart_reference.rst
@@ -102,7 +102,7 @@ Multipart reference
 
    .. method:: decode(data)
 
-      Decodes data according the specified ``Content-Encoding``
+      Decodes data synchronously according the specified ``Content-Encoding``
       or ``Content-Transfer-Encoding`` headers value.
 
       Supports ``gzip``, ``deflate`` and ``identity`` encodings for
@@ -116,6 +116,34 @@ Multipart reference
       :raises: :exc:`RuntimeError` - if encoding is unknown.
 
       :rtype: bytes
+
+      .. note::
+
+         For large payloads, consider using :meth:`decode_async` instead
+         to avoid blocking the event loop during decompression.
+
+   .. method:: decode_async(data)
+      :async:
+
+      Decodes data asynchronously according the specified ``Content-Encoding``
+      or ``Content-Transfer-Encoding`` headers value.
+
+      This method offloads decompression to an executor for large payloads
+      to avoid blocking the event loop.
+
+      Supports ``gzip``, ``deflate`` and ``identity`` encodings for
+      ``Content-Encoding`` header.
+
+      Supports ``base64``, ``quoted-printable``, ``binary`` encodings for
+      ``Content-Transfer-Encoding`` header.
+
+      :param bytearray data: Data to decode.
+
+      :raises: :exc:`RuntimeError` - if encoding is unknown.
+
+      :rtype: bytes
+
+      .. versionadded:: 3.13.4
 
    .. method:: get_charset(default=None)
 


### PR DESCRIPTION
(cherry picked from commit a47740c093dcc5291fb7e43788a9432b20093834)
