### PR TITLE
Allow `JSONEncoder` to return bytes directly

### DIFF
--- a/CHANGES/11989.feature.rst
+++ b/CHANGES/11989.feature.rst
@@ -1,0 +1,6 @@
+Added explicit APIs for bytes-returning JSON serializer:
+``JSONEncoderBytes`` type, ``JsonBytesPayload``,
+``json_bytes_response()``, ``WebSocketResponse.send_json_bytes()`` and
+``ClientWebSocketResponse.send_json_bytes()`` methods, and
+``json_serialize_bytes`` parameter for ``ClientSession``
+-- by :user:`kevinpark1217`.

--- a/CHANGES/11989.feature.rst
+++ b/CHANGES/11989.feature.rst
@@ -1,6 +1,7 @@
 Added explicit APIs for bytes-returning JSON serializer:
 ``JSONBytesEncoder`` type, ``JsonBytesPayload``,
-``json_bytes_response()``, ``WebSocketResponse.send_json_bytes()`` and
-``ClientWebSocketResponse.send_json_bytes()`` methods, and
-``json_serialize_bytes`` parameter for ``ClientSession``
+:func:`~aiohttp.web.json_bytes_response`,
+:meth:`~aiohttp.web.WebSocketResponse.send_json_bytes` and
+:meth:`~aiohttp.ClientWebSocketResponse.send_json_bytes` methods, and
+``json_serialize_bytes`` parameter for :class:`~aiohttp.ClientSession`
 -- by :user:`kevinpark1217`.

--- a/CHANGES/11989.feature.rst
+++ b/CHANGES/11989.feature.rst
@@ -1,5 +1,5 @@
 Added explicit APIs for bytes-returning JSON serializer:
-``JSONEncoderBytes`` type, ``JsonBytesPayload``,
+``JSONBytesEncoder`` type, ``JsonBytesPayload``,
 ``json_bytes_response()``, ``WebSocketResponse.send_json_bytes()`` and
 ``ClientWebSocketResponse.send_json_bytes()`` methods, and
 ``json_serialize_bytes`` parameter for ``ClientSession``

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -107,8 +107,8 @@ from .http import WS_KEY, HttpVersion, WebSocketReader, WebSocketWriter
 from .http_websocket import WSHandshakeError, ws_ext_gen, ws_ext_parse
 from .tracing import Trace, TraceConfig
 from .typedefs import (
+    JSONBytesEncoder,
     JSONEncoder,
-    JSONEncoderBytes,
     LooseCookies,
     LooseHeaders,
     StrOrURL,
@@ -311,7 +311,7 @@ class ClientSession:
         skip_auto_headers: Iterable[str] | None = None,
         auth: BasicAuth | None = None,
         json_serialize: JSONEncoder = json.dumps,
-        json_serialize_bytes: JSONEncoderBytes | None = None,
+        json_serialize_bytes: JSONBytesEncoder | None = None,
         request_class: type[ClientRequest] = ClientRequest,
         response_class: type[ClientResponse] = ClientResponse,
         ws_response_class: type[ClientWebSocketResponse] = ClientWebSocketResponse,

--- a/aiohttp/client_ws.py
+++ b/aiohttp/client_ws.py
@@ -276,7 +276,7 @@ class ClientWebSocketResponse(Generic[_DecodeText]):
 
     async def send_json_bytes(
         self,
-        data: object,
+        data: Any,
         compress: int | None = None,
         *,
         dumps: JSONBytesEncoder,

--- a/aiohttp/client_ws.py
+++ b/aiohttp/client_ws.py
@@ -26,6 +26,7 @@ from .typedefs import (
     DEFAULT_JSON_ENCODER,
     JSONDecoder,
     JSONEncoder,
+    JSONEncoderBytes,
 )
 
 if sys.version_info >= (3, 13):
@@ -272,6 +273,19 @@ class ClientWebSocketResponse(Generic[_DecodeText]):
         dumps: JSONEncoder = DEFAULT_JSON_ENCODER,
     ) -> None:
         await self.send_str(dumps(data), compress=compress)
+
+    async def send_json_bytes(
+        self,
+        data: Any,
+        dumps: JSONEncoderBytes,
+        compress: int | None = None,
+    ) -> None:
+        """Send JSON data using a bytes-returning encoder as a binary frame.
+
+        Use this when your JSON encoder (like orjson) returns bytes
+        instead of str, avoiding the encode/decode overhead.
+        """
+        await self.send_bytes(dumps(data), compress=compress)
 
     async def close(self, *, code: int = WSCloseCode.OK, message: bytes = b"") -> bool:
         # we need to break `receive()` cycle first,

--- a/aiohttp/client_ws.py
+++ b/aiohttp/client_ws.py
@@ -24,9 +24,9 @@ from .streams import EofStream
 from .typedefs import (
     DEFAULT_JSON_DECODER,
     DEFAULT_JSON_ENCODER,
+    JSONBytesEncoder,
     JSONDecoder,
     JSONEncoder,
-    JSONEncoderBytes,
 )
 
 if sys.version_info >= (3, 13):
@@ -276,9 +276,10 @@ class ClientWebSocketResponse(Generic[_DecodeText]):
 
     async def send_json_bytes(
         self,
-        data: Any,
-        dumps: JSONEncoderBytes,
+        data: object,
         compress: int | None = None,
+        *,
+        dumps: JSONBytesEncoder,
     ) -> None:
         """Send JSON data using a bytes-returning encoder as a binary frame.
 

--- a/aiohttp/payload.py
+++ b/aiohttp/payload.py
@@ -23,7 +23,7 @@ from .helpers import (
     sentinel,
 )
 from .streams import StreamReader
-from .typedefs import JSONEncoder
+from .typedefs import JSONEncoder, JSONEncoderBytes
 
 __all__ = (
     "PAYLOAD_REGISTRY",
@@ -38,6 +38,7 @@ __all__ = (
     "TextIOPayload",
     "StringIOPayload",
     "JsonPayload",
+    "JsonBytesPayload",
     "AsyncIterablePayload",
 )
 
@@ -934,6 +935,29 @@ class JsonPayload(BytesPayload):
             dumps(value).encode(encoding),
             content_type=content_type,
             encoding=encoding,
+            *args,
+            **kwargs,
+        )
+
+
+class JsonBytesPayload(BytesPayload):
+    """JSON payload for encoders that return bytes directly.
+
+    Use this when your JSON encoder (like orjson) returns bytes
+    instead of str, avoiding the encode/decode overhead.
+    """
+
+    def __init__(
+        self,
+        value: Any,
+        dumps: JSONEncoderBytes,
+        content_type: str = "application/json",
+        *args: Any,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(
+            dumps(value),
+            content_type=content_type,
             *args,
             **kwargs,
         )

--- a/aiohttp/payload.py
+++ b/aiohttp/payload.py
@@ -23,7 +23,7 @@ from .helpers import (
     sentinel,
 )
 from .streams import StreamReader
-from .typedefs import JSONEncoder, JSONEncoderBytes
+from .typedefs import JSONBytesEncoder, JSONEncoder
 
 __all__ = (
     "PAYLOAD_REGISTRY",
@@ -949,11 +949,11 @@ class JsonBytesPayload(BytesPayload):
 
     def __init__(
         self,
-        value: Any,
-        dumps: JSONEncoderBytes,
+        value: object,
+        dumps: JSONBytesEncoder,
         content_type: str = "application/json",
-        *args: Any,
-        **kwargs: Any,
+        *args: object,
+        **kwargs: object,
     ) -> None:
         super().__init__(
             dumps(value),

--- a/aiohttp/payload.py
+++ b/aiohttp/payload.py
@@ -949,11 +949,11 @@ class JsonBytesPayload(BytesPayload):
 
     def __init__(
         self,
-        value: object,
+        value: Any,
         dumps: JSONBytesEncoder,
         content_type: str = "application/json",
-        *args: object,
-        **kwargs: object,
+        *args: Any,
+        **kwargs: Any,
     ) -> None:
         super().__init__(
             dumps(value),

--- a/aiohttp/typedefs.py
+++ b/aiohttp/typedefs.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 
 Byteish = bytes | bytearray | memoryview
 JSONEncoder = Callable[[Any], str]
-JSONEncoderBytes = Callable[[Any], bytes]
+JSONBytesEncoder = Callable[[Any], bytes]
 JSONDecoder = Callable[[str], Any]
 LooseHeaders = (
     Mapping[str, str]

--- a/aiohttp/typedefs.py
+++ b/aiohttp/typedefs.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
 
 Byteish = bytes | bytearray | memoryview
 JSONEncoder = Callable[[Any], str]
+JSONEncoderBytes = Callable[[Any], bytes]
 JSONDecoder = Callable[[str], Any]
 LooseHeaders = (
     Mapping[str, str]

--- a/aiohttp/web.py
+++ b/aiohttp/web.py
@@ -81,7 +81,13 @@ from .web_log import AccessLogger
 from .web_middlewares import middleware, normalize_path_middleware
 from .web_protocol import PayloadAccessError, RequestHandler, RequestPayloadError
 from .web_request import BaseRequest, FileField, Request
-from .web_response import ContentCoding, Response, StreamResponse, json_response
+from .web_response import (
+    ContentCoding,
+    Response,
+    StreamResponse,
+    json_bytes_response,
+    json_response,
+)
 from .web_routedef import (
     AbstractRouteDef,
     RouteDef,
@@ -208,6 +214,7 @@ __all__ = (
     "ContentCoding",
     "Response",
     "StreamResponse",
+    "json_bytes_response",
     "json_response",
     "ResponseKey",
     # web_routedef

--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -32,12 +32,18 @@ from .helpers import (
 )
 from .http import SERVER_SOFTWARE, HttpVersion10, HttpVersion11
 from .payload import Payload
-from .typedefs import JSONEncoder, LooseHeaders
+from .typedefs import JSONEncoder, JSONEncoderBytes, LooseHeaders
 
 REASON_PHRASES = {http_status.value: http_status.phrase for http_status in HTTPStatus}
 LARGE_BODY_SIZE = 1024**2
 
-__all__ = ("ContentCoding", "StreamResponse", "Response", "json_response")
+__all__ = (
+    "ContentCoding",
+    "StreamResponse",
+    "Response",
+    "json_response",
+    "json_bytes_response",
+)
 
 
 if TYPE_CHECKING:
@@ -752,6 +758,35 @@ def json_response(
             text = dumps(data)
     return Response(
         text=text,
+        body=body,
+        status=status,
+        reason=reason,
+        headers=headers,
+        content_type=content_type,
+    )
+
+
+def json_bytes_response(
+    data: Any = sentinel,
+    *,
+    dumps: JSONEncoderBytes,
+    body: bytes | None = None,
+    status: int = 200,
+    reason: str | None = None,
+    headers: LooseHeaders | None = None,
+    content_type: str = "application/json",
+) -> Response:
+    """Create a JSON response using a bytes-returning encoder.
+
+    Use this when your JSON encoder (like orjson) returns bytes
+    instead of str, avoiding the encode/decode overhead.
+    """
+    if data is not sentinel:
+        if body:
+            raise ValueError("only one of data or body should be specified")
+        else:
+            body = dumps(data)
+    return Response(
         body=body,
         status=status,
         reason=reason,

--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -767,7 +767,7 @@ def json_response(
 
 
 def json_bytes_response(
-    data: object = sentinel,
+    data: Any = sentinel,
     *,
     dumps: JSONBytesEncoder,
     body: bytes | None = None,

--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -32,7 +32,7 @@ from .helpers import (
 )
 from .http import SERVER_SOFTWARE, HttpVersion10, HttpVersion11
 from .payload import Payload
-from .typedefs import JSONEncoder, JSONEncoderBytes, LooseHeaders
+from .typedefs import JSONBytesEncoder, JSONEncoder, LooseHeaders
 
 REASON_PHRASES = {http_status.value: http_status.phrase for http_status in HTTPStatus}
 LARGE_BODY_SIZE = 1024**2
@@ -767,9 +767,9 @@ def json_response(
 
 
 def json_bytes_response(
-    data: Any = sentinel,
+    data: object = sentinel,
     *,
-    dumps: JSONEncoderBytes,
+    dumps: JSONBytesEncoder,
     body: bytes | None = None,
     status: int = 200,
     reason: str | None = None,
@@ -782,7 +782,7 @@ def json_bytes_response(
     instead of str, avoiding the encode/decode overhead.
     """
     if data is not sentinel:
-        if body:
+        if body is not None:
             raise ValueError("only one of data or body should be specified")
         else:
             body = dumps(data)

--- a/aiohttp/web_ws.py
+++ b/aiohttp/web_ws.py
@@ -452,7 +452,7 @@ class WebSocketResponse(StreamResponse, Generic[_DecodeText]):
 
     async def send_json_bytes(
         self,
-        data: object,
+        data: Any,
         compress: int | None = None,
         *,
         dumps: JSONBytesEncoder,

--- a/aiohttp/web_ws.py
+++ b/aiohttp/web_ws.py
@@ -37,7 +37,7 @@ from .http import (
 from .http_websocket import _INTERNAL_RECEIVE_TYPES, WSMessageError
 from .log import ws_logger
 from .streams import EofStream
-from .typedefs import JSONDecoder, JSONEncoder
+from .typedefs import JSONDecoder, JSONEncoder, JSONEncoderBytes
 from .web_exceptions import HTTPBadRequest, HTTPException
 from .web_request import BaseRequest
 from .web_response import StreamResponse
@@ -449,6 +449,19 @@ class WebSocketResponse(StreamResponse, Generic[_DecodeText]):
         dumps: JSONEncoder = json.dumps,
     ) -> None:
         await self.send_str(dumps(data), compress=compress)
+
+    async def send_json_bytes(
+        self,
+        data: Any,
+        dumps: JSONEncoderBytes,
+        compress: int | None = None,
+    ) -> None:
+        """Send JSON data using a bytes-returning encoder as a binary frame.
+
+        Use this when your JSON encoder (like orjson) returns bytes
+        instead of str, avoiding the encode/decode overhead.
+        """
+        await self.send_bytes(dumps(data), compress=compress)
 
     async def write_eof(self) -> None:  # type: ignore[override]
         if self._eof_sent:

--- a/aiohttp/web_ws.py
+++ b/aiohttp/web_ws.py
@@ -37,7 +37,7 @@ from .http import (
 from .http_websocket import _INTERNAL_RECEIVE_TYPES, WSMessageError
 from .log import ws_logger
 from .streams import EofStream
-from .typedefs import JSONDecoder, JSONEncoder, JSONEncoderBytes
+from .typedefs import JSONBytesEncoder, JSONDecoder, JSONEncoder
 from .web_exceptions import HTTPBadRequest, HTTPException
 from .web_request import BaseRequest
 from .web_response import StreamResponse
@@ -452,9 +452,10 @@ class WebSocketResponse(StreamResponse, Generic[_DecodeText]):
 
     async def send_json_bytes(
         self,
-        data: Any,
-        dumps: JSONEncoderBytes,
+        data: object,
         compress: int | None = None,
+        *,
+        dumps: JSONBytesEncoder,
     ) -> None:
         """Send JSON data using a bytes-returning encoder as a binary frame.
 

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -1833,6 +1833,28 @@ manually.
          The method is converted into :term:`coroutine`,
          *compress* parameter added.
 
+   .. method:: send_json_bytes(data, compress=None, *, dumps)
+      :async:
+
+      Send *data* to peer as a JSON binary frame using a bytes-returning encoder.
+
+      :param data: data to send.
+
+      :param int compress: sets specific level of compression for
+                           single message,
+                           ``None`` for not overriding per-socket setting.
+
+      :param collections.abc.Callable dumps: any :term:`callable` that accepts an object and
+                             returns JSON as :class:`bytes`
+                             (e.g. ``orjson.dumps``).
+
+      :raise RuntimeError: if connection is not started or closing
+
+      :raise ValueError: if data is not serializable object
+
+      :raise TypeError: if value returned by ``dumps(data)`` is not
+                        :class:`bytes`
+
    .. method:: send_frame(message, opcode, compress=None)
       :async:
 

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -227,6 +227,7 @@ nowait
 OAuth
 Online
 optimizations
+orjson
 os
 outcoming
 Overridable

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -1401,8 +1401,8 @@ Return :class:`Response` with predefined ``'application/json'``
 content type and *data* encoded by ``dumps`` parameter
 which must return :class:`bytes` directly (e.g. ``orjson.dumps``).
 
-Use this when your JSON encoder returns bytes instead of str,
-avoiding the str-to-bytes encoding overhead.
+Use this when your JSON encoder returns :class:`bytes` instead of :class:`str`,
+avoiding the :class:`str`-to-:class:`bytes` encoding overhead.
 
 
 .. class:: ResponseKey(name, t)

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -1200,6 +1200,27 @@ and :ref:`aiohttp-web-signals` handlers::
          The method is converted into :term:`coroutine`,
          *compress* parameter added.
 
+   .. method:: send_json_bytes(data, compress=None, *, dumps)
+      :async:
+
+      Send *data* to peer as a JSON binary frame using a bytes-returning encoder.
+
+      :param data: data to send.
+
+      :param int compress: sets specific level of compression for
+                           single message,
+                           ``None`` for not overriding per-socket setting.
+
+      :param collections.abc.Callable dumps: any :term:`callable` that accepts an object and
+                             returns JSON as :class:`bytes`
+                             (e.g. ``orjson.dumps``).
+
+      :raise RuntimeError: if the connection is not started.
+
+      :raise ValueError: if data is not serializable object
+
+      :raise TypeError: if value returned by ``dumps`` param is not :class:`bytes`
+
    .. method:: send_frame(message, opcode, compress=None)
       :async:
 
@@ -1370,6 +1391,18 @@ and :ref:`aiohttp-web-signals` handlers::
 Return :class:`Response` with predefined ``'application/json'``
 content type and *data* encoded by ``dumps`` parameter
 (:func:`json.dumps` by default).
+
+
+.. function:: json_bytes_response([data], *, dumps, body=None, \
+                                  status=200, reason=None, headers=None, \
+                                  content_type='application/json')
+
+Return :class:`Response` with predefined ``'application/json'``
+content type and *data* encoded by ``dumps`` parameter
+which must return :class:`bytes` directly (e.g. ``orjson.dumps``).
+
+Use this when your JSON encoder returns bytes instead of str,
+avoiding the str-to-bytes encoding overhead.
 
 
 .. class:: ResponseKey(name, t)

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -2193,6 +2193,27 @@ async def test_json_custom(aiohttp_client: AiohttpClient) -> None:
         await client.post("/", data="some data", json={"some": "data"})
 
 
+async def test_json_serialize_bytes(aiohttp_client: AiohttpClient) -> None:
+    """Test ClientSession.json_serialize_bytes with bytes-returning encoder."""
+
+    async def handler(request: web.Request) -> web.Response:
+        assert request.content_type == "application/json"
+        data = await request.json()
+        return web.Response(body=aiohttp.JsonPayload(data))
+
+    json_bytes_encoder = mock.Mock(side_effect=lambda x: json.dumps(x).encode("utf-8"))
+
+    app = web.Application()
+    app.router.add_post("/", handler)
+    client = await aiohttp_client(app, json_serialize_bytes=json_bytes_encoder)
+
+    async with client.post("/", json={"some": "data"}) as resp:
+        assert resp.status == 200
+        assert json_bytes_encoder.called
+        content = await resp.json()
+    assert content == {"some": "data"}
+
+
 async def test_expect_continue(aiohttp_client: AiohttpClient) -> None:
     expect_called = False
 

--- a/tests/test_client_ws_functional.py
+++ b/tests/test_client_ws_functional.py
@@ -259,7 +259,7 @@ async def test_send_json_bytes_custom_encoder(aiohttp_client: AiohttpClient) -> 
     app.router.add_route("GET", "/", handler)
     client = await aiohttp_client(app)
     resp = await client.ws_connect("/")
-    await resp.send_json_bytes({"test": "value"}, custom_encoder)
+    await resp.send_json_bytes({"test": "value"}, dumps=custom_encoder)
     await resp.close()
 
 

--- a/tests/test_client_ws_functional.py
+++ b/tests/test_client_ws_functional.py
@@ -205,6 +205,64 @@ async def test_send_recv_json_bytes(aiohttp_client: AiohttpClient) -> None:
     await resp.close()
 
 
+async def test_send_json_bytes_client(aiohttp_client: AiohttpClient) -> None:
+    """Test ClientWebSocketResponse.send_json_bytes sends binary frame."""
+
+    async def handler(request: web.Request) -> web.WebSocketResponse:
+        ws = web.WebSocketResponse()
+        await ws.prepare(request)
+
+        msg = await ws.receive()
+        assert msg.type is WSMsgType.BINARY
+        data = json.loads(msg.data)
+        await ws.send_json_bytes(
+            {"response": data["request"]},
+            dumps=lambda x: json.dumps(x).encode("utf-8"),
+        )
+        await ws.close()
+        return ws
+
+    app = web.Application()
+    app.router.add_route("GET", "/", handler)
+    client = await aiohttp_client(app)
+    resp = await client.ws_connect("/")
+    test_payload = {"request": "test"}
+    await resp.send_json_bytes(
+        test_payload, dumps=lambda x: json.dumps(x).encode("utf-8")
+    )
+
+    msg = await resp.receive()
+    assert msg.type is WSMsgType.BINARY
+    data = json.loads(msg.data)
+    assert data["response"] == test_payload["request"]
+    await resp.close()
+
+
+async def test_send_json_bytes_custom_encoder(aiohttp_client: AiohttpClient) -> None:
+    """Test send_json_bytes with custom bytes-returning encoder."""
+
+    def custom_encoder(obj: object) -> bytes:
+        return json.dumps(obj, separators=(",", ":")).encode("utf-8")
+
+    async def handler(request: web.Request) -> web.WebSocketResponse:
+        ws = web.WebSocketResponse()
+        await ws.prepare(request)
+
+        msg = await ws.receive()
+        assert msg.type is WSMsgType.BINARY
+        # Custom encoder uses compact separators
+        assert msg.data == b'{"test":"value"}'
+        await ws.close()
+        return ws
+
+    app = web.Application()
+    app.router.add_route("GET", "/", handler)
+    client = await aiohttp_client(app)
+    resp = await client.ws_connect("/")
+    await resp.send_json_bytes({"test": "value"}, custom_encoder)
+    await resp.close()
+
+
 async def test_send_recv_frame(aiohttp_client: AiohttpClient) -> None:
     async def handler(request: web.Request) -> web.WebSocketResponse:
         ws = web.WebSocketResponse()

--- a/tests/test_client_ws_functional.py
+++ b/tests/test_client_ws_functional.py
@@ -241,9 +241,6 @@ async def test_send_json_bytes_client(aiohttp_client: AiohttpClient) -> None:
 async def test_send_json_bytes_custom_encoder(aiohttp_client: AiohttpClient) -> None:
     """Test send_json_bytes with custom bytes-returning encoder."""
 
-    def custom_encoder(obj: object) -> bytes:
-        return json.dumps(obj, separators=(",", ":")).encode("utf-8")
-
     async def handler(request: web.Request) -> web.WebSocketResponse:
         ws = web.WebSocketResponse()
         await ws.prepare(request)
@@ -259,7 +256,10 @@ async def test_send_json_bytes_custom_encoder(aiohttp_client: AiohttpClient) -> 
     app.router.add_route("GET", "/", handler)
     client = await aiohttp_client(app)
     resp = await client.ws_connect("/")
-    await resp.send_json_bytes({"test": "value"}, dumps=custom_encoder)
+    await resp.send_json_bytes(
+        {"test": "value"},
+        dumps=lambda x: json.dumps(x, separators=(",", ":")).encode("utf-8"),
+    )
     await resp.close()
 
 

--- a/tests/test_payload.py
+++ b/tests/test_payload.py
@@ -1221,6 +1221,40 @@ def test_json_payload_size() -> None:
     assert jp_custom.size == len(expected_custom.encode("utf-16"))
 
 
+def test_json_bytes_payload() -> None:
+    """Test JsonBytesPayload with a bytes-returning encoder."""
+    data = {"hello": "world"}
+
+    # Test with standard library encoder
+    jp = payload.JsonBytesPayload(data, dumps=lambda x: json.dumps(x).encode("utf-8"))
+    expected = json.dumps(data).encode("utf-8")
+    assert jp.size == len(expected)
+
+    # Test with custom bytes-returning encoder (compact separators)
+    jp_custom = payload.JsonBytesPayload(
+        data, dumps=lambda x: json.dumps(x, separators=(",", ":")).encode("utf-8")
+    )
+    expected_custom = json.dumps(data, separators=(",", ":")).encode("utf-8")
+    assert jp_custom.size == len(expected_custom)
+
+
+def test_json_bytes_payload_content_type() -> None:
+    """Test JsonBytesPayload content_type."""
+    data = {"test": "data"}
+
+    # Default content type
+    jp = payload.JsonBytesPayload(data, dumps=lambda x: json.dumps(x).encode("utf-8"))
+    assert jp.content_type == "application/json"
+
+    # Custom content type
+    jp_custom = payload.JsonBytesPayload(
+        data,
+        dumps=lambda x: json.dumps(x).encode("utf-8"),
+        content_type="application/vnd.api+json",
+    )
+    assert jp_custom.content_type == "application/vnd.api+json"
+
+
 async def test_text_io_payload_size_matches_file_encoding(tmp_path: Path) -> None:
     """Test TextIOPayload.size when file encoding matches payload encoding."""
     # Create UTF-8 file

--- a/tests/test_web_response.py
+++ b/tests/test_web_response.py
@@ -1474,9 +1474,9 @@ class TestJSONBytesResponse:
     def test_passing_body_only(self) -> None:
         resp = web.json_bytes_response(
             dumps=lambda x: json.dumps(x).encode("utf-8"),
-            body=json.dumps("jaysawn").encode("utf-8"),
+            body=b'"jaysawn"',
         )
-        assert resp.body == json.dumps("jaysawn").encode("utf-8")
+        assert resp.body == b'"jaysawn"'
 
     def test_data_and_body_raises_value_error(self) -> None:
         with pytest.raises(ValueError) as excinfo:

--- a/tests/test_web_response.py
+++ b/tests/test_web_response.py
@@ -1464,6 +1464,50 @@ class TestJSONResponse:
         assert "application/vnd.json+api" == resp.content_type
 
 
+class TestJSONBytesResponse:
+    def test_content_type_is_application_json_by_default(self) -> None:
+        resp = web.json_bytes_response(
+            "", dumps=lambda x: json.dumps(x).encode("utf-8")
+        )
+        assert "application/json" == resp.content_type
+
+    def test_passing_body_only(self) -> None:
+        resp = web.json_bytes_response(
+            dumps=lambda x: json.dumps(x).encode("utf-8"),
+            body=json.dumps("jaysawn").encode("utf-8"),
+        )
+        assert resp.body == json.dumps("jaysawn").encode("utf-8")
+
+    def test_data_and_body_raises_value_error(self) -> None:
+        with pytest.raises(ValueError) as excinfo:
+            web.json_bytes_response(
+                data="foo", dumps=lambda x: json.dumps(x).encode("utf-8"), body=b"bar"
+            )
+        expected_message = "only one of data or body should be specified"
+        assert expected_message == excinfo.value.args[0]
+
+    def test_body_is_json_encoded_bytes(self) -> None:
+        resp = web.json_bytes_response(
+            {"foo": 42}, dumps=lambda x: json.dumps(x).encode("utf-8")
+        )
+        assert json.dumps({"foo": 42}).encode("utf-8") == resp.body
+
+    def test_content_type_is_overrideable(self) -> None:
+        resp = web.json_bytes_response(
+            {"foo": 42},
+            dumps=lambda x: json.dumps(x).encode("utf-8"),
+            content_type="application/vnd.json+api",
+        )
+        assert "application/vnd.json+api" == resp.content_type
+
+    def test_custom_dumps(self) -> None:
+        resp = web.json_bytes_response(
+            {"foo": 42},
+            dumps=lambda x: json.dumps(x, separators=(",", ":")).encode("utf-8"),
+        )
+        assert b'{"foo":42}' == resp.body
+
+
 @pytest.mark.dev_mode
 async def test_no_warn_small_cookie(
     buf: bytearray, writer: AbstractStreamWriter

--- a/tests/test_web_websocket.py
+++ b/tests/test_web_websocket.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 import time
 from typing import Protocol
 from unittest import mock
@@ -152,6 +153,22 @@ async def test_send_json_nonjson(make_request: _RequestMaker) -> None:
     await ws.prepare(req)
     with pytest.raises(TypeError):
         await ws.send_json(set())
+
+
+async def test_nonstarted_send_json_bytes() -> None:
+    ws = web.WebSocketResponse()
+    with pytest.raises(RuntimeError):
+        await ws.send_json_bytes(
+            {"type": "json"}, dumps=lambda x: json.dumps(x).encode("utf-8")
+        )
+
+
+async def test_send_json_bytes_nonjson(make_request: _RequestMaker) -> None:
+    req = make_request("GET", "/")
+    ws = web.WebSocketResponse()
+    await ws.prepare(req)
+    with pytest.raises(TypeError):
+        await ws.send_json_bytes(set(), dumps=lambda x: json.dumps(x).encode("utf-8"))
 
 
 async def test_write_non_prepared() -> None:
@@ -315,6 +332,20 @@ async def test_send_json_closed(make_request: _RequestMaker) -> None:
 
     with pytest.raises(ConnectionError):
         await ws.send_json({"type": "json"})
+
+
+async def test_send_json_bytes_closed(make_request: _RequestMaker) -> None:
+    req = make_request("GET", "/")
+    ws = web.WebSocketResponse()
+    await ws.prepare(req)
+    assert ws._reader is not None
+    ws._reader.feed_data(WS_CLOSED_MESSAGE)
+    await ws.close()
+
+    with pytest.raises(ConnectionError):
+        await ws.send_json_bytes(
+            {"type": "json"}, dumps=lambda x: json.dumps(x).encode("utf-8")
+        )
 
 
 async def test_send_frame_closed(make_request: _RequestMaker) -> None:

--- a/tests/test_web_websocket.py
+++ b/tests/test_web_websocket.py
@@ -170,6 +170,10 @@ async def test_send_json_bytes_nonjson(make_request: _RequestMaker) -> None:
     with pytest.raises(TypeError):
         await ws.send_json_bytes(set(), dumps=lambda x: json.dumps(x).encode("utf-8"))
 
+    assert ws._reader is not None
+    ws._reader.feed_data(WS_CLOSED_MESSAGE)
+    await ws.close()
+
 
 async def test_write_non_prepared() -> None:
     ws = web.WebSocketResponse()


### PR DESCRIPTION
## Summary

Add explicit APIs for bytes-returning JSON serializers (like `orjson`), addressing maintainer feedback to avoid `isinstance()` checks in hot paths.

## Changes

1. **Kept `JSONEncoder` unchanged** - still returns `str` only
2. **Added new `JSONBytesEncoder` type** - `Callable[[Any], bytes]`
3. **No default bytes encoder** - users must explicitly provide their encoder (e.g., `orjson.dumps`)
4. **No `isinstance()` checks in hot paths** - separate explicit APIs instead
5. **Uses `object` instead of `Any`** for data parameters in new APIs
6. **`dumps` is keyword-only** in `send_json_bytes()` methods, matching `send_json()` signature

## New APIs

- `JSONBytesEncoder` type in `typedefs.py`
- `JsonBytesPayload` class - requires `dumps` parameter
- `json_bytes_response()` function - requires `dumps` parameter
- `send_json_bytes()` methods on `WebSocketResponse` and `ClientWebSocketResponse` - sends as binary frames, requires `dumps` keyword argument
- `ClientSession(json_serialize_bytes=...)` parameter - `None` by default, falls back to `json_serialize` if not set

## Documentation

- Added Sphinx doc entries for `json_bytes_response()`, `WebSocketResponse.send_json_bytes()`, and `ClientWebSocketResponse.send_json_bytes()`
- Changelog uses proper RST cross-reference roles

## Benefits

- Avoids runtime overhead of `isinstance()` checks
- Makes WebSocket frame type explicit (binary for bytes)
- Provides clear API separation for different use cases
- No behavioral changes to existing code

Closes #11988