### PR TITLE
Fix test_invalid_idna for idna 3.11 compatibility

### DIFF
--- a/CHANGES/12027.misc.rst
+++ b/CHANGES/12027.misc.rst
@@ -1,0 +1,1 @@
+Fixed ``test_invalid_idna`` to work with ``idna`` 3.11 by using an invalid character (``\u0080``) that is rejected by ``yarl`` during URL construction -- by :user:`rodrigobnogueira`.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -318,6 +318,7 @@ Raúl Cumplido
 Required Field
 Robert Lu
 Robert Nikolich
+Rodrigo Nogueira
 Roman Markeloff
 Roman Podoliaka
 Roman Postnov

--- a/requirements/base-ft.txt
+++ b/requirements/base-ft.txt
@@ -24,7 +24,7 @@ frozenlist==1.8.0
     #   aiosignal
 gunicorn==25.0.1
     # via -r requirements/base-ft.in
-idna==3.7
+idna==3.11
     # via yarl
 multidict==6.7.1
     # via

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -24,7 +24,7 @@ frozenlist==1.8.0
     #   aiosignal
 gunicorn==25.0.1
     # via -r requirements/base.in
-idna==3.7
+idna==3.11
     # via yarl
 multidict==6.7.1
     # via

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -85,7 +85,7 @@ gunicorn==25.0.1
     # via -r requirements/base.in
 identify==2.6.16
     # via pre-commit
-idna==3.7
+idna==3.11
     # via
     #   requests
     #   trustme

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -83,7 +83,7 @@ gunicorn==25.0.1
     # via -r requirements/base.in
 identify==2.6.16
     # via pre-commit
-idna==3.7
+idna==3.11
     # via
     #   requests
     #   trustme

--- a/requirements/doc-spelling.txt
+++ b/requirements/doc-spelling.txt
@@ -18,7 +18,7 @@ click==8.3.1
     # via towncrier
 docutils==0.21.2
     # via sphinx
-idna==3.7
+idna==3.11
     # via requests
 imagesize==1.4.1
     # via sphinx

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -18,7 +18,7 @@ click==8.3.1
     # via towncrier
 docutils==0.21.2
     # via sphinx
-idna==3.7
+idna==3.11
     # via requests
 imagesize==1.4.1
     # via sphinx

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -37,7 +37,7 @@ freezegun==1.5.5
     # via -r requirements/lint.in
 identify==2.6.16
     # via pre-commit
-idna==3.7
+idna==3.11
     # via trustme
 iniconfig==2.3.0
     # via pytest

--- a/requirements/runtime-deps.txt
+++ b/requirements/runtime-deps.txt
@@ -22,7 +22,7 @@ frozenlist==1.8.0
     # via
     #   -r requirements/runtime-deps.in
     #   aiosignal
-idna==3.7
+idna==3.11
     # via yarl
 multidict==6.7.1
     # via

--- a/requirements/test-common.txt
+++ b/requirements/test-common.txt
@@ -28,7 +28,7 @@ forbiddenfruit==0.1.4
     # via blockbuster
 freezegun==1.5.5
     # via -r requirements/test-common.in
-idna==3.7
+idna==3.11
     # via trustme
 iniconfig==2.3.0
     # via pytest

--- a/requirements/test-ft.txt
+++ b/requirements/test-ft.txt
@@ -47,7 +47,7 @@ frozenlist==1.8.0
     #   aiosignal
 gunicorn==25.0.1
     # via -r requirements/base-ft.in
-idna==3.7
+idna==3.11
     # via
     #   trustme
     #   yarl

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -47,7 +47,7 @@ frozenlist==1.8.0
     #   aiosignal
 gunicorn==25.0.1
     # via -r requirements/base.in
-idna==3.7
+idna==3.11
     # via
     #   trustme
     #   yarl

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -3273,7 +3273,7 @@ async def test_request_raise_for_status_coro(aiohttp_client: AiohttpClient) -> N
 async def test_invalid_idna() -> None:
     async with aiohttp.ClientSession() as session:
         with pytest.raises(aiohttp.InvalidURL):
-            await session.get("http://\u2061owhefopw.com")
+            await session.get("http://\u0080owhefopw.com")
 
 
 async def test_creds_in_auth_and_url() -> None:


### PR DESCRIPTION
## What do these changes do?

- Replace \u2061 (FUNCTION APPLICATION) with \u0080 (PAD character) in test
- idna 3.11 now silently removes \u2061 instead of raising an exception
- \u0080 is rejected by yarl during URL construction and correctly raises InvalidURL
- Pin idna==3.11

## Are there changes in behavior for the user?

No. This is a test-only fix with no impact on user-facing behavior.

## Is it a substantial burden for the maintainers to support this?

No. This is a minimal change that updates a single test character and pins the `idna` dependency to ensure compatibility with the latest version. The fix is straightforward and does not introduce any new complexity.

## Related issue number

Fixes #12027

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
- [x] Add a new news fragment into the `CHANGES/` folder
