### PR TITLE
Fix access log timestamps ignoring daylight savings time

### DIFF
--- a/CHANGES/11283.bugfix.rst
+++ b/CHANGES/11283.bugfix.rst
@@ -1,0 +1,3 @@
+Fixed access log timestamps ignoring daylight saving time (DST) changes. The
+previous implementation used :py:data:`time.timezone` which is a constant and
+does not reflect DST transitions -- by :user:`nightcityblade`.

--- a/aiohttp/web_log.py
+++ b/aiohttp/web_log.py
@@ -141,7 +141,7 @@ class AccessLogger(AbstractAccessLogger):
         return ip if ip is not None else "-"
 
     @classmethod
-    def _get_local_time(cls) -> tuple[datetime.timezone, datetime.datetime]:
+    def _get_local_time(cls) -> datetime.datetime:
         if cls._cached_tz is None or time_mod.time() >= cls._cached_tz_expires:
             gmtoff = time_mod.localtime().tm_gmtoff
             cls._cached_tz = tz = datetime.timezone(datetime.timedelta(seconds=gmtoff))

--- a/aiohttp/web_log.py
+++ b/aiohttp/web_log.py
@@ -149,7 +149,7 @@ class AccessLogger(AbstractAccessLogger):
             d = datetime.datetime.now(tz) + datetime.timedelta(minutes=30)
             d = d.replace(minute=30 if d.minute >= 30 else 0, second=0, microsecond=0)
             cls._cached_tz_expires = d.timestamp()
-        
+
         # Return both timezone and current datetime for reuse
         current_datetime = datetime.datetime.now(cls._cached_tz)
         return cls._cached_tz, current_datetime

--- a/aiohttp/web_log.py
+++ b/aiohttp/web_log.py
@@ -5,7 +5,8 @@ import os
 import re
 import time as time_mod
 from collections import namedtuple
-from typing import Any, Callable, Dict, Iterable, List, Tuple  # noqa
+from collections.abc import Iterable
+from typing import Any, Callable, ClassVar
 
 from .abc import AbstractAccessLogger
 from .web_request import BaseRequest
@@ -59,6 +60,9 @@ class AccessLogger(AbstractAccessLogger):
     FORMAT_RE = re.compile(r"%(\{([A-Za-z0-9\-_]+)\}([ioe])|[atPrsbOD]|Tf?)")
     CLEANUP_RE = re.compile(r"(%[^s])")
     _FORMAT_CACHE: dict[str, tuple[str, list[KeyMethod]]] = {}
+
+    _cached_tz: ClassVar[datetime.timezone | None] = None
+    _cached_tz_expires: ClassVar[float] = 0.0
 
     def __init__(self, logger: logging.Logger, log_format: str = LOG_FORMAT) -> None:
         """Initialise the logger.
@@ -136,27 +140,24 @@ class AccessLogger(AbstractAccessLogger):
         ip = request.remote
         return ip if ip is not None else "-"
 
-    _cached_tz: datetime.timezone | None = None
-    _cached_tz_expires: float = 0.0
-
     @classmethod
-    def _get_local_timezone(cls) -> tuple[datetime.timezone, datetime.datetime]:
-        now = time_mod.time()
-        if cls._cached_tz is None or now >= cls._cached_tz_expires:
+    def _get_local_time(cls) -> tuple[datetime.timezone, datetime.datetime]:
+        if cls._cached_tz is None or time_mod.time() >= cls._cached_tz_expires:
             gmtoff = time_mod.localtime().tm_gmtoff
-            tz = datetime.timezone(datetime.timedelta(seconds=gmtoff))
-            cls._cached_tz = tz
-            d = datetime.datetime.now(tz) + datetime.timedelta(minutes=30)
+            cls._cached_tz = tz = datetime.timezone(datetime.timedelta(seconds=gmtoff))
+
+            now = datetime.datetime.now(tz)
+            # Expire at every 30 mins, as any DST change should occur at 0/30 mins past.
+            d = now + datetime.timedelta(minutes=30)
             d = d.replace(minute=30 if d.minute >= 30 else 0, second=0, microsecond=0)
             cls._cached_tz_expires = d.timestamp()
+            return now
 
-        # Return both timezone and current datetime for reuse
-        current_datetime = datetime.datetime.now(cls._cached_tz)
-        return cls._cached_tz, current_datetime
+        return datetime.datetime.now(cls._cached_tz)
 
     @staticmethod
     def _format_t(request: BaseRequest, response: StreamResponse, time: float) -> str:
-        tz, now = AccessLogger._get_local_timezone()
+        now = AccessLogger._get_local_time()
         start_time = now - datetime.timedelta(seconds=time)
         return start_time.strftime("[%d/%b/%Y:%H:%M:%S %z]")
 

--- a/aiohttp/web_log.py
+++ b/aiohttp/web_log.py
@@ -6,7 +6,7 @@ import re
 import time as time_mod
 from collections import namedtuple
 from collections.abc import Iterable
-from typing import Any, Callable, ClassVar
+from typing import Callable, ClassVar
 
 from .abc import AbstractAccessLogger
 from .web_request import BaseRequest

--- a/tests/test_web_log.py
+++ b/tests/test_web_log.py
@@ -202,7 +202,8 @@ def test_access_logger_dst_timezone(monkeypatch: pytest.MonkeyPatch) -> None:
 
     # Verify cached tz works too
     assert access_logger._cached_tz is not None
-    access_logger.log(request, response, 0.0)
+    with mock.patch("aiohttp.web_log.time_mode.time", return_value=access_logger._cached_tz_expires - 1):
+        access_logger.log(request, response, 0.0)
     call3 = mock_logger.info.call_args[0][0]
     assert "-0400" in call3, f"Expected EDT offset in {call3}"
 

--- a/tests/test_web_log.py
+++ b/tests/test_web_log.py
@@ -200,6 +200,12 @@ def test_access_logger_dst_timezone(monkeypatch: pytest.MonkeyPatch) -> None:
     assert "02:00:00 -0500" in call1
     assert "03:00:00 -0400" in call2
 
+    # Verify cached tz works too
+    assert access_logger._cached_tz is not None
+    access_logger.log(request, response, 0.0)
+    call3 = mock_logger.info.call_args[0][0]
+    assert "-0400" in call3, f"Expected EDT offset in {call3}"
+
 
 def test_access_logger_dicts() -> None:
     log_format = "%{User-Agent}i %{Content-Length}o %{None}i"

--- a/tests/test_web_log.py
+++ b/tests/test_web_log.py
@@ -203,7 +203,7 @@ def test_access_logger_dst_timezone(monkeypatch: pytest.MonkeyPatch) -> None:
     # Verify cached tz works too
     assert access_logger._cached_tz is not None
     with mock.patch(
-        "aiohttp.web_log.time_mode.time",
+        "aiohttp.web_log.time_mod.time",
         return_value=access_logger._cached_tz_expires - 1,
     ):
         access_logger.log(request, response, 0.0)

--- a/tests/test_web_log.py
+++ b/tests/test_web_log.py
@@ -94,10 +94,29 @@ def test_access_logger_atoms(
     class PatchedDatetime(datetime.datetime):
         @classmethod
         def now(cls, tz: datetime.tzinfo | None = None) -> Self:
-            return cls(1843, 1, 1, 0, 30, tzinfo=tz)
+            # Simulate: real UTC time is 1842-12-31 16:30, convert to local tz
+            utc = datetime.datetime(1842, 12, 31, 16, 30, tzinfo=datetime.timezone.utc)
+            if tz is not None:
+                local = utc.astimezone(tz)
+                return cls(  # type: ignore[return-value]
+                    local.year,
+                    local.month,
+                    local.day,
+                    local.hour,
+                    local.minute,
+                    local.second,
+                    tzinfo=tz,
+                )
+            return cls(1842, 12, 31, 16, 30, tzinfo=tz)  # type: ignore[return-value]
 
     monkeypatch.setattr("datetime.datetime", PatchedDatetime)
-    monkeypatch.setattr("time.timezone", -28800)
+    # Mock localtime to return CST (+0800 = 28800 seconds)
+    mock_localtime = mock.Mock()
+    mock_localtime.return_value.tm_gmtoff = 28800
+    monkeypatch.setattr("aiohttp.web_log.time_mod.localtime", mock_localtime)
+    # Clear cached timezone so it gets rebuilt with our mock
+    AccessLogger._cached_tz = None
+    AccessLogger._cached_tz_expires = 0.0
     monkeypatch.setattr("os.getpid", lambda: 42)
     mock_logger = mock.Mock()
     access_logger = AccessLogger(mock_logger, log_format)
@@ -113,6 +132,75 @@ def test_access_logger_atoms(
     assert not mock_logger.exception.called, mock_logger.exception.call_args
 
     mock_logger.info.assert_called_with(expected, extra=extra)
+
+
+@pytest.mark.skipif(
+    IS_PYPY,
+    reason="PyPy has issues with patching datetime.datetime",
+)
+def test_access_logger_dst_timezone(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Test that _format_t uses the current local UTC offset, not a cached one.
+
+    This ensures timestamps are correct during DST transitions. The old
+    implementation used time.timezone which is a constant and doesn't
+    reflect DST changes.
+    """
+    # Simulate a timezone that observes DST (e.g., US Eastern)
+    # During EST: UTC-5 (-18000s), during EDT: UTC-4 (-14400s)
+    gmtoff_est = -18000  # UTC-5
+    gmtoff_edt = -14400  # UTC-4
+
+    class PatchedDatetime(datetime.datetime):
+        @classmethod
+        def now(cls, tz: datetime.tzinfo | None = None) -> Self:
+            # Simulate: real UTC time is 07:00, convert to local tz
+            utc = datetime.datetime(2024, 3, 10, 7, 0, 0, tzinfo=datetime.timezone.utc)
+            if tz is not None:
+                local = utc.astimezone(tz)
+                return cls(  # type: ignore[return-value]
+                    local.year,
+                    local.month,
+                    local.day,
+                    local.hour,
+                    local.minute,
+                    local.second,
+                    tzinfo=tz,
+                )
+            return cls(2024, 3, 10, 7, 0, 0, tzinfo=tz)  # type: ignore[return-value]
+
+    monkeypatch.setattr("datetime.datetime", PatchedDatetime)
+    mock_localtime = mock.Mock()
+    mock_localtime.return_value.tm_gmtoff = gmtoff_est
+    monkeypatch.setattr("aiohttp.web_log.time_mod.localtime", mock_localtime)
+    # Force cache refresh
+    AccessLogger._cached_tz = None
+    AccessLogger._cached_tz_expires = 0.0
+
+    mock_logger = mock.Mock()
+    access_logger = AccessLogger(mock_logger, "%t")
+    request = mock.Mock(
+        headers={}, method="GET", path_qs="/", version=(1, 1), remote="127.0.0.1"
+    )
+    response = mock.Mock(headers={}, body_length=0, status=200)
+
+    # During EST (UTC-5): time is 07:00-05:00 = 02:00 EST
+    access_logger.log(request, response, 0.0)
+    call1 = mock_logger.info.call_args[0][0]
+    assert "-0500" in call1, f"Expected EST offset in {call1}"
+
+    mock_logger.reset_mock()
+
+    # Switch to EDT (UTC-4): force cache invalidation
+    mock_localtime.return_value.tm_gmtoff = gmtoff_edt
+    AccessLogger._cached_tz = None
+    AccessLogger._cached_tz_expires = 0.0
+    access_logger.log(request, response, 0.0)
+    call2 = mock_logger.info.call_args[0][0]
+    assert "-0400" in call2, f"Expected EDT offset in {call2}"
+
+    # Verify the hour changed too (02:00 -> 03:00)
+    assert "02:00:00 -0500" in call1
+    assert "03:00:00 -0400" in call2
 
 
 def test_access_logger_dicts() -> None:

--- a/tests/test_web_log.py
+++ b/tests/test_web_log.py
@@ -94,20 +94,19 @@ def test_access_logger_atoms(
     class PatchedDatetime(datetime.datetime):
         @classmethod
         def now(cls, tz: datetime.tzinfo | None = None) -> Self:
+            assert tz is not None
             # Simulate: real UTC time is 1842-12-31 16:30, convert to local tz
             utc = datetime.datetime(1842, 12, 31, 16, 30, tzinfo=datetime.timezone.utc)
-            if tz is not None:
-                local = utc.astimezone(tz)
-                return cls(
-                    local.year,
-                    local.month,
-                    local.day,
-                    local.hour,
-                    local.minute,
-                    local.second,
-                    tzinfo=tz,
-                )
-            return cls(1842, 12, 31, 16, 30, tzinfo=tz)
+            local = utc.astimezone(tz)
+            return cls(
+                local.year,
+                local.month,
+                local.day,
+                local.hour,
+                local.minute,
+                local.second,
+                tzinfo=tz,
+            )
 
     monkeypatch.setattr("datetime.datetime", PatchedDatetime)
     # Mock localtime to return CST (+0800 = 28800 seconds)
@@ -153,20 +152,19 @@ def test_access_logger_dst_timezone(monkeypatch: pytest.MonkeyPatch) -> None:
     class PatchedDatetime(datetime.datetime):
         @classmethod
         def now(cls, tz: datetime.tzinfo | None = None) -> Self:
+            assert tz is not None
             # Simulate: real UTC time is 07:00, convert to local tz
             utc = datetime.datetime(2024, 3, 10, 7, 0, 0, tzinfo=datetime.timezone.utc)
-            if tz is not None:
-                local = utc.astimezone(tz)
-                return cls(
-                    local.year,
-                    local.month,
-                    local.day,
-                    local.hour,
-                    local.minute,
-                    local.second,
-                    tzinfo=tz,
-                )
-            return cls(2024, 3, 10, 7, 0, 0, tzinfo=tz)
+            local = utc.astimezone(tz)
+            return cls(
+                local.year,
+                local.month,
+                local.day,
+                local.hour,
+                local.minute,
+                local.second,
+                tzinfo=tz,
+            )
 
     monkeypatch.setattr("datetime.datetime", PatchedDatetime)
     mock_localtime = mock.Mock()

--- a/tests/test_web_log.py
+++ b/tests/test_web_log.py
@@ -202,7 +202,10 @@ def test_access_logger_dst_timezone(monkeypatch: pytest.MonkeyPatch) -> None:
 
     # Verify cached tz works too
     assert access_logger._cached_tz is not None
-    with mock.patch("aiohttp.web_log.time_mode.time", return_value=access_logger._cached_tz_expires - 1):
+    with mock.patch(
+        "aiohttp.web_log.time_mode.time",
+        return_value=access_logger._cached_tz_expires - 1,
+    ):
         access_logger.log(request, response, 0.0)
     call3 = mock_logger.info.call_args[0][0]
     assert "-0400" in call3, f"Expected EDT offset in {call3}"

--- a/tests/test_web_log.py
+++ b/tests/test_web_log.py
@@ -98,7 +98,7 @@ def test_access_logger_atoms(
             utc = datetime.datetime(1842, 12, 31, 16, 30, tzinfo=datetime.timezone.utc)
             if tz is not None:
                 local = utc.astimezone(tz)
-                return cls(  # type: ignore[return-value]
+                return cls(
                     local.year,
                     local.month,
                     local.day,
@@ -107,7 +107,7 @@ def test_access_logger_atoms(
                     local.second,
                     tzinfo=tz,
                 )
-            return cls(1842, 12, 31, 16, 30, tzinfo=tz)  # type: ignore[return-value]
+            return cls(1842, 12, 31, 16, 30, tzinfo=tz)
 
     monkeypatch.setattr("datetime.datetime", PatchedDatetime)
     # Mock localtime to return CST (+0800 = 28800 seconds)
@@ -157,7 +157,7 @@ def test_access_logger_dst_timezone(monkeypatch: pytest.MonkeyPatch) -> None:
             utc = datetime.datetime(2024, 3, 10, 7, 0, 0, tzinfo=datetime.timezone.utc)
             if tz is not None:
                 local = utc.astimezone(tz)
-                return cls(  # type: ignore[return-value]
+                return cls(
                     local.year,
                     local.month,
                     local.day,
@@ -166,7 +166,7 @@ def test_access_logger_dst_timezone(monkeypatch: pytest.MonkeyPatch) -> None:
                     local.second,
                     tzinfo=tz,
                 )
-            return cls(2024, 3, 10, 7, 0, 0, tzinfo=tz)  # type: ignore[return-value]
+            return cls(2024, 3, 10, 7, 0, 0, tzinfo=tz)
 
     monkeypatch.setattr("datetime.datetime", PatchedDatetime)
     mock_localtime = mock.Mock()


### PR DESCRIPTION
## Description

Fixes #11283.

The `_format_t` method in `web_log.py` used `time.timezone` to construct the timezone offset, but `time.timezone` is a constant representing the **standard time** UTC offset and does not account for daylight savings time. This causes access log timestamps to show the wrong time and offset during DST periods.

## Changes

Replaced the manual timezone construction with `datetime.now(tz=datetime.timezone.utc).astimezone()`, which correctly resolves to the system's local timezone **including DST**. Also removed the now-unused `import time as time_mod`.

## Before / After

**Before (during MDT, UTC-6):**
```
[08/Jul/2025:12:58:46 -0700]  # Wrong: shows MST offset
```

**After:**
```
[08/Jul/2025:13:58:46 -0600]  # Correct: shows MDT offset
```