### PR TITLE
Fix digest auth dropping challenge fields with empty string values

### DIFF
--- a/CHANGES/12097.bugfix.rst
+++ b/CHANGES/12097.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed digest auth dropping challenge fields with empty string values -- by :user:`bysiber`.

--- a/aiohttp/client_middleware_digest_auth.py
+++ b/aiohttp/client_middleware_digest_auth.py
@@ -414,7 +414,7 @@ class DigestAuthMiddleware:
         # Extract challenge parameters
         self._challenge = {}
         for field in CHALLENGE_FIELDS:
-            if value := header_pairs.get(field):
+            if (value := header_pairs.get(field)) is not None:
                 self._challenge[field] = value
 
         # Update protection space based on domain parameter or default to origin

--- a/tests/test_client_middleware_digest_auth.py
+++ b/tests/test_client_middleware_digest_auth.py
@@ -114,6 +114,13 @@ def mock_md5_digest() -> Generator[mock.MagicMock, None, None]:
             True,
             {"realm": "test", "nonce": "abc", "qop": "auth"},
         ),
+        # Valid digest with empty realm (RFC 7616 Section 3.3 allows this)
+        (
+            401,
+            {"www-authenticate": 'Digest realm="", nonce="abc", qop="auth"'},
+            True,
+            {"realm": "", "nonce": "abc", "qop": "auth"},
+        ),
         # Non-401 status
         (200, {}, False, {}),  # No challenge should be set
     ],


### PR DESCRIPTION
## What do these changes do?

Fix `DigestAuthMiddleware._authenticate` silently dropping challenge fields that have empty string values.

The current code uses `if value := header_pairs.get(field):` which relies on truthiness check. Since empty strings are falsy in Python, any challenge field with an empty value (e.g., `realm=""`) is excluded from `self._challenge`. This causes `_encode()` to later raise a `ClientError` complaining about a missing `realm` parameter, even though the server did provide one.

The `_encode()` method already acknowledges that empty realm values are valid per RFC 7616 (Section 3.3 — the realm directive SHOULD contain the host name but MAY be empty). The fix changes the check to `is not None` so that only genuinely absent fields are skipped while empty values are preserved.

Empty `nonce` values are still correctly rejected by the existing validation in `_encode()`:
```python
if not nonce:
    raise ClientError("Security issue: Digest auth challenge contains empty 'nonce' value")
```

## Are there changes in behavior for the user?

Yes — digest authentication against servers that send `realm=""` (or other empty challenge fields) will now work instead of raising `ClientError`.

## Is it a substantial burden for the maintainers to support this?

No, this is a single-line change.

## Related issue number

N/A

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] Add a new news fragment into the `CHANGES/` folder
  - naming format: `<issue_or_PR_number>.<type>.rst`
  - `<type>` is one of `feature`, `bugfix`, `doc`, `removal`, `misc`
