### PR TITLE
docs: Document asyncio.TimeoutError for WebSocketResponse.receive methods

### DIFF
--- a/CHANGES/12042.doc.rst
+++ b/CHANGES/12042.doc.rst
@@ -1,0 +1,2 @@
+Documented :exc:`asyncio.TimeoutError` for ``WebSocketResponse.receive()``
+and related methods -- by :user:`veeceey`.

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -1275,6 +1275,8 @@ and :ref:`aiohttp-web-signals` handlers::
 
       :raise RuntimeError: if connection is not started
 
+      :raise asyncio.TimeoutError: if timeout expires before receiving a message
+
    .. method:: receive_str(*, timeout=None)
       :async:
 
@@ -1292,6 +1294,8 @@ and :ref:`aiohttp-web-signals` handlers::
       :return str: peer's message content.
 
       :raise aiohttp.WSMessageTypeError: if message is not :const:`~aiohttp.WSMsgType.TEXT`.
+
+      :raise asyncio.TimeoutError: if timeout expires before receiving a message
 
    .. method:: receive_bytes(*, timeout=None)
       :async:
@@ -1311,6 +1315,8 @@ and :ref:`aiohttp-web-signals` handlers::
       :return bytes: peer's message content.
 
       :raise aiohttp.WSMessageTypeError: if message is not :const:`~aiohttp.WSMsgType.BINARY`.
+
+      :raise asyncio.TimeoutError: if timeout expires before receiving a message
 
    .. method:: receive_json(*, loads=json.loads, timeout=None)
       :async:
@@ -1335,6 +1341,7 @@ and :ref:`aiohttp-web-signals` handlers::
 
       :raise TypeError: if message is :const:`~aiohttp.WSMsgType.BINARY`.
       :raise ValueError: if message is not valid JSON.
+      :raise asyncio.TimeoutError: if timeout expires before receiving a message
 
 
 .. seealso:: :ref:`WebSockets handling<aiohttp-web-websockets>`


### PR DESCRIPTION
## Summary
- Added documentation for `asyncio.TimeoutError` exception raised by `WebSocketResponse.receive()` and related methods
- Updated documentation for `receive_str()`, `receive_bytes()`, and `receive_json()` methods

## Context
The WebSocketResponse.receive() method and its variants (receive_str, receive_bytes, receive_json) accept a timeout parameter, but the documentation didn't specify which exception is raised when the timeout expires. Users had to dig through the source code to discover that `asyncio.TimeoutError` is raised.

## Changes
Added `:raise asyncio.TimeoutError:` documentation to:
- `WebSocketResponse.receive()`
- `WebSocketResponse.receive_str()`
- `WebSocketResponse.receive_bytes()`
- `WebSocketResponse.receive_json()`

## Test plan
- [x] Documentation change only, no functional code changes
- [x] Verified that the exception is indeed raised in the source code (line 584-585 in aiohttp/web_ws.py)

Fixes #3962