### PR TITLE
Add :canonical: directives for intersphinx cross-referencing

### DIFF
--- a/CHANGES/10468.doc.rst
+++ b/CHANGES/10468.doc.rst
@@ -1,3 +1,3 @@
 Added ``:canonical:`` directives to documentation reference pages, enabling
-intersphinx cross-referencing via fully-qualified module paths (e.g.
+``Intersphinx`` cross-referencing via fully-qualified module paths (e.g.
 ``aiohttp.client.ClientSession``) -- by :user:`danielalanbates`.

--- a/CHANGES/10468.doc.rst
+++ b/CHANGES/10468.doc.rst
@@ -1,0 +1,3 @@
+Added ``:canonical:`` directives to documentation reference pages, enabling
+intersphinx cross-referencing via fully-qualified module paths (e.g.
+``aiohttp.client.ClientSession``) -- by :user:`danielalanbates`.

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -60,6 +60,7 @@ The client session supports the context manager protocol for self closing.
                          max_headers=128, \
                          fallback_charset_resolver=lambda r, b: "utf-8", \
                          ssl_shutdown_timeout=0)
+   :canonical: aiohttp.client.ClientSession
 
    The class for creating client sessions and making requests.
 
@@ -912,6 +913,7 @@ certification chaining.
                         max_headers=None, \
                         version=aiohttp.HttpVersion11, \
                         connector=None)
+   :canonical: aiohttp.client.request
    :async:
 
    Asynchronous context manager for performing an asynchronous HTTP
@@ -1093,6 +1095,7 @@ is controlled by *force_close* constructor's parameter).
 .. class:: BaseConnector(*, keepalive_timeout=15, \
                          force_close=False, limit=100, limit_per_host=0, \
                          enable_cleanup_closed=False, loop=None)
+   :canonical: aiohttp.connector.BaseConnector
 
    Base class for all connectors.
 
@@ -1215,6 +1218,7 @@ is controlled by *force_close* constructor's parameter).
                  enable_cleanup_closed=False, timeout_ceil_threshold=5, \
                  happy_eyeballs_delay=0.25, interleave=None, loop=None, \
                  socket_factory=None, ssl_shutdown_timeout=0)
+   :canonical: aiohttp.connector.TCPConnector
 
    Connector for working with *HTTP* and *HTTPS* via *TCP* sockets.
 
@@ -1394,6 +1398,7 @@ is controlled by *force_close* constructor's parameter).
 .. class:: UnixConnector(path, *, conn_timeout=None, \
                          keepalive_timeout=30, limit=100, \
                          force_close=False, loop=None)
+   :canonical: aiohttp.connector.UnixConnector
 
    Unix socket connector.
 
@@ -1424,6 +1429,7 @@ is controlled by *force_close* constructor's parameter).
 
 
 .. class:: Connection
+   :canonical: aiohttp.connector.Connection
 
    Encapsulates single connection in connector object.
 
@@ -1462,6 +1468,7 @@ Response object
 ---------------
 
 .. class:: ClientResponse
+   :canonical: aiohttp.client_reqrep.ClientResponse
 
    Client response returned by :meth:`aiohttp.ClientSession.request` and family.
 
@@ -1713,6 +1720,7 @@ not create an instance of class :class:`ClientWebSocketResponse`
 manually.
 
 .. class:: ClientWebSocketResponse()
+   :canonical: aiohttp.client_ws.ClientWebSocketResponse
 
    Class for handling client-side websockets.
 
@@ -1931,6 +1939,7 @@ ClientRequest
 -------------
 
 .. class:: ClientRequest
+   :canonical: aiohttp.client_reqrep.ClientRequest
 
    Represents an HTTP request to be sent by the client.
 
@@ -2149,6 +2158,7 @@ Utilities
 
 .. class:: ClientTimeout(*, total=None, connect=None, \
                          sock_connect=None, sock_read=None)
+   :canonical: aiohttp.client.ClientTimeout
 
    A data class for client timeout settings.
 
@@ -2187,6 +2197,7 @@ Utilities
 
 
 .. class:: ClientWSTimeout(*, ws_receive=None, ws_close=None)
+   :canonical: aiohttp.client_ws.ClientWSTimeout
 
    A data class for websocket client timeout settings.
 
@@ -2228,6 +2239,7 @@ Utilities
 
 
 .. class:: ETag(name, is_weak=False)
+   :canonical: aiohttp.helpers.ETag
 
    Represents `ETag` identifier.
 
@@ -2243,6 +2255,7 @@ Utilities
 
 
 .. class:: ContentDisposition
+   :canonical: aiohttp.client_reqrep.ContentDisposition
 
     A data class to represent the Content-Disposition header,
     available as :attr:`ClientResponse.content_disposition` attribute.
@@ -2263,6 +2276,7 @@ Utilities
 
 
 .. class:: RequestInfo()
+   :canonical: aiohttp.client_reqrep.RequestInfo
 
    A :class:`typing.NamedTuple` with request URL and headers from :class:`~aiohttp.ClientRequest`
    object, available as :attr:`ClientResponse.request_info` attribute.
@@ -2288,6 +2302,7 @@ Utilities
 
 
 .. class:: BasicAuth(login, password='', encoding='latin1')
+   :canonical: aiohttp.helpers.BasicAuth
 
    HTTP basic authentication helper.
 
@@ -2328,6 +2343,7 @@ Utilities
 
 
 .. class:: DigestAuthMiddleware(login, password, *, preemptive=True)
+   :canonical: aiohttp.client_middleware_digest_auth.DigestAuthMiddleware
 
    HTTP digest authentication client middleware.
 
@@ -2387,6 +2403,7 @@ Utilities
 
 
 .. class:: CookieJar(*, unsafe=False, quote_cookie=True, treat_as_secure_origin = [])
+   :canonical: aiohttp.cookiejar.CookieJar
 
    The cookie jar instance is available as :attr:`ClientSession.cookie_jar`.
 
@@ -2488,6 +2505,7 @@ Utilities
 
 
 .. class:: DummyCookieJar(*, loop=None)
+   :canonical: aiohttp.cookiejar.DummyCookieJar
 
    Dummy cookie jar which does not store cookies but ignores them.
 
@@ -2501,6 +2519,7 @@ Utilities
 
 
 .. class:: Fingerprint(digest)
+   :canonical: aiohttp.client_reqrep.Fingerprint
 
    Fingerprint helper for checking SSL certificates by *SHA256* digest.
 
@@ -2521,6 +2540,7 @@ Utilities
    .. versionadded:: 3.0
 
 .. function:: set_zlib_backend(lib)
+   :canonical: aiohttp.compression_utils.set_zlib_backend
 
    Sets the compression backend for zlib-based operations.
 
@@ -2559,6 +2579,7 @@ Otherwise, ``application/x-www-form-urlencoded`` is used.
 on being called.
 
 .. class:: FormData(fields, quote_fields=True, charset=None)
+   :canonical: aiohttp.formdata.FormData
 
    Helper class for multipart/form-data and application/x-www-form-urlencoded body generation.
 
@@ -2634,6 +2655,7 @@ chunks or not enough data that satisfy the content-length header.
 All exceptions are available as members of *aiohttp* module.
 
 .. exception:: ClientError
+   :canonical: aiohttp.client_exceptions.ClientError
 
    Base class for all client specific exceptions.
 
@@ -2641,6 +2663,7 @@ All exceptions are available as members of *aiohttp* module.
 
 
 .. class:: ClientPayloadError
+   :canonical: aiohttp.client_exceptions.ClientPayloadError
 
    This exception can only be raised while reading the response
    payload if one of these errors occurs:
@@ -2652,6 +2675,7 @@ All exceptions are available as members of *aiohttp* module.
    Derived from :exc:`ClientError`
 
 .. exception:: InvalidURL
+   :canonical: aiohttp.client_exceptions.InvalidURL
 
    URL used for fetching is malformed, e.g. it does not contain host
    part.
@@ -2667,30 +2691,35 @@ All exceptions are available as members of *aiohttp* module.
       Invalid URL description, :class:`str` instance or :data:`None`.
 
 .. exception:: InvalidUrlClientError
+   :canonical: aiohttp.client_exceptions.InvalidUrlClientError
 
    Base class for all errors related to client url.
 
    Derived from :exc:`InvalidURL`
 
 .. exception:: RedirectClientError
+   :canonical: aiohttp.client_exceptions.RedirectClientError
 
    Base class for all errors related to client redirects.
 
    Derived from :exc:`ClientError`
 
 .. exception:: NonHttpUrlClientError
+   :canonical: aiohttp.client_exceptions.NonHttpUrlClientError
 
    Base class for all errors related to non http client urls.
 
    Derived from :exc:`ClientError`
 
 .. exception:: InvalidUrlRedirectClientError
+   :canonical: aiohttp.client_exceptions.InvalidUrlRedirectClientError
 
    Redirect URL is malformed, e.g. it does not contain host part.
 
    Derived from :exc:`InvalidUrlClientError` and :exc:`RedirectClientError`
 
 .. exception:: NonHttpUrlRedirectClientError
+   :canonical: aiohttp.client_exceptions.NonHttpUrlRedirectClientError
 
    Redirect URL does not contain http schema.
 
@@ -2700,6 +2729,7 @@ Response errors
 ^^^^^^^^^^^^^^^
 
 .. exception:: ClientResponseError
+   :canonical: aiohttp.client_exceptions.ClientResponseError
 
    These exceptions could happen after we get response from server.
 
@@ -2737,6 +2767,7 @@ Response errors
 
 
 .. class:: ContentTypeError
+   :canonical: aiohttp.client_exceptions.ContentTypeError
 
    Invalid content type.
 
@@ -2746,6 +2777,7 @@ Response errors
 
 
 .. class:: TooManyRedirects
+   :canonical: aiohttp.client_exceptions.TooManyRedirects
 
    Client was redirected too many times.
 
@@ -2758,12 +2790,14 @@ Response errors
 
 
 .. class:: WSServerHandshakeError
+   :canonical: aiohttp.client_exceptions.WSServerHandshakeError
 
    Web socket server response error.
 
    Derived from :exc:`ClientResponseError`
 
 .. exception:: WSMessageTypeError
+   :canonical: aiohttp.client_exceptions.WSMessageTypeError
 
    Received WebSocket message of unexpected type
 
@@ -2773,16 +2807,19 @@ Connection errors
 ^^^^^^^^^^^^^^^^^
 
 .. class:: ClientConnectionError
+   :canonical: aiohttp.client_exceptions.ClientConnectionError
 
    These exceptions related to low-level connection problems.
 
    Derived from :exc:`ClientError`
 
 .. class:: ClientConnectionResetError
+   :canonical: aiohttp.client_exceptions.ClientConnectionResetError
 
    Derived from :exc:`ClientConnectionError` and :exc:`ConnectionResetError`
 
 .. class:: ClientOSError
+   :canonical: aiohttp.client_exceptions.ClientOSError
 
    Subset of connection errors that are initiated by an :exc:`OSError`
    exception.
@@ -2790,46 +2827,55 @@ Connection errors
    Derived from :exc:`ClientConnectionError` and :exc:`OSError`
 
 .. class:: ClientConnectorError
+   :canonical: aiohttp.client_exceptions.ClientConnectorError
 
    Connector related exceptions.
 
    Derived from :exc:`ClientOSError`
 
 .. class:: ClientConnectorDNSError
+   :canonical: aiohttp.client_exceptions.ClientConnectorDNSError
 
    DNS resolution error.
 
    Derived from :exc:`ClientConnectorError`
 
 .. class:: ClientProxyConnectionError
+   :canonical: aiohttp.client_exceptions.ClientProxyConnectionError
 
    Derived from :exc:`ClientConnectorError`
 
 .. class:: ClientSSLError
+   :canonical: aiohttp.client_exceptions.ClientSSLError
 
    Derived from :exc:`ClientConnectorError`
 
 .. class:: ClientConnectorSSLError
+   :canonical: aiohttp.client_exceptions.ClientConnectorSSLError
 
    Response ssl error.
 
    Derived from :exc:`ClientSSLError` and :exc:`ssl.SSLError`
 
 .. class:: ClientConnectorCertificateError
+   :canonical: aiohttp.client_exceptions.ClientConnectorCertificateError
 
    Response certificate error.
 
    Derived from :exc:`ClientSSLError` and :exc:`ssl.CertificateError`
 
 .. class:: UnixClientConnectorError
+   :canonical: aiohttp.client_exceptions.UnixClientConnectorError
 
    Derived from :exc:`ClientConnectorError`
 
 .. class:: ServerConnectionError
+   :canonical: aiohttp.client_exceptions.ServerConnectionError
 
    Derived from :exc:`ClientConnectionError`
 
 .. class:: ServerDisconnectedError
+   :canonical: aiohttp.client_exceptions.ServerDisconnectedError
 
    Server disconnected.
 
@@ -2841,12 +2887,14 @@ Connection errors
 
 
 .. class:: ServerFingerprintMismatch
+   :canonical: aiohttp.client_exceptions.ServerFingerprintMismatch
 
    Server fingerprint mismatch.
 
    Derived from :exc:`ServerConnectionError`
 
 .. class:: ServerTimeoutError
+   :canonical: aiohttp.client_exceptions.ServerTimeoutError
 
    Server operation timeout: read timeout, etc.
 
@@ -2856,12 +2904,14 @@ Connection errors
    Derived from :exc:`ServerConnectionError` and :exc:`asyncio.TimeoutError`
 
 .. class:: ConnectionTimeoutError
+   :canonical: aiohttp.client_exceptions.ConnectionTimeoutError
 
    Connection timeout on ``connect`` and ``sock_connect`` timeouts.
 
    Derived from :exc:`ServerTimeoutError`
 
 .. class:: SocketTimeoutError
+   :canonical: aiohttp.client_exceptions.SocketTimeoutError
 
    Reading from socket timeout on ``sock_read`` timeout.
 

--- a/docs/multipart_reference.rst
+++ b/docs/multipart_reference.rst
@@ -6,6 +6,7 @@ Multipart reference
 ===================
 
 .. class:: MultipartResponseWrapper(resp, stream)
+   :canonical: aiohttp.multipart.MultipartResponseWrapper
 
    Wrapper around the :class:`MultipartReader` to take care about
    underlying connection and close it when it needs in.
@@ -30,6 +31,7 @@ Multipart reference
 
 
 .. class:: BodyPartReader(boundary, headers, content)
+   :canonical: aiohttp.multipart.BodyPartReader
 
    Multipart reader for single body part.
 
@@ -168,6 +170,7 @@ Multipart reference
 
 
 .. class:: MultipartReader(headers, content)
+   :canonical: aiohttp.multipart.MultipartReader
 
    Multipart body reader.
 
@@ -201,6 +204,7 @@ Multipart reference
 
 
 .. class:: MultipartWriter(subtype='mixed', boundary=None, close_boundary=True)
+   :canonical: aiohttp.multipart.MultipartWriter
 
    Multipart body writer.
 

--- a/docs/streams.rst
+++ b/docs/streams.rst
@@ -12,6 +12,7 @@ Streaming API
 
 
 .. class:: StreamReader
+   :canonical: aiohttp.streams.StreamReader
 
    The reader from incoming stream.
 

--- a/docs/tracing_reference.rst
+++ b/docs/tracing_reference.rst
@@ -185,6 +185,7 @@ Classes
 -------
 
 .. class:: TraceConfig(trace_config_ctx_factory=SimpleNamespace)
+   :canonical: aiohttp.tracing.TraceConfig
 
    Trace config is the configuration object used to trace requests
    launched by a :class:`ClientSession` object using different events
@@ -339,6 +340,7 @@ Classes
 
 
 .. class:: TraceRequestStartParams
+   :canonical: aiohttp.tracing.TraceRequestStartParams
 
    See :attr:`TraceConfig.on_request_start` for details.
 
@@ -356,6 +358,7 @@ Classes
 
 
 .. class:: TraceRequestChunkSentParams
+   :canonical: aiohttp.tracing.TraceRequestChunkSentParams
 
    .. versionadded:: 3.1
 
@@ -375,6 +378,7 @@ Classes
 
 
 .. class:: TraceResponseChunkReceivedParams
+   :canonical: aiohttp.tracing.TraceResponseChunkReceivedParams
 
    .. versionadded:: 3.1
 
@@ -394,6 +398,7 @@ Classes
 
 
 .. class:: TraceRequestEndParams
+   :canonical: aiohttp.tracing.TraceRequestEndParams
 
    See :attr:`TraceConfig.on_request_end` for details.
 
@@ -415,6 +420,7 @@ Classes
 
 
 .. class:: TraceRequestExceptionParams
+   :canonical: aiohttp.tracing.TraceRequestExceptionParams
 
    See :attr:`TraceConfig.on_request_exception` for details.
 
@@ -436,6 +442,7 @@ Classes
 
 
 .. class:: TraceRequestRedirectParams
+   :canonical: aiohttp.tracing.TraceRequestRedirectParams
 
    See :attr:`TraceConfig.on_request_redirect` for details.
 
@@ -457,6 +464,7 @@ Classes
 
 
 .. class:: TraceConnectionQueuedStartParams
+   :canonical: aiohttp.tracing.TraceConnectionQueuedStartParams
 
    See :attr:`TraceConfig.on_connection_queued_start` for details.
 
@@ -464,6 +472,7 @@ Classes
 
 
 .. class:: TraceConnectionQueuedEndParams
+   :canonical: aiohttp.tracing.TraceConnectionQueuedEndParams
 
    See :attr:`TraceConfig.on_connection_queued_end` for details.
 
@@ -471,6 +480,7 @@ Classes
 
 
 .. class:: TraceConnectionCreateStartParams
+   :canonical: aiohttp.tracing.TraceConnectionCreateStartParams
 
    See :attr:`TraceConfig.on_connection_create_start` for details.
 
@@ -478,6 +488,7 @@ Classes
 
 
 .. class:: TraceConnectionCreateEndParams
+   :canonical: aiohttp.tracing.TraceConnectionCreateEndParams
 
    See :attr:`TraceConfig.on_connection_create_end` for details.
 
@@ -485,6 +496,7 @@ Classes
 
 
 .. class:: TraceConnectionReuseconnParams
+   :canonical: aiohttp.tracing.TraceConnectionReuseconnParams
 
    See :attr:`TraceConfig.on_connection_reuseconn` for details.
 
@@ -492,6 +504,7 @@ Classes
 
 
 .. class:: TraceDnsResolveHostStartParams
+   :canonical: aiohttp.tracing.TraceDnsResolveHostStartParams
 
    See :attr:`TraceConfig.on_dns_resolvehost_start` for details.
 
@@ -501,6 +514,7 @@ Classes
 
 
 .. class:: TraceDnsResolveHostEndParams
+   :canonical: aiohttp.tracing.TraceDnsResolveHostEndParams
 
    See :attr:`TraceConfig.on_dns_resolvehost_end` for details.
 
@@ -510,6 +524,7 @@ Classes
 
 
 .. class:: TraceDnsCacheHitParams
+   :canonical: aiohttp.tracing.TraceDnsCacheHitParams
 
    See :attr:`TraceConfig.on_dns_cache_hit` for details.
 
@@ -519,6 +534,7 @@ Classes
 
 
 .. class:: TraceDnsCacheMissParams
+   :canonical: aiohttp.tracing.TraceDnsCacheMissParams
 
    See :attr:`TraceConfig.on_dns_cache_miss` for details.
 
@@ -528,6 +544,7 @@ Classes
 
 
 .. class:: TraceRequestHeadersSentParams
+   :canonical: aiohttp.tracing.TraceRequestHeadersSentParams
 
    See :attr:`TraceConfig.on_request_headers_sent` for details.
 

--- a/docs/web_exceptions.rst
+++ b/docs/web_exceptions.rst
@@ -119,6 +119,7 @@ Base HTTP Exception
 
 .. exception:: HTTPException(*, headers=None, reason=None, text=None, \
                              content_type=None)
+   :canonical: aiohttp.web_exceptions.HTTPException
 
    The base class for HTTP server exceptions. Inherited from :exc:`Exception`.
 
@@ -239,39 +240,47 @@ classes reflected in exceptions hierarchy. E.g. ``raise web.HTTPNoContent`` may 
 strange a little but the construction is absolutely legal.
 
 .. exception:: HTTPSuccessful
+   :canonical: aiohttp.web_exceptions.HTTPSuccessful
 
    A base class for the category, a subclass of :exc:`HTTPException`.
 
 .. exception:: HTTPOk
+   :canonical: aiohttp.web_exceptions.HTTPOk
 
    An exception for *200 OK*, a subclass of :exc:`HTTPSuccessful`.
 
 .. exception:: HTTPCreated
+   :canonical: aiohttp.web_exceptions.HTTPCreated
 
    An exception for *201 Created*, a subclass of :exc:`HTTPSuccessful`.
 
 .. exception:: HTTPAccepted
+   :canonical: aiohttp.web_exceptions.HTTPAccepted
 
    An exception for *202 Accepted*, a subclass of :exc:`HTTPSuccessful`.
 
 .. exception:: HTTPNonAuthoritativeInformation
+   :canonical: aiohttp.web_exceptions.HTTPNonAuthoritativeInformation
 
    An exception for *203 Non-Authoritative Information*, a subclass of
    :exc:`HTTPSuccessful`.
 
 .. exception:: HTTPNoContent
+   :canonical: aiohttp.web_exceptions.HTTPNoContent
 
    An exception for *204 No Content*, a subclass of :exc:`HTTPSuccessful`.
 
    Has no HTTP body.
 
 .. exception:: HTTPResetContent
+   :canonical: aiohttp.web_exceptions.HTTPResetContent
 
    An exception for *205 Reset Content*, a subclass of :exc:`HTTPSuccessful`.
 
    Has no HTTP body.
 
 .. exception:: HTTPPartialContent
+   :canonical: aiohttp.web_exceptions.HTTPPartialContent
 
    An exception for *206 Partial Content*, a subclass of :exc:`HTTPSuccessful`.
 
@@ -282,11 +291,13 @@ HTTP exceptions for status code in range 300-399, e.g. ``raise
 web.HTTPMovedPermanently(location='/new/path')``.
 
 .. exception:: HTTPRedirection
+   :canonical: aiohttp.web_exceptions.HTTPRedirection
 
    A base class for the category, a subclass of :exc:`HTTPException`.
 
 .. exception:: HTTPMove(location, *, headers=None, reason=None, text=None, \
                         content_type=None)
+   :canonical: aiohttp.web_exceptions.HTTPMove
 
    A base class for redirections with implied *Location* header,
    all redirections except :exc:`HTTPNotModified`.
@@ -301,36 +312,44 @@ web.HTTPMovedPermanently(location='/new/path')``.
       A *Location* HTTP header value, :class:`yarl.URL`.
 
 .. exception:: HTTPMultipleChoices
+   :canonical: aiohttp.web_exceptions.HTTPMultipleChoices
 
    An exception for *300 Multiple Choices*, a subclass of :exc:`HTTPMove`.
 
 .. exception:: HTTPMovedPermanently
+   :canonical: aiohttp.web_exceptions.HTTPMovedPermanently
 
    An exception for *301 Moved Permanently*, a subclass of :exc:`HTTPMove`.
 
 .. exception:: HTTPFound
+   :canonical: aiohttp.web_exceptions.HTTPFound
 
    An exception for *302 Found*, a subclass of :exc:`HTTPMove`.
 
 .. exception:: HTTPSeeOther
+   :canonical: aiohttp.web_exceptions.HTTPSeeOther
 
    An exception for *303 See Other*, a subclass of :exc:`HTTPMove`.
 
 .. exception:: HTTPNotModified
+   :canonical: aiohttp.web_exceptions.HTTPNotModified
 
    An exception for *304 Not Modified*, a subclass of :exc:`HTTPRedirection`.
 
    Has no HTTP body.
 
 .. exception:: HTTPUseProxy
+   :canonical: aiohttp.web_exceptions.HTTPUseProxy
 
    An exception for *305 Use Proxy*, a subclass of :exc:`HTTPMove`.
 
 .. exception:: HTTPTemporaryRedirect
+   :canonical: aiohttp.web_exceptions.HTTPTemporaryRedirect
 
    An exception for *307 Temporary Redirect*, a subclass of :exc:`HTTPMove`.
 
 .. exception:: HTTPPermanentRedirect
+   :canonical: aiohttp.web_exceptions.HTTPPermanentRedirect
 
    An exception for *308 Permanent Redirect*, a subclass of :exc:`HTTPMove`.
 
@@ -341,33 +360,40 @@ Client Errors
 HTTP exceptions for status code in range 400-499, e.g. ``raise web.HTTPNotFound()``.
 
 .. exception:: HTTPClientError
+   :canonical: aiohttp.web_exceptions.HTTPClientError
 
    A base class for the category, a subclass of :exc:`HTTPException`.
 
 .. exception:: HTTPBadRequest
+   :canonical: aiohttp.web_exceptions.HTTPBadRequest
 
    An exception for *400 Bad Request*, a subclass of :exc:`HTTPClientError`.
 
 .. exception:: HTTPUnauthorized
+   :canonical: aiohttp.web_exceptions.HTTPUnauthorized
 
    An exception for *401 Unauthorized*, a subclass of :exc:`HTTPClientError`.
 
 .. exception:: HTTPPaymentRequired
+   :canonical: aiohttp.web_exceptions.HTTPPaymentRequired
 
    An exception for *402 Payment Required*, a subclass of
    :exc:`HTTPClientError`.
 
 .. exception:: HTTPForbidden
+   :canonical: aiohttp.web_exceptions.HTTPForbidden
 
    An exception for *403 Forbidden*, a subclass of :exc:`HTTPClientError`.
 
 .. exception:: HTTPNotFound
+   :canonical: aiohttp.web_exceptions.HTTPNotFound
 
    An exception for *404 Not Found*, a subclass of :exc:`HTTPClientError`.
 
 .. exception:: HTTPMethodNotAllowed(method, allowed_methods, *, \
                                     headers=None, reason=None, text=None, \
                                     content_type=None)
+   :canonical: aiohttp.web_exceptions.HTTPMethodNotAllowed
 
    An exception for *405 Method Not Allowed*, a subclass of
    :exc:`HTTPClientError`.
@@ -389,36 +415,44 @@ HTTP exceptions for status code in range 400-499, e.g. ``raise web.HTTPNotFound(
       Requested but not allowed HTTP method.
 
 .. exception:: HTTPNotAcceptable
+   :canonical: aiohttp.web_exceptions.HTTPNotAcceptable
 
    An exception for *406 Not Acceptable*, a subclass of :exc:`HTTPClientError`.
 
 .. exception:: HTTPProxyAuthenticationRequired
+   :canonical: aiohttp.web_exceptions.HTTPProxyAuthenticationRequired
 
    An exception for *407 Proxy Authentication Required*, a subclass of
    :exc:`HTTPClientError`.
 
 .. exception:: HTTPRequestTimeout
+   :canonical: aiohttp.web_exceptions.HTTPRequestTimeout
 
    An exception for *408 Request Timeout*, a subclass of :exc:`HTTPClientError`.
 
 .. exception:: HTTPConflict
+   :canonical: aiohttp.web_exceptions.HTTPConflict
 
    An exception for *409 Conflict*, a subclass of :exc:`HTTPClientError`.
 
 .. exception:: HTTPGone
+   :canonical: aiohttp.web_exceptions.HTTPGone
 
    An exception for *410 Gone*, a subclass of :exc:`HTTPClientError`.
 
 .. exception:: HTTPLengthRequired
+   :canonical: aiohttp.web_exceptions.HTTPLengthRequired
 
    An exception for *411 Length Required*, a subclass of :exc:`HTTPClientError`.
 
 .. exception:: HTTPPreconditionFailed
+   :canonical: aiohttp.web_exceptions.HTTPPreconditionFailed
 
    An exception for *412 Precondition Failed*, a subclass of
    :exc:`HTTPClientError`.
 
 .. exception:: HTTPRequestEntityTooLarge(max_size, actual_size, **kwargs)
+   :canonical: aiohttp.web_exceptions.HTTPRequestEntityTooLarge
 
    An exception for *413 Entity Too Large*, a subclass of :exc:`HTTPClientError`.
 
@@ -429,49 +463,60 @@ HTTP exceptions for status code in range 400-499, e.g. ``raise web.HTTPNotFound(
    For other acceptable parameters see :exc:`HTTPException` constructor.
 
 .. exception:: HTTPRequestURITooLong
+   :canonical: aiohttp.web_exceptions.HTTPRequestURITooLong
 
    An exception for *414 URI is too long*, a subclass of :exc:`HTTPClientError`.
 
 .. exception:: HTTPUnsupportedMediaType
+   :canonical: aiohttp.web_exceptions.HTTPUnsupportedMediaType
 
    An exception for *415 Entity body in unsupported format*, a subclass of
    :exc:`HTTPClientError`.
 
 .. exception:: HTTPRequestRangeNotSatisfiable
+   :canonical: aiohttp.web_exceptions.HTTPRequestRangeNotSatisfiable
 
    An exception for *416 Cannot satisfy request range*, a subclass of
    :exc:`HTTPClientError`.
 
 .. exception:: HTTPExpectationFailed
+   :canonical: aiohttp.web_exceptions.HTTPExpectationFailed
 
    An exception for *417 Expect condition could not be satisfied*, a subclass of
    :exc:`HTTPClientError`.
 
 .. exception:: HTTPMisdirectedRequest
+   :canonical: aiohttp.web_exceptions.HTTPMisdirectedRequest
 
    An exception for *421 Misdirected Request*, a subclass of :exc:`HTTPClientError`.
 
 .. exception:: HTTPUnprocessableEntity
+   :canonical: aiohttp.web_exceptions.HTTPUnprocessableEntity
 
    An exception for *422 Unprocessable Entity*, a subclass of :exc:`HTTPClientError`.
 
 .. exception:: HTTPFailedDependency
+   :canonical: aiohttp.web_exceptions.HTTPFailedDependency
 
    An exception for *424 Failed Dependency*, a subclass of :exc:`HTTPClientError`.
 
 .. exception:: HTTPUpgradeRequired
+   :canonical: aiohttp.web_exceptions.HTTPUpgradeRequired
 
    An exception for *426 Upgrade Required*, a subclass of :exc:`HTTPClientError`.
 
 .. exception:: HTTPPreconditionRequired
+   :canonical: aiohttp.web_exceptions.HTTPPreconditionRequired
 
    An exception for *428 Precondition Required*, a subclass of :exc:`HTTPClientError`.
 
 .. exception:: HTTPTooManyRequests
+   :canonical: aiohttp.web_exceptions.HTTPTooManyRequests
 
    An exception for *429 Too Many Requests*, a subclass of :exc:`HTTPClientError`.
 
 .. exception:: HTTPRequestHeaderFieldsTooLarge
+   :canonical: aiohttp.web_exceptions.HTTPRequestHeaderFieldsTooLarge
 
    An exception for *431 Requests Header Fields Too Large*, a subclass of
    :exc:`HTTPClientError`.
@@ -481,6 +526,7 @@ HTTP exceptions for status code in range 400-499, e.g. ``raise web.HTTPNotFound(
                                               reason=None, \
                                               text=None, \
                                               content_type=None)
+   :canonical: aiohttp.web_exceptions.HTTPUnavailableForLegalReasons
 
 
    An exception for *451 Unavailable For Legal Reasons*, a subclass of
@@ -505,51 +551,62 @@ HTTP exceptions for status code in range 500-599, e.g. ``raise web.HTTPBadGatewa
 
 
 .. exception:: HTTPServerError
+   :canonical: aiohttp.web_exceptions.HTTPServerError
 
    A base class for the category, a subclass of :exc:`HTTPException`.
 
 .. exception:: HTTPInternalServerError
+   :canonical: aiohttp.web_exceptions.HTTPInternalServerError
 
    An exception for *500 Server got itself in trouble*, a subclass of
    :exc:`HTTPServerError`.
 
 .. exception:: HTTPNotImplemented
+   :canonical: aiohttp.web_exceptions.HTTPNotImplemented
 
    An exception for *501 Server does not support this operation*, a subclass of
    :exc:`HTTPServerError`.
 
 .. exception:: HTTPBadGateway
+   :canonical: aiohttp.web_exceptions.HTTPBadGateway
 
    An exception for *502 Invalid responses from another server/proxy*, a
    subclass of :exc:`HTTPServerError`.
 
 .. exception:: HTTPServiceUnavailable
+   :canonical: aiohttp.web_exceptions.HTTPServiceUnavailable
 
    An exception for *503 The server cannot process the request due to a high
    load*, a subclass of :exc:`HTTPServerError`.
 
 .. exception:: HTTPGatewayTimeout
+   :canonical: aiohttp.web_exceptions.HTTPGatewayTimeout
 
    An exception for *504 The gateway server did not receive a timely response*,
    a subclass of :exc:`HTTPServerError`.
 
 .. exception:: HTTPVersionNotSupported
+   :canonical: aiohttp.web_exceptions.HTTPVersionNotSupported
 
    An exception for *505 Cannot fulfill request*, a subclass of :exc:`HTTPServerError`.
 
 .. exception:: HTTPVariantAlsoNegotiates
+   :canonical: aiohttp.web_exceptions.HTTPVariantAlsoNegotiates
 
    An exception for *506 Variant Also Negotiates*, a subclass of :exc:`HTTPServerError`.
 
 .. exception:: HTTPInsufficientStorage
+   :canonical: aiohttp.web_exceptions.HTTPInsufficientStorage
 
    An exception for *507 Insufficient Storage*, a subclass of :exc:`HTTPServerError`.
 
 .. exception:: HTTPNotExtended
+   :canonical: aiohttp.web_exceptions.HTTPNotExtended
 
    An exception for *510 Not Extended*, a subclass of :exc:`HTTPServerError`.
 
 .. exception:: HTTPNetworkAuthenticationRequired
+   :canonical: aiohttp.web_exceptions.HTTPNetworkAuthenticationRequired
 
    An exception for *511 Network Authentication Required*, a subclass of
    :exc:`HTTPServerError`.

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -24,6 +24,7 @@ data<aiohttp-web-data-sharing>` among :ref:`aiohttp-web-middlewares`
 and :ref:`aiohttp-web-signals` handlers.
 
 .. class:: BaseRequest
+   :canonical: aiohttp.web_request.BaseRequest
 
    .. attribute:: version
 
@@ -491,6 +492,7 @@ and :ref:`aiohttp-web-signals` handlers.
           internal machinery.
 
 .. class:: Request
+   :canonical: aiohttp.web_request.Request
 
    A request used for receiving request's information by *web handler*.
 
@@ -535,6 +537,7 @@ and :ref:`aiohttp-web-signals` handlers.
 
 
 .. class:: RequestKey(name, t)
+   :canonical: aiohttp.helpers.RequestKey
 
    Keys for use in :class:`Request`.
 
@@ -585,6 +588,7 @@ and :ref:`aiohttp-web-signals` handlers::
 
 
 .. class:: StreamResponse(*, status=200, reason=None)
+   :canonical: aiohttp.web_response.StreamResponse
 
    The base class for the *HTTP response* handling.
 
@@ -861,6 +865,7 @@ and :ref:`aiohttp-web-signals` handlers::
 .. class:: Response(*, body=None, status=200, reason=None, text=None, \
                     headers=None, content_type=None, charset=None, \
                     zlib_executor_size=sentinel, zlib_executor=None)
+   :canonical: aiohttp.web_response.Response
 
    The most usable response class, inherited from :class:`StreamResponse`.
 
@@ -912,6 +917,7 @@ and :ref:`aiohttp-web-signals` handlers::
 
 
 .. class:: FileResponse(*, path, chunk_size=256*1024, status=200, reason=None, headers=None)
+   :canonical: aiohttp.web_fileresponse.FileResponse
 
    The response class used to send files, inherited from :class:`StreamResponse`.
 
@@ -940,6 +946,7 @@ and :ref:`aiohttp-web-signals` handlers::
                              autoclose=True, autoping=True, heartbeat=None, \
                              protocols=(), compress=True, max_msg_size=4194304, \
                              writer_limit=65536, decode_text=True)
+   :canonical: aiohttp.web_ws.WebSocketResponse
 
    Class for handling server-side websockets, inherited from
    :class:`StreamResponse`.
@@ -1348,6 +1355,7 @@ and :ref:`aiohttp-web-signals` handlers::
 
 
 .. class:: WebSocketReady
+   :canonical: aiohttp.web_ws.WebSocketReady
 
    A named tuple for returning result from
    :meth:`WebSocketResponse.can_prepare`.
@@ -1374,6 +1382,7 @@ and :ref:`aiohttp-web-signals` handlers::
                             status=200, reason=None, headers=None, \
                             content_type='application/json', \
                             dumps=json.dumps)
+   :canonical: aiohttp.web_response.json_response
 
 Return :class:`Response` with predefined ``'application/json'``
 content type and *data* encoded by ``dumps`` parameter
@@ -1381,6 +1390,7 @@ content type and *data* encoded by ``dumps`` parameter
 
 
 .. class:: ResponseKey(name, t)
+   :canonical: aiohttp.helpers.ResponseKey
 
    Keys for use in :class:`Response`.
 
@@ -1398,6 +1408,7 @@ Application and Router
 .. class:: Application(*, logger=<default>, middlewares=(), \
                        handler_args=None, client_max_size=1024**2, \
                        debug=...)
+   :canonical: aiohttp.web_app.Application
 
    Application is a synonym for web-server.
 
@@ -1651,6 +1662,7 @@ Application and Router
 
 
 .. class:: AppKey(name, t)
+   :canonical: aiohttp.helpers.AppKey
 
    This class should be used for the keys in :class:`Application`. They
    provide a type-safe alternative to `str` keys when checking your code
@@ -1666,6 +1678,7 @@ Application and Router
 
 
 .. class:: Server
+   :canonical: aiohttp.web_server.Server
 
    A protocol factory compatible with
    :meth:`~asyncio.AbstractEventLoop.create_server`.
@@ -1689,6 +1702,7 @@ Application and Router
 
 
 .. class:: UrlDispatcher()
+   :canonical: aiohttp.web_urldispatcher.UrlDispatcher
 
    For dispatching URLs to :ref:`handlers<aiohttp-web-handler>`
    :mod:`aiohttp.web` uses *routers*, which is any object that implements
@@ -2030,6 +2044,7 @@ Resource classes hierarchy::
 
 
 .. class:: AbstractResource
+   :canonical: aiohttp.web_urldispatcher.AbstractResource
 
    A base class for all resources.
 
@@ -2082,6 +2097,7 @@ Resource classes hierarchy::
 
 
 .. class:: Resource
+   :canonical: aiohttp.web_urldispatcher.Resource
 
    A base class for new-style resources, inherits :class:`AbstractResource`.
 
@@ -2108,6 +2124,7 @@ Resource classes hierarchy::
 
 
 .. class:: PlainResource
+   :canonical: aiohttp.web_urldispatcher.PlainResource
 
    A resource, inherited from :class:`Resource`.
 
@@ -2127,6 +2144,7 @@ Resource classes hierarchy::
 
 
 .. class:: DynamicResource
+   :canonical: aiohttp.web_urldispatcher.DynamicResource
 
    A resource, inherited from :class:`Resource`.
 
@@ -2153,6 +2171,7 @@ Resource classes hierarchy::
 
 
 .. class:: StaticResource
+   :canonical: aiohttp.web_urldispatcher.StaticResource
 
    A resource, inherited from :class:`Resource`.
 
@@ -2189,6 +2208,7 @@ Resource classes hierarchy::
 
 
 .. class:: PrefixedSubAppResource
+   :canonical: aiohttp.web_urldispatcher.PrefixedSubAppResource
 
    A resource for serving nested applications. The class instance is
    returned by :class:`~aiohttp.web.Application.add_subapp` call.
@@ -2227,6 +2247,7 @@ Route classes hierarchy::
 and *405 Method Not Allowed*.
 
 .. class:: AbstractRoute
+   :canonical: aiohttp.web_urldispatcher.AbstractRoute
 
    Base class for routes served by :class:`UrlDispatcher`.
 
@@ -2259,11 +2280,13 @@ and *405 Method Not Allowed*.
       ``100-continue`` handler.
 
 .. class:: ResourceRoute
+   :canonical: aiohttp.web_urldispatcher.ResourceRoute
 
    The route class for handling different HTTP methods for :class:`Resource`.
 
 
 .. class:: SystemRoute
+   :canonical: aiohttp.web_urldispatcher.SystemRoute
 
    The route class for handling URL resolution errors like like *404 Not Found*
    and *405 Method Not Allowed*.
@@ -2305,6 +2328,7 @@ The definition is created by functions like :func:`get` or
                           web.post('/post', handle_post),
 
 .. class:: AbstractRouteDef
+   :canonical: aiohttp.web_routedef.AbstractRouteDef
 
    A base class for route definitions.
 
@@ -2327,6 +2351,7 @@ The definition is created by functions like :func:`get` or
 
 
 .. class:: RouteDef
+   :canonical: aiohttp.web_routedef.RouteDef
 
    A definition of not registered yet route.
 
@@ -2358,6 +2383,7 @@ The definition is created by functions like :func:`get` or
 
 
 .. class:: StaticDef
+   :canonical: aiohttp.web_routedef.StaticDef
 
    A definition of static file resource.
 
@@ -2384,6 +2410,7 @@ The definition is created by functions like :func:`get` or
 
 .. function:: get(path, handler, *, name=None, allow_head=True, \
               expect_handler=None)
+   :canonical: aiohttp.web_routedef.get
 
    Return :class:`RouteDef` for processing ``GET`` requests. See
    :meth:`UrlDispatcher.add_get` for information about parameters.
@@ -2391,6 +2418,7 @@ The definition is created by functions like :func:`get` or
    .. versionadded:: 2.3
 
 .. function:: post(path, handler, *, name=None, expect_handler=None)
+   :canonical: aiohttp.web_routedef.post
 
    Return :class:`RouteDef` for processing ``POST`` requests. See
    :meth:`UrlDispatcher.add_post` for information about parameters.
@@ -2398,6 +2426,7 @@ The definition is created by functions like :func:`get` or
    .. versionadded:: 2.3
 
 .. function:: head(path, handler, *, name=None, expect_handler=None)
+   :canonical: aiohttp.web_routedef.head
 
    Return :class:`RouteDef` for processing ``HEAD`` requests. See
    :meth:`UrlDispatcher.add_head` for information about parameters.
@@ -2405,6 +2434,7 @@ The definition is created by functions like :func:`get` or
    .. versionadded:: 2.3
 
 .. function:: put(path, handler, *, name=None, expect_handler=None)
+   :canonical: aiohttp.web_routedef.put
 
    Return :class:`RouteDef` for processing ``PUT`` requests. See
    :meth:`UrlDispatcher.add_put` for information about parameters.
@@ -2412,6 +2442,7 @@ The definition is created by functions like :func:`get` or
    .. versionadded:: 2.3
 
 .. function:: patch(path, handler, *, name=None, expect_handler=None)
+   :canonical: aiohttp.web_routedef.patch
 
    Return :class:`RouteDef` for processing ``PATCH`` requests. See
    :meth:`UrlDispatcher.add_patch` for information about parameters.
@@ -2419,6 +2450,7 @@ The definition is created by functions like :func:`get` or
    .. versionadded:: 2.3
 
 .. function:: delete(path, handler, *, name=None, expect_handler=None)
+   :canonical: aiohttp.web_routedef.delete
 
    Return :class:`RouteDef` for processing ``DELETE`` requests. See
    :meth:`UrlDispatcher.add_delete` for information about parameters.
@@ -2426,6 +2458,7 @@ The definition is created by functions like :func:`get` or
    .. versionadded:: 2.3
 
 .. function:: view(path, handler, *, name=None, expect_handler=None)
+   :canonical: aiohttp.web_routedef.view
 
    Return :class:`RouteDef` for processing ``ANY`` requests. See
    :meth:`UrlDispatcher.add_view` for information about parameters.
@@ -2436,6 +2469,7 @@ The definition is created by functions like :func:`get` or
                      chunk_size=256*1024, \
                      show_index=False, follow_symlinks=False, \
                      append_version=False)
+   :canonical: aiohttp.web_routedef.static
 
    Return :class:`StaticDef` for processing static files.
 
@@ -2445,6 +2479,7 @@ The definition is created by functions like :func:`get` or
    .. versionadded:: 3.1
 
 .. function:: route(method, path, handler, *, name=None, expect_handler=None)
+   :canonical: aiohttp.web_routedef.route
 
    Return :class:`RouteDef` for processing requests that decided by
    ``method``. See :meth:`UrlDispatcher.add_route` for information
@@ -2486,6 +2521,7 @@ A routes table definition used for describing routes by decorators
            ...
 
 .. class:: RouteTableDef()
+   :canonical: aiohttp.web_routedef.RouteTableDef
 
    A sequence of :class:`RouteDef` instances (implements
    :class:`collections.abc.Sequence` protocol).
@@ -2576,6 +2612,7 @@ In general the result may be any object derived from
 :class:`UrlDispatcher` router).
 
 .. class:: UrlMappingMatchInfo
+   :canonical: aiohttp.web_urldispatcher.UrlMappingMatchInfo
 
    Inherited from :class:`dict` and :class:`~aiohttp.abc.AbstractMatchInfo`. Dict
    items are filled by matching info and is :term:`resource`\-specific.
@@ -2597,6 +2634,7 @@ View
 ^^^^
 
 .. class:: View(request)
+   :canonical: aiohttp.web_urldispatcher.View
 
    Inherited from :class:`~aiohttp.abc.AbstractView`.
 
@@ -2661,6 +2699,7 @@ application on specific TCP or Unix socket, e.g.::
 
 
 .. class:: BaseRunner
+   :canonical: aiohttp.web_runner.BaseRunner
 
    A base class for runners. Use :class:`AppRunner` for serving
    :class:`Application`, :class:`ServerRunner` for low-level
@@ -2696,6 +2735,7 @@ application on specific TCP or Unix socket, e.g.::
 
 
 .. class:: AppRunner(app, *, handle_signals=False, **kwargs)
+   :canonical: aiohttp.web_runner.AppRunner
 
    A runner for :class:`Application`. Used with conjunction with sites
    to serve on specific port.
@@ -2774,6 +2814,7 @@ application on specific TCP or Unix socket, e.g.::
 
 
 .. class:: ServerRunner(web_server, *, handle_signals=False, **kwargs)
+   :canonical: aiohttp.web_runner.ServerRunner
 
    A runner for low-level :class:`Server`. Used with conjunction with sites
    to serve on specific port.
@@ -2796,6 +2837,7 @@ application on specific TCP or Unix socket, e.g.::
       :ref:`aiohttp-web-lowlevel` demonstrates low-level server usage
 
 .. class:: BaseSite
+   :canonical: aiohttp.web_runner.BaseSite
 
    An abstract class for handled sites.
 
@@ -2819,6 +2861,7 @@ application on specific TCP or Unix socket, e.g.::
                    shutdown_timeout=60.0, ssl_context=None, \
                    backlog=128, reuse_address=None, \
                    reuse_port=None)
+   :canonical: aiohttp.web_runner.TCPSite
 
    Serve a runner on TCP socket.
 
@@ -2857,6 +2900,7 @@ application on specific TCP or Unix socket, e.g.::
 .. class:: UnixSite(runner, path, *, \
                    shutdown_timeout=60.0, ssl_context=None, \
                    backlog=128)
+   :canonical: aiohttp.web_runner.UnixSite
 
    Serve a runner on UNIX socket.
 
@@ -2880,6 +2924,7 @@ application on specific TCP or Unix socket, e.g.::
                        ``128`` by default.
 
 .. class:: NamedPipeSite(runner, path, *, shutdown_timeout=60.0)
+   :canonical: aiohttp.web_runner.NamedPipeSite
 
    Serve a runner on Named Pipe in Windows.
 
@@ -2895,6 +2940,7 @@ application on specific TCP or Unix socket, e.g.::
 .. class:: SockSite(runner, sock, *, \
                    shutdown_timeout=60.0, ssl_context=None, \
                    backlog=128)
+   :canonical: aiohttp.web_runner.SockSite
 
    Serve a runner on UNIX socket.
 
@@ -2918,6 +2964,7 @@ application on specific TCP or Unix socket, e.g.::
                        ``128`` by default.
 
 .. exception:: GracefulExit
+   :canonical: aiohttp.web_runner.GracefulExit
 
    Raised by signal handlers for :data:`signal.SIGINT` and :data:`signal.SIGTERM`
    defined in :class:`AppRunner` and :class:`ServerRunner`
@@ -2931,6 +2978,7 @@ Utilities
 ---------
 
 .. class:: FileField
+   :canonical: aiohttp.web_request.FileField
 
    A :mod:`dataclass <dataclasses>` instance that is returned as
    multidict value by :meth:`aiohttp.web.BaseRequest.post` if field is uploaded file.
@@ -3099,6 +3147,7 @@ Constants
 ---------
 
 .. class:: ContentCoding
+   :canonical: aiohttp.web_response.ContentCoding
 
    An :class:`enum.Enum` class of available Content Codings.
 
@@ -3123,6 +3172,7 @@ Middlewares
                                         remove_slash=False, \
                                         merge_slashes=True, \
                                         redirect_class=HTTPPermanentRedirect)
+   :canonical: aiohttp.web_middlewares.normalize_path_middleware
 
    Middleware factory which produces a middleware that normalizes
    the path of a request. By normalizing it means:

--- a/docs/websocket_utilities.rst
+++ b/docs/websocket_utilities.rst
@@ -5,6 +5,7 @@ WebSocket utilities
 ===================
 
 .. class:: WSCloseCode
+   :canonical: aiohttp._websocket.models.WSCloseCode
 
     An :class:`~enum.IntEnum` for keeping close message code.
 
@@ -94,6 +95,7 @@ WebSocket utilities
 
 
 .. class:: WSMsgType
+   :canonical: aiohttp._websocket.models.WSMsgType
 
    An :class:`~enum.IntEnum` for describing :class:`WSMessage` type.
 


### PR DESCRIPTION
## Summary

Fixes #10468

When other projects use `autodoc` or `intersphinx` to reference aiohttp objects, they resolve the fully-qualified module path (e.g. `aiohttp.client.ClientSession`) from the object's `__module__` attribute. Since our docs only document the public aliases (e.g. `aiohttp.ClientSession` via `.. currentmodule:: aiohttp`), these cross-references fail with warnings like:

```
WARNING: py:class reference target not found: aiohttp.client.ClientSession
```

This PR adds `:canonical:` directive options to all `class`, `function`, and `exception` directives across the reference documentation. The `:canonical:` option (available since Sphinx 4.0) tells Sphinx to register each object under both its documented name and its actual module path in the intersphinx inventory, enabling cross-referencing via either path.

### Files changed

- `docs/client_reference.rst` — 50 canonical directives (ClientSession, connectors, exceptions, etc.)
- `docs/web_reference.rst` — 50 canonical directives (Request, Response, Application, routing, runners, etc.)
- `docs/web_exceptions.rst` — 57 canonical directives (all HTTP exception classes)
- `docs/tracing_reference.rst` — 17 canonical directives (TraceConfig and all trace param classes)
- `docs/multipart_reference.rst` — 4 canonical directives (MultipartReader, MultipartWriter, etc.)
- `docs/websocket_utilities.rst` — 2 canonical directives (WSCloseCode, WSMsgType)
- `docs/streams.rst` — 1 canonical directive (StreamReader)
- `CHANGES/10468.doc.rst` — changelog entry

### How it works

For example, `ClientSession` is defined in `aiohttp.client` but documented under `.. currentmodule:: aiohttp`:

```rst
.. class:: ClientSession(base_url=None, *, ...)
   :canonical: aiohttp.client.ClientSession
```

This registers `aiohttp.client.ClientSession` as an alias in the Sphinx inventory, so intersphinx lookups from other projects will resolve correctly while the docs continue to display the public API path `aiohttp.ClientSession`.

## Test plan

- [ ] Verify the docs build successfully with `make html` (no new warnings)
- [ ] Verify intersphinx inventory contains both public and canonical names
- [ ] Test cross-referencing from an external project using autodoc

*This PR was created with the assistance of Claude Opus 4.6 by Anthropic. Happy to make any adjustments! Reviewed and submitted by a human.*