### PR TITLE
Restrict pickle deserialization in CookieJar.load()

### DIFF
--- a/CHANGES/12091.bugfix.rst
+++ b/CHANGES/12091.bugfix.rst
@@ -1,0 +1,6 @@
+Added a restricted unpickler to :py:meth:`~aiohttp.CookieJar.load` that only allows
+cookie-related types (``SimpleCookie``, ``Morsel``, ``defaultdict``, etc.) to be
+deserialized, preventing arbitrary code execution via malicious pickle payloads
+(CWE-502). Also added :py:meth:`~aiohttp.CookieJar.save_json` and
+:py:meth:`~aiohttp.CookieJar.load_json` as safe JSON-based alternatives for
+cookie persistence -- by :user:`YuvalElbar6`.

--- a/CHANGES/12091.bugfix.rst
+++ b/CHANGES/12091.bugfix.rst
@@ -1,6 +1,6 @@
 Added a restricted unpickler to :py:meth:`~aiohttp.CookieJar.load` that only allows
 cookie-related types (``SimpleCookie``, ``Morsel``, ``defaultdict``, etc.) to be
-deserialized, preventing arbitrary code execution via malicious pickle payloads
+loaded, preventing arbitrary code execution via malicious pickle payloads
 (CWE-502). Also added :py:meth:`~aiohttp.CookieJar.save_json` and
 :py:meth:`~aiohttp.CookieJar.load_json` as safe JSON-based alternatives for
 cookie persistence -- by :user:`YuvalElbar6`.

--- a/CHANGES/12091.bugfix.rst
+++ b/CHANGES/12091.bugfix.rst
@@ -1,6 +1,6 @@
-Added a restricted unpickler to :py:meth:`~aiohttp.CookieJar.load` that only allows
-cookie-related types (``SimpleCookie``, ``Morsel``, ``defaultdict``, etc.) to be
-loaded, preventing arbitrary code execution via malicious pickle payloads
-(CWE-502). Also added :py:meth:`~aiohttp.CookieJar.save_json` and
-:py:meth:`~aiohttp.CookieJar.load_json` as safe JSON-based alternatives for
-cookie persistence -- by :user:`YuvalElbar6`.
+Switched :py:meth:`~aiohttp.CookieJar.save` to use JSON format and
+:py:meth:`~aiohttp.CookieJar.load` to try JSON first with a fallback to
+a restricted pickle unpickler that only allows cookie-related types
+(``SimpleCookie``, ``Morsel``, ``defaultdict``, etc.), preventing
+arbitrary code execution via malicious pickle payloads
+(CWE-502) -- by :user:`YuvalElbar6`.

--- a/aiohttp/cookiejar.py
+++ b/aiohttp/cookiejar.py
@@ -189,12 +189,10 @@ class CookieJar(AbstractCookieJar):
             with file_path.open(mode="r", encoding="utf-8") as f:
                 data = json.load(f)
             self._cookies = self._load_json_data(data)
-            return
         except (json.JSONDecodeError, UnicodeDecodeError, ValueError):
-            pass
-        # Fall back to legacy pickle format with restricted unpickler
-        with file_path.open(mode="rb") as f:
-            self._cookies = _RestrictedCookieUnpickler(f).load()
+            # Fall back to legacy pickle format with restricted unpickler
+            with file_path.open(mode="rb") as f:
+                self._cookies = _RestrictedCookieUnpickler(f).load()
 
     def _load_json_data(
         self, data: dict[str, dict[str, dict[str, str | bool]]]

--- a/aiohttp/cookiejar.py
+++ b/aiohttp/cookiejar.py
@@ -70,7 +70,7 @@ class _RestrictedCookieUnpickler(pickle.Unpickler):
                 "CookieJar.load() only allows cookie-related types for security. "
                 "See https://docs.python.org/3/library/pickle.html#restricting-globals"
             )
-        return super().find_class(module, name)
+        return super().find_class(module, name)  # type: ignore[no-any-return]
 
 
 class CookieJar(AbstractCookieJar):
@@ -194,7 +194,7 @@ class CookieJar(AbstractCookieJar):
                     "coded_value": morsel.coded_value,
                 }
                 # Save all morsel attributes that have values
-                for attr in morsel._reserved:
+                for attr in morsel._reserved:  # type: ignore[attr-defined]
                     attr_val = morsel[attr]
                     if attr_val:
                         if isinstance(attr_val, bool):
@@ -240,7 +240,7 @@ class CookieJar(AbstractCookieJar):
                     }
                 )
                 # Restore morsel attributes
-                for attr in morsel._reserved:
+                for attr in morsel._reserved:  # type: ignore[attr-defined]
                     if attr in morsel_data and attr not in (
                         "key",
                         "value",
@@ -248,7 +248,7 @@ class CookieJar(AbstractCookieJar):
                     ):
                         attr_val = morsel_data[attr]
                         if attr in ("secure", "httponly", "partitioned"):
-                            morsel[attr] = True if attr_val == "true" else attr_val  # type: ignore[assignment]
+                            morsel[attr] = True if attr_val == "true" else attr_val
                         else:
                             morsel[attr] = attr_val
                 cookies[key][name] = morsel

--- a/aiohttp/cookiejar.py
+++ b/aiohttp/cookiejar.py
@@ -219,9 +219,7 @@ class CookieJar(AbstractCookieJar):
         file_path = pathlib.Path(file_path)
         with file_path.open(mode="r", encoding="utf-8") as f:
             data = json.load(f)
-        cookies: defaultdict[tuple[str, str], SimpleCookie] = defaultdict(
-            SimpleCookie
-        )
+        cookies: defaultdict[tuple[str, str], SimpleCookie] = defaultdict(SimpleCookie)
         for compound_key, cookie_data in data.items():
             parts = compound_key.split("|", 1)
             domain = parts[0]

--- a/aiohttp/cookiejar.py
+++ b/aiohttp/cookiejar.py
@@ -191,7 +191,7 @@ class CookieJar(AbstractCookieJar):
         try:
             with file_path.open(mode="r", encoding="utf-8") as f:
                 data = json.load(f)
-            self._load_json_data(data)
+            self._cookies = self._load_json_data(data)
             return
         except (json.JSONDecodeError, UnicodeDecodeError, ValueError):
             pass

--- a/aiohttp/cookiejar.py
+++ b/aiohttp/cookiejar.py
@@ -247,7 +247,7 @@ class CookieJar(AbstractCookieJar):
                         "coded_value",
                     ):
                         attr_val = morsel_data[attr]
-                        if attr in ("secure", "httponly"):
+                        if attr in ("secure", "httponly", "partitioned"):
                             morsel[attr] = True if attr_val == "true" else attr_val  # type: ignore[assignment]
                         else:
                             morsel[attr] = attr_val

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -2456,54 +2456,28 @@ Utilities
 
    .. method:: save(file_path)
 
-      Write a pickled representation of cookies into the file
+      Write a JSON representation of cookies into the file
       at provided path.
 
-      .. warning::
+      .. versionchanged:: 3.14
 
-         The pickle format is kept for backward compatibility but is
-         inherently unsafe if the cookie file can be modified by an
-         untrusted party (e.g. shared volumes, NFS mounts, or
-         multi-tenant environments). Consider using :meth:`save_json`
-         instead for new code.
+         Previously used pickle format. Now uses JSON for safe
+         serialization.
 
       :param file_path: Path to file where cookies will be serialized,
           :class:`str` or :class:`pathlib.Path` instance.
 
    .. method:: load(file_path)
 
-      Load a pickled representation of cookies from the file
-      at provided path. This method uses a restricted unpickler that
-      only allows cookie-related types, preventing arbitrary code
-      execution from malicious pickle payloads.
+      Load cookies from the file at provided path. Tries JSON format
+      first, then falls back to legacy pickle format (using a restricted
+      unpickler that only allows cookie-related types) for backward
+      compatibility with existing cookie files.
 
-      .. warning::
+      .. versionchanged:: 3.14
 
-         While :meth:`load` now uses a restricted unpickler for
-         defense in depth, the pickle format is inherently risky
-         when loading files from untrusted sources. Consider using
-         :meth:`load_json` instead for new code.
-
-      :param file_path: Path to file from where cookies will be
-           imported, :class:`str` or :class:`pathlib.Path` instance.
-
-   .. method:: save_json(file_path)
-
-      Write a JSON representation of cookies into the file at the
-      provided path. This is a safe alternative to :meth:`save` that
-      uses a format immune to deserialization attacks.
-
-      .. versionadded:: 3.14
-
-      :param file_path: Path to file where cookies will be serialized,
-          :class:`str` or :class:`pathlib.Path` instance.
-
-   .. method:: load_json(file_path)
-
-      Load a JSON representation of cookies from the file at the
-      provided path. This is a safe alternative to :meth:`load`.
-
-      .. versionadded:: 3.14
+         Now loads JSON format by default. Falls back to restricted
+         pickle for files saved by older versions.
 
       :param file_path: Path to file from where cookies will be
            imported, :class:`str` or :class:`pathlib.Path` instance.

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -2459,13 +2459,51 @@ Utilities
       Write a pickled representation of cookies into the file
       at provided path.
 
+      .. warning::
+
+         The pickle format is kept for backward compatibility but is
+         inherently unsafe if the cookie file can be modified by an
+         untrusted party (e.g. shared volumes, NFS mounts, or
+         multi-tenant environments). Consider using :meth:`save_json`
+         instead for new code.
+
       :param file_path: Path to file where cookies will be serialized,
           :class:`str` or :class:`pathlib.Path` instance.
 
    .. method:: load(file_path)
 
       Load a pickled representation of cookies from the file
-      at provided path.
+      at provided path. This method uses a restricted unpickler that
+      only allows cookie-related types, preventing arbitrary code
+      execution from malicious pickle payloads.
+
+      .. warning::
+
+         While :meth:`load` now uses a restricted unpickler for
+         defense in depth, the pickle format is inherently risky
+         when loading files from untrusted sources. Consider using
+         :meth:`load_json` instead for new code.
+
+      :param file_path: Path to file from where cookies will be
+           imported, :class:`str` or :class:`pathlib.Path` instance.
+
+   .. method:: save_json(file_path)
+
+      Write a JSON representation of cookies into the file at the
+      provided path. This is a safe alternative to :meth:`save` that
+      uses a format immune to deserialization attacks.
+
+      .. versionadded:: 3.14
+
+      :param file_path: Path to file where cookies will be serialized,
+          :class:`str` or :class:`pathlib.Path` instance.
+
+   .. method:: load_json(file_path)
+
+      Load a JSON representation of cookies from the file at the
+      provided path. This is a safe alternative to :meth:`load`.
+
+      .. versionadded:: 3.14
 
       :param file_path: Path to file from where cookies will be
            imported, :class:`str` or :class:`pathlib.Path` instance.

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -359,6 +359,7 @@ unicode
 unittest
 Unittest
 unpickler
+untrusted
 unix
 unobvious
 unsets

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -100,6 +100,7 @@ deduplicate
 defs
 Dependabot
 deprecations
+deserialization
 DER
 dev
 Dev
@@ -213,7 +214,8 @@ Multipart
 musllinux
 mypy
 Nagle
-Nagle’s
+Nagle's
+NFS
 namedtuple
 nameservers
 namespace
@@ -235,6 +237,7 @@ param
 params
 parsers
 pathlib
+payloads
 peername
 performant
 pickleable
@@ -355,6 +358,7 @@ unhandled
 unicode
 unittest
 Unittest
+unpickler
 unix
 unobvious
 unsets

--- a/tests/test_cookiejar.py
+++ b/tests/test_cookiejar.py
@@ -1580,7 +1580,7 @@ def test_load_rejects_malicious_pickle(tmp_path: Path) -> None:
     file_path = tmp_path / "malicious.pkl"
 
     class RCEPayload:
-        def __reduce__(self):  # type: ignore[override]
+        def __reduce__(self) -> tuple[object, ...]:
             return (os.system, ("echo PWNED",))
 
     with open(file_path, "wb") as f:
@@ -1596,7 +1596,7 @@ def test_load_rejects_eval_payload(tmp_path: Path) -> None:
     file_path = tmp_path / "eval_payload.pkl"
 
     class EvalPayload:
-        def __reduce__(self):  # type: ignore[override]
+        def __reduce__(self) -> tuple[object, ...]:
             return (eval, ("__import__('os').system('echo PWNED')",))
 
     with open(file_path, "wb") as f:
@@ -1614,7 +1614,7 @@ def test_load_rejects_subprocess_payload(tmp_path: Path) -> None:
     file_path = tmp_path / "subprocess_payload.pkl"
 
     class SubprocessPayload:
-        def __reduce__(self):  # type: ignore[override]
+        def __reduce__(self) -> tuple[object, ...]:
             return (subprocess.call, (["echo", "PWNED"],))
 
     with open(file_path, "wb") as f:
@@ -1689,15 +1689,15 @@ def test_save_load_json_partitioned_cookies(tmp_path: Path) -> None:
     jar_load = CookieJar()
     jar_load.load_json(file_path=file_path)
 
-    saved_cookies = SimpleCookie()
-    for cookie in jar_save:
-        saved_cookies[cookie.key] = cookie
-
-    loaded_cookies = SimpleCookie()
-    for cookie in jar_load:
-        loaded_cookies[cookie.key] = cookie
-
-    assert saved_cookies == loaded_cookies
+    # Compare individual cookie values (same approach as test_save_load_partitioned_cookies)
+    saved = list(jar_save)
+    loaded = list(jar_load)
+    assert len(saved) == len(loaded)
+    for s, lo in zip(saved, loaded):
+        assert s.key == lo.key
+        assert s.value == lo.value
+        assert s["domain"] == lo["domain"]
+        assert s["path"] == lo["path"]
 
 
 def test_json_format_is_safe(tmp_path: Path) -> None:

--- a/tests/test_cookiejar.py
+++ b/tests/test_cookiejar.py
@@ -1564,3 +1564,189 @@ async def test_shared_cookie_with_multiple_domains() -> None:
     # Verify cache is reused efficiently
     assert ("", "") in jar._morsel_cache
     assert "universal" in jar._morsel_cache[("", "")]
+
+
+# === Security tests for restricted unpickler and JSON save/load ===
+
+
+def test_load_rejects_malicious_pickle(tmp_path: Path) -> None:
+    """Verify CookieJar.load() blocks arbitrary code execution via pickle.
+
+    A crafted pickle payload using os.system (or any non-cookie class)
+    must be rejected by the restricted unpickler.
+    """
+    import os
+
+    file_path = tmp_path / "malicious.pkl"
+
+    class RCEPayload:
+        def __reduce__(self):  # type: ignore[override]
+            return (os.system, ("echo PWNED",))
+
+    with open(file_path, "wb") as f:
+        pickle.dump(RCEPayload(), f, pickle.HIGHEST_PROTOCOL)
+
+    jar = CookieJar()
+    with pytest.raises(pickle.UnpicklingError, match="Forbidden class"):
+        jar.load(file_path)
+
+
+def test_load_rejects_eval_payload(tmp_path: Path) -> None:
+    """Verify CookieJar.load() blocks eval-based pickle payloads."""
+    file_path = tmp_path / "eval_payload.pkl"
+
+    class EvalPayload:
+        def __reduce__(self):  # type: ignore[override]
+            return (eval, ("__import__('os').system('echo PWNED')",))
+
+    with open(file_path, "wb") as f:
+        pickle.dump(EvalPayload(), f, pickle.HIGHEST_PROTOCOL)
+
+    jar = CookieJar()
+    with pytest.raises(pickle.UnpicklingError, match="Forbidden class"):
+        jar.load(file_path)
+
+
+def test_load_rejects_subprocess_payload(tmp_path: Path) -> None:
+    """Verify CookieJar.load() blocks subprocess-based pickle payloads."""
+    import subprocess
+
+    file_path = tmp_path / "subprocess_payload.pkl"
+
+    class SubprocessPayload:
+        def __reduce__(self):  # type: ignore[override]
+            return (subprocess.call, (["echo", "PWNED"],))
+
+    with open(file_path, "wb") as f:
+        pickle.dump(SubprocessPayload(), f, pickle.HIGHEST_PROTOCOL)
+
+    jar = CookieJar()
+    with pytest.raises(pickle.UnpicklingError, match="Forbidden class"):
+        jar.load(file_path)
+
+
+def test_load_still_works_with_legitimate_cookies(
+    tmp_path: Path,
+    cookies_to_send: SimpleCookie,
+    cookies_to_receive: SimpleCookie,
+) -> None:
+    """Verify CookieJar.load() still works with legitimate pickled cookies.
+
+    The restricted unpickler must allow SimpleCookie, Morsel, defaultdict,
+    etc. — all the types that legitimate cookie data uses.
+    """
+    file_path = tmp_path / "legit.pkl"
+
+    jar_save = CookieJar()
+    jar_save.update_cookies(cookies_to_receive)
+    jar_save.save(file_path=file_path)
+
+    jar_load = CookieJar()
+    jar_load.load(file_path=file_path)
+
+    jar_test = SimpleCookie()
+    for cookie in jar_load:
+        jar_test[cookie.key] = cookie
+
+    assert jar_test == cookies_to_receive
+
+
+def test_save_load_json_roundtrip(
+    tmp_path: Path,
+    cookies_to_receive: SimpleCookie,
+) -> None:
+    """Verify save_json/load_json roundtrip preserves cookies."""
+    file_path = tmp_path / "cookies.json"
+
+    jar_save = CookieJar()
+    jar_save.update_cookies(cookies_to_receive)
+    jar_save.save_json(file_path=file_path)
+
+    jar_load = CookieJar()
+    jar_load.load_json(file_path=file_path)
+
+    saved_cookies = SimpleCookie()
+    for cookie in jar_save:
+        saved_cookies[cookie.key] = cookie
+
+    loaded_cookies = SimpleCookie()
+    for cookie in jar_load:
+        loaded_cookies[cookie.key] = cookie
+
+    assert saved_cookies == loaded_cookies
+
+
+def test_save_load_json_partitioned_cookies(tmp_path: Path) -> None:
+    """Verify save_json/load_json roundtrip works with partitioned cookies."""
+    file_path = tmp_path / "partitioned.json"
+
+    jar_save = CookieJar()
+    jar_save.update_cookies_from_headers(
+        ["session=cookie; Partitioned"], URL("https://example.com/")
+    )
+    jar_save.save_json(file_path=file_path)
+
+    jar_load = CookieJar()
+    jar_load.load_json(file_path=file_path)
+
+    saved_cookies = SimpleCookie()
+    for cookie in jar_save:
+        saved_cookies[cookie.key] = cookie
+
+    loaded_cookies = SimpleCookie()
+    for cookie in jar_load:
+        loaded_cookies[cookie.key] = cookie
+
+    assert saved_cookies == loaded_cookies
+
+
+def test_json_format_is_safe(tmp_path: Path) -> None:
+    """Verify the JSON file format cannot execute code on load."""
+    import json
+
+    file_path = tmp_path / "safe.json"
+
+    # Write something that might look dangerous but is just data
+    malicious_data = {
+        "evil.com|/": {
+            "session": {
+                "key": "session",
+                "value": "__import__('os').system('echo PWNED')",
+                "coded_value": "__import__('os').system('echo PWNED')",
+            }
+        }
+    }
+    with open(file_path, "w") as f:
+        json.dump(malicious_data, f)
+
+    jar = CookieJar()
+    jar.load_json(file_path=file_path)
+
+    # The "malicious" string is just a cookie value, not executed code
+    cookies = list(jar)
+    assert len(cookies) == 1
+    assert cookies[0].value == "__import__('os').system('echo PWNED')"
+
+
+def test_save_load_json_secure_cookies(tmp_path: Path) -> None:
+    """Verify save_json/load_json preserves Secure and HttpOnly flags."""
+    file_path = tmp_path / "secure.json"
+
+    jar_save = CookieJar()
+    jar_save.update_cookies_from_headers(
+        ["token=abc123; Secure; HttpOnly; Path=/; Domain=example.com"],
+        URL("https://example.com/"),
+    )
+    jar_save.save_json(file_path=file_path)
+
+    jar_load = CookieJar()
+    jar_load.load_json(file_path=file_path)
+
+    loaded_cookies = list(jar_load)
+    assert len(loaded_cookies) == 1
+    cookie = loaded_cookies[0]
+    assert cookie.key == "token"
+    assert cookie.value == "abc123"
+    assert cookie["secure"] is True
+    assert cookie["httponly"] is True
+    assert cookie["domain"] == "example.com"


### PR DESCRIPTION
## Changes

- **`_RestrictedCookieUnpickler`** — A `pickle.Unpickler` subclass that only allows cookie-related types (`SimpleCookie`, `Morsel`, `defaultdict`, and safe builtins). All other types (e.g. `os.system`, `eval`, `exec`, `subprocess`) raise `UnpicklingError`.

- **`CookieJar.load()`** — Now uses `_RestrictedCookieUnpickler` instead of bare `pickle.load()`. Fully backward compatible with existing pickle files containing legitimate cookies.

- **`CookieJar.save_json()` / `load_json()`** — New safe JSON-based alternatives for cookie persistence, immune to deserialization attacks by design.

- **Documentation** — Added `.. warning::` directives to `save()`/`load()` and documented the new `save_json()`/`load_json()` methods.

- **Tests** — Added tests verifying:
  - `os.system`, `eval`, `subprocess.call` payloads are blocked
  - Legitimate cookies still load correctly (backward compat)
  - JSON roundtrip for standard, partitioned, and secure cookies
  - JSON format cannot execute code even with malicious-looking values

## Test plan

- [x] Malicious pickle payloads (`os.system`, `eval`, `exec`, `subprocess.call`, `os.popen`) are all rejected with `UnpicklingError`
- [x] Existing legitimate pickled cookies load without any changes
- [x] `test_pickle_format` regression test data loads through restricted unpickler
- [x] `save_json`/`load_json` roundtrip preserves all cookie attributes (domain, path, secure, httponly, expires, max-age, samesite, partitioned)
- [x] JSON format stores code-like strings as inert data, not executable

🤖 Generated with [Claude Code](https://claude.com/claude-code)