### PR TITLE
Allow `JSONEncoder` to return bytes directly (#11989)

### DIFF
--- a/CHANGES/11989.feature.rst
+++ b/CHANGES/11989.feature.rst
@@ -1,0 +1,7 @@
+Added explicit APIs for bytes-returning JSON serializer:
+``JSONBytesEncoder`` type, ``JsonBytesPayload``,
+:func:`~aiohttp.web.json_bytes_response`,
+:meth:`~aiohttp.web.WebSocketResponse.send_json_bytes` and
+:meth:`~aiohttp.ClientWebSocketResponse.send_json_bytes` methods, and
+``json_serialize_bytes`` parameter for :class:`~aiohttp.ClientSession`
+-- by :user:`kevinpark1217`.

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -104,7 +104,14 @@ from .helpers import (
 from .http import WS_KEY, HttpVersion, WebSocketReader, WebSocketWriter
 from .http_websocket import WSHandshakeError, ws_ext_gen, ws_ext_parse
 from .tracing import Trace, TraceConfig
-from .typedefs import JSONEncoder, LooseCookies, LooseHeaders, Query, StrOrURL
+from .typedefs import (
+    JSONBytesEncoder,
+    JSONEncoder,
+    LooseCookies,
+    LooseHeaders,
+    Query,
+    StrOrURL,
+)
 
 __all__ = (
     # client_exceptions
@@ -271,6 +278,7 @@ class ClientSession:
             "_default_auth",
             "_version",
             "_json_serialize",
+            "_json_serialize_bytes",
             "_requote_redirect_url",
             "_timeout",
             "_raise_for_status",
@@ -311,6 +319,7 @@ class ClientSession:
         skip_auto_headers: Iterable[str] | None = None,
         auth: BasicAuth | None = None,
         json_serialize: JSONEncoder = json.dumps,
+        json_serialize_bytes: JSONBytesEncoder | None = None,
         request_class: type[ClientRequest] = ClientRequest,
         response_class: type[ClientResponse] = ClientResponse,
         ws_response_class: type[ClientWebSocketResponse] = ClientWebSocketResponse,
@@ -421,6 +430,7 @@ class ClientSession:
         self._default_auth = auth
         self._version = version
         self._json_serialize = json_serialize
+        self._json_serialize_bytes = json_serialize_bytes
         self._raise_for_status = raise_for_status
         self._auto_decompress = auto_decompress
         self._trust_env = trust_env
@@ -561,7 +571,10 @@ class ClientSession:
                 "data and json parameters can not be used at the same time"
             )
         elif json is not None:
-            data = payload.JsonPayload(json, dumps=self._json_serialize)
+            if self._json_serialize_bytes is not None:
+                data = payload.JsonBytesPayload(json, dumps=self._json_serialize_bytes)
+            else:
+                data = payload.JsonPayload(json, dumps=self._json_serialize)
 
         if not isinstance(chunked, bool) and chunked is not None:
             warnings.warn("Chunk size is deprecated #1615", DeprecationWarning)

--- a/aiohttp/client_ws.py
+++ b/aiohttp/client_ws.py
@@ -27,6 +27,7 @@ from .streams import EofStream
 from .typedefs import (
     DEFAULT_JSON_DECODER,
     DEFAULT_JSON_ENCODER,
+    JSONBytesEncoder,
     JSONDecoder,
     JSONEncoder,
 )
@@ -302,6 +303,20 @@ class ClientWebSocketResponse(Generic[_DecodeText]):
         dumps: JSONEncoder = DEFAULT_JSON_ENCODER,
     ) -> None:
         await self.send_str(dumps(data), compress=compress)
+
+    async def send_json_bytes(
+        self,
+        data: Any,
+        compress: int | None = None,
+        *,
+        dumps: JSONBytesEncoder,
+    ) -> None:
+        """Send JSON data using a bytes-returning encoder as a binary frame.
+
+        Use this when your JSON encoder (like orjson) returns bytes
+        instead of str, avoiding the encode/decode overhead.
+        """
+        await self.send_bytes(dumps(data), compress=compress)
 
     async def close(self, *, code: int = WSCloseCode.OK, message: bytes = b"") -> bool:
         # we need to break `receive()` cycle first,

--- a/aiohttp/payload.py
+++ b/aiohttp/payload.py
@@ -23,7 +23,7 @@ from .helpers import (
     sentinel,
 )
 from .streams import StreamReader
-from .typedefs import JSONEncoder, _CIMultiDict
+from .typedefs import JSONBytesEncoder, JSONEncoder, _CIMultiDict
 
 __all__ = (
     "PAYLOAD_REGISTRY",
@@ -38,6 +38,7 @@ __all__ = (
     "TextIOPayload",
     "StringIOPayload",
     "JsonPayload",
+    "JsonBytesPayload",
     "AsyncIterablePayload",
 )
 
@@ -938,6 +939,29 @@ class JsonPayload(BytesPayload):
             dumps(value).encode(encoding),
             content_type=content_type,
             encoding=encoding,
+            *args,
+            **kwargs,
+        )
+
+
+class JsonBytesPayload(BytesPayload):
+    """JSON payload for encoders that return bytes directly.
+
+    Use this when your JSON encoder (like orjson) returns bytes
+    instead of str, avoiding the encode/decode overhead.
+    """
+
+    def __init__(
+        self,
+        value: Any,
+        dumps: JSONBytesEncoder,
+        content_type: str = "application/json",
+        *args: Any,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(
+            dumps(value),
+            content_type=content_type,
             *args,
             **kwargs,
         )

--- a/aiohttp/typedefs.py
+++ b/aiohttp/typedefs.py
@@ -27,6 +27,7 @@ else:
 
 Byteish = Union[bytes, bytearray, memoryview]
 JSONEncoder = Callable[[Any], str]
+JSONBytesEncoder = Callable[[Any], bytes]
 JSONDecoder = Callable[[str], Any]
 LooseHeaders = Union[
     Mapping[str, str],

--- a/aiohttp/web.py
+++ b/aiohttp/web.py
@@ -96,6 +96,7 @@ from .web_response import (
     ContentCoding as ContentCoding,
     Response as Response,
     StreamResponse as StreamResponse,
+    json_bytes_response as json_bytes_response,
     json_response as json_response,
 )
 from .web_routedef import (
@@ -228,6 +229,7 @@ __all__ = (
     "ContentCoding",
     "Response",
     "StreamResponse",
+    "json_bytes_response",
     "json_response",
     "ResponseKey",
     # web_routedef

--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -32,12 +32,18 @@ from .helpers import (
 )
 from .http import SERVER_SOFTWARE, HttpVersion10, HttpVersion11
 from .payload import Payload
-from .typedefs import JSONEncoder, LooseHeaders
+from .typedefs import JSONBytesEncoder, JSONEncoder, LooseHeaders
 
 REASON_PHRASES = {http_status.value: http_status.phrase for http_status in HTTPStatus}
 LARGE_BODY_SIZE = 1024**2
 
-__all__ = ("ContentCoding", "StreamResponse", "Response", "json_response")
+__all__ = (
+    "ContentCoding",
+    "StreamResponse",
+    "Response",
+    "json_response",
+    "json_bytes_response",
+)
 
 
 if TYPE_CHECKING:
@@ -872,6 +878,35 @@ def json_response(
             text = dumps(data)
     return Response(
         text=text,
+        body=body,
+        status=status,
+        reason=reason,
+        headers=headers,
+        content_type=content_type,
+    )
+
+
+def json_bytes_response(
+    data: Any = sentinel,
+    *,
+    dumps: JSONBytesEncoder,
+    body: bytes | None = None,
+    status: int = 200,
+    reason: str | None = None,
+    headers: LooseHeaders | None = None,
+    content_type: str = "application/json",
+) -> Response:
+    """Create a JSON response using a bytes-returning encoder.
+
+    Use this when your JSON encoder (like orjson) returns bytes
+    instead of str, avoiding the encode/decode overhead.
+    """
+    if data is not sentinel:
+        if body is not None:
+            raise ValueError("only one of data or body should be specified")
+        else:
+            body = dumps(data)
+    return Response(
         body=body,
         status=status,
         reason=reason,

--- a/aiohttp/web_ws.py
+++ b/aiohttp/web_ws.py
@@ -34,7 +34,7 @@ from .http import (
 from .http_websocket import _INTERNAL_RECEIVE_TYPES
 from .log import ws_logger
 from .streams import EofStream
-from .typedefs import JSONDecoder, JSONEncoder
+from .typedefs import JSONBytesEncoder, JSONDecoder, JSONEncoder
 from .web_exceptions import HTTPBadRequest, HTTPException
 from .web_request import BaseRequest
 from .web_response import StreamResponse
@@ -480,6 +480,20 @@ class WebSocketResponse(StreamResponse, Generic[_DecodeText]):
         dumps: JSONEncoder = json.dumps,
     ) -> None:
         await self.send_str(dumps(data), compress=compress)
+
+    async def send_json_bytes(
+        self,
+        data: Any,
+        compress: int | None = None,
+        *,
+        dumps: JSONBytesEncoder,
+    ) -> None:
+        """Send JSON data using a bytes-returning encoder as a binary frame.
+
+        Use this when your JSON encoder (like orjson) returns bytes
+        instead of str, avoiding the encode/decode overhead.
+        """
+        await self.send_bytes(dumps(data), compress=compress)
 
     async def write_eof(self) -> None:  # type: ignore[override]
         if self._eof_sent:

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -1850,6 +1850,28 @@ manually.
          The method is converted into :term:`coroutine`,
          *compress* parameter added.
 
+   .. method:: send_json_bytes(data, compress=None, *, dumps)
+      :async:
+
+      Send *data* to peer as a JSON binary frame using a bytes-returning encoder.
+
+      :param data: data to send.
+
+      :param int compress: sets specific level of compression for
+                           single message,
+                           ``None`` for not overriding per-socket setting.
+
+      :param collections.abc.Callable dumps: any :term:`callable` that accepts an object and
+                             returns JSON as :class:`bytes`
+                             (e.g. ``orjson.dumps``).
+
+      :raise RuntimeError: if connection is not started or closing
+
+      :raise ValueError: if data is not serializable object
+
+      :raise TypeError: if value returned by ``dumps(data)`` is not
+                        :class:`bytes`
+
    .. method:: send_frame(message, opcode, compress=None)
       :async:
 

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -227,6 +227,7 @@ nowait
 OAuth
 Online
 optimizations
+orjson
 os
 outcoming
 Overridable

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -1232,6 +1232,27 @@ and :ref:`aiohttp-web-signals` handlers::
          The method is converted into :term:`coroutine`,
          *compress* parameter added.
 
+   .. method:: send_json_bytes(data, compress=None, *, dumps)
+      :async:
+
+      Send *data* to peer as a JSON binary frame using a bytes-returning encoder.
+
+      :param data: data to send.
+
+      :param int compress: sets specific level of compression for
+                           single message,
+                           ``None`` for not overriding per-socket setting.
+
+      :param collections.abc.Callable dumps: any :term:`callable` that accepts an object and
+                             returns JSON as :class:`bytes`
+                             (e.g. ``orjson.dumps``).
+
+      :raise RuntimeError: if the connection is not started.
+
+      :raise ValueError: if data is not serializable object
+
+      :raise TypeError: if value returned by ``dumps`` param is not :class:`bytes`
+
    .. method:: send_frame(message, opcode, compress=None)
       :async:
 
@@ -1443,6 +1464,18 @@ the handler.
       HTTP status code for this exception class.  This attribute is usually
       defined at the class level.  ``self.status_code`` is passed to the
       :class:`Response` initializer.
+
+
+.. function:: json_bytes_response([data], *, dumps, body=None, \
+                                  status=200, reason=None, headers=None, \
+                                  content_type='application/json')
+
+Return :class:`Response` with predefined ``'application/json'``
+content type and *data* encoded by ``dumps`` parameter
+which must return :class:`bytes` directly (e.g. ``orjson.dumps``).
+
+Use this when your JSON encoder returns :class:`bytes` instead of :class:`str`,
+avoiding the :class:`str`-to-:class:`bytes` encoding overhead.
 
 
 .. class:: ResponseKey(name, t)

--- a/tests/test_client_ws_functional.py
+++ b/tests/test_client_ws_functional.py
@@ -17,7 +17,6 @@ from aiohttp import (
     hdrs,
     web,
 )
-from aiohttp._websocket.models import WSMessageBinary
 from aiohttp._websocket.reader import WebSocketDataQueue
 from aiohttp.client_ws import ClientWSTimeout
 from aiohttp.http import WSCloseCode
@@ -202,7 +201,6 @@ async def test_send_recv_json_bytes(aiohttp_client: AiohttpClient) -> None:
     client = await aiohttp_client(app)
     resp = await client.ws_connect("/")
     data = await resp.receive()
-    assert isinstance(data, WSMessageBinary)
     assert data.json() == {"response": "x"}
     await resp.close()
 

--- a/tests/test_client_ws_functional.py
+++ b/tests/test_client_ws_functional.py
@@ -188,6 +188,82 @@ async def test_send_recv_json(aiohttp_client: AiohttpClient) -> None:
     await resp.close()
 
 
+async def test_send_recv_json_bytes(aiohttp_client: AiohttpClient) -> None:
+    async def handler(request: web.Request) -> web.WebSocketResponse:
+        ws = web.WebSocketResponse()
+        await ws.prepare(request)
+        await ws.send_bytes(json.dumps({"response": "x"}).encode())
+        await ws.close()
+        return ws
+
+    app = web.Application()
+    app.router.add_route("GET", "/", handler)
+    client = await aiohttp_client(app)
+    resp = await client.ws_connect("/")
+    data = await resp.receive()
+    assert isinstance(data, WSMessageBinary)
+    assert data.json() == {"response": "x"}
+    await resp.close()
+
+
+async def test_send_json_bytes_client(aiohttp_client: AiohttpClient) -> None:
+    """Test ClientWebSocketResponse.send_json_bytes sends binary frame."""
+
+    async def handler(request: web.Request) -> web.WebSocketResponse:
+        ws = web.WebSocketResponse()
+        await ws.prepare(request)
+
+        msg = await ws.receive()
+        assert msg.type is WSMsgType.BINARY
+        data = json.loads(msg.data)
+        await ws.send_json_bytes(
+            {"response": data["request"]},
+            dumps=lambda x: json.dumps(x).encode("utf-8"),
+        )
+        await ws.close()
+        return ws
+
+    app = web.Application()
+    app.router.add_route("GET", "/", handler)
+    client = await aiohttp_client(app)
+    resp = await client.ws_connect("/")
+    test_payload = {"request": "test"}
+    await resp.send_json_bytes(
+        test_payload, dumps=lambda x: json.dumps(x).encode("utf-8")
+    )
+
+    msg = await resp.receive()
+    assert msg.type is WSMsgType.BINARY
+    data = json.loads(msg.data)
+    assert data["response"] == test_payload["request"]
+    await resp.close()
+
+
+async def test_send_json_bytes_custom_encoder(aiohttp_client: AiohttpClient) -> None:
+    """Test send_json_bytes with custom bytes-returning encoder."""
+
+    async def handler(request: web.Request) -> web.WebSocketResponse:
+        ws = web.WebSocketResponse()
+        await ws.prepare(request)
+
+        msg = await ws.receive()
+        assert msg.type is WSMsgType.BINARY
+        # Custom encoder uses compact separators
+        assert msg.data == b'{"test":"value"}'
+        await ws.close()
+        return ws
+
+    app = web.Application()
+    app.router.add_route("GET", "/", handler)
+    client = await aiohttp_client(app)
+    resp = await client.ws_connect("/")
+    await resp.send_json_bytes(
+        {"test": "value"},
+        dumps=lambda x: json.dumps(x, separators=(",", ":")).encode("utf-8"),
+    )
+    await resp.close()
+
+
 async def test_send_recv_frame(aiohttp_client: AiohttpClient) -> None:
     async def handler(request: web.Request) -> web.WebSocketResponse:
         ws = web.WebSocketResponse()

--- a/tests/test_client_ws_functional.py
+++ b/tests/test_client_ws_functional.py
@@ -17,6 +17,7 @@ from aiohttp import (
     hdrs,
     web,
 )
+from aiohttp._websocket.models import WSMessageBinary
 from aiohttp._websocket.reader import WebSocketDataQueue
 from aiohttp.client_ws import ClientWSTimeout
 from aiohttp.http import WSCloseCode

--- a/tests/test_payload.py
+++ b/tests/test_payload.py
@@ -1222,6 +1222,40 @@ def test_json_payload_size() -> None:
     assert jp_custom.size == len(expected_custom.encode("utf-16"))
 
 
+def test_json_bytes_payload() -> None:
+    """Test JsonBytesPayload with a bytes-returning encoder."""
+    data = {"hello": "world"}
+
+    # Test with standard library encoder
+    jp = payload.JsonBytesPayload(data, dumps=lambda x: json.dumps(x).encode("utf-8"))
+    expected = json.dumps(data).encode("utf-8")
+    assert jp.size == len(expected)
+
+    # Test with custom bytes-returning encoder (compact separators)
+    jp_custom = payload.JsonBytesPayload(
+        data, dumps=lambda x: json.dumps(x, separators=(",", ":")).encode("utf-8")
+    )
+    expected_custom = json.dumps(data, separators=(",", ":")).encode("utf-8")
+    assert jp_custom.size == len(expected_custom)
+
+
+def test_json_bytes_payload_content_type() -> None:
+    """Test JsonBytesPayload content_type."""
+    data = {"test": "data"}
+
+    # Default content type
+    jp = payload.JsonBytesPayload(data, dumps=lambda x: json.dumps(x).encode("utf-8"))
+    assert jp.content_type == "application/json"
+
+    # Custom content type
+    jp_custom = payload.JsonBytesPayload(
+        data,
+        dumps=lambda x: json.dumps(x).encode("utf-8"),
+        content_type="application/vnd.api+json",
+    )
+    assert jp_custom.content_type == "application/vnd.api+json"
+
+
 async def test_text_io_payload_size_matches_file_encoding(tmp_path: Path) -> None:
     """Test TextIOPayload.size when file encoding matches payload encoding."""
     # Create UTF-8 file

--- a/tests/test_web_response.py
+++ b/tests/test_web_response.py
@@ -16,7 +16,7 @@ from re_assert import Matches
 
 from aiohttp import HttpVersion, HttpVersion10, HttpVersion11, hdrs, web
 
-from aiohttp.abc improt AbstractStreamWriter
+from aiohttp.abc import AbstractStreamWriter
 from aiohttp.helpers import ETag
 from aiohttp.http_writer import StreamWriter, _serialize_headers
 from aiohttp.multipart import BodyPartReader, MultipartWriter

--- a/tests/test_web_response.py
+++ b/tests/test_web_response.py
@@ -3,6 +3,7 @@ import datetime
 import gzip
 import io
 import json
+import re
 import sys
 from collections.abc import AsyncIterator, Iterator
 from concurrent.futures import ThreadPoolExecutor
@@ -13,7 +14,8 @@ import pytest
 from multidict import CIMultiDict, CIMultiDictProxy, MultiDict
 from re_assert import Matches
 
-from aiohttp import HttpVersion, HttpVersion10, HttpVersion11, hdrs
+from aiohttp import HttpVersion, HttpVersion10, HttpVersion11, hdrs, web
+from aiohttp.abc improt AbstractStreamWriter
 from aiohttp.helpers import ETag
 from aiohttp.http_writer import StreamWriter, _serialize_headers
 from aiohttp.multipart import BodyPartReader, MultipartWriter

--- a/tests/test_web_response.py
+++ b/tests/test_web_response.py
@@ -15,6 +15,7 @@ from multidict import CIMultiDict, CIMultiDictProxy, MultiDict
 from re_assert import Matches
 
 from aiohttp import HttpVersion, HttpVersion10, HttpVersion11, hdrs, web
+
 from aiohttp.abc improt AbstractStreamWriter
 from aiohttp.helpers import ETag
 from aiohttp.http_writer import StreamWriter, _serialize_headers

--- a/tests/test_web_response.py
+++ b/tests/test_web_response.py
@@ -15,7 +15,6 @@ from multidict import CIMultiDict, CIMultiDictProxy, MultiDict
 from re_assert import Matches
 
 from aiohttp import HttpVersion, HttpVersion10, HttpVersion11, hdrs, web
-
 from aiohttp.abc import AbstractStreamWriter
 from aiohttp.helpers import ETag
 from aiohttp.http_writer import StreamWriter, _serialize_headers

--- a/tests/test_web_response.py
+++ b/tests/test_web_response.py
@@ -1620,6 +1620,87 @@ class TestJSONResponse:
         assert "application/vnd.json+api" == resp.content_type
 
 
+class TestJSONBytesResponse:
+    def test_content_type_is_application_json_by_default(self) -> None:
+        resp = web.json_bytes_response(
+            "", dumps=lambda x: json.dumps(x).encode("utf-8")
+        )
+        assert "application/json" == resp.content_type
+
+    def test_passing_body_only(self) -> None:
+        resp = web.json_bytes_response(
+            dumps=lambda x: json.dumps(x).encode("utf-8"),
+            body=b'"jaysawn"',
+        )
+        assert resp.body == b'"jaysawn"'
+
+    def test_data_and_body_raises_value_error(self) -> None:
+        with pytest.raises(ValueError) as excinfo:
+            web.json_bytes_response(
+                data="foo", dumps=lambda x: json.dumps(x).encode("utf-8"), body=b"bar"
+            )
+        expected_message = "only one of data or body should be specified"
+        assert expected_message == excinfo.value.args[0]
+
+    def test_body_is_json_encoded_bytes(self) -> None:
+        resp = web.json_bytes_response(
+            {"foo": 42}, dumps=lambda x: json.dumps(x).encode("utf-8")
+        )
+        assert json.dumps({"foo": 42}).encode("utf-8") == resp.body
+
+    def test_content_type_is_overrideable(self) -> None:
+        resp = web.json_bytes_response(
+            {"foo": 42},
+            dumps=lambda x: json.dumps(x).encode("utf-8"),
+            content_type="application/vnd.json+api",
+        )
+        assert "application/vnd.json+api" == resp.content_type
+
+    def test_custom_dumps(self) -> None:
+        resp = web.json_bytes_response(
+            {"foo": 42},
+            dumps=lambda x: json.dumps(x, separators=(",", ":")).encode("utf-8"),
+        )
+        assert b'{"foo":42}' == resp.body
+
+
+@pytest.mark.dev_mode
+async def test_no_warn_small_cookie(
+    buf: bytearray, writer: AbstractStreamWriter
+) -> None:
+    resp = web.Response()
+    resp.set_cookie("foo", "ÿ" + "8" * 4064, max_age=2600)  # No warning
+    req = make_request("GET", "/", writer=writer)
+
+    await resp.prepare(req)
+    await resp.write_eof()
+
+    match = re.search(b"Set-Cookie: (.*?)\r\n", buf)
+    assert match is not None
+    cookie = match.group(1)
+    assert len(cookie) == 4096
+
+
+@pytest.mark.dev_mode
+async def test_warn_large_cookie(buf: bytearray, writer: AbstractStreamWriter) -> None:
+    resp = web.Response()
+
+    with pytest.warns(
+        UserWarning,
+        match="The size of is too large, it might get ignored by the client.",
+    ):
+        resp.set_cookie("foo", "ÿ" + "8" * 4065, max_age=2600)
+    req = make_request("GET", "/", writer=writer)
+
+    await resp.prepare(req)
+    await resp.write_eof()
+
+    match = re.search(b"Set-Cookie: (.*?)\r\n", buf)
+    assert match is not None
+    cookie = match.group(1)
+    assert len(cookie) == 4097
+
+
 @pytest.mark.parametrize("loose_header_type", (MultiDict, CIMultiDict, dict))
 async def test_passing_cimultidict_to_web_response_not_mutated(
     loose_header_type: type,

--- a/tests/test_web_response.py
+++ b/tests/test_web_response.py
@@ -3,7 +3,6 @@ import datetime
 import gzip
 import io
 import json
-import re
 import sys
 from collections.abc import AsyncIterator, Iterator
 from concurrent.futures import ThreadPoolExecutor
@@ -15,7 +14,6 @@ from multidict import CIMultiDict, CIMultiDictProxy, MultiDict
 from re_assert import Matches
 
 from aiohttp import HttpVersion, HttpVersion10, HttpVersion11, hdrs, web
-from aiohttp.abc import AbstractStreamWriter
 from aiohttp.helpers import ETag
 from aiohttp.http_writer import StreamWriter, _serialize_headers
 from aiohttp.multipart import BodyPartReader, MultipartWriter

--- a/tests/test_web_websocket.py
+++ b/tests/test_web_websocket.py
@@ -231,7 +231,7 @@ async def test_send_json_bytes_nonjson(make_request: _RequestMaker) -> None:
         await ws.send_json_bytes(set(), dumps=lambda x: json.dumps(x).encode("utf-8"))
 
     assert ws._reader is not None
-    ws._reader.feed_data(WS_CLOSED_MESSAGE)
+    ws._reader.feed_data(WS_CLOSED_MESSAGE, 0)
     await ws.close()
 
 
@@ -428,7 +428,7 @@ async def test_send_json_bytes_closed(make_request: _RequestMaker) -> None:
     ws = web.WebSocketResponse()
     await ws.prepare(req)
     assert ws._reader is not None
-    ws._reader.feed_data(WS_CLOSED_MESSAGE)
+    ws._reader.feed_data(WS_CLOSED_MESSAGE, 0)
     await ws.close()
 
     with pytest.raises(ConnectionError):

--- a/tests/test_web_websocket.py
+++ b/tests/test_web_websocket.py
@@ -1,7 +1,7 @@
 import asyncio
 import json
 import time
-from typing import Any
+from typing import Any, Protocol
 from unittest import mock
 
 import aiosignal
@@ -14,6 +14,16 @@ from aiohttp.streams import EofStream
 from aiohttp.test_utils import make_mocked_request
 from aiohttp.web import HTTPBadRequest, WebSocketResponse
 from aiohttp.web_ws import WebSocketReady
+
+
+class _RequestMaker(Protocol):
+    def __call__(
+        self,
+        method: str,
+        path: str,
+        headers: CIMultiDict[str] | None = None,
+        protocols: bool = False,
+    ) -> web.Request: ...
 
 
 @pytest.fixture


### PR DESCRIPTION
(cherry picked from commit 67fa1f5e64a95a5e081f566c4718bc7062c7dbdb)