### PR TITLE
Change .decode_async() to .decode_iter()

### DIFF
--- a/CHANGES/11898.bugfix.rst
+++ b/CHANGES/11898.bugfix.rst
@@ -3,5 +3,8 @@ for backward compatibility. The method was inadvertently changed to async
 in 3.13.3 as part of the decompression bomb security fix. A new
 :py:meth:`~aiohttp.BodyPartReader.decode_iter` method is now available
 for non-blocking decompression of large payloads using an async generator.
-Internal aiohttp code uses the async variant to maintain security protections
--- by :user:`bdraco`.
+Internal aiohttp code uses the async variant to maintain security protections.
+
+Changed multipart processing chunk sizes from 64 KiB to 256KiB, to better
+match aiohttp internals
+-- by :user:`bdraco` and :user:`Dreamsorcerer`.

--- a/CHANGES/11898.bugfix.rst
+++ b/CHANGES/11898.bugfix.rst
@@ -1,6 +1,7 @@
 Restored :py:meth:`~aiohttp.BodyPartReader.decode` as a synchronous method
 for backward compatibility. The method was inadvertently changed to async
 in 3.13.3 as part of the decompression bomb security fix. A new
-:py:meth:`~aiohttp.BodyPartReader.decode_async` method is now available
-for non-blocking decompression of large payloads. Internal aiohttp code
-uses the async variant to maintain security protections -- by :user:`bdraco`.
+:py:meth:`~aiohttp.BodyPartReader.decode_iter` method is now available
+for non-blocking decompression of large payloads using an async generator.
+Internal aiohttp code uses the async variant to maintain security protections
+-- by :user:`bdraco`.

--- a/aiohttp/multipart.py
+++ b/aiohttp/multipart.py
@@ -521,7 +521,7 @@ class BodyPartReader:
         return data
 
     async def decode_iter(self, data: bytes) -> AsyncIterator[bytes]:
-        """Decodes data asynchronously.
+        """Async generator that yields decoded data chunks.
 
         Decodes data according the specified Content-Encoding
         or Content-Transfer-Encoding headers value.

--- a/aiohttp/multipart.py
+++ b/aiohttp/multipart.py
@@ -558,8 +558,6 @@ class BodyPartReader:
                 suppress_deflate_header=True,
             )
             yield await d.decompress(data, max_length=self._max_decompress_size)
-            while d.data_available:
-                yield await d.decompress(b"", max_length=self._max_decompress_size)
         else:
             raise RuntimeError(f"unknown content encoding: {encoding}")
 

--- a/aiohttp/web_request.py
+++ b/aiohttp/web_request.py
@@ -714,17 +714,17 @@ class BaseRequest(MutableMapping[str | RequestKey[Any], Any], HeadersMixin):
                         tmp = await self._loop.run_in_executor(
                             None, tempfile.TemporaryFile
                         )
-                        chunk = await field.read_chunk(size=2**16)
-                        while chunk:
-                            chunk = await field.decode_async(chunk)
-                            await self._loop.run_in_executor(None, tmp.write, chunk)
-                            size += len(chunk)
-                            if 0 < max_size < size:
-                                await self._loop.run_in_executor(None, tmp.close)
-                                raise HTTPRequestEntityTooLarge(
-                                    max_size=max_size, actual_size=size
+                        while chunk := await field.read_chunk(size=2**18):
+                            async for decoded_chunk in field.decode_iter(chunk):
+                                await self._loop.run_in_executor(
+                                    None, tmp.write, decoded_chunk
                                 )
-                            chunk = await field.read_chunk(size=2**16)
+                                size += len(decoded_chunk)
+                                if 0 < max_size < size:
+                                    await self._loop.run_in_executor(None, tmp.close)
+                                    raise HTTPRequestEntityTooLarge(
+                                        max_size=max_size, actual_size=size
+                                    )
                         await self._loop.run_in_executor(None, tmp.seek, 0)
 
                         if field_ct is None:

--- a/docs/multipart_reference.rst
+++ b/docs/multipart_reference.rst
@@ -119,14 +119,17 @@ Multipart reference
 
       .. note::
 
-         For large payloads, consider using :meth:`decode_async` instead
+         For large payloads, consider using :meth:`decode_iter` instead
          to avoid blocking the event loop during decompression.
 
-   .. method:: decode_async(data)
+   .. method:: decode_iter(data)
       :async:
 
       Decodes data asynchronously according the specified ``Content-Encoding``
       or ``Content-Transfer-Encoding`` headers value.
+
+      This is an async iterator and will return decoded data in chunks. This
+      can be used to avoid loading large payloads into memory.
 
       This method offloads decompression to an executor for large payloads
       to avoid blocking the event loop.

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -404,7 +404,8 @@ class TestPartReader:
             result = b""
             while not obj.at_eof():
                 chunk = await obj.read_chunk(size=6)
-                result += await obj.decode_async(chunk)
+                async for decoded_chunk in obj.decode_iter(chunk):
+                    result += decoded_chunk
         assert b"Time to Relax!" == result
 
     async def test_decode_with_content_encoding_deflate(self) -> None:

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -397,7 +397,7 @@ class TestPartReader:
                 result += obj.decode(chunk)
         assert b"Time to Relax!" == result
 
-    async def test_decode_async_with_content_transfer_encoding_base64(self) -> None:
+    async def test_decode_iter_with_content_transfer_encoding_base64(self) -> None:
         h = CIMultiDictProxy(CIMultiDict({CONTENT_TRANSFER_ENCODING: "base64"}))
         with Stream(b"VG\r\r\nltZSB0byBSZ\r\nWxheCE=\r\n--:--") as stream:
             obj = aiohttp.BodyPartReader(BOUNDARY, h, stream)


### PR DESCRIPTION
Pulling this out of #11966, as it should be backported to 3.13.
.decode_async() is not in any current release, so we can replace this now before it becomes part of the API.

Using an async generator is needed to fix the decompression code in #11966, plus it can help improve memory concerns in some parts of the code. In this implementation, the code will only ever yield once, but this will change in #11966.