### PR TITLE
Fix ValueError with ClientTimeout(total=0) in TLS connections

### DIFF
--- a/CHANGES/11859.bugfix.rst
+++ b/CHANGES/11859.bugfix.rst
@@ -1,1 +1,1 @@
-Fixed ``ValueError`` when creating a TLS connection with ``ClientTimeout(total=0)`` by converting ``0`` to ``None`` before passing to ``ssl_handshake_timeout`` in :py:meth:`asyncio.loop.start_tls` -- by :user:`veeceey`.
+Fixed :exc:`ValueError` when creating a TLS connection with ``ClientTimeout(total=0)`` by converting ``0`` to ``None`` before passing to ``ssl_handshake_timeout`` in :py:meth:`asyncio.loop.start_tls` -- by :user:`veeceey`.

--- a/CHANGES/11859.bugfix.rst
+++ b/CHANGES/11859.bugfix.rst
@@ -1,1 +1,1 @@
-Fixed ``ValueError`` when creating a TLS connection with ``ClientTimeout(total=0)`` by converting ``0`` to ``None`` before passing to ``ssl_handshake_timeout`` in :py:func:`asyncio.loop.start_tls` -- by :user:`veeceey`.
+Fixed ``ValueError`` when creating a TLS connection with ``ClientTimeout(total=0)`` by converting ``0`` to ``None`` before passing to ``ssl_handshake_timeout`` in :py:meth:`asyncio.loop.start_tls` -- by :user:`veeceey`.

--- a/CHANGES/11859.bugfix.rst
+++ b/CHANGES/11859.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed ``ValueError`` when creating a TLS connection with ``ClientTimeout(total=0)`` by converting ``0`` to ``None`` before passing to ``ssl_handshake_timeout`` in :py:func:`asyncio.loop.start_tls` -- by :user:`veeceey`.

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -1436,7 +1436,7 @@ class TCPConnector(BaseConnector):
                             tls_proto,
                             sslcontext,
                             server_hostname=req.server_hostname or req.host,
-                            ssl_handshake_timeout=timeout.total,
+                            ssl_handshake_timeout=timeout.total or None,
                             ssl_shutdown_timeout=self._ssl_shutdown_timeout,
                         )
                     else:
@@ -1445,7 +1445,7 @@ class TCPConnector(BaseConnector):
                             tls_proto,
                             sslcontext,
                             server_hostname=req.server_hostname or req.host,
-                            ssl_handshake_timeout=timeout.total,
+                            ssl_handshake_timeout=timeout.total or None,
                         )
                 except BaseException:
                     # We need to close the underlying transport since

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -2514,6 +2514,7 @@ async def test_start_tls_exception_with_ssl_shutdown_timeout_nonzero_pre_311(
     underlying_transport.close.assert_called_once()
     underlying_transport.abort.assert_not_called()
 
+
 async def test_start_tls_with_zero_total_timeout(
     loop: asyncio.AbstractEventLoop,
 ) -> None:

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -36,6 +36,7 @@ from aiohttp.connector import (
     _ConnectTunnelConnection,
     _DNSCacheTable,
 )
+from aiohttp.pytest_plugin import AiohttpClient, AiohttpServer
 from aiohttp.resolver import ResolveResult
 from aiohttp.test_utils import unused_port
 from aiohttp.tracing import Trace

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -2514,6 +2514,46 @@ async def test_start_tls_exception_with_ssl_shutdown_timeout_nonzero_pre_311(
     underlying_transport.close.assert_called_once()
     underlying_transport.abort.assert_not_called()
 
+async def test_start_tls_with_zero_total_timeout(
+    loop: asyncio.AbstractEventLoop,
+) -> None:
+    """Test _start_tls_connection with ClientTimeout(total=0).
+
+    Regression test for https://github.com/aio-libs/aiohttp/issues/11859
+    When total=0 (meaning no timeout), ssl_handshake_timeout should receive
+    None instead of 0, as asyncio requires a positive number or None.
+    """
+    conn = aiohttp.TCPConnector()
+
+    underlying_transport = mock.Mock()
+    req = mock.Mock()
+    req.server_hostname = None
+    req.host = "example.com"
+    req.is_ssl = mock.Mock(return_value=True)
+
+    tls_transport = mock.Mock(spec=asyncio.Transport)
+    tls_transport.get_extra_info = mock.Mock(return_value=mock.Mock())
+
+    start_tls_mock = mock.AsyncMock(return_value=tls_transport)
+
+    with (
+        mock.patch.object(
+            conn, "_get_ssl_context", return_value=ssl.create_default_context()
+        ),
+        mock.patch.object(conn._loop, "start_tls", start_tls_mock),
+        mock.patch.object(conn, "_get_fingerprint", return_value=None),
+    ):
+        await conn._start_tls_connection(
+            underlying_transport, req, ClientTimeout(total=0)
+        )
+
+    # Verify start_tls was called with ssl_handshake_timeout=None, not 0
+    call_kwargs = start_tls_mock.call_args[1]
+    assert call_kwargs.get("ssl_handshake_timeout") is None, (
+        f"ssl_handshake_timeout should be None when total=0, "
+        f"got {call_kwargs.get('ssl_handshake_timeout')!r}"
+    )
+
 
 async def test_invalid_ssl_param() -> None:
     with pytest.raises(TypeError):

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -2516,44 +2516,33 @@ async def test_start_tls_exception_with_ssl_shutdown_timeout_nonzero_pre_311(
 
 
 async def test_start_tls_with_zero_total_timeout(
-    loop: asyncio.AbstractEventLoop,
+    aiohttp_server: AiohttpServer,
+    aiohttp_client: AiohttpClient,
+    ssl_ctx: ssl.SSLContext,
+    client_ssl_ctx: ssl.SSLContext,
 ) -> None:
-    """Test _start_tls_connection with ClientTimeout(total=0).
+    """Test that ClientTimeout(total=0) works with TLS connections.
 
     Regression test for https://github.com/aio-libs/aiohttp/issues/11859
     When total=0 (meaning no timeout), ssl_handshake_timeout should receive
-    None instead of 0, as asyncio requires a positive number or None.
+    None instead of 0, as asyncio raises ValueError for 0.
     """
-    conn = aiohttp.TCPConnector()
 
-    underlying_transport = mock.Mock()
-    req = mock.Mock()
-    req.server_hostname = None
-    req.host = "example.com"
-    req.is_ssl = mock.Mock(return_value=True)
+    async def handler(request: web.Request) -> web.Response:
+        return web.Response(text="ok")
 
-    tls_transport = mock.Mock(spec=asyncio.Transport)
-    tls_transport.get_extra_info = mock.Mock(return_value=mock.Mock())
+    app = web.Application()
+    app.router.add_get("/", handler)
+    server = await aiohttp_server(app, ssl=ssl_ctx)
 
-    start_tls_mock = mock.AsyncMock(return_value=tls_transport)
+    connector = aiohttp.TCPConnector(ssl=client_ssl_ctx)
+    client = await aiohttp_client(server, connector=connector)
 
-    with (
-        mock.patch.object(
-            conn, "_get_ssl_context", return_value=ssl.create_default_context()
-        ),
-        mock.patch.object(conn._loop, "start_tls", start_tls_mock),
-        mock.patch.object(conn, "_get_fingerprint", return_value=None),
-    ):
-        await conn._start_tls_connection(
-            underlying_transport, req, ClientTimeout(total=0)
-        )
-
-    # Verify start_tls was called with ssl_handshake_timeout=None, not 0
-    call_kwargs = start_tls_mock.call_args[1]
-    assert call_kwargs.get("ssl_handshake_timeout") is None, (
-        f"ssl_handshake_timeout should be None when total=0, "
-        f"got {call_kwargs.get('ssl_handshake_timeout')!r}"
-    )
+    # This used to raise ValueError: ssl_handshake_timeout should be a
+    # positive number, got 0
+    async with client.get("/", timeout=ClientTimeout(total=0)) as resp:
+        assert resp.status == 200
+        assert await resp.text() == "ok"
 
 
 async def test_invalid_ssl_param() -> None:


### PR DESCRIPTION
Backport of #12044 to the 3.14 branch as requested.

Fixes `ValueError: ssl_handshake_timeout should be a positive number, got 0` when creating a TLS connection with `ClientTimeout(total=0)`.

The docs say `None` or `0` disables the timeout, but `asyncio.loop.start_tls()` only accepts `None` or positive values. The fix normalizes `0` to `None` with `timeout.total or None`.

Includes a functional regression test with a real TLS server/client.

Fixes #11859