### PR TITLE
Update ujson to orjson in documentation

### DIFF
--- a/docs/client_quickstart.rst
+++ b/docs/client_quickstart.rst
@@ -210,15 +210,15 @@ serialization.  But it is possible to use different
 ``serializer``. :class:`ClientSession` accepts ``json_serialize``
 parameter::
 
-  import ujson
+  import orjson
 
   async with aiohttp.ClientSession(
-          json_serialize=ujson.dumps) as session:
+          json_serialize=orjson.dumps) as session:
       await session.post(url, json={'test': 'object'})
 
 .. note::
 
-   ``ujson`` library is faster than standard :mod:`json` but slightly
+   ``orjson`` library is faster than standard :mod:`json` but slightly
    incompatible.
 
 JSON Response Content


### PR DESCRIPTION
## Summary
- Replaces deprecated `ujson` library with `orjson` in the client quickstart documentation
- Addresses issue #10795

## Motivation
The ujson library is now in maintenance-only mode, and its documentation explicitly recommends migrating to [orjson](https://pypi.org/project/orjson/), which is both faster and more secure.

From ujson's PyPI page:
> UltraJSON's architecture is fundamentally ill-suited to making changes without risk of introducing new security vulnerabilities. As a result, this library has been put into a maintenance-only mode... Users are encouraged to migrate to orjson which is both much faster and less likely to introduce a surprise buffer overflow vulnerability in the future.

## Changes
- Updated code example in `docs/client_quickstart.rst` to use `orjson.dumps` instead of `ujson.dumps`
- Updated documentation note to reference `orjson` instead of `ujson`

## Testing
- Documentation change only, no functional code changes
- Verified the syntax and formatting are correct

Fixes #10795