### PR TITLE
Make tests pass after year 2027

### DIFF
--- a/CHANGES/12088.bugfix.rst
+++ b/CHANGES/12088.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed tests to pass when run after 2027-05-31 -- by :user:`bmwiedemann`.

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -5450,30 +5450,30 @@ async def test_amazon_like_cookie_scenario(aiohttp_client: AiohttpClient) -> Non
         # Simulate Amazon-like cookies from the issue
         cookies = [
             "session-id=146-7423990-7621939; Domain=.amazon.it; "
-            "Expires=Mon, 31-May-2027 10:00:00 GMT; Path=/; "
+            "Expires=Mon, 31-May-3024 10:00:00 GMT; Path=/; "
             "Secure; HttpOnly",
             "session-id=147-8529641-8642103; Domain=.www.amazon.it; "
-            "Expires=Mon, 31-May-2027 10:00:00 GMT; Path=/; HttpOnly",
+            "Expires=Mon, 31-May-3024 10:00:00 GMT; Path=/; HttpOnly",
             "session-id-time=2082758401l; Domain=.amazon.it; "
-            "Expires=Mon, 31-May-2027 10:00:00 GMT; Path=/; Secure",
+            "Expires=Mon, 31-May-3024 10:00:00 GMT; Path=/; Secure",
             "session-id-time=2082758402l; Domain=.www.amazon.it; "
-            "Expires=Mon, 31-May-2027 10:00:00 GMT; Path=/",
+            "Expires=Mon, 31-May-3024 10:00:00 GMT; Path=/",
             "ubid-acbit=257-7531983-5395266; Domain=.amazon.it; "
-            "Expires=Mon, 31-May-2027 10:00:00 GMT; Path=/; Secure",
+            "Expires=Mon, 31-May-3024 10:00:00 GMT; Path=/; Secure",
             'x-acbit="KdvJzu8W@Fx6Jj3EuNFLuP0N7OtkuCfs"; Version=1; '
             "Domain=.amazon.it; Path=/; Secure; HttpOnly",
             "at-acbit=Atza|IwEBIM-gLr8; Domain=.amazon.it; "
-            "Expires=Mon, 31-May-2027 10:00:00 GMT; Path=/; "
+            "Expires=Mon, 31-May-3024 10:00:00 GMT; Path=/; "
             "Secure; HttpOnly",
             'sess-at-acbit="4+6VzSJPHIFD/OqO264hFxIng8Y="; '
-            "Domain=.amazon.it; Expires=Mon, 31-May-2027 10:00:00 GMT; "
+            "Domain=.amazon.it; Expires=Mon, 31-May-3024 10:00:00 GMT; "
             "Path=/; Secure; HttpOnly",
             "lc-acbit=it_IT; Domain=.amazon.it; "
-            "Expires=Mon, 31-May-2027 10:00:00 GMT; Path=/",
+            "Expires=Mon, 31-May-3024 10:00:00 GMT; Path=/",
             "i18n-prefs=EUR; Domain=.amazon.it; "
-            "Expires=Mon, 31-May-2027 10:00:00 GMT; Path=/",
+            "Expires=Mon, 31-May-3024 10:00:00 GMT; Path=/",
             "av-profile=null; Domain=.amazon.it; "
-            "Expires=Mon, 31-May-2027 10:00:00 GMT; Path=/; Secure",
+            "Expires=Mon, 31-May-3024 10:00:00 GMT; Path=/; Secure",
             'user-pref-token="Am81ywsJ69xObBnuJ2FbilVH0mg="; '
             "Domain=.amazon.it; Path=/; Secure",
         ]

--- a/tests/test_cookiejar.py
+++ b/tests/test_cookiejar.py
@@ -1307,7 +1307,7 @@ def test_update_cookies_from_headers_with_attributes() -> None:
         "secure-cookie=value1; Secure; HttpOnly; SameSite=Strict",
         "expiring-cookie=value2; Max-Age=3600; Path=/app",
         "domain-cookie=value3; Domain=.example.com; Path=/",
-        "dated-cookie=value4; Expires=Wed, 09 Jun 2030 10:18:14 GMT",
+        "dated-cookie=value4; Expires=Wed, 09 Jun 3024 10:18:14 GMT",
     ]
 
     jar.update_cookies_from_headers(headers, url)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

These changes are necessary to allow tests to pass after 2027-05-31

## Are there changes in behavior for the user?

No

## Is it a substantial burden for the maintainers to support this?

No

<!--
Stop right there! Pause. Just for a minute... Can you think of anything
obvious that would complicate the ongoing development of this project?

Try to consider if you'd be able to maintain it throughout the next
5 years. Does it seem viable? Tell us your thoughts! We'd very much
love to hear what the consequences of merging this patch might be...

This will help us assess if your change is something we'd want to
entertain early in the review process. Thank you in advance!
-->

## Related issue number

NA

## Checklist

- [X] I think the code is well written
- [X] Unit tests for the changes exist
- [X] Documentation reflects the changes
- [X] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [X] Add a new news fragment into the `CHANGES/` folder
  * name it `<issue_or_pr_num>.<type>.rst` (e.g. `588.bugfix.rst`)
  * if you don't have an issue number, change it to the pull request
    number after creating the PR
    * `.bugfix`: A bug fix for something the maintainers deemed an
      improper undesired behavior that got corrected to match
      pre-agreed expectations.
    * `.misc`: Changes that are hard to assign to any of the above
      categories.
  * Make sure to use full sentences with correct case and punctuation,
    for example:
    ```rst
    Fixed issue with non-ascii contents in doctest text files
    -- by :user:`contributor-gh-handle`.
    ```

    Use the past tense or the present tense a non-imperative mood,
    referring to what's changed compared to the last released version
    of this project.


Note: I tested that tests pass on i586 and x86_64.

Note2: year 3024 was chosen because it is far enough into the future and it matches the previous day-of-week, so that the diff is more readable. And the previous "Wed, 09 Jun 2030" actually got the day-of-week wrong. 

Background:
As part of my work on reproducible builds for openSUSE, I check that software still gives identical build results in the future.
The usual offset is +16 years, because that is how long I expect some software will be used in some places.
This showed up failing tests in our `python-aiohttp` 3.13.3 package build.
See https://reproducible-builds.org/ for why this matters.