### PR TITLE
docs: Replace deprecated ujson with orjson in client quickstart

### DIFF
--- a/CHANGES/12041.doc.rst
+++ b/CHANGES/12041.doc.rst
@@ -1,0 +1,2 @@
+Replaced deprecated ``ujson`` with ``orjson`` in client quickstart documentation
+-- by :user:`veeceey`.

--- a/CHANGES/12041.doc.rst
+++ b/CHANGES/12041.doc.rst
@@ -1,2 +1,2 @@
-Replaced deprecated ``ujson`` with ``orjson`` in client quickstart documentation
+Replaced deprecated ``ujson`` with ``orjson`` in client Quickstart documentation
 -- by :user:`veeceey`.

--- a/docs/client_quickstart.rst
+++ b/docs/client_quickstart.rst
@@ -210,16 +210,16 @@ serialization.  But it is possible to use different
 ``serializer``. :class:`ClientSession` accepts ``json_serialize``
 parameter::
 
-  import ujson
+  import orjson
 
   async with aiohttp.ClientSession(
-          json_serialize=ujson.dumps) as session:
+          json_serialize=orjson.dumps) as session:
       await session.post(url, json={'test': 'object'})
 
 .. note::
 
-   ``ujson`` library is faster than standard :mod:`json` but slightly
-   incompatible.
+   ``orjson`` library is significantly faster than standard :mod:`json`
+   and provides better compatibility than the deprecated ``ujson`` library.
 
 JSON Response Content
 =====================


### PR DESCRIPTION
## Summary
- Replaced deprecated `ujson` reference with `orjson` in client quickstart documentation
- Updated note to reflect that `orjson` is faster and more compatible than the now-deprecated `ujson`

## Context
The `ujson` library has been put into maintenance-only mode due to security concerns and architectural issues. The library's PyPI page now recommends migrating to `orjson`, which is both significantly faster and less prone to security vulnerabilities.

## Changes
- Updated code example to use `orjson.dumps` instead of `ujson.dumps`
- Modified documentation note to recommend `orjson` and mention `ujson`'s deprecation

## Test plan
- [x] Documentation change only, no functional code changes
- [x] Verified documentation builds correctly

Fixes #10795