### PR TITLE
docs: Replace deprecated ujson with orjson in client quickstart

### DIFF
--- a/docs/client_quickstart.rst
+++ b/docs/client_quickstart.rst
@@ -210,16 +210,17 @@ serialization.  But it is possible to use different
 ``serializer``. :class:`ClientSession` accepts ``json_serialize``
 parameter::
 
-  import ujson
+  import orjson
 
   async with aiohttp.ClientSession(
-          json_serialize=ujson.dumps) as session:
+          json_serialize=orjson.dumps) as session:
       await session.post(url, json={'test': 'object'})
 
 .. note::
 
-   ``ujson`` library is faster than standard :mod:`json` but slightly
-   incompatible.
+   ``orjson`` library is significantly faster than standard :mod:`json`.
+   Note that ``orjson.dumps()`` returns ``bytes``, not ``str``, which works
+   with aiohttp's JSON handling.
 
 JSON Response Content
 =====================


### PR DESCRIPTION
## Summary

Replaces the deprecated `ujson` library with `orjson` in the client quickstart documentation.

## Problem

The `ujson` library mentioned in the documentation is now deprecated and in maintenance-only mode. The ujson maintainers recommend migrating to `orjson`, which is both faster and more secure.

## Changes

- Replaced `ujson` import and usage example with `orjson`
- Updated the note to clarify that:
  - `orjson` is significantly faster than standard `json`
  - `orjson.dumps()` returns `bytes` instead of `str`, which works with aiohttp's JSON handling

## Related Issues

Closes #10795

## Testing

This is a documentation-only change. No code changes were made.