### PR TITLE
[PR #11737/f30f43e6 backport][3.13] Skip benchmarks in ci when running in fork repositories

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -23,8 +23,32 @@ env:
   FORCE_COLOR: 1  # Request colored output from CLI tools supporting it
   MYPY_FORCE_COLOR: 1
   PY_COLORS: 1
+  UPSTREAM_REPOSITORY_ID: >-
+    13258039
+
+permissions: {}
 
 jobs:
+
+  pre-setup:
+    name: Pre-Setup global build settings
+    runs-on: ubuntu-latest
+    outputs:
+      upstream-repository-id: ${{ env.UPSTREAM_REPOSITORY_ID }}
+      release-requested: >-
+        ${{
+          (
+            github.event_name == 'push'
+            && github.ref_type == 'tag'
+          )
+          && true
+          || false
+        }}
+    steps:
+      - name: Dummy
+        if: false
+        run: |
+          echo "Pre-setup step"
 
   lint:
     name: Linter
@@ -243,8 +267,11 @@ jobs:
 
   benchmark:
     name: Benchmark
-    needs: gen_llhttp
-
+    needs:
+    - gen_llhttp
+    - pre-setup  # transitive, for accessing settings
+    if: >-
+      needs.pre-setup.outputs.upstream-repository-id == github.repository_id
     runs-on: ubuntu-latest
     timeout-minutes: 12
     steps:
@@ -279,7 +306,6 @@ jobs:
       uses: CodSpeedHQ/action@v4
       with:
         mode: instrumentation
-        token: ${{ secrets.CODSPEED_TOKEN }}
         run: python -Im pytest --no-cov --numprocesses=0 -vvvvv --codspeed
 
 
@@ -301,9 +327,10 @@ jobs:
   pre-deploy:
     name: Pre-Deploy
     runs-on: ubuntu-latest
-    needs: check
-    # Run only on pushing a tag
-    if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
+    needs:
+    - check
+    - pre-setup  # transitive, for accessing settings
+    if: fromJSON(needs.pre-setup.outputs.release-requested)
     steps:
       - name: Dummy
         run: |
@@ -443,8 +470,13 @@ jobs:
 
   deploy:
     name: Deploy
-    needs: [build-tarball, build-wheels]
+    needs:
+    - build-tarball
+    - build-wheels
+    - pre-setup  # transitive, for accessing settings
     runs-on: ubuntu-latest
+    if: >-
+      needs.pre-setup.outputs.upstream-repository-id == github.repository_id
 
     permissions:
       contents: write  # IMPORTANT: mandatory for making GitHub Releases

--- a/CHANGES/11737.contrib.rst
+++ b/CHANGES/11737.contrib.rst
@@ -1,0 +1,3 @@
+The benchmark CI job now runs only in the upstream repository -- by :user:`Cycloctane`.
+
+It used to always fail in forks, which this change fixed.


### PR DESCRIPTION
# Description

## What do these changes do?

This is a backport of PR #11737 to the `3.13` branch.

Forks cannot use codspeed account, which can make benchmark job in ci fail if aiohttp contributors want to run test workflow on their forks. This change makes unnecessary steps skip if the triggered workflow is not in the main repository.

## Are there changes in behavior for the user?

aiohttp contributors can now run github action workflows to test changes in their forks without unnecessary errors.

## Is it a substantial burden for the maintainers to support this?

No, this is a straightforward CI configuration change.

## Related issue number

Backport of #11737

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
- [x] Add a new news fragment into the `CHANGES/` folder
