### PR TITLE
fix: do not use `get_event_loop` in GunicornWebWorker - 3.13

### DIFF
--- a/CHANGES/11701.bugfix.rst
+++ b/CHANGES/11701.bugfix.rst
@@ -1,0 +1,3 @@
+Fixed ``RuntimeError: An event loop is running`` error when using ``aiohttp.GunicornWebWorker``
+or ``aiohttp.GunicornUVLoopWebWorker`` on Python >=3.14.
+-- by :user:`Tasssadar`.

--- a/aiohttp/worker.py
+++ b/aiohttp/worker.py
@@ -36,7 +36,6 @@ __all__ = ("GunicornWebWorker", "GunicornUVLoopWebWorker")
 
 
 class GunicornWebWorker(base.Worker):  # type: ignore[misc,no-any-unimported]
-
     DEFAULT_AIOHTTP_LOG_FORMAT = AccessLogger.LOG_FORMAT
     DEFAULT_GUNICORN_LOG_FORMAT = GunicornAccessLogFormat.default
 
@@ -49,7 +48,11 @@ class GunicornWebWorker(base.Worker):  # type: ignore[misc,no-any-unimported]
 
     def init_process(self) -> None:
         # create new event_loop after fork
-        asyncio.get_event_loop().close()
+        try:
+            asyncio.get_event_loop().close()
+        except RuntimeError:
+            # No loop was running
+            pass
 
         self.loop = asyncio.new_event_loop()
         asyncio.set_event_loop(self.loop)
@@ -245,7 +248,11 @@ class GunicornUVLoopWebWorker(GunicornWebWorker):
 
         # Close any existing event loop before setting a
         # new policy.
-        asyncio.get_event_loop().close()
+        try:
+            asyncio.get_event_loop().close()
+        except RuntimeError:
+            # No loop was running
+            pass
 
         # Setup uvloop policy, so that every
         # asyncio.get_event_loop() will create an instance


### PR DESCRIPTION
Fixes gunicorn with 3.14. Already fixed in master as part of explicit loop parameter removal, but the changes are missing in 3.13 (and can't be just backported because they are breaking).

3.13 branch: this PR
3.14 branch: https://github.com/aio-libs/aiohttp/pull/12058

Updates #11701