### PR TITLE
Fix websocket heartbeat timeout on slow receives

### DIFF
--- a/CHANGES/0000.bugfix.rst
+++ b/CHANGES/0000.bugfix.rst
@@ -1,0 +1,2 @@
+Reset the WebSocket heartbeat timer on inbound data to avoid false ping/pong timeouts while receiving large frames
+-- by :user:`hoffmang9`.

--- a/aiohttp/_websocket/reader.py
+++ b/aiohttp/_websocket/reader.py
@@ -1,5 +1,7 @@
 """Reader for WebSocket protocol versions 13 and 8."""
 
+import asyncio
+from collections.abc import Callable
 from typing import TYPE_CHECKING
 
 from ..helpers import NO_EXTENSIONS
@@ -29,3 +31,42 @@ else:
 
         WebSocketReader = WebSocketReaderPython
         WebSocketDataQueue = WebSocketDataQueuePython
+
+
+class _WebSocketDataReceivedCallbackWrapper:
+    """Wrap a websocket parser and call a callback on any inbound bytes.
+
+    This wrapper is intentionally kept in pure-Python so it works for both the
+    pure-python websocket reader and the accelerated `reader_c` extension.
+    """
+
+    __slots__ = ("_parser", "_data_received_cb", "_loop", "_reset_handle")
+
+    def __init__(
+        self,
+        parser: object,
+        data_received_cb: Callable[[], None],
+        loop: asyncio.AbstractEventLoop,
+    ) -> None:
+        self._parser = parser
+        self._data_received_cb = data_received_cb
+        self._loop = loop
+        self._reset_handle: asyncio.Handle | None = None
+
+    def feed_data(self, data):  # type: ignore[no-untyped-def]
+        if data:
+            # Coalesce multiple feed_data() calls into one heartbeat reset
+            # per event-loop iteration.
+            if self._reset_handle is None:
+                self._reset_handle = self._loop.call_soon(self._on_data_received)
+        return self._parser.feed_data(data)  # type: ignore[attr-defined]
+
+    def _on_data_received(self) -> None:
+        self._reset_handle = None
+        self._data_received_cb()
+
+    def feed_eof(self) -> None:
+        if self._reset_handle is not None:
+            self._reset_handle.cancel()
+            self._reset_handle = None
+        self._parser.feed_eof()  # type: ignore[attr-defined]

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -37,7 +37,7 @@ from multidict import CIMultiDict, MultiDict, MultiDictProxy, istr
 from yarl import URL, Query
 
 from . import hdrs, http, payload
-from ._websocket.reader import WebSocketDataQueue
+from ._websocket.reader import WebSocketDataQueue, _WebSocketDataReceivedCallbackWrapper
 from .abc import AbstractCookieJar
 from .client_exceptions import (
     ClientConnectionError,
@@ -1203,9 +1203,6 @@ class ClientSession:
             transport = conn.transport
             assert transport is not None
             reader = WebSocketDataQueue(conn_proto, 2**16, loop=self._loop)
-            conn_proto.set_parser(
-                WebSocketReader(reader, max_msg_size, decode_text=decode_text), reader
-            )
             writer = WebSocketWriter(
                 conn_proto,
                 transport,
@@ -1217,7 +1214,7 @@ class ClientSession:
             resp.close()
             raise
         else:
-            return self._ws_response_class(
+            ws_resp = self._ws_response_class(
                 reader,
                 writer,
                 protocol,
@@ -1230,6 +1227,16 @@ class ClientSession:
                 compress=compress,
                 client_notakeover=notakeover,
             )
+            parser = WebSocketReader(reader, max_msg_size, decode_text=decode_text)
+            # Only wrap when heartbeat is enabled to avoid overhead.
+            if heartbeat is not None:
+                parser = _WebSocketDataReceivedCallbackWrapper(
+                    parser,
+                    ws_resp._reset_heartbeat,
+                    self._loop,
+                )
+            conn_proto.set_parser(parser, reader)
+            return ws_resp
 
     def _prepare_headers(self, headers: LooseHeaders | None) -> "CIMultiDict[str]":
         """Add default headers and transform it to CIMultiDict"""

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -761,8 +761,9 @@ The client session supports the context manager protocol for self closing.
       :param float heartbeat: Send *ping* message every *heartbeat*
                               seconds and wait *pong* response, if
                               *pong* response is not received then
-                              close connection. The timer is reset on any data
-                              reception.(optional)
+                              close connection. The timer is reset on any
+                              inbound data reception (coalesced per event loop
+                              iteration). (optional)
 
       :param str origin: Origin header to send to server(optional)
 

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -968,7 +968,8 @@ and :ref:`aiohttp-web-signals` handlers::
    :param float heartbeat: Send `ping` message every `heartbeat`
                            seconds and wait `pong` response, close
                            connection if `pong` response is not
-                           received. The timer is reset on any data reception.
+                           received. The timer is reset on any inbound data
+                           reception (coalesced per event loop iteration).
 
    :param float timeout: Timeout value for the ``close``
                          operation. After sending the close websocket message,

--- a/tests/test_client_ws_functional.py
+++ b/tests/test_client_ws_functional.py
@@ -1,6 +1,8 @@
 import asyncio
 import json
+import struct
 import sys
+from contextlib import suppress
 from typing import Literal, NoReturn
 from unittest import mock
 
@@ -816,6 +818,72 @@ async def test_heartbeat_no_pong(aiohttp_client: AiohttpClient) -> None:
     await asyncio.sleep(0.2)
     assert ping_received
     assert resp.close_code is WSCloseCode.ABNORMAL_CLOSURE
+
+
+async def test_heartbeat_is_reset_on_any_data_reception(
+    aiohttp_client: AiohttpClient,
+) -> None:
+    """Slowly receiving a single large frame should not trip heartbeat.
+
+    Regression test for the behavior described in
+    https://github.com/aio-libs/aiohttp/discussions/12023: on slow connections,
+    the websocket heartbeat used to be reset only after a full message was read,
+    which could cause a ping/pong timeout while bytes were still being received.
+    """
+    payload = b"x" * 2048
+    heartbeat = 0.05
+    chunk_size = 64
+    delay = 0.01
+
+    async def handler(request: web.Request) -> web.WebSocketResponse:
+        ws = web.WebSocketResponse()
+        await ws.prepare(request)
+
+        assert ws._writer is not None
+        transport = ws._writer.transport
+
+        # Server-to-client frames are not masked.
+        length = len(payload)
+        if length < 126:
+            header = bytes((0x82, length))
+        elif length < 65536:
+            header = bytes((0x82, 126)) + struct.pack("!H", length)
+        else:
+            header = bytes((0x82, 127)) + struct.pack("!Q", length)
+
+        frame = header + payload
+        for i in range(0, len(frame), chunk_size):
+            if transport.is_closing():
+                break
+            transport.write(frame[i : i + chunk_size])
+            await asyncio.sleep(delay)
+
+        # Ensure the server side is cleaned up.
+        with suppress(asyncio.TimeoutError):
+            await ws.receive(timeout=1.0)
+        with suppress(Exception):
+            await ws.close()
+        return ws
+
+    app = web.Application()
+    app.router.add_route("GET", "/", handler)
+    client = await aiohttp_client(app)
+
+    resp = await client.ws_connect("/", heartbeat=heartbeat)
+    # If heartbeat was not reset on any incoming bytes, the client would start
+    # sending PINGs while we're still streaming the message body, and since the
+    # server handler never calls receive(), no PONG would be produced and the
+    # client would close with a ping/pong timeout.
+    with mock.patch.object(
+        resp._writer, "send_frame", wraps=resp._writer.send_frame
+    ) as sf:
+        msg = await resp.receive()
+        assert (
+            sf.call_args_list.count(mock.call(b"", WSMsgType.PING)) == 0
+        ), "Heartbeat PING sent while data was still being received"
+    assert msg.type is WSMsgType.BINARY
+    assert msg.data == payload
+    await resp.close()
 
 
 async def test_heartbeat_no_pong_after_receive_many_messages(

--- a/tests/test_client_ws_functional.py
+++ b/tests/test_client_ws_functional.py
@@ -820,7 +820,7 @@ async def test_heartbeat_no_pong(aiohttp_client: AiohttpClient) -> None:
     assert resp.close_code is WSCloseCode.ABNORMAL_CLOSURE
 
 
-async def test_heartbeat_is_reset_on_any_data_reception(
+async def test_heartbeat_does_not_timeout_while_receiving_large_frame(
     aiohttp_client: AiohttpClient,
 ) -> None:
     """Slowly receiving a single large frame should not trip heartbeat.


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?
Reset websocket heartbeat on any inbound data (coalesced per event-loop tick) so slow/large frame reception doesn’t trigger ping/pong timeouts mid-message. Add a regression test that simulates slow, chunked delivery of a single large binary frame.
<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?
Yes.
WebSocket heartbeat is now reset when any bytes are received, not only after a full websocket message is assembled.
This avoids false disconnects on slow links when receiving large frames.
The additional work is only enabled when heartbeat is set, and is coalesced to at most once per loop iteration.

<!-- Outline any notable behaviour for the end users. -->

## Is it a substantial burden for the maintainers to support this?

<!--
Stop right there! Pause. Just for a minute... Can you think of anything
obvious that would complicate the ongoing development of this project?

Try to consider if you'd be able to maintain it throughout the next
5 years. Does it seem viable? Tell us your thoughts! We'd very much
love to hear what the consequences of merging this patch might be...

This will help us assess if your change is something we'd want to
entertain early in the review process. Thank you in advance!
-->
No. It’s a small, self-contained change implemented as a parser wrapper (pure-Python, works with both Python and accelerated reader), plus a focused regression test. No public API changes and very minimal docs changes

## Related issue number

<!-- Will this resolve any open issues? -->
<!-- Remember to prefix with 'Fixes' if it closes an issue (e.g. 'Fixes #123'). -->
Refs aio-libs/aiohttp Discussion aio-libs#12023

## Checklist

- [ x] I think the code is well written
- [ x] Unit tests for the changes exist
- [ x] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x ] Add a new news fragment into the `CHANGES/` folder
  * name it `<issue_or_pr_num>.<type>.rst` (e.g. `588.bugfix.rst`)
  * if you don't have an issue number, change it to the pull request
    number after creating the PR
    * `.bugfix`: A bug fix for something the maintainers deemed an
      improper undesired behavior that got corrected to match
      pre-agreed expectations.
    * `.feature`: A new behavior, public APIs. That sort of stuff.
    * `.deprecation`: A declaration of future API removals and breaking
      changes in behavior.
    * `.breaking`: When something public is removed in a breaking way.
      Could be deprecated in an earlier release.
    * `.doc`: Notable updates to the documentation structure or build
      process.
    * `.packaging`: Notes for downstreams about unobvious side effects
      and tooling. Changes in the test invocation considerations and
      runtime assumptions.
    * `.contrib`: Stuff that affects the contributor experience. e.g.
      Running tests, building the docs, setting up the development
      environment.
    * `.misc`: Changes that are hard to assign to any of the above
      categories.
  * Make sure to use full sentences with correct case and punctuation,
    for example:
    ```rst
    Fixed issue with non-ascii contents in doctest text files
    -- by :user:`contributor-gh-handle`.
    ```

    Use the past tense or the present tense a non-imperative mood,
    referring to what's changed compared to the last released version
    of this project.
