### PR TITLE
Fix _sendfile_fallback over-reading beyond requested count

### DIFF
--- a/CHANGES/12096.bugfix.rst
+++ b/CHANGES/12096.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed _sendfile_fallback over-reading beyond requested count -- by :user:`bysiber`.

--- a/aiohttp/web_fileresponse.py
+++ b/aiohttp/web_fileresponse.py
@@ -105,11 +105,11 @@ class FileResponse(StreamResponse):
         chunk_size = self._chunk_size
         loop = asyncio.get_event_loop()
         chunk = await loop.run_in_executor(
-            None, self._seek_and_read, fobj, offset, chunk_size
+            None, self._seek_and_read, fobj, offset, min(chunk_size, count)
         )
         while chunk:
             await writer.write(chunk)
-            count = count - chunk_size
+            count = count - len(chunk)
             if count <= 0:
                 break
             chunk = await loop.run_in_executor(None, fobj.read, min(chunk_size, count))

--- a/tests/test_web_sendfile.py
+++ b/tests/test_web_sendfile.py
@@ -1,4 +1,5 @@
 import asyncio
+import io
 from pathlib import Path
 from stat import S_IFREG, S_IRUSR, S_IWUSR
 from unittest import mock
@@ -161,3 +162,32 @@ async def test_file_response_sends_headers_immediately() -> None:
 
     # Headers should be sent immediately
     writer.send_headers.assert_called_once()
+
+
+async def test_sendfile_fallback_respects_count_boundary() -> None:
+    """Regression test: _sendfile_fallback should not read beyond the requested count.
+
+    Previously the first chunk used the full chunk_size even when count was smaller,
+    and the loop subtracted chunk_size instead of the actual bytes read.  Both bugs
+    could cause extra data to be sent when serving range requests.
+    """
+    file_data = b"A" * 100 + b"B" * 50  # 150 bytes total
+    fobj = io.BytesIO(file_data)
+
+    writer = mock.AsyncMock()
+    written = bytearray()
+
+    async def capture_write(data: bytes) -> None:
+        written.extend(data)
+
+    writer.write = capture_write
+    writer.drain = mock.AsyncMock()
+
+    file_sender = FileResponse("dummy.bin")
+    file_sender._chunk_size = 64  # smaller than count to test multi-chunk
+
+    # Request only the first 100 bytes (offset=0, count=100)
+    await file_sender._sendfile_fallback(writer, fobj, offset=0, count=100)
+
+    assert bytes(written) == b"A" * 100
+    assert len(written) == 100


### PR DESCRIPTION
## What do these changes do?

Fix two related issues in `FileResponse._sendfile_fallback` where the method could read and send more bytes than the requested `count`:

1. The initial `_seek_and_read` call uses `chunk_size` (default 256 KiB) without capping it to `count`. For small range requests (e.g., `Range: bytes=0-99`) served through the fallback path, this causes reading far more data from the file than requested.

2. The loop decrements `count` by `chunk_size` instead of `len(chunk)`. If a read returns fewer bytes than `chunk_size` (which can happen near EOF or due to OS buffering), this causes the remaining byte count to underflow prematurely, potentially cutting the response short.

The fix caps the initial read to `min(chunk_size, count)` — matching what subsequent reads already do — and decrements by actual bytes read rather than the requested size.

## Are there changes in behavior for the user?

Only when using the sendfile fallback path (compression enabled or `AIOHTTP_NOSENDFILE=1`). Range request responses will now correctly send exactly the number of bytes indicated by `Content-Length`, rather than potentially sending excess data.

## Is it a substantial burden for the maintainers to support this?

No, this is a minimal two-line fix in a single method.

## Related issue number

N/A

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] Add a new news fragment into the `CHANGES/` folder
  - naming format: `<issue_or_PR_number>.<type>.rst`
  - `<type>` is one of `feature`, `bugfix`, `doc`, `removal`, `misc`
