### PR TITLE
Add max_headers parameter

### DIFF
--- a/CHANGES/11955.feature.rst
+++ b/CHANGES/11955.feature.rst
@@ -1,0 +1,1 @@
+Added ``max_headers`` parameter to limit the number of headers that should be read from a response -- by :user:`Dreamsorcerer`.

--- a/aiohttp/_http_parser.pyx
+++ b/aiohttp/_http_parser.pyx
@@ -679,8 +679,7 @@ cdef int cb_on_url(cparser.llhttp_t* parser,
     cdef HttpParser pyparser = <HttpParser>parser.data
     try:
         if length > pyparser._max_line_size:
-            raise LineTooLong(
-                'Status line is too long', pyparser._max_line_size, length)
+            raise LineTooLong(b"Status line is too long", pyparser._max_line_size, length)
         extend(pyparser._buf, at, length)
     except BaseException as ex:
         pyparser._last_error = ex
@@ -695,8 +694,7 @@ cdef int cb_on_status(cparser.llhttp_t* parser,
     cdef str reason
     try:
         if length > pyparser._max_line_size:
-            raise LineTooLong(
-                'Status line is too long', pyparser._max_line_size, length)
+            raise LineTooLong(b"Status line is too long", pyparser._max_line_size, length)
         extend(pyparser._buf, at, length)
     except BaseException as ex:
         pyparser._last_error = ex
@@ -713,8 +711,7 @@ cdef int cb_on_header_field(cparser.llhttp_t* parser,
         pyparser._on_status_complete()
         size = len(pyparser._raw_name) + length
         if size > pyparser._max_field_size:
-            raise LineTooLong(
-                'Header name is too long', pyparser._max_field_size, size)
+            raise LineTooLong(b"Header name is too long", pyparser._max_field_size, size)
         pyparser._on_header_field(at, length)
     except BaseException as ex:
         pyparser._last_error = ex
@@ -730,8 +727,7 @@ cdef int cb_on_header_value(cparser.llhttp_t* parser,
     try:
         size = len(pyparser._raw_value) + length
         if size > pyparser._max_field_size:
-            raise LineTooLong(
-                'Header value is too long', pyparser._max_field_size, size)
+            raise LineTooLong(b"Header value is too long", pyparser._max_field_size, size)
         pyparser._on_header_value(at, length)
     except BaseException as ex:
         pyparser._last_error = ex

--- a/aiohttp/_http_parser.pyx
+++ b/aiohttp/_http_parser.pyx
@@ -329,7 +329,7 @@ cdef class HttpParser:
         self, cparser.llhttp_type mode,
         object protocol, object loop, int limit,
         object timer=None,
-        size_t max_line_size=8190, size_t max_headers=32768,
+        size_t max_line_size=8190, size_t max_headers=128,
         size_t max_field_size=8190, payload_exception=None,
         bint response_with_body=True, bint read_until_eof=False,
         bint auto_decompress=True,
@@ -383,6 +383,8 @@ cdef class HttpParser:
             value = self._raw_value.decode('utf-8', 'surrogateescape')
 
             self._headers.append((name, value))
+            if len(self._headers) > self._max_headers:
+                raise BadHttpMessage("Too many headers received")
 
             if name is CONTENT_ENCODING:
                 self._content_encoding = value
@@ -574,7 +576,7 @@ cdef class HttpRequestParser(HttpParser):
 
     def __init__(
         self, protocol, loop, int limit, timer=None,
-        size_t max_line_size=8190, size_t max_headers=32768,
+        size_t max_line_size=8190, size_t max_headers=128,
         size_t max_field_size=8190, payload_exception=None,
         bint response_with_body=True, bint read_until_eof=False,
         bint auto_decompress=True,
@@ -638,7 +640,7 @@ cdef class HttpResponseParser(HttpParser):
 
     def __init__(
         self, protocol, loop, int limit, timer=None,
-            size_t max_line_size=8190, size_t max_headers=32768,
+            size_t max_line_size=8190, size_t max_headers=128,
             size_t max_field_size=8190, payload_exception=None,
             bint response_with_body=True, bint read_until_eof=False,
             bint auto_decompress=True

--- a/aiohttp/_http_parser.pyx
+++ b/aiohttp/_http_parser.pyx
@@ -679,7 +679,7 @@ cdef int cb_on_url(cparser.llhttp_t* parser,
     cdef HttpParser pyparser = <HttpParser>parser.data
     try:
         if length > pyparser._max_line_size:
-            raise LineTooLong(b"Status line is too long", pyparser._max_line_size, length)
+            raise LineTooLong(b"Status line is too long", pyparser._max_line_size)
         extend(pyparser._buf, at, length)
     except BaseException as ex:
         pyparser._last_error = ex
@@ -694,7 +694,7 @@ cdef int cb_on_status(cparser.llhttp_t* parser,
     cdef str reason
     try:
         if length > pyparser._max_line_size:
-            raise LineTooLong(b"Status line is too long", pyparser._max_line_size, length)
+            raise LineTooLong(b"Status line is too long", pyparser._max_line_size)
         extend(pyparser._buf, at, length)
     except BaseException as ex:
         pyparser._last_error = ex
@@ -711,7 +711,7 @@ cdef int cb_on_header_field(cparser.llhttp_t* parser,
         pyparser._on_status_complete()
         size = len(pyparser._raw_name) + length
         if size > pyparser._max_field_size:
-            raise LineTooLong(b"Header name is too long", pyparser._max_field_size, size)
+            raise LineTooLong(b"Header name is too long", pyparser._max_field_size)
         pyparser._on_header_field(at, length)
     except BaseException as ex:
         pyparser._last_error = ex
@@ -727,7 +727,7 @@ cdef int cb_on_header_value(cparser.llhttp_t* parser,
     try:
         size = len(pyparser._raw_value) + length
         if size > pyparser._max_field_size:
-            raise LineTooLong(b"Header value is too long", pyparser._max_field_size, size)
+            raise LineTooLong(b"Header value is too long", pyparser._max_field_size)
         pyparser._on_header_value(at, length)
     except BaseException as ex:
         pyparser._last_error = ex

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -194,6 +194,7 @@ class _RequestOptions(TypedDict, total=False):
     auto_decompress: bool | None
     max_line_size: int | None
     max_field_size: int | None
+    max_headers: int | None
     middlewares: Sequence[ClientMiddlewareType] | None
 
 
@@ -317,6 +318,7 @@ class ClientSession:
         read_bufsize: int = 2**16,
         max_line_size: int = 8190,
         max_field_size: int = 8190,
+        max_headers: int = 128,
         fallback_charset_resolver: _CharsetResolver = lambda r, b: "utf-8",
         middlewares: Sequence[ClientMiddlewareType] = (),
         ssl_shutdown_timeout: _SENTINEL | None | float = sentinel,
@@ -386,6 +388,7 @@ class ClientSession:
         self._read_bufsize = read_bufsize
         self._max_line_size = max_line_size
         self._max_field_size = max_field_size
+        self._max_headers = max_headers
 
         # Convert to list of tuples
         if headers:
@@ -485,6 +488,7 @@ class ClientSession:
         auto_decompress: bool | None = None,
         max_line_size: int | None = None,
         max_field_size: int | None = None,
+        max_headers: int | None = None,
         middlewares: Sequence[ClientMiddlewareType] | None = None,
     ) -> ClientResponse:
         # NOTE: timeout clamps existing connect and read timeouts.  We cannot
@@ -570,6 +574,9 @@ class ClientSession:
 
         if max_field_size is None:
             max_field_size = self._max_field_size
+
+        if max_headers is None:
+            max_headers = self._max_headers
 
         traces = [
             Trace(
@@ -710,6 +717,7 @@ class ClientSession:
                             timeout_ceil_threshold=self._connector._timeout_ceil_threshold,
                             max_line_size=max_line_size,
                             max_field_size=max_field_size,
+                            max_headers=max_headers,
                         )
                         try:
                             resp = await req._send(conn)

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -284,6 +284,7 @@ class ClientSession:
         "_read_bufsize",
         "_max_line_size",
         "_max_field_size",
+        "_max_headers",
         "_resolve_charset",
         "_default_proxy",
         "_default_proxy_auth",

--- a/aiohttp/client_proto.py
+++ b/aiohttp/client_proto.py
@@ -230,6 +230,7 @@ class ResponseHandler(BaseProtocol, DataQueue[tuple[RawResponseMessage, StreamRe
         timeout_ceil_threshold: float = 5,
         max_line_size: int = 8190,
         max_field_size: int = 8190,
+        max_headers: int = 128,
     ) -> None:
         self._skip_payload = skip_payload
 
@@ -248,6 +249,7 @@ class ResponseHandler(BaseProtocol, DataQueue[tuple[RawResponseMessage, StreamRe
             auto_decompress=auto_decompress,
             max_line_size=max_line_size,
             max_field_size=max_field_size,
+            max_headers=max_headers,
         )
 
         if self._tail:

--- a/aiohttp/http_exceptions.py
+++ b/aiohttp/http_exceptions.py
@@ -78,7 +78,7 @@ class DecompressSizeError(PayloadEncodingError):
 
 
 class LineTooLong(BadHttpMessage):
-    def __init__(self, line: bytes, limit: str = "Unknown") -> None:
+    def __init__(self, line: bytes, limit: int) -> None:
         super().__init__(f"Got more than {limit} bytes when reading: {line!r}.")
         self.args = (line, limit)
 

--- a/aiohttp/http_exceptions.py
+++ b/aiohttp/http_exceptions.py
@@ -78,13 +78,9 @@ class DecompressSizeError(PayloadEncodingError):
 
 
 class LineTooLong(BadHttpMessage):
-    def __init__(
-        self, line: bytes, limit: str = "Unknown", actual_size: str = "Unknown"
-    ) -> None:
-        super().__init__(
-            f"Got more than {limit} bytes ({actual_size}) when reading {line}."
-        )
-        self.args = (line, limit, actual_size)
+    def __init__(self, line: bytes, limit: str = "Unknown") -> None:
+        super().__init__(f"Got more than {limit} bytes when reading: {line!r}.")
+        self.args = (line, limit)
 
 
 class InvalidHeader(BadHttpMessage):

--- a/aiohttp/http_exceptions.py
+++ b/aiohttp/http_exceptions.py
@@ -79,7 +79,7 @@ class DecompressSizeError(PayloadEncodingError):
 
 class LineTooLong(BadHttpMessage):
     def __init__(
-        self, line: str, limit: str = "Unknown", actual_size: str = "Unknown"
+        self, line: bytes, limit: str = "Unknown", actual_size: str = "Unknown"
     ) -> None:
         super().__init__(
             f"Got more than {limit} bytes ({actual_size}) when reading {line}."

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -823,9 +823,7 @@ class HttpPayloadParser:
                 if self._chunk == ChunkState.PARSE_TRAILERS:
                     max_line_length = self._max_field_size
                 if len(self._chunk_tail) > max_line_length:
-                    raise LineTooLong(
-                        self._chunk_tail[:100] + b"...", max_line_length
-                    )
+                    raise LineTooLong(self._chunk_tail[:100] + b"...", max_line_length)
 
                 chunk = self._chunk_tail + chunk
                 self._chunk_tail = b""

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -164,9 +164,7 @@ class HeadersParser:
                     header_length += len(line)
                     if header_length > self.max_field_size:
                         raise LineTooLong(
-                            "request header field {}".format(
-                                bname.decode("utf8", "backslashreplace")
-                            ),
+                            b"request header field: " + bname,
                             str(self.max_field_size),
                             str(header_length),
                         )
@@ -304,7 +302,7 @@ class HttpParser(abc.ABC, Generic[_MsgT]):
                     line_length = len(line)
                     if line_length > max_line_length:
                         raise LineTooLong(
-                            line[:100].decode() + "...",
+                            line[:100] + b"...",
                             str(max_line_length),
                             str(line_length),
                         )
@@ -441,7 +439,7 @@ class HttpParser(abc.ABC, Generic[_MsgT]):
                     tail_length = len(self._tail)
                     if tail_length > self.max_line_size:
                         raise LineTooLong(
-                            self._tail[:100].decode() + "...",
+                            self._tail[:100] + b"...",
                             str(self.max_line_size),
                             str(tail_length),
                         )
@@ -837,7 +835,7 @@ class HttpPayloadParser:
                         max_line_length = self._max_field_size
                     if tail_length > max_line_length:
                         raise LineTooLong(
-                            self._chunk_tail[:100].decode() + "...",
+                            self._chunk_tail[:100] + b"...",
                             str(max_line_length),
                             str(tail_length),
                         )

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -164,7 +164,9 @@ class HeadersParser:
                     header_length += len(line)
                     if header_length > self.max_field_size:
                         header_line = bname + b": " + b"".join(bvalue_lst)
-                        raise LineTooLong(header_line[:100] + b"...", self.max_field_size)
+                        raise LineTooLong(
+                            header_line[:100] + b"...", self.max_field_size
+                        )
                     bvalue_lst.append(line)
 
                     # next line

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -163,7 +163,9 @@ class HeadersParser:
                 while continuation:
                     header_length += len(line)
                     if header_length > self.max_field_size:
-                        raise LineTooLong(b"request header field: " + bname, self.max_field_size)
+                        raise LineTooLong(
+                            b"request header field: " + bname, self.max_field_size
+                        )
                     bvalue_lst.append(line)
 
                     # next line
@@ -822,7 +824,9 @@ class HttpPayloadParser:
                     if self._chunk == ChunkState.PARSE_TRAILERS:
                         max_line_length = self._max_field_size
                     if tail_length > max_line_length:
-                        raise LineTooLong(self._chunk_tail[:100] + b"...", max_line_length)
+                        raise LineTooLong(
+                            self._chunk_tail[:100] + b"...", max_line_length
+                        )
 
                 chunk = self._chunk_tail + chunk
                 self._chunk_tail = b""

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -163,8 +163,8 @@ class HeadersParser:
                 while continuation:
                     header_length += len(line)
                     if header_length > self.max_field_size:
-                        l = bname + b": " + b"".join(bvalue_lst)
-                        raise LineTooLong(l[:100] + b"...", self.max_field_size)
+                        header_line = bname + b": " + b"".join(bvalue_lst)
+                        raise LineTooLong(header_line[:100] + b"...", self.max_field_size)
                     bvalue_lst.append(line)
 
                     # next line

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -297,11 +297,11 @@ class HttpParser(abc.ABC, Generic[_MsgT]):
 
                     # line found
                     line = data[start_pos:pos]
+                    if SEP == b"\n":  # For lax response parsing
+                        line = line.rstrip(b"\r")
                     if len(line) > max_line_length:
                         raise LineTooLong(line[:100] + b"...", max_line_length)
 
-                    if SEP == b"\n":  # For lax response parsing
-                        line = line.rstrip(b"\r")
                     self._lines.append(line)
                     # After processing the status/request line, everything is a header.
                     max_line_length = self.max_field_size

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -903,6 +903,10 @@ class HttpPayloadParser:
                     chunk = chunk[pos + len(SEP) :]
                     if SEP == b"\n":  # For lax response parsing
                         line = line.rstrip(b"\r")
+
+                    if len(line) > self._max_field_size:
+                        raise LineTooLong(line[:100] + b"...", self._max_field_size)
+
                     self._trailer_lines.append(line)
 
                     if len(self._trailer_lines) > self._max_trailers:

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -304,7 +304,7 @@ class HttpParser(abc.ABC, Generic[_MsgT]):
                     line_length = len(line)
                     if line_length > max_line_length:
                         raise LineTooLong(
-                            line[:100] + b"...",
+                            line[:100].decode() + "...",
                             str(max_line_length),
                             str(line_length),
                         )
@@ -441,7 +441,7 @@ class HttpParser(abc.ABC, Generic[_MsgT]):
                     tail_length = len(self._tail)
                     if tail_length > self.max_line_size:
                         raise LineTooLong(
-                            self._tail[:100] + b"...",
+                            self._tail[:100].decode() + "...",
                             str(self.max_line_size),
                             str(tail_length),
                         )
@@ -837,7 +837,7 @@ class HttpPayloadParser:
                         max_line_length = self._max_field_size
                     if tail_length > max_line_length:
                         raise LineTooLong(
-                            self._chunk_tail[:100] + b"...",
+                            self._chunk_tail[:100].decode() + "...",
                             str(max_line_length),
                             str(tail_length),
                         )

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -163,9 +163,8 @@ class HeadersParser:
                 while continuation:
                     header_length += len(line)
                     if header_length > self.max_field_size:
-                        raise LineTooLong(
-                            b"request header field: " + bname, self.max_field_size
-                        )
+                        l = bname + b": " + b"".join(bvalue_lst)
+                        raise LineTooLong(l[:100] + b"...", self.max_field_size)
                     bvalue_lst.append(line)
 
                     # next line

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -163,11 +163,7 @@ class HeadersParser:
                 while continuation:
                     header_length += len(line)
                     if header_length > self.max_field_size:
-                        raise LineTooLong(
-                            b"request header field: " + bname,
-                            str(self.max_field_size),
-                            str(header_length),
-                        )
+                        raise LineTooLong(b"request header field: " + bname, self.max_field_size)
                     bvalue_lst.append(line)
 
                     # next line
@@ -301,11 +297,7 @@ class HttpParser(abc.ABC, Generic[_MsgT]):
                     line = data[start_pos:pos]
                     line_length = len(line)
                     if line_length > max_line_length:
-                        raise LineTooLong(
-                            line[:100] + b"...",
-                            str(max_line_length),
-                            str(line_length),
-                        )
+                        raise LineTooLong(line[:100] + b"...", max_line_length)
 
                     if SEP == b"\n":  # For lax response parsing
                         line = line.rstrip(b"\r")
@@ -438,11 +430,7 @@ class HttpParser(abc.ABC, Generic[_MsgT]):
                     self._tail = data[start_pos:]
                     tail_length = len(self._tail)
                     if tail_length > self.max_line_size:
-                        raise LineTooLong(
-                            self._tail[:100] + b"...",
-                            str(self.max_line_size),
-                            str(tail_length),
-                        )
+                        raise LineTooLong(self._tail[:100] + b"...", self.max_line_size)
                     data = EMPTY
                     break
 
@@ -834,11 +822,7 @@ class HttpPayloadParser:
                     if self._chunk == ChunkState.PARSE_TRAILERS:
                         max_line_length = self._max_field_size
                     if tail_length > max_line_length:
-                        raise LineTooLong(
-                            self._chunk_tail[:100] + b"...",
-                            str(max_line_length),
-                            str(tail_length),
-                        )
+                        raise LineTooLong(self._chunk_tail[:100] + b"...", max_line_length)
 
                 chunk = self._chunk_tail + chunk
                 self._chunk_tail = b""

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -297,8 +297,7 @@ class HttpParser(abc.ABC, Generic[_MsgT]):
 
                     # line found
                     line = data[start_pos:pos]
-                    line_length = len(line)
-                    if line_length > max_line_length:
+                    if len(line) > max_line_length:
                         raise LineTooLong(line[:100] + b"...", max_line_length)
 
                     if SEP == b"\n":  # For lax response parsing
@@ -430,8 +429,7 @@ class HttpParser(abc.ABC, Generic[_MsgT]):
                         should_close = msg.should_close
                 else:
                     self._tail = data[start_pos:]
-                    tail_length = len(self._tail)
-                    if tail_length > self.max_line_size:
+                    if len(self._tail) > self.max_line_size:
                         raise LineTooLong(self._tail[:100] + b"...", self.max_line_size)
                     data = EMPTY
                     break
@@ -819,11 +817,10 @@ class HttpPayloadParser:
             if self._chunk_tail:
                 # If not processing the body, we should check the length is sane.
                 if self._chunk != ChunkState.PARSE_CHUNKED_CHUNK:
-                    tail_length = len(self._chunk_tail)
                     max_line_length = self._max_line_size
                     if self._chunk == ChunkState.PARSE_TRAILERS:
                         max_line_length = self._max_field_size
-                    if tail_length > max_line_length:
+                    if len(self._chunk_tail) > max_line_length:
                         raise LineTooLong(
                             self._chunk_tail[:100] + b"...", max_line_length
                         )

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -816,15 +816,16 @@ class HttpPayloadParser:
         # Chunked transfer encoding parser
         elif self._type == ParseState.PARSE_CHUNKED:
             if self._chunk_tail:
-                # If not processing the body, we should check the length is sane.
-                if self._chunk != ChunkState.PARSE_CHUNKED_CHUNK:
-                    max_line_length = self._max_line_size
-                    if self._chunk == ChunkState.PARSE_TRAILERS:
-                        max_line_length = self._max_field_size
-                    if len(self._chunk_tail) > max_line_length:
-                        raise LineTooLong(
-                            self._chunk_tail[:100] + b"...", max_line_length
-                        )
+                # We should never have a tail if we're inside the payload body.
+                assert self._chunk != ChunkState.PARSE_CHUNKED_CHUNK
+                # We should check the length is sane.
+                max_line_length = self._max_line_size
+                if self._chunk == ChunkState.PARSE_TRAILERS:
+                    max_line_length = self._max_field_size
+                if len(self._chunk_tail) > max_line_length:
+                    raise LineTooLong(
+                        self._chunk_tail[:100] + b"...", max_line_length
+                    )
 
                 chunk = self._chunk_tail + chunk
                 self._chunk_tail = b""

--- a/aiohttp/web_protocol.py
+++ b/aiohttp/web_protocol.py
@@ -196,6 +196,7 @@ class RequestHandler(BaseProtocol, Generic[_Request]):
         access_log: Logger | None = access_logger,
         access_log_format: str = AccessLogger.LOG_FORMAT,
         max_line_size: int = 8190,
+        max_headers: int = 128,
         max_field_size: int = 8190,
         lingering_time: float = 10.0,
         read_bufsize: int = 2**16,
@@ -238,6 +239,7 @@ class RequestHandler(BaseProtocol, Generic[_Request]):
             read_bufsize,
             max_line_size=max_line_size,
             max_field_size=max_field_size,
+            max_headers=max_headers,
             payload_exception=RequestPayloadError,
             auto_decompress=auto_decompress,
         )

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -57,6 +57,7 @@ The client session supports the context manager protocol for self closing.
                          read_bufsize=2**16, \
                          max_line_size=8190, \
                          max_field_size=8190, \
+                         max_headers=128, \
                          fallback_charset_resolver=lambda r, b: "utf-8", \
                          ssl_shutdown_timeout=0)
 
@@ -229,7 +230,9 @@ The client session supports the context manager protocol for self closing.
 
    :param int max_line_size: Maximum allowed size of lines in responses.
 
-   :param int max_field_size: Maximum allowed size of header fields in responses.
+   :param int max_field_size: Maximum allowed size of header name and value combined in responses.
+
+   :param int max_headers: Maximum number of headers and trailers combined in responses.
 
    :param Callable[[ClientResponse,bytes],str] fallback_charset_resolver:
       A :term:`callable` that accepts a :class:`ClientResponse` and the
@@ -409,7 +412,8 @@ The client session supports the context manager protocol for self closing.
                          read_bufsize=None, \
                          auto_decompress=None, \
                          max_line_size=None, \
-                         max_field_size=None)
+                         max_field_size=None, \
+                         max_headers=None)
       :async:
       :noindexentry:
 
@@ -573,7 +577,9 @@ The client session supports the context manager protocol for self closing.
 
       :param int max_line_size: Maximum allowed size of lines in responses.
 
-      :param int max_field_size: Maximum allowed size of header fields in responses.
+      :param int max_field_size: Maximum allowed size of header name and value combined in responses.
+
+      :param int max_headers: Maximum number of headers and trailers combined in responses.
 
       :return ClientResponse: a :class:`client response <ClientResponse>`
          object.
@@ -902,6 +908,7 @@ certification chaining.
                         auto_decompress=None, \
                         max_line_size=None, \
                         max_field_size=None, \
+                        max_headers=None, \
                         version=aiohttp.HttpVersion11, \
                         connector=None)
    :async:
@@ -1039,7 +1046,9 @@ certification chaining.
 
    :param int max_line_size: Maximum allowed size of lines in responses.
 
-   :param int max_field_size: Maximum allowed size of header fields in responses.
+   :param int max_field_size: Maximum allowed size of header name and value combined in responses.
+
+   :param int max_headers: Maximum number of headers and trailers combined in responses.
 
    :param aiohttp.protocol.HttpVersion version: Request HTTP version,
       ``HTTP 1.1`` by default. (optional)

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -2723,8 +2723,10 @@ application on specific TCP or Unix socket, e.g.::
         :attr:`helpers.AccessLogger.LOG_FORMAT`.
    :param int max_line_size: Optional maximum header line size. Default:
         ``8190``.
-   :param int max_field_size: Optional maximum header field size. Default:
+   :param int max_field_size: Optional maximum header combined name and value size. Default:
         ``8190``.
+   :param int max_headers: Optional maximum number of headers and trailers combined. Default:
+        ``128``.
 
    :param float lingering_time: Maximum time during which the server
         reads and ignores additional data coming from the client when

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -4464,7 +4464,7 @@ async def test_max_field_size_session_explicit(aiohttp_client: AiohttpClient) ->
 
 async def test_max_field_size_request_explicit(aiohttp_client: AiohttpClient) -> None:
     async def handler(request: web.Request) -> web.Response:
-        return web.Response(headers={"Custom": "x" * 8193})
+        return web.Response(headers={"Custom": "x" * 8192})
 
     app = web.Application()
     app.add_routes([web.get("/", handler)])
@@ -4472,7 +4472,7 @@ async def test_max_field_size_request_explicit(aiohttp_client: AiohttpClient) ->
     client = await aiohttp_client(app)
 
     async with client.get("/", max_field_size=8200) as resp:
-        assert resp.headers["Custom"] == "x" * 8193
+        assert resp.headers["Custom"] == "x" * 8192
 
 
 async def test_max_line_size_session_default(aiohttp_client: AiohttpClient) -> None:
@@ -4524,7 +4524,7 @@ async def test_max_line_size_request_explicit(aiohttp_client: AiohttpClient) -> 
 
     client = await aiohttp_client(app)
 
-    async with client.get("/", max_line_size=8200) as resp:
+    async with client.get("/", max_line_size=8210) as resp:
         assert resp.reason == "x" * 8197
 
 

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -4502,6 +4502,19 @@ async def test_max_headers_session_explicit(aiohttp_client: AiohttpClient) -> No
         assert resp.headers["Custom-129"] == "x"
 
 
+async def test_max_headers_request_explicit(aiohttp_client: AiohttpClient) -> None:
+    async def handler(request: web.Request) -> web.Response:
+        return web.Response(headers={f"Custom-{i}": "x" for i in range(130)})
+
+    app = web.Application()
+    app.add_routes([web.get("/", handler)])
+
+    client = await aiohttp_client(app)
+
+    async with client.get("/", max_headers=140) as resp:
+        assert resp.headers["Custom-129"] == "x"
+
+
 async def test_max_field_size_request_explicit(aiohttp_client: AiohttpClient) -> None:
     async def handler(request: web.Request) -> web.Response:
         return web.Response(headers={"Custom": "x" * 8192})

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -4424,7 +4424,7 @@ async def test_http_empty_data_text(aiohttp_client: AiohttpClient) -> None:
 
 async def test_max_field_size_session_default(aiohttp_client: AiohttpClient) -> None:
     async def handler(request: web.Request) -> web.Response:
-        return web.Response(headers={"Custom": "x" * 8190})
+        return web.Response(headers={"Custom": "x" * 8183})
 
     app = web.Application()
     app.add_routes([web.get("/", handler)])
@@ -4432,7 +4432,7 @@ async def test_max_field_size_session_default(aiohttp_client: AiohttpClient) -> 
     client = await aiohttp_client(app)
 
     async with client.get("/") as resp:
-        assert resp.headers["Custom"] == "x" * 8190
+        assert resp.headers["Custom"] == "x" * 8183
 
 
 async def test_max_field_size_session_default_fail(
@@ -4451,28 +4451,28 @@ async def test_max_field_size_session_default_fail(
 
 async def test_max_field_size_session_explicit(aiohttp_client: AiohttpClient) -> None:
     async def handler(request: web.Request) -> web.Response:
-        return web.Response(headers={"Custom": "x" * 8191})
+        return web.Response(headers={"Custom": "x" * 8193})
 
     app = web.Application()
     app.add_routes([web.get("/", handler)])
 
-    client = await aiohttp_client(app, max_field_size=8191)
+    client = await aiohttp_client(app, max_field_size=8200)
 
     async with client.get("/") as resp:
-        assert resp.headers["Custom"] == "x" * 8191
+        assert resp.headers["Custom"] == "x" * 8193
 
 
 async def test_max_field_size_request_explicit(aiohttp_client: AiohttpClient) -> None:
     async def handler(request: web.Request) -> web.Response:
-        return web.Response(headers={"Custom": "x" * 8191})
+        return web.Response(headers={"Custom": "x" * 8193})
 
     app = web.Application()
     app.add_routes([web.get("/", handler)])
 
     client = await aiohttp_client(app)
 
-    async with client.get("/", max_field_size=8191) as resp:
-        assert resp.headers["Custom"] == "x" * 8191
+    async with client.get("/", max_field_size=8200) as resp:
+        assert resp.headers["Custom"] == "x" * 8193
 
 
 async def test_max_line_size_session_default(aiohttp_client: AiohttpClient) -> None:

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -4424,7 +4424,7 @@ async def test_http_empty_data_text(aiohttp_client: AiohttpClient) -> None:
 
 async def test_max_field_size_session_default(aiohttp_client: AiohttpClient) -> None:
     async def handler(request: web.Request) -> web.Response:
-        return web.Response(headers={"Custom": "x" * 8183})
+        return web.Response(headers={"Custom": "x" * 8182})
 
     app = web.Application()
     app.add_routes([web.get("/", handler)])
@@ -4432,7 +4432,7 @@ async def test_max_field_size_session_default(aiohttp_client: AiohttpClient) -> 
     client = await aiohttp_client(app)
 
     async with client.get("/") as resp:
-        assert resp.headers["Custom"] == "x" * 8183
+        assert resp.headers["Custom"] == "x" * 8182
 
 
 async def test_max_field_size_session_default_fail(
@@ -4451,7 +4451,7 @@ async def test_max_field_size_session_default_fail(
 
 async def test_max_field_size_session_explicit(aiohttp_client: AiohttpClient) -> None:
     async def handler(request: web.Request) -> web.Response:
-        return web.Response(headers={"Custom": "x" * 8193})
+        return web.Response(headers={"Custom": "x" * 8192})
 
     app = web.Application()
     app.add_routes([web.get("/", handler)])
@@ -4459,7 +4459,7 @@ async def test_max_field_size_session_explicit(aiohttp_client: AiohttpClient) ->
     client = await aiohttp_client(app, max_field_size=8200)
 
     async with client.get("/") as resp:
-        assert resp.headers["Custom"] == "x" * 8193
+        assert resp.headers["Custom"] == "x" * 8192
 
 
 async def test_max_field_size_request_explicit(aiohttp_client: AiohttpClient) -> None:
@@ -4477,7 +4477,7 @@ async def test_max_field_size_request_explicit(aiohttp_client: AiohttpClient) ->
 
 async def test_max_line_size_session_default(aiohttp_client: AiohttpClient) -> None:
     async def handler(request: web.Request) -> web.Response:
-        return web.Response(status=200, reason="x" * 8190)
+        return web.Response(status=200, reason="x" * 8177)
 
     app = web.Application()
     app.add_routes([web.get("/", handler)])
@@ -4485,7 +4485,7 @@ async def test_max_line_size_session_default(aiohttp_client: AiohttpClient) -> N
     client = await aiohttp_client(app)
 
     async with client.get("/") as resp:
-        assert resp.reason == "x" * 8190
+        assert resp.reason == "x" * 8177
 
 
 async def test_max_line_size_session_default_fail(
@@ -4504,28 +4504,28 @@ async def test_max_line_size_session_default_fail(
 
 async def test_max_line_size_session_explicit(aiohttp_client: AiohttpClient) -> None:
     async def handler(request: web.Request) -> web.Response:
-        return web.Response(status=200, reason="x" * 8191)
+        return web.Response(status=200, reason="x" * 8197)
 
     app = web.Application()
     app.add_routes([web.get("/", handler)])
 
-    client = await aiohttp_client(app, max_line_size=8191)
+    client = await aiohttp_client(app, max_line_size=8210)
 
     async with client.get("/") as resp:
-        assert resp.reason == "x" * 8191
+        assert resp.reason == "x" * 8197
 
 
 async def test_max_line_size_request_explicit(aiohttp_client: AiohttpClient) -> None:
     async def handler(request: web.Request) -> web.Response:
-        return web.Response(status=200, reason="x" * 8191)
+        return web.Response(status=200, reason="x" * 8197)
 
     app = web.Application()
     app.add_routes([web.get("/", handler)])
 
     client = await aiohttp_client(app)
 
-    async with client.get("/", max_line_size=8191) as resp:
-        assert resp.reason == "x" * 8191
+    async with client.get("/", max_line_size=8200) as resp:
+        assert resp.reason == "x" * 8197
 
 
 async def test_rejected_upload(

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -4464,7 +4464,7 @@ async def test_max_field_size_session_explicit(aiohttp_client: AiohttpClient) ->
 
 async def test_max_headers_session_default(aiohttp_client: AiohttpClient) -> None:
     async def handler(request: web.Request) -> web.Response:
-        return web.Response(headers={f"Custom-{i}": "x" for i in range(127)})
+        return web.Response(headers={f"Custom-{i}": "x" for i in range(120)})
 
     app = web.Application()
     app.add_routes([web.get("/", handler)])
@@ -4472,7 +4472,7 @@ async def test_max_headers_session_default(aiohttp_client: AiohttpClient) -> Non
     client = await aiohttp_client(app)
 
     async with client.get("/") as resp:
-        assert resp.headers["Custom-126"] == "x"
+        assert resp.headers["Custom-119"] == "x"
 
 
 async def test_max_headers_session_default_fail(
@@ -4496,7 +4496,7 @@ async def test_max_headers_session_explicit(aiohttp_client: AiohttpClient) -> No
     app = web.Application()
     app.add_routes([web.get("/", handler)])
 
-    client = await aiohttp_client(app, max_headers=132)
+    client = await aiohttp_client(app, max_headers=140)
 
     async with client.get("/") as resp:
         assert resp.headers["Custom-129"] == "x"

--- a/tests/test_http_exceptions.py
+++ b/tests/test_http_exceptions.py
@@ -101,7 +101,7 @@ class TestLineTooLong:
     def test_repr(self) -> None:
         err = http_exceptions.LineTooLong(line=b"spam", limit=10)
         assert repr(err) == (
-            "<LineTooLong: 400, message=\"Got more than "
+            '<LineTooLong: 400, message="Got more than '
             "10 bytes when reading: b'spam'.\">"
         )
 

--- a/tests/test_http_exceptions.py
+++ b/tests/test_http_exceptions.py
@@ -101,8 +101,8 @@ class TestLineTooLong:
     def test_repr(self) -> None:
         err = http_exceptions.LineTooLong(line=b"spam", limit=10)
         assert repr(err) == (
-            "<LineTooLong: 400, message='Got more than "
-            "10 bytes when reading: b'spam'.'>"
+            "<LineTooLong: 400, message=\"Got more than "
+            "10 bytes when reading: b'spam'.\">"
         )
 
 

--- a/tests/test_http_exceptions.py
+++ b/tests/test_http_exceptions.py
@@ -77,32 +77,32 @@ class TestBadHttpMessage:
 
 class TestLineTooLong:
     def test_ctor(self) -> None:
-        err = http_exceptions.LineTooLong("spam", "10", "12")
+        err = http_exceptions.LineTooLong("spam", 10)
         assert err.code == 400
-        assert err.message == "Got more than 10 bytes (12) when reading spam."
+        assert err.message == "Got more than 10 bytes when reading: b'spam'."
         assert err.headers is None
 
     def test_pickle(self) -> None:
-        err = http_exceptions.LineTooLong(line="spam", limit="10", actual_size="12")
+        err = http_exceptions.LineTooLong(line="spam", limit=10)
         err.foo = "bar"  # type: ignore[attr-defined]
         for proto in range(pickle.HIGHEST_PROTOCOL + 1):
             pickled = pickle.dumps(err, proto)
             err2 = pickle.loads(pickled)
             assert err2.code == 400
-            assert err2.message == ("Got more than 10 bytes (12) when reading spam.")
+            assert err2.message == ("Got more than 10 bytes when reading: b'spam'.")
             assert err2.headers is None
             assert err2.foo == "bar"
 
     def test_str(self) -> None:
-        err = http_exceptions.LineTooLong(line="spam", limit="10", actual_size="12")
-        expected = "400, message:\n  Got more than 10 bytes (12) when reading spam."
+        err = http_exceptions.LineTooLong(line="spam", limit=10)
+        expected = "400, message:\n  Got more than 10 bytes when reading: b'spam'."
         assert str(err) == expected
 
     def test_repr(self) -> None:
-        err = http_exceptions.LineTooLong(line="spam", limit="10", actual_size="12")
+        err = http_exceptions.LineTooLong(line="spam", limit=10)
         assert repr(err) == (
             "<LineTooLong: 400, message='Got more than "
-            "10 bytes (12) when reading spam.'>"
+            "10 bytes when reading: b'spam'.'>"
         )
 
 

--- a/tests/test_http_exceptions.py
+++ b/tests/test_http_exceptions.py
@@ -77,13 +77,13 @@ class TestBadHttpMessage:
 
 class TestLineTooLong:
     def test_ctor(self) -> None:
-        err = http_exceptions.LineTooLong("spam", 10)
+        err = http_exceptions.LineTooLong(b"spam", 10)
         assert err.code == 400
         assert err.message == "Got more than 10 bytes when reading: b'spam'."
         assert err.headers is None
 
     def test_pickle(self) -> None:
-        err = http_exceptions.LineTooLong(line="spam", limit=10)
+        err = http_exceptions.LineTooLong(line=b"spam", limit=10)
         err.foo = "bar"  # type: ignore[attr-defined]
         for proto in range(pickle.HIGHEST_PROTOCOL + 1):
             pickled = pickle.dumps(err, proto)
@@ -94,12 +94,12 @@ class TestLineTooLong:
             assert err2.foo == "bar"
 
     def test_str(self) -> None:
-        err = http_exceptions.LineTooLong(line="spam", limit=10)
+        err = http_exceptions.LineTooLong(line=b"spam", limit=10)
         expected = "400, message:\n  Got more than 10 bytes when reading: b'spam'."
         assert str(err) == expected
 
     def test_repr(self) -> None:
-        err = http_exceptions.LineTooLong(line="spam", limit=10)
+        err = http_exceptions.LineTooLong(line=b"spam", limit=10)
         assert repr(err) == (
             "<LineTooLong: 400, message='Got more than "
             "10 bytes when reading: b'spam'.'>"

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -770,7 +770,7 @@ async def test_max_trailer_size(parser: HttpRequestParser, size: int) -> None:
     value = b"t" * size
     text = (
         b"GET /test HTTP/1.1\r\nTransfer-Encoding: chunked\r\n\r\n"
-        + hex(4000).encode()
+        + hex(4000)[2:].encode()
         + b"\r\n"
         + b"b" * 4000
         + b"\r\n0\r\ntest: "

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -796,9 +796,9 @@ def test_max_trailer_size(parser: HttpRequestParser, size: int) -> None:
 def test_max_headers(parser: HttpRequestParser, headers: int, trailers: int) -> None:
     text = (
         b"GET /test HTTP/1.1\r\nTransfer-Encoding: chunked"
-        + sum((b"\r\nHeader-{}: Value".format(i) for i in range(headers)), start=b"")
+        + sum((b"\r\nHeader-%d: Value" % i for i in range(headers)), start=b"")
         + b"\r\n\r\n4\r\ntest\r\n0"
-        + sum((b"\r\nTrailer-{}: Value".format(i) for i in range(trailers)), start=b"")
+        + sum((b"\r\nTrailer-%d: Value" % i for i in range(trailers)), start=b"")
         + b"\r\n\r\n"
     )
 

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -839,7 +839,7 @@ def test_max_header_value_size_continuation(
 def test_max_header_value_size_continuation_under_limit(
     response: HttpResponseParser,
 ) -> None:
-    value = b"A" * 8185
+    value = b"A" * 8179
     text = b"HTTP/1.1 200 Ok\r\ndata: test\r\n " + value + b"\r\n\r\n"
 
     messages, upgrade, tail = response.feed_data(text)

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -798,7 +798,9 @@ def test_max_headers(parser: HttpRequestParser, headers: int, trailers: int) -> 
 
     match = "Too many (headers|trailers) received"
     with pytest.raises(http_exceptions.BadHttpMessage, match=match):
-        parser.feed_data(text)
+        messages, upgrade, tail = parser.feed_data(text)
+        # Trailers are not seen until payload is read.
+        await messages[0][-1].read()
 
 
 def test_max_header_value_size_under_limit(parser: HttpRequestParser) -> None:

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -727,8 +727,8 @@ def test_max_header_field_size(parser: HttpRequestParser, size: int) -> None:
             parser.feed_data(text[i : i + 5000])
 
 
-def test_max_header_field_size_under_limit(parser: HttpRequestParser) -> None:
-    name = b"t" * 8190
+def test_max_header_size_under_limit(parser: HttpRequestParser) -> None:
+    name = b"t" * 8185
     text = b"GET /test HTTP/1.1\r\n" + name + b":data\r\n\r\n"
 
     messages, upgrade, tail = parser.feed_data(text)
@@ -802,7 +802,7 @@ def test_max_headers(parser: HttpRequestParser, headers: int, trailers: int) -> 
 
 
 def test_max_header_value_size_under_limit(parser: HttpRequestParser) -> None:
-    value = b"A" * 8190
+    value = b"A" * 8185
     text = b"GET /test HTTP/1.1\r\ndata:" + value + b"\r\n\r\n"
 
     messages, upgrade, tail = parser.feed_data(text)
@@ -1080,7 +1080,7 @@ def test_http_request_max_status_line(parser: HttpRequestParser, size: int) -> N
 
 
 def test_http_request_max_status_line_under_limit(parser: HttpRequestParser) -> None:
-    path = b"t" * (8190 - 5)
+    path = b"t" * 8172
     messages, upgraded, tail = parser.feed_data(
         b"GET /path" + path + b" HTTP/1.1\r\n\r\n"
     )
@@ -1169,7 +1169,7 @@ def test_http_response_parser_bad_status_line_too_long(
 def test_http_response_parser_status_line_under_limit(
     response: HttpResponseParser,
 ) -> None:
-    reason = b"O" * 8190
+    reason = b"O" * 8177
     messages, upgraded, tail = response.feed_data(
         b"HTTP/1.1 200 " + reason + b"\r\n\r\n"
     )

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -287,15 +287,6 @@ def test_whitespace_before_header(parser: HttpRequestParser) -> None:
         parser.feed_data(text)
 
 
-def test_parse_headers_longline(parser: HttpRequestParser) -> None:
-    invalid_unicode_byte = b"\xd9"
-    header_name = b"Test" + invalid_unicode_byte + b"Header" + b"A" * 8192
-    text = b"GET /test HTTP/1.1\r\n" + header_name + b": test\r\n" + b"\r\n" + b"\r\n"
-    with pytest.raises(http_exceptions.LineTooLong):
-        for i in range(0, len(text), 8000):
-            parser.feed_data(text[i : i + 8000])
-
-
 @pytest.fixture
 def xfail_c_parser_status(request: pytest.FixtureRequest) -> None:
     if isinstance(request.getfixturevalue("parser"), HttpRequestParserPy):

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -723,7 +723,7 @@ def test_max_header_field_size(parser: HttpRequestParser, size: int) -> None:
 
     match = "400, message:\n  Got more than 8190 bytes when reading"
     with pytest.raises(http_exceptions.LineTooLong, match=match):
-        for i in range(0, len(text), 5000):
+        for i in range(0, len(text), 5000):  # pragma: no branch
             parser.feed_data(text[i : i + 5000])
 
 
@@ -752,7 +752,7 @@ def test_max_header_value_size(parser: HttpRequestParser, size: int) -> None:
 
     match = "400, message:\n  Got more than 8190 bytes when reading"
     with pytest.raises(http_exceptions.LineTooLong, match=match):
-        for i in range(0, len(text), 4000):
+        for i in range(0, len(text), 4000):  # pragma: no branch
             parser.feed_data(text[i : i + 4000])
 
 
@@ -781,7 +781,7 @@ async def test_max_trailer_size(parser: HttpRequestParser, size: int) -> None:
     match = "400, message:\n  Got more than 8190 bytes when reading"
     with pytest.raises(http_exceptions.LineTooLong, match=match):
         payload = None
-        for i in range(0, len(text), 3000):
+        for i in range(0, len(text), 3000):  # pragma: no branch
             messages, upgrade, tail = parser.feed_data(text[i : i + 3000])
             if messages:
                 payload = messages[0][-1]
@@ -836,7 +836,7 @@ def test_max_header_value_size_continuation(
 
     match = "400, message:\n  Got more than 8190 bytes when reading"
     with pytest.raises(http_exceptions.LineTooLong, match=match):
-        for i in range(0, len(text), 9000):
+        for i in range(0, len(text), 9000):  # pragma: no branch
             response.feed_data(text[i : i + 9000])
 
 
@@ -2044,7 +2044,7 @@ class TestDeflateBuffer:
         dbuf = DeflateBuffer(buf, "deflate")
 
         # Feed compressed data in chunks (simulating network streaming)
-        for i in range(0, len(compressed), chunk_size):
+        for i in range(0, len(compressed), chunk_size):  # pragma: no branch
             chunk = compressed[i : i + chunk_size]
             dbuf.feed_data(chunk)
 

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -769,7 +769,9 @@ def test_max_header_combined_size(parser: HttpRequestParser) -> None:
 async def test_max_trailer_size(parser: HttpRequestParser, size: int) -> None:
     value = b"t" * size
     text = (
-        b"GET /test HTTP/1.1\r\nTransfer-Encoding: chunked\r\n\r\n4000\r\n"
+        b"GET /test HTTP/1.1\r\nTransfer-Encoding: chunked\r\n\r\n"
+        + hex(4000).encode()
+        + b"\r\n"
         + b"b" * 4000
         + b"\r\n0\r\ntest: "
         + value

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -730,7 +730,7 @@ def test_max_header_field_size(parser: HttpRequestParser, size: int) -> None:
     name = b"t" * size
     text = b"GET /test HTTP/1.1\r\n" + name + b":data\r\n\r\n"
 
-    match = f"400, message:\n  Got more than 8190 bytes when reading"
+    match = "400, message:\n  Got more than 8190 bytes when reading"
     with pytest.raises(http_exceptions.LineTooLong, match=match):
         for i in range(0, len(text), 5000):
             parser.feed_data(text[i : i + 5000])
@@ -759,7 +759,7 @@ def test_max_header_value_size(parser: HttpRequestParser, size: int) -> None:
     name = b"t" * size
     text = b"GET /test HTTP/1.1\r\ndata:" + name + b"\r\n\r\n"
 
-    match = f"400, message:\n  Got more than 8190 bytes when reading"
+    match = "400, message:\n  Got more than 8190 bytes when reading"
     with pytest.raises(http_exceptions.LineTooLong, match=match):
         for i in range(0, len(text), 4000):
             parser.feed_data(text[i : i + 4000])
@@ -775,7 +775,7 @@ def test_max_header_combined_size(parser: HttpRequestParser) -> None:
         + b"\r\n\r\n"
     )
 
-    match = f"400, message:\n  Got more than 8190 bytes when reading"
+    match = "400, message:\n  Got more than 8190 bytes when reading"
     with pytest.raises(http_exceptions.LineTooLong, match=match):
         parser.feed_data(text)
 
@@ -789,7 +789,7 @@ def test_max_trailer_size(parser: HttpRequestParser, size: int) -> None:
         + b"\r\n\r\n"
     )
 
-    match = f"400, message:\n  Got more than 8190 bytes when reading"
+    match = "400, message:\n  Got more than 8190 bytes when reading"
     with pytest.raises(http_exceptions.LineTooLong, match=match):
         for i in range(0, len(text), 3000):
             parser.feed_data(text[i : i + 3000])
@@ -835,7 +835,7 @@ def test_max_header_value_size_continuation(
     name = b"T" * (size - 5)
     text = b"HTTP/1.1 200 Ok\r\ndata: test\r\n " + name + b"\r\n\r\n"
 
-    match = f"400, message:\n  Got more than 8190 bytes when reading"
+    match = "400, message:\n  Got more than 8190 bytes when reading"
     with pytest.raises(http_exceptions.LineTooLong, match=match):
         for i in range(0, len(text), 9000):
             response.feed_data(text[i : i + 9000])
@@ -1083,7 +1083,7 @@ def test_http_request_parser_bad_nonascii_uri(parser: HttpRequestParser) -> None
 @pytest.mark.parametrize("size", [40965, 8191])
 def test_http_request_max_status_line(parser: HttpRequestParser, size: int) -> None:
     path = b"t" * (size - 5)
-    match = f"400, message:\n  Got more than 8190 bytes when reading"
+    match = "400, message:\n  Got more than 8190 bytes when reading"
     with pytest.raises(http_exceptions.LineTooLong, match=match):
         parser.feed_data(b"GET /path" + path + b" HTTP/1.1\r\n\r\n")
 
@@ -1170,7 +1170,7 @@ def test_http_response_parser_bad_status_line_too_long(
     response: HttpResponseParser, size: int
 ) -> None:
     reason = b"t" * (size - 2)
-    match = f"400, message:\n  Got more than 8190 bytes when reading"
+    match = "400, message:\n  Got more than 8190 bytes when reading"
     with pytest.raises(http_exceptions.LineTooLong, match=match):
         response.feed_data(b"HTTP/1.1 200 Ok" + reason + b"\r\n\r\n")
 

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -30,9 +30,6 @@ from aiohttp.http_parser import (
 )
 from aiohttp.http_writer import HttpVersion
 
-if sys.version_info >= (3, 12):
-    from itertools import batched
-
 try:
     try:
         import brotlicffi as brotli
@@ -290,14 +287,13 @@ def test_whitespace_before_header(parser: HttpRequestParser) -> None:
         parser.feed_data(text)
 
 
-@pytest.mark.skipif(sys.version_info < (3, 12), reason="batched() is not available")
 def test_parse_headers_longline(parser: HttpRequestParser) -> None:
     invalid_unicode_byte = b"\xd9"
     header_name = b"Test" + invalid_unicode_byte + b"Header" + b"A" * 8192
     text = b"GET /test HTTP/1.1\r\n" + header_name + b": test\r\n" + b"\r\n" + b"\r\n"
     with pytest.raises(http_exceptions.LineTooLong):
-        for chunk in batched(text, 8000):
-            parser.feed_data(chunk)
+        for i in range(0, len(text), 8000):
+            parser.feed_data(text[i:i+8000)
 
 
 @pytest.fixture
@@ -729,7 +725,6 @@ def test_invalid_name(parser: HttpRequestParser) -> None:
         parser.feed_data(text)
 
 
-@pytest.mark.skipif(sys.version_info < (3, 12), reason="batched() is not available")
 @pytest.mark.parametrize("size", [40960, 8191])
 def test_max_header_field_size(parser: HttpRequestParser, size: int) -> None:
     name = b"t" * size
@@ -737,8 +732,8 @@ def test_max_header_field_size(parser: HttpRequestParser, size: int) -> None:
 
     match = f"400, message:\n  Got more than 8190 bytes \\({size}\\) when reading"
     with pytest.raises(http_exceptions.LineTooLong, match=match):
-        for chunk in batched(text, 5000):
-            parser.feed_data(chunk)
+        for i in range(0, len(text), 5000):
+            parser.feed_data(text[i:i+5000)
 
 
 def test_max_header_field_size_under_limit(parser: HttpRequestParser) -> None:
@@ -759,7 +754,6 @@ def test_max_header_field_size_under_limit(parser: HttpRequestParser) -> None:
     assert msg.url == URL("/test")
 
 
-@pytest.mark.skipif(sys.version_info < (3, 12), reason="batched() is not available")
 @pytest.mark.parametrize("size", [40960, 8191])
 def test_max_header_value_size(parser: HttpRequestParser, size: int) -> None:
     name = b"t" * size
@@ -767,8 +761,8 @@ def test_max_header_value_size(parser: HttpRequestParser, size: int) -> None:
 
     match = f"400, message:\n  Got more than 8190 bytes \\({size}\\) when reading"
     with pytest.raises(http_exceptions.LineTooLong, match=match):
-        for chunk in batched(text, 4000):
-            parser.feed_data(chunk)
+        for i in range(0, len(text), 4000):
+            parser.feed_data(text[i:i+4000)
 
 
 def test_max_header_combined_size(parser: HttpRequestParser) -> None:
@@ -786,7 +780,6 @@ def test_max_header_combined_size(parser: HttpRequestParser) -> None:
         parser.feed_data(text)
 
 
-@pytest.mark.skipif(sys.version_info < (3, 12), reason="batched() is not available")
 @pytest.mark.parametrize("size", [40960, 8191])
 def test_max_trailer_size(parser: HttpRequestParser, size: int) -> None:
     value = b"t" * size
@@ -798,8 +791,8 @@ def test_max_trailer_size(parser: HttpRequestParser, size: int) -> None:
 
     match = f"400, message:\n  Got more than 8190 bytes \\({size}\\) when reading"
     with pytest.raises(http_exceptions.LineTooLong, match=match):
-        for chunk in batched(text, 3000):
-            parser.feed_data(chunk)
+        for i in range(0, len(text), 3000):
+            parser.feed_data(text[i:i+3000)
 
 
 @pytest.mark.parametrize("headers,trailers", ((129, 0), (0, 129), (64, 65)))
@@ -835,7 +828,6 @@ def test_max_header_value_size_under_limit(parser: HttpRequestParser) -> None:
     assert msg.url == URL("/test")
 
 
-@pytest.mark.skipif(sys.version_info < (3, 12), reason="batched() is not available")
 @pytest.mark.parametrize("size", [40965, 8191])
 def test_max_header_value_size_continuation(
     response: HttpResponseParser, size: int
@@ -845,8 +837,8 @@ def test_max_header_value_size_continuation(
 
     match = f"400, message:\n  Got more than 8190 bytes \\({size}\\) when reading"
     with pytest.raises(http_exceptions.LineTooLong, match=match):
-        for chunk in batched(text, 9000):
-            response.feed_data(chunk)
+        for i in range(0, len(text), 9000):
+            response.feed_data(text[i:i+9000)
 
 
 def test_max_header_value_size_continuation_under_limit(

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -846,7 +846,7 @@ def test_max_header_value_size_continuation(
     match = f"400, message:\n  Got more than 8190 bytes \\({size}\\) when reading"
     with pytest.raises(http_exceptions.LineTooLong, match=match):
         for chunk in batched(text, 9000):
-            parser.feed_data(chunk)
+            response.feed_data(chunk)
 
 
 def test_max_header_value_size_continuation_under_limit(

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -293,7 +293,7 @@ def test_parse_headers_longline(parser: HttpRequestParser) -> None:
     text = b"GET /test HTTP/1.1\r\n" + header_name + b": test\r\n" + b"\r\n" + b"\r\n"
     with pytest.raises(http_exceptions.LineTooLong):
         for i in range(0, len(text), 8000):
-            parser.feed_data(text[i:i+8000)
+            parser.feed_data(text[i:i+8000])
 
 
 @pytest.fixture
@@ -733,7 +733,7 @@ def test_max_header_field_size(parser: HttpRequestParser, size: int) -> None:
     match = f"400, message:\n  Got more than 8190 bytes \\({size}\\) when reading"
     with pytest.raises(http_exceptions.LineTooLong, match=match):
         for i in range(0, len(text), 5000):
-            parser.feed_data(text[i:i+5000)
+            parser.feed_data(text[i:i+5000])
 
 
 def test_max_header_field_size_under_limit(parser: HttpRequestParser) -> None:
@@ -762,7 +762,7 @@ def test_max_header_value_size(parser: HttpRequestParser, size: int) -> None:
     match = f"400, message:\n  Got more than 8190 bytes \\({size}\\) when reading"
     with pytest.raises(http_exceptions.LineTooLong, match=match):
         for i in range(0, len(text), 4000):
-            parser.feed_data(text[i:i+4000)
+            parser.feed_data(text[i:i+4000])
 
 
 def test_max_header_combined_size(parser: HttpRequestParser) -> None:
@@ -792,7 +792,7 @@ def test_max_trailer_size(parser: HttpRequestParser, size: int) -> None:
     match = f"400, message:\n  Got more than 8190 bytes \\({size}\\) when reading"
     with pytest.raises(http_exceptions.LineTooLong, match=match):
         for i in range(0, len(text), 3000):
-            parser.feed_data(text[i:i+3000)
+            parser.feed_data(text[i:i+3000])
 
 
 @pytest.mark.parametrize("headers,trailers", ((129, 0), (0, 129), (64, 65)))
@@ -838,7 +838,7 @@ def test_max_header_value_size_continuation(
     match = f"400, message:\n  Got more than 8190 bytes \\({size}\\) when reading"
     with pytest.raises(http_exceptions.LineTooLong, match=match):
         for i in range(0, len(text), 9000):
-            response.feed_data(text[i:i+9000)
+            response.feed_data(text[i:i+9000])
 
 
 def test_max_header_value_size_continuation_under_limit(

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -769,7 +769,9 @@ def test_max_header_combined_size(parser: HttpRequestParser) -> None:
 async def test_max_trailer_size(parser: HttpRequestParser, size: int) -> None:
     value = b"t" * size
     text = (
-        b"GET /test HTTP/1.1\r\nTransfer-Encoding: chunked\r\n\r\n4\r\ntest\r\n0\r\ntest: "
+        b"GET /test HTTP/1.1\r\nTransfer-Encoding: chunked\r\n\r\n4000\r\n"
+        + b"b" * 4000
+        + b"\r\n0\r\ntest: "
         + value
         + b"\r\n\r\n"
     )

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -1,6 +1,7 @@
 # Tests for aiohttp/protocol.py
 
 import asyncio
+import re
 import sys
 import zlib
 from collections.abc import Iterable
@@ -10,7 +11,6 @@ from unittest import mock
 from urllib.parse import quote
 
 import pytest
-import re_
 from multidict import CIMultiDict
 from yarl import URL
 

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -1,7 +1,6 @@
 # Tests for aiohttp/protocol.py
 
 import asyncio
-import re_
 import sys
 import zlib
 from collections.abc import Iterable
@@ -11,6 +10,7 @@ from unittest import mock
 from urllib.parse import quote
 
 import pytest
+import re_
 from multidict import CIMultiDict
 from yarl import URL
 

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -796,9 +796,9 @@ def test_max_trailer_size(parser: HttpRequestParser, size: int) -> None:
 def test_max_headers(parser: HttpRequestParser, headers: int, trailers: int) -> None:
     text = (
         b"GET /test HTTP/1.1\r\nTransfer-Encoding: chunked"
-        + b"".join((b"\r\nHeader-%d: Value" % i for i in range(headers)), start=b"")
+        + b"".join(b"\r\nHeader-%d: Value" % i for i in range(headers))
         + b"\r\n\r\n4\r\ntest\r\n0"
-        + b"".join((b"\r\nTrailer-%d: Value" % i for i in range(trailers)), start=b"")
+        + b"".join(b"\r\nTrailer-%d: Value" % i for i in range(trailers))
         + b"\r\n\r\n"
     )
 

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -766,7 +766,7 @@ def test_max_header_combined_size(parser: HttpRequestParser) -> None:
 
 
 @pytest.mark.parametrize("size", [40960, 8191])
-def test_max_trailer_size(parser: HttpRequestParser, size: int) -> None:
+async def test_max_trailer_size(parser: HttpRequestParser, size: int) -> None:
     value = b"t" * size
     text = (
         b"GET /test HTTP/1.1\r\nTransfer-Encoding: chunked\r\n\r\n4\r\ntest\r\n0\r\ntest: "

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -796,9 +796,9 @@ def test_max_trailer_size(parser: HttpRequestParser, size: int) -> None:
 def test_max_headers(parser: HttpRequestParser, headers: int, trailers: int) -> None:
     text = (
         b"GET /test HTTP/1.1\r\nTransfer-Encoding: chunked"
-        + sum((b"\r\nHeader-%d: Value" % i for i in range(headers)), start=b"")
+        + b"".join((b"\r\nHeader-%d: Value" % i for i in range(headers)), start=b"")
         + b"\r\n\r\n4\r\ntest\r\n0"
-        + sum((b"\r\nTrailer-%d: Value" % i for i in range(trailers)), start=b"")
+        + b"".join((b"\r\nTrailer-%d: Value" % i for i in range(trailers)), start=b"")
         + b"\r\n\r\n"
     )
 

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -293,7 +293,7 @@ def test_parse_headers_longline(parser: HttpRequestParser) -> None:
     text = b"GET /test HTTP/1.1\r\n" + header_name + b": test\r\n" + b"\r\n" + b"\r\n"
     with pytest.raises(http_exceptions.LineTooLong):
         for i in range(0, len(text), 8000):
-            parser.feed_data(text[i:i+8000])
+            parser.feed_data(text[i : i + 8000])
 
 
 @pytest.fixture
@@ -733,7 +733,7 @@ def test_max_header_field_size(parser: HttpRequestParser, size: int) -> None:
     match = f"400, message:\n  Got more than 8190 bytes \\({size}\\) when reading"
     with pytest.raises(http_exceptions.LineTooLong, match=match):
         for i in range(0, len(text), 5000):
-            parser.feed_data(text[i:i+5000])
+            parser.feed_data(text[i : i + 5000])
 
 
 def test_max_header_field_size_under_limit(parser: HttpRequestParser) -> None:
@@ -762,7 +762,7 @@ def test_max_header_value_size(parser: HttpRequestParser, size: int) -> None:
     match = f"400, message:\n  Got more than 8190 bytes \\({size}\\) when reading"
     with pytest.raises(http_exceptions.LineTooLong, match=match):
         for i in range(0, len(text), 4000):
-            parser.feed_data(text[i:i+4000])
+            parser.feed_data(text[i : i + 4000])
 
 
 def test_max_header_combined_size(parser: HttpRequestParser) -> None:
@@ -792,7 +792,7 @@ def test_max_trailer_size(parser: HttpRequestParser, size: int) -> None:
     match = f"400, message:\n  Got more than 8190 bytes \\({size}\\) when reading"
     with pytest.raises(http_exceptions.LineTooLong, match=match):
         for i in range(0, len(text), 3000):
-            parser.feed_data(text[i:i+3000])
+            parser.feed_data(text[i : i + 3000])
 
 
 @pytest.mark.parametrize("headers,trailers", ((129, 0), (0, 129), (64, 65)))
@@ -838,7 +838,7 @@ def test_max_header_value_size_continuation(
     match = f"400, message:\n  Got more than 8190 bytes \\({size}\\) when reading"
     with pytest.raises(http_exceptions.LineTooLong, match=match):
         for i in range(0, len(text), 9000):
-            response.feed_data(text[i:i+9000])
+            response.feed_data(text[i : i + 9000])
 
 
 def test_max_header_value_size_continuation_under_limit(

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -730,7 +730,7 @@ def test_max_header_field_size(parser: HttpRequestParser, size: int) -> None:
     name = b"t" * size
     text = b"GET /test HTTP/1.1\r\n" + name + b":data\r\n\r\n"
 
-    match = f"400, message:\n  Got more than 8190 bytes \\({size}\\) when reading"
+    match = f"400, message:\n  Got more than 8190 bytes when reading"
     with pytest.raises(http_exceptions.LineTooLong, match=match):
         for i in range(0, len(text), 5000):
             parser.feed_data(text[i : i + 5000])
@@ -759,7 +759,7 @@ def test_max_header_value_size(parser: HttpRequestParser, size: int) -> None:
     name = b"t" * size
     text = b"GET /test HTTP/1.1\r\ndata:" + name + b"\r\n\r\n"
 
-    match = f"400, message:\n  Got more than 8190 bytes \\({size}\\) when reading"
+    match = f"400, message:\n  Got more than 8190 bytes when reading"
     with pytest.raises(http_exceptions.LineTooLong, match=match):
         for i in range(0, len(text), 4000):
             parser.feed_data(text[i : i + 4000])
@@ -775,7 +775,7 @@ def test_max_header_combined_size(parser: HttpRequestParser) -> None:
         + b"\r\n\r\n"
     )
 
-    match = f"400, message:\n  Got more than 8190 bytes \\({8202}\\) when reading"
+    match = f"400, message:\n  Got more than 8190 bytes when reading"
     with pytest.raises(http_exceptions.LineTooLong, match=match):
         parser.feed_data(text)
 
@@ -789,7 +789,7 @@ def test_max_trailer_size(parser: HttpRequestParser, size: int) -> None:
         + b"\r\n\r\n"
     )
 
-    match = f"400, message:\n  Got more than 8190 bytes \\({size}\\) when reading"
+    match = f"400, message:\n  Got more than 8190 bytes when reading"
     with pytest.raises(http_exceptions.LineTooLong, match=match):
         for i in range(0, len(text), 3000):
             parser.feed_data(text[i : i + 3000])
@@ -835,7 +835,7 @@ def test_max_header_value_size_continuation(
     name = b"T" * (size - 5)
     text = b"HTTP/1.1 200 Ok\r\ndata: test\r\n " + name + b"\r\n\r\n"
 
-    match = f"400, message:\n  Got more than 8190 bytes \\({size}\\) when reading"
+    match = f"400, message:\n  Got more than 8190 bytes when reading"
     with pytest.raises(http_exceptions.LineTooLong, match=match):
         for i in range(0, len(text), 9000):
             response.feed_data(text[i : i + 9000])
@@ -1083,7 +1083,7 @@ def test_http_request_parser_bad_nonascii_uri(parser: HttpRequestParser) -> None
 @pytest.mark.parametrize("size", [40965, 8191])
 def test_http_request_max_status_line(parser: HttpRequestParser, size: int) -> None:
     path = b"t" * (size - 5)
-    match = f"400, message:\n  Got more than 8190 bytes \\({size}\\) when reading"
+    match = f"400, message:\n  Got more than 8190 bytes when reading"
     with pytest.raises(http_exceptions.LineTooLong, match=match):
         parser.feed_data(b"GET /path" + path + b" HTTP/1.1\r\n\r\n")
 
@@ -1170,7 +1170,7 @@ def test_http_response_parser_bad_status_line_too_long(
     response: HttpResponseParser, size: int
 ) -> None:
     reason = b"t" * (size - 2)
-    match = f"400, message:\n  Got more than 8190 bytes \\({size}\\) when reading"
+    match = f"400, message:\n  Got more than 8190 bytes when reading"
     with pytest.raises(http_exceptions.LineTooLong, match=match):
         response.feed_data(b"HTTP/1.1 200 Ok" + reason + b"\r\n\r\n")
 

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -786,9 +786,9 @@ def test_max_trailer_size(parser: HttpRequestParser, size: int) -> None:
 def test_max_headers(parser: HttpRequestParser, headers: int, trailers: int) -> None:
     text = (
         b"GET /test HTTP/1.1\r\nTransfer-Encoding: chunked"
-        + sum(b"\r\nHeader-{}: Value".format(i) for i in range(headers), start=b"") +
+        + sum((b"\r\nHeader-{}: Value".format(i) for i in range(headers)), start=b"") +
         b"\r\n\r\n4\r\ntest\r\n0"
-        + sum(b"\r\nTrailer-{}: Value".format(i) for i in range(trailers), start=b"") +
+        + sum((b"\r\nTrailer-{}: Value".format(i) for i in range(trailers)), start=b"") +
         b"\r\n\r\n"
     )
 

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -765,7 +765,13 @@ def test_max_header_value_size(parser: HttpRequestParser, size: int) -> None:
 
 def test_max_header_combined_size(parser: HttpRequestParser) -> None:
     k = b"t" * 4100
-    text = b"GET /test HTTP/1.1\r\nTransfer-Encoding: chunked\r\n\r\n4\r\ntest\r\n0\r\n" + k + b": " + k + b"\r\n\r\n"
+    text = (
+        b"GET /test HTTP/1.1\r\nTransfer-Encoding: chunked\r\n\r\n4\r\ntest\r\n0\r\n"
+        + k
+        + b": "
+        + k
+        + b"\r\n\r\n"
+    )
 
     match = f"400, message:\n  Got more than 8190 bytes \\({8202}\\) when reading"
     with pytest.raises(http_exceptions.LineTooLong, match=match):
@@ -775,7 +781,11 @@ def test_max_header_combined_size(parser: HttpRequestParser) -> None:
 @pytest.mark.parametrize("size", [40960, 8191])
 def test_max_trailer_size(parser: HttpRequestParser, size: int) -> None:
     value = b"t" * size
-    text = b"GET /test HTTP/1.1\r\nTransfer-Encoding: chunked\r\n\r\n4\r\ntest\r\n0\r\ntest: " + value + b"\r\n\r\n"
+    text = (
+        b"GET /test HTTP/1.1\r\nTransfer-Encoding: chunked\r\n\r\n4\r\ntest\r\n0\r\ntest: "
+        + value
+        + b"\r\n\r\n"
+    )
 
     match = f"400, message:\n  Got more than 8190 bytes \\({size}\\) when reading"
     with pytest.raises(http_exceptions.LineTooLong, match=match):
@@ -786,10 +796,10 @@ def test_max_trailer_size(parser: HttpRequestParser, size: int) -> None:
 def test_max_headers(parser: HttpRequestParser, headers: int, trailers: int) -> None:
     text = (
         b"GET /test HTTP/1.1\r\nTransfer-Encoding: chunked"
-        + sum((b"\r\nHeader-{}: Value".format(i) for i in range(headers)), start=b"") +
-        b"\r\n\r\n4\r\ntest\r\n0"
-        + sum((b"\r\nTrailer-{}: Value".format(i) for i in range(trailers)), start=b"") +
-        b"\r\n\r\n"
+        + sum((b"\r\nHeader-{}: Value".format(i) for i in range(headers)), start=b"")
+        + b"\r\n\r\n4\r\ntest\r\n0"
+        + sum((b"\r\nTrailer-{}: Value".format(i) for i in range(trailers)), start=b"")
+        + b"\r\n\r\n"
     )
 
     match = "Too many (headers|trailers) received"

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -787,7 +787,9 @@ def test_max_trailer_size(parser: HttpRequestParser, size: int) -> None:
 
 
 @pytest.mark.parametrize("headers,trailers", ((129, 0), (0, 129), (64, 65)))
-async def test_max_headers(parser: HttpRequestParser, headers: int, trailers: int) -> None:
+async def test_max_headers(
+    parser: HttpRequestParser, headers: int, trailers: int
+) -> None:
     text = (
         b"GET /test HTTP/1.1\r\nTransfer-Encoding: chunked"
         + b"".join(b"\r\nHeader-%d: Value" % i for i in range(headers))

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -787,7 +787,7 @@ def test_max_trailer_size(parser: HttpRequestParser, size: int) -> None:
 
 
 @pytest.mark.parametrize("headers,trailers", ((129, 0), (0, 129), (64, 65)))
-def test_max_headers(parser: HttpRequestParser, headers: int, trailers: int) -> None:
+async def test_max_headers(parser: HttpRequestParser, headers: int, trailers: int) -> None:
     text = (
         b"GET /test HTTP/1.1\r\nTransfer-Encoding: chunked"
         + b"".join(b"\r\nHeader-%d: Value" % i for i in range(headers))


### PR DESCRIPTION
Also tweaks to max_line_size/max_field_size.

Prior art for the max number of fields: cpython has a limit of 100 and appears to have only a couple of user complaints (https://github.com/python/cpython/issues/131724, https://github.com/Azure/azure-cli/issues/28309) about a Microsoft site sometimes using slightly over 100 (101 and 108 reported) headers, so our limit is just a little higher.