### PR TITLE
Reject ClientTimeout(total=0) in v4, use None to disable timeouts

### DIFF
--- a/CHANGES/11859.bugfix.rst
+++ b/CHANGES/11859.bugfix.rst
@@ -1,1 +1,1 @@
-Fixed ``ValueError`` when creating a TLS connection with ``ClientTimeout(total=0)`` by converting ``0`` to ``None`` before passing to ``ssl_handshake_timeout`` in :py:meth:`asyncio.loop.start_tls` -- by :user:`veeceey`.
+Fixed :exc:`ValueError` when creating a TLS connection with ``ClientTimeout(total=0)`` by converting ``0`` to ``None`` before passing to ``ssl_handshake_timeout`` in :py:meth:`asyncio.loop.start_tls` -- by :user:`veeceey`.

--- a/CHANGES/11859.bugfix.rst
+++ b/CHANGES/11859.bugfix.rst
@@ -1,1 +1,1 @@
-Fixed :exc:`ValueError` when creating a TLS connection with ``ClientTimeout(total=0)`` by converting ``0`` to ``None`` before passing to ``ssl_handshake_timeout`` in :py:meth:`asyncio.loop.start_tls` -- by :user:`veeceey`.
+Removed support for ``ClientTimeout(total=0)`` to disable timeouts. Use ``None`` instead of ``0`` to disable the total timeout. Passing ``0`` now raises :exc:`ValueError` with a clear error message -- by :user:`veeceey`.

--- a/CHANGES/11859.bugfix.rst
+++ b/CHANGES/11859.bugfix.rst
@@ -1,1 +1,1 @@
-Fixed ``ValueError`` when creating a TLS connection with ``ClientTimeout(total=0)`` by converting ``0`` to ``None`` before passing to ``ssl_handshake_timeout`` in :py:func:`asyncio.loop.start_tls` -- by :user:`veeceey`.
+Fixed ``ValueError`` when creating a TLS connection with ``ClientTimeout(total=0)`` by converting ``0`` to ``None`` before passing to ``ssl_handshake_timeout`` in :py:meth:`asyncio.loop.start_tls` -- by :user:`veeceey`.

--- a/CHANGES/11859.bugfix.rst
+++ b/CHANGES/11859.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed ``ValueError`` when creating a TLS connection with ``ClientTimeout(total=0)`` by converting ``0`` to ``None`` before passing to ``ssl_handshake_timeout`` in :py:func:`asyncio.loop.start_tls` -- by :user:`veeceey`.

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -240,6 +240,14 @@ class ClientTimeout:
     # - or use https://docs.python.org/3/library/dataclasses.html#dataclasses.replace
     # to overwrite the defaults
 
+    def __post_init__(self) -> None:
+        if self.total is not None and self.total == 0:
+            raise ValueError(
+                "total timeout must be a positive number or None to disable, "
+                "got 0. Using 0 to disable timeouts is no longer supported, "
+                "use None instead."
+            )
+
 
 # 5 Minute default read timeout
 DEFAULT_TIMEOUT: Final[ClientTimeout] = ClientTimeout(total=5 * 60, sock_connect=30)

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -1324,7 +1324,7 @@ class TCPConnector(BaseConnector):
                             tls_proto,
                             sslcontext,
                             server_hostname=req.server_hostname or req.url.raw_host,
-                            ssl_handshake_timeout=timeout.total or None,
+                            ssl_handshake_timeout=timeout.total,
                             ssl_shutdown_timeout=self._ssl_shutdown_timeout,
                         )
                     else:
@@ -1333,7 +1333,7 @@ class TCPConnector(BaseConnector):
                             tls_proto,
                             sslcontext,
                             server_hostname=req.server_hostname or req.url.raw_host,
-                            ssl_handshake_timeout=timeout.total or None,
+                            ssl_handshake_timeout=timeout.total,
                         )
                 except BaseException:
                     # We need to close the underlying transport since

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -1324,7 +1324,7 @@ class TCPConnector(BaseConnector):
                             tls_proto,
                             sslcontext,
                             server_hostname=req.server_hostname or req.url.raw_host,
-                            ssl_handshake_timeout=timeout.total,
+                            ssl_handshake_timeout=timeout.total or None,
                             ssl_shutdown_timeout=self._ssl_shutdown_timeout,
                         )
                     else:
@@ -1333,7 +1333,7 @@ class TCPConnector(BaseConnector):
                             tls_proto,
                             sslcontext,
                             server_hostname=req.server_hostname or req.url.raw_host,
-                            ssl_handshake_timeout=timeout.total,
+                            ssl_handshake_timeout=timeout.total or None,
                         )
                 except BaseException:
                     # We need to close the underlying transport since

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -2655,44 +2655,33 @@ async def test_start_tls_exception_with_ssl_shutdown_timeout_nonzero_pre_311(
 
 
 async def test_start_tls_with_zero_total_timeout(
-    loop: asyncio.AbstractEventLoop,
+    aiohttp_server: AiohttpServer,
+    aiohttp_client: AiohttpClient,
+    ssl_ctx: ssl.SSLContext,
+    client_ssl_ctx: ssl.SSLContext,
 ) -> None:
-    """Test _start_tls_connection with ClientTimeout(total=0).
+    """Test that ClientTimeout(total=0) works with TLS connections.
 
     Regression test for https://github.com/aio-libs/aiohttp/issues/11859
     When total=0 (meaning no timeout), ssl_handshake_timeout should receive
-    None instead of 0, as asyncio requires a positive number or None.
+    None instead of 0, as asyncio raises ValueError for 0.
     """
-    conn = aiohttp.TCPConnector()
 
-    underlying_transport = mock.Mock()
-    req = mock.Mock()
-    req.server_hostname = None
-    req.host = "example.com"
-    req.is_ssl = mock.Mock(return_value=True)
+    async def handler(request: web.Request) -> web.Response:
+        return web.Response(text="ok")
 
-    tls_transport = mock.Mock(spec=asyncio.Transport)
-    tls_transport.get_extra_info = mock.Mock(return_value=mock.Mock())
+    app = web.Application()
+    app.router.add_get("/", handler)
+    server = await aiohttp_server(app, ssl=ssl_ctx)
 
-    start_tls_mock = mock.AsyncMock(return_value=tls_transport)
+    connector = aiohttp.TCPConnector(ssl=client_ssl_ctx)
+    client = await aiohttp_client(server, connector=connector)
 
-    with (
-        mock.patch.object(
-            conn, "_get_ssl_context", return_value=ssl.create_default_context()
-        ),
-        mock.patch.object(conn._loop, "start_tls", start_tls_mock),
-        mock.patch.object(conn, "_get_fingerprint", return_value=None),
-    ):
-        await conn._start_tls_connection(
-            underlying_transport, req, ClientTimeout(total=0)
-        )
-
-    # Verify start_tls was called with ssl_handshake_timeout=None, not 0
-    call_kwargs = start_tls_mock.call_args[1]
-    assert call_kwargs.get("ssl_handshake_timeout") is None, (
-        f"ssl_handshake_timeout should be None when total=0, "
-        f"got {call_kwargs.get('ssl_handshake_timeout')!r}"
-    )
+    # This used to raise ValueError: ssl_handshake_timeout should be a
+    # positive number, got 0
+    async with client.get("/", timeout=ClientTimeout(total=0)) as resp:
+        assert resp.status == 200
+        assert await resp.text() == "ok"
 
 
 async def test_invalid_ssl_param() -> None:

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -1492,7 +1492,7 @@ async def test_tcp_connector_cancel_dns_error_captured(
         )
         m_resolver().resolve.return_value = dns_response_error()
         m_resolver().close = mock.AsyncMock()
-        f = loop.create_task(conn._create_direct_connection(req, [], ClientTimeout(0)))
+        f = loop.create_task(conn._create_direct_connection(req, [], ClientTimeout()))
 
         await asyncio.sleep(0)
         f.cancel()

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -2653,6 +2653,7 @@ async def test_start_tls_exception_with_ssl_shutdown_timeout_nonzero_pre_311(
     underlying_transport.close.assert_called_once()
     underlying_transport.abort.assert_not_called()
 
+
 async def test_start_tls_with_zero_total_timeout(
     loop: asyncio.AbstractEventLoop,
 ) -> None:


### PR DESCRIPTION
Fixes #11859

Instead of normalizing `total=0` to `None`, this PR removes support for `ClientTimeout(total=0)` entirely in v4. 

`asyncio.loop.start_tls()` only accepts `None` or a positive number for `ssl_handshake_timeout`, so passing `total=0` caused a `ValueError`. Rather than working around it, we now reject `total=0` upfront with a clear error message directing users to use `None` instead.

The backport to 3.14 (#12067) keeps the normalization approach for backwards compatibility.

**Changes:**
- Add `__post_init__` validation to `ClientTimeout` that rejects `total=0`
- Revert the `timeout.total or None` workaround in `connector.py`
- Replace functional TLS test with validation tests
- Update changelog