### PR TITLE
Fix/ws heartbeat reset on data (#12030) - fix backport merge

### DIFF
--- a/CHANGES/12030.bugfix.rst
+++ b/CHANGES/12030.bugfix.rst
@@ -1,0 +1,2 @@
+Reset the WebSocket heartbeat timer on inbound data to avoid false ping/pong timeouts while receiving large frames
+-- by :user:`hoffmang9`.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -115,6 +115,7 @@ Dmitry Trofimov
 Dmytro Bohomiakov
 Dmytro Kuznetsov
 Dustin J. Mitchell
+Earle Lowe
 Eduard Iskandarov
 Eli Ribble
 Elizabeth Leddy
@@ -139,6 +140,7 @@ Gabriel Tremblay
 Gang Ji
 Gary Leung
 Gary Wilson Jr.
+Gene Hoffman
 Gennady Andreyev
 Georges Dubus
 Greg Holt

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -1269,9 +1269,6 @@ class ClientSession:
             transport = conn.transport
             assert transport is not None
             reader = WebSocketDataQueue(conn_proto, 2**16, loop=self._loop)
-            conn_proto.set_parser(
-                WebSocketReader(reader, max_msg_size, decode_text=decode_text), reader
-            )
             writer = WebSocketWriter(
                 conn_proto,
                 transport,
@@ -1283,7 +1280,7 @@ class ClientSession:
             resp.close()
             raise
         else:
-            return self._ws_response_class(
+            ws_resp = self._ws_response_class(
                 reader,
                 writer,
                 protocol,
@@ -1296,6 +1293,10 @@ class ClientSession:
                 compress=compress,
                 client_notakeover=notakeover,
             )
+            parser = WebSocketReader(reader, max_msg_size, decode_text=decode_text)
+            cb = None if heartbeat is None else ws_resp._on_data_received
+            conn_proto.set_parser(parser, reader, data_received_cb=cb)
+            return ws_resp
 
     def _prepare_headers(self, headers: LooseHeaders | None) -> "CIMultiDict[str]":
         """Add default headers and transform it to CIMultiDict"""

--- a/aiohttp/client_ws.py
+++ b/aiohttp/client_ws.py
@@ -98,11 +98,17 @@ class ClientWebSocketResponse(Generic[_DecodeText]):
         self._compress = compress
         self._client_notakeover = client_notakeover
         self._ping_task: asyncio.Task[None] | None = None
+        self._need_heartbeat_reset = False
+        self._heartbeat_reset_handle: asyncio.Handle | None = None
 
         self._reset_heartbeat()
 
     def _cancel_heartbeat(self) -> None:
         self._cancel_pong_response_cb()
+        if self._heartbeat_reset_handle is not None:
+            self._heartbeat_reset_handle.cancel()
+            self._heartbeat_reset_handle = None
+        self._need_heartbeat_reset = False
         if self._heartbeat_cb is not None:
             self._heartbeat_cb.cancel()
             self._heartbeat_cb = None
@@ -114,6 +120,23 @@ class ClientWebSocketResponse(Generic[_DecodeText]):
         if self._pong_response_cb is not None:
             self._pong_response_cb.cancel()
             self._pong_response_cb = None
+
+    def _on_data_received(self) -> None:
+        if self._heartbeat is None or self._need_heartbeat_reset:
+            return
+        loop = self._loop
+        assert loop is not None
+        # Coalesce multiple chunks received in the same loop tick into a single
+        # heartbeat reset. Resetting immediately per chunk increases timer churn.
+        self._need_heartbeat_reset = True
+        self._heartbeat_reset_handle = loop.call_soon(self._flush_heartbeat_reset)
+
+    def _flush_heartbeat_reset(self) -> None:
+        self._heartbeat_reset_handle = None
+        if not self._need_heartbeat_reset:
+            return
+        self._reset_heartbeat()
+        self._need_heartbeat_reset = False
 
     def _reset_heartbeat(self) -> None:
         if self._heartbeat is None:
@@ -138,6 +161,12 @@ class ClientWebSocketResponse(Generic[_DecodeText]):
 
     def _send_heartbeat(self) -> None:
         self._heartbeat_cb = None
+
+        # If heartbeat reset is pending (data is being received), skip sending
+        # the ping and let the reset callback handle rescheduling the heartbeat.
+        if self._need_heartbeat_reset:
+            return
+
         loop = self._loop
         now = loop.time()
         if now < self._heartbeat_when:
@@ -365,7 +394,6 @@ class ClientWebSocketResponse(Generic[_DecodeText]):
                             msg = await self._reader.read()
                     else:
                         msg = await self._reader.read()
-                    self._reset_heartbeat()
                 finally:
                     self._waiting = False
                     if self._close_wait:

--- a/aiohttp/web_ws.py
+++ b/aiohttp/web_ws.py
@@ -90,6 +90,8 @@ class WebSocketResponse(StreamResponse, Generic[_DecodeText]):
     _heartbeat_cb: asyncio.TimerHandle | None = None
     _pong_response_cb: asyncio.TimerHandle | None = None
     _ping_task: asyncio.Task[None] | None = None
+    _need_heartbeat_reset: bool = False
+    _heartbeat_reset_handle: asyncio.Handle | None = None
 
     def __init__(
         self,
@@ -118,9 +120,15 @@ class WebSocketResponse(StreamResponse, Generic[_DecodeText]):
         self._max_msg_size = max_msg_size
         self._writer_limit = writer_limit
         self._decode_text = decode_text
+        self._need_heartbeat_reset = False
+        self._heartbeat_reset_handle = None
 
     def _cancel_heartbeat(self) -> None:
         self._cancel_pong_response_cb()
+        if self._heartbeat_reset_handle is not None:
+            self._heartbeat_reset_handle.cancel()
+            self._heartbeat_reset_handle = None
+        self._need_heartbeat_reset = False
         if self._heartbeat_cb is not None:
             self._heartbeat_cb.cancel()
             self._heartbeat_cb = None
@@ -132,6 +140,23 @@ class WebSocketResponse(StreamResponse, Generic[_DecodeText]):
         if self._pong_response_cb is not None:
             self._pong_response_cb.cancel()
             self._pong_response_cb = None
+
+    def _on_data_received(self) -> None:
+        if self._heartbeat is None or self._need_heartbeat_reset:
+            return
+        loop = self._loop
+        assert loop is not None
+        # Coalesce multiple chunks received in the same loop tick into a single
+        # heartbeat reset. Resetting immediately per chunk increases timer churn.
+        self._need_heartbeat_reset = True
+        self._heartbeat_reset_handle = loop.call_soon(self._flush_heartbeat_reset)
+
+    def _flush_heartbeat_reset(self) -> None:
+        self._heartbeat_reset_handle = None
+        if not self._need_heartbeat_reset:
+            return
+        self._reset_heartbeat()
+        self._need_heartbeat_reset = False
 
     def _reset_heartbeat(self) -> None:
         if self._heartbeat is None:
@@ -156,6 +181,12 @@ class WebSocketResponse(StreamResponse, Generic[_DecodeText]):
 
     def _send_heartbeat(self) -> None:
         self._heartbeat_cb = None
+
+        # If heartbeat reset is pending (data is being received), skip sending
+        # the ping and let the reset callback handle rescheduling the heartbeat.
+        if self._need_heartbeat_reset:
+            return
+
         loop = self._loop
         assert loop is not None and self._writer is not None
         now = loop.time()
@@ -349,14 +380,14 @@ class WebSocketResponse(StreamResponse, Generic[_DecodeText]):
         loop = self._loop
         assert loop is not None
         self._reader = WebSocketDataQueue(request._protocol, 2**16, loop=loop)
-        request.protocol.set_parser(
-            WebSocketReader(
-                self._reader,
-                self._max_msg_size,
-                compress=bool(self._compress),
-                decode_text=self._decode_text,
-            )
+        parser = WebSocketReader(
+            self._reader,
+            self._max_msg_size,
+            compress=bool(self._compress),
+            decode_text=self._decode_text,
         )
+        cb = None if self._heartbeat is None else self._on_data_received
+        request.protocol.set_parser(parser, data_received_cb=cb)
         # disable HTTP keepalive for WebSocket
         request.protocol.keep_alive(False)
 
@@ -576,7 +607,6 @@ class WebSocketResponse(StreamResponse, Generic[_DecodeText]):
                             msg = await self._reader.read()
                     else:
                         msg = await self._reader.read()
-                    self._reset_heartbeat()
                 finally:
                     self._waiting = False
                     if self._close_wait:

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -777,8 +777,9 @@ The client session supports the context manager protocol for self closing.
       :param float heartbeat: Send *ping* message every *heartbeat*
                               seconds and wait *pong* response, if
                               *pong* response is not received then
-                              close connection. The timer is reset on any data
-                              reception.(optional)
+                              close connection. The timer is reset on any
+                              inbound data reception (coalesced per event loop
+                              iteration). (optional)
 
       :param str origin: Origin header to send to server(optional)
 

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -999,7 +999,8 @@ and :ref:`aiohttp-web-signals` handlers::
    :param float heartbeat: Send `ping` message every `heartbeat`
                            seconds and wait `pong` response, close
                            connection if `pong` response is not
-                           received. The timer is reset on any data reception.
+                           received. The timer is reset on any inbound data
+                           reception (coalesced per event loop iteration).
 
    :param float timeout: Timeout value for the ``close``
                          operation. After sending the close websocket message,

--- a/tests/test_client_ws.py
+++ b/tests/test_client_ws.py
@@ -620,7 +620,135 @@ async def test_receive_runtime_err(loop) -> None:
         await resp.receive()
 
 
-async def test_ws_connect_close_resp_on_err(loop, ws_key, key_data) -> None:
+async def test_heartbeat_reset_coalesces_on_data(
+    loop: asyncio.AbstractEventLoop,
+) -> None:
+    response = mock.Mock()
+    response.connection = None
+    resp = client.ClientWebSocketResponse(
+        mock.Mock(),
+        mock.Mock(),
+        None,
+        response,
+        aiohttp.ClientWSTimeout(ws_receive=10.0),
+        True,
+        True,
+        loop,
+        heartbeat=0.05,
+    )
+    with mock.patch.object(resp, "_reset_heartbeat", autospec=True) as reset:
+        resp._on_data_received()
+        resp._on_data_received()
+
+        await asyncio.sleep(0)
+
+        assert reset.call_count == 1
+
+
+async def test_receive_does_not_reset_heartbeat(
+    loop: asyncio.AbstractEventLoop,
+) -> None:
+    response = mock.Mock()
+    response.connection = None
+    msg = mock.Mock(type=aiohttp.WSMsgType.TEXT)
+    reader = mock.Mock()
+    reader.read = mock.AsyncMock(return_value=msg)
+    resp = client.ClientWebSocketResponse(
+        reader,
+        mock.Mock(),
+        None,
+        response,
+        aiohttp.ClientWSTimeout(ws_receive=10.0),
+        True,
+        True,
+        loop,
+        heartbeat=0.05,
+    )
+    with mock.patch.object(resp, "_reset_heartbeat", autospec=True) as reset:
+        received = await resp.receive()
+
+    assert received is msg
+    reset.assert_not_called()
+
+
+async def test_cancel_heartbeat_cancels_pending_heartbeat_reset_handle(
+    loop: asyncio.AbstractEventLoop,
+) -> None:
+    response = mock.Mock()
+    response.connection = None
+    resp = client.ClientWebSocketResponse(
+        mock.Mock(),
+        mock.Mock(),
+        None,
+        response,
+        aiohttp.ClientWSTimeout(ws_receive=10.0),
+        True,
+        True,
+        loop,
+        heartbeat=0.05,
+    )
+
+    resp._on_data_received()
+    handle = resp._heartbeat_reset_handle
+    assert handle is not None
+
+    resp._cancel_heartbeat()
+
+    assert resp._heartbeat_reset_handle is None
+    assert resp._need_heartbeat_reset is False
+    assert handle.cancelled()
+
+
+async def test_flush_heartbeat_reset_returns_early_when_not_needed(
+    loop: asyncio.AbstractEventLoop,
+) -> None:
+    response = mock.Mock()
+    response.connection = None
+    resp = client.ClientWebSocketResponse(
+        mock.Mock(),
+        mock.Mock(),
+        None,
+        response,
+        aiohttp.ClientWSTimeout(ws_receive=10.0),
+        True,
+        True,
+        loop,
+        heartbeat=0.05,
+    )
+    resp._need_heartbeat_reset = False
+
+    with mock.patch.object(resp, "_reset_heartbeat", autospec=True) as reset:
+        resp._flush_heartbeat_reset()
+        reset.assert_not_called()
+
+
+async def test_send_heartbeat_returns_early_when_reset_is_pending(
+    loop: asyncio.AbstractEventLoop,
+) -> None:
+    response = mock.Mock()
+    response.connection = None
+    writer = mock.Mock()
+    resp = client.ClientWebSocketResponse(
+        mock.Mock(),
+        writer,
+        None,
+        response,
+        aiohttp.ClientWSTimeout(ws_receive=10.0),
+        True,
+        True,
+        loop,
+        heartbeat=0.05,
+    )
+    resp._need_heartbeat_reset = True
+
+    resp._send_heartbeat()
+
+    writer.send_frame.assert_not_called()
+
+
+async def test_ws_connect_close_resp_on_err(
+    loop: asyncio.AbstractEventLoop, ws_key: str, key_data: bytes
+) -> None:
     resp = mock.Mock()
     resp.status = 500
     resp.headers = {

--- a/tests/test_client_ws_functional.py
+++ b/tests/test_client_ws_functional.py
@@ -1,6 +1,8 @@
 import asyncio
 import json
+import struct
 import sys
+from contextlib import suppress
 from typing import Any, Literal, NoReturn
 from unittest import mock
 
@@ -796,6 +798,64 @@ async def test_heartbeat_no_pong(aiohttp_client: AiohttpClient) -> None:
     await asyncio.sleep(0.2)
     assert ping_received
     assert resp.close_code is WSCloseCode.ABNORMAL_CLOSURE
+
+
+async def test_heartbeat_does_not_timeout_while_receiving_large_frame(
+    aiohttp_client: AiohttpClient,
+) -> None:
+    """Slowly receiving a single large frame should not trip heartbeat.
+
+    Regression test for the behavior described in
+    https://github.com/aio-libs/aiohttp/discussions/12023: on slow connections,
+    the websocket heartbeat used to be reset only after a full message was read,
+    which could cause a ping/pong timeout while bytes were still being received.
+    """
+    payload = b"x" * 2048
+    heartbeat = 0.05
+    chunk_size = 64
+    delay = 0.01
+
+    async def handler(request: web.Request) -> web.WebSocketResponse:
+        ws = web.WebSocketResponse()
+        await ws.prepare(request)
+
+        assert ws._writer is not None
+        transport = ws._writer.transport
+
+        # Server-to-client frames are not masked.
+        length = len(payload)  # payload is fixed length of 2048 bytes
+        header = bytes((0x82, 126)) + struct.pack("!H", length)
+
+        frame = header + payload
+        for i in range(0, len(frame), chunk_size):
+            transport.write(frame[i : i + chunk_size])
+            await asyncio.sleep(delay)
+
+        # Ensure the server side is cleaned up.
+        with suppress(asyncio.TimeoutError):
+            await ws.receive(timeout=1.0)
+        with suppress(Exception):
+            await ws.close()
+        return ws
+
+    app = web.Application()
+    app.router.add_route("GET", "/", handler)
+    client = await aiohttp_client(app)
+
+    async with client.ws_connect("/", heartbeat=heartbeat) as resp:
+        # If heartbeat was not reset on any incoming bytes, the client would start
+        # sending PINGs while we're still streaming the message body, and since the
+        # server handler never calls receive(), no PONG would be produced and the
+        # client would close with a ping/pong timeout.
+        with mock.patch.object(
+            resp._writer, "send_frame", wraps=resp._writer.send_frame
+        ) as sf:
+            msg = await resp.receive()
+            assert (
+                sf.call_args_list.count(mock.call(b"", WSMsgType.PING)) == 0
+            ), "Heartbeat PING sent while data was still being received"
+        assert msg.type is WSMsgType.BINARY
+        assert msg.data == payload
 
 
 async def test_heartbeat_no_pong_after_receive_many_messages(

--- a/tests/test_web_protocol.py
+++ b/tests/test_web_protocol.py
@@ -1,0 +1,48 @@
+import asyncio
+from typing import Any, cast
+from unittest import mock
+
+from aiohttp.web_protocol import RequestHandler
+
+
+class _DummyManager:
+    def __init__(self) -> None:
+        self.request_handler = mock.Mock()
+        self.request_factory = mock.Mock()
+
+
+class _DummyParser:
+    def __init__(self) -> None:
+        self.received: list[bytes] = []
+
+    def feed_data(self, data: bytes) -> tuple[bool, bytes]:
+        self.received.append(data)
+        return False, b""
+
+
+def test_set_parser_does_not_call_data_received_cb_for_tail(
+    loop: asyncio.AbstractEventLoop,
+) -> None:
+    handler: RequestHandler[Any] = RequestHandler(cast(Any, _DummyManager()), loop=loop)
+    handler._message_tail = b"tail"
+    cb = mock.Mock()
+    parser = _DummyParser()
+
+    handler.set_parser(parser, data_received_cb=cb)
+
+    cb.assert_not_called()
+    assert parser.received == [b"tail"]
+
+
+def test_data_received_calls_data_received_cb(
+    loop: asyncio.AbstractEventLoop,
+) -> None:
+    handler: RequestHandler[Any] = RequestHandler(cast(Any, _DummyManager()), loop=loop)
+    cb = mock.Mock()
+    parser = _DummyParser()
+
+    handler.set_parser(parser, data_received_cb=cb)
+    handler.data_received(b"x")
+
+    assert cb.call_count == 1
+    assert parser.received == [b"x"]

--- a/tests/test_web_websocket.py
+++ b/tests/test_web_websocket.py
@@ -29,6 +29,7 @@ def app(loop):
 def protocol():
     ret = mock.Mock()
     ret.set_parser.return_value = ret
+    ret._timeout_ceil_threshold = 5
     return ret
 
 
@@ -102,6 +103,41 @@ async def test_nonstarted_receive_str() -> None:
     ws = WebSocketResponse()
     with pytest.raises(RuntimeError):
         await ws.receive_str()
+
+
+async def test_cancel_heartbeat_cancels_pending_heartbeat_reset_handle(
+    loop: asyncio.AbstractEventLoop,
+) -> None:
+    ws = web.WebSocketResponse(heartbeat=0.05)
+    ws._loop = loop
+    ws._on_data_received()
+    handle = ws._heartbeat_reset_handle
+    assert handle is not None
+
+    ws._cancel_heartbeat()
+
+    assert ws._heartbeat_reset_handle is None
+    assert ws._need_heartbeat_reset is False
+    assert handle.cancelled()
+
+
+async def test_flush_heartbeat_reset_returns_early_when_not_needed() -> None:
+    ws = web.WebSocketResponse(heartbeat=0.05)
+    ws._need_heartbeat_reset = False
+
+    with mock.patch.object(ws, "_reset_heartbeat") as reset:
+        ws._flush_heartbeat_reset()
+        reset.assert_not_called()
+
+
+async def test_send_heartbeat_returns_early_when_reset_is_pending() -> None:
+    ws = web.WebSocketResponse(heartbeat=0.05)
+    ws._need_heartbeat_reset = True
+
+    ws._send_heartbeat()
+
+    assert ws._pong_response_cb is None
+    assert ws._ping_task is None
 
 
 async def test_nonstarted_receive_bytes() -> None:
@@ -186,6 +222,36 @@ async def test_heartbeat_timeout(make_request: Any) -> None:
     ws._req.transport.close.side_effect = lambda: future.set_result(None)
     await future
     assert ws.closed
+
+
+async def test_heartbeat_reset_coalesces_on_data(
+    make_request: Any,
+) -> None:
+    req = make_request("GET", "/")
+    ws = web.WebSocketResponse(heartbeat=0.05)
+    await ws.prepare(req)
+
+    with mock.patch.object(ws, "_reset_heartbeat") as reset:
+        ws._on_data_received()
+        ws._on_data_received()
+
+        await asyncio.sleep(0)
+
+        assert reset.call_count == 1
+
+
+async def test_receive_does_not_reset_heartbeat() -> None:
+    ws = web.WebSocketResponse(heartbeat=0.05)
+    msg = mock.Mock(type=WSMsgType.TEXT)
+    reader = mock.Mock()
+    reader.read = mock.AsyncMock(return_value=msg)
+    ws._reader = reader
+
+    with mock.patch.object(ws, "_reset_heartbeat") as reset:
+        received = await ws.receive()
+
+    assert received is msg
+    reset.assert_not_called()
 
 
 def test_websocket_ready() -> None:


### PR DESCRIPTION
(cherry picked from commit a640f4f2c42d9d92267340f6f5db510f5b1b5b66)
<!-- Thank you for your contribution! -->

## What do these changes do?
Reset websocket heartbeat on any inbound data (coalesced per event-loop tick) so slow/large frame reception doesn’t trigger ping/pong timeouts mid-message. Add a regression test that simulates slow, chunked delivery of a single large binary frame.
<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?
Yes.
WebSocket heartbeat is now reset when any bytes are received, not only after a full websocket message is assembled.
This avoids false disconnects on slow links when receiving large frames.
The additional work is only enabled when heartbeat is set, and is coalesced to at most once per loop iteration.

<!-- Outline any notable behaviour for the end users. -->

## Is it a substantial burden for the maintainers to support this?

<!--
Stop right there! Pause. Just for a minute... Can you think of anything
obvious that would complicate the ongoing development of this project?

Try to consider if you'd be able to maintain it throughout the next
5 years. Does it seem viable? Tell us your thoughts! We'd very much
love to hear what the consequences of merging this patch might be...

This will help us assess if your change is something we'd want to
entertain early in the review process. Thank you in advance!
-->
No. The change remains small and self-contained, but the implementation is now simpler than the original approach: heartbeat reset wiring is done via existing protocol parser callbacks (no wrapper class), with coalesced reset logic in websocket response objects. It keeps behavior internal (no public API changes), adds focused regression/coverage tests (including slow/chunked frame handling), and only minimal documentation/changelog surface. Overall maintenance burden should be low.

## Related issue number

<!-- Will this resolve any open issues? -->
<!-- Remember to prefix with 'Fixes' if it closes an issue (e.g. 'Fixes #123'). -->
Refs aio-libs/aiohttp Discussion aio-libs#12023

## Checklist

- [ x] I think the code is well written
- [ x] Unit tests for the changes exist
- [ x] Documentation reflects the changes
- [ x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x ] Add a new news fragment into the `CHANGES/` folder
  * name it `<issue_or_pr_num>.<type>.rst` (e.g. `588.bugfix.rst`)
  * if you don't have an issue number, change it to the pull request
    number after creating the PR
    * `.bugfix`: A bug fix for something the maintainers deemed an
      improper undesired behavior that got corrected to match
      pre-agreed expectations.
    * `.feature`: A new behavior, public APIs. That sort of stuff.
    * `.deprecation`: A declaration of future API removals and breaking
      changes in behavior.
    * `.breaking`: When something public is removed in a breaking way.
      Could be deprecated in an earlier release.
    * `.doc`: Notable updates to the documentation structure or build
      process.
    * `.packaging`: Notes for downstreams about unobvious side effects
      and tooling. Changes in the test invocation considerations and
      runtime assumptions.
    * `.contrib`: Stuff that affects the contributor experience. e.g.
      Running tests, building the docs, setting up the development
      environment.
    * `.misc`: Changes that are hard to assign to any of the above
      categories.
  * Make sure to use full sentences with correct case and punctuation,
    for example:
    ```rst
    Fixed issue with non-ascii contents in doctest text files
    -- by :user:`contributor-gh-handle`.
    ```

    Use the past tense or the present tense a non-imperative mood,
    referring to what's changed compared to the last released version
    of this project.
