### PR TITLE
fix: widen trace_request_ctx type to accept any object

### DIFF
--- a/CHANGES/10753.bugfix.rst
+++ b/CHANGES/10753.bugfix.rst
@@ -1,0 +1,1 @@
+Widened ``trace_request_ctx`` parameter type from ``Mapping[str, Any] | None`` to ``object`` to allow passing instances of user-defined classes as trace context -- by :user:`nightcityblade`.

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -16,7 +16,6 @@ from collections.abc import (
     Coroutine,
     Generator,
     Iterable,
-    Mapping,
     Sequence,
 )
 from contextlib import suppress
@@ -189,7 +188,7 @@ class _RequestOptions(TypedDict, total=False):
     ssl: SSLContext | bool | Fingerprint
     server_hostname: str | None
     proxy_headers: LooseHeaders | None
-    trace_request_ctx: Mapping[str, Any] | None
+    trace_request_ctx: object
     read_bufsize: int | None
     auto_decompress: bool | None
     max_line_size: int | None
@@ -492,7 +491,7 @@ class ClientSession:
         ssl: SSLContext | bool | Fingerprint = True,
         server_hostname: str | None = None,
         proxy_headers: LooseHeaders | None = None,
-        trace_request_ctx: Mapping[str, Any] | None = None,
+        trace_request_ctx: object = None,
         read_bufsize: int | None = None,
         auto_decompress: bool | None = None,
         max_line_size: int | None = None,

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -59,6 +59,19 @@ class TestTraceConfig:
         )
         assert trace_config_ctx.trace_request_ctx is trace_request_ctx
 
+    def test_trace_config_ctx_custom_class(self) -> None:
+        """Custom class instances should be accepted as trace_request_ctx (#10753)."""
+
+        class MyContext:
+            def __init__(self, request_id: int) -> None:
+                self.request_id = request_id
+
+        ctx = MyContext(request_id=42)
+        trace_config = TraceConfig()
+        trace_config_ctx = trace_config.trace_config_ctx(trace_request_ctx=ctx)
+        assert trace_config_ctx.trace_request_ctx is ctx
+        assert trace_config_ctx.trace_request_ctx.request_id == 42
+
     def test_freeze(self) -> None:
         trace_config = TraceConfig()
         trace_config.freeze()


### PR DESCRIPTION
## Summary

Fixes #10753

The `trace_request_ctx` parameter on `ClientSession._request()` was typed as `Mapping[str, Any] | None`, which prevented passing instances of user-defined classes (e.g. dataclasses) as trace context.

Since `TraceConfig.trace_config_ctx()` already accepts `Any`, this widens the parameter type to `object` as suggested by @Dreamsorcerer in the issue discussion.

## Changes

- `aiohttp/client.py`: Changed `trace_request_ctx` type annotation from `Mapping[str, Any] | None` to `object` (2 locations: `_RequestOptions` TypedDict and `_request()` method)
- Removed unused `Mapping` import
- Added changelog entry