### PR TITLE
Fix server hang on chunked transfer encoding size mismatch

### DIFF
--- a/CHANGES/10596.bugfix.rst
+++ b/CHANGES/10596.bugfix.rst
@@ -1,0 +1,4 @@
+Fixed server hanging indefinitely when chunked transfer encoding chunk-size
+does not match actual data length. The server now raises
+:py:exc:`TransferEncodingError` instead of waiting forever for data that will
+never arrive -- by :user:`Fridayai700`.

--- a/CHANGES/10596.bugfix.rst
+++ b/CHANGES/10596.bugfix.rst
@@ -1,4 +1,4 @@
 Fixed server hanging indefinitely when chunked transfer encoding chunk-size
 does not match actual data length. The server now raises
-:py:exc:`TransferEncodingError` instead of waiting forever for data that will
+``TransferEncodingError`` instead of waiting forever for data that will
 never arrive -- by :user:`Fridayai700`.

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -889,7 +889,7 @@ class HttpPayloadParser:
                     if chunk[: len(SEP)] == SEP:
                         chunk = chunk[len(SEP) :]
                         self._chunk = ChunkState.PARSE_CHUNKED_SIZE
-                    elif len(chunk) >= len(SEP) or chunk != SEP[:len(chunk)]:
+                    elif len(chunk) >= len(SEP) or chunk != SEP[: len(chunk)]:
                         exc = TransferEncodingError(
                             "Chunk size mismatch: expected CRLF after chunk data"
                         )

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -889,6 +889,12 @@ class HttpPayloadParser:
                     if chunk[: len(SEP)] == SEP:
                         chunk = chunk[len(SEP) :]
                         self._chunk = ChunkState.PARSE_CHUNKED_SIZE
+                    elif len(chunk) >= len(SEP) or chunk != SEP[:len(chunk)]:
+                        exc = TransferEncodingError(
+                            "Chunk size mismatch: expected CRLF after chunk data"
+                        )
+                        set_exception(self.payload, exc)
+                        raise exc
                     else:
                         self._chunk_tail = chunk
                         return False, b""


### PR DESCRIPTION
## Summary

Fixes #10596.

When chunked transfer encoding `chunk-size` does not match the actual data length, the server hangs indefinitely instead of rejecting the request. Per RFC 9112, `chunk-data` must be exactly `chunk-size` octets followed by CRLF.

**Root cause:** In `PARSE_CHUNKED_CHUNK_EOF` state (after consuming `chunk-size` bytes), any data that doesn't start with `\r\n` is stored in `_chunk_tail` and the parser returns `False` — waiting forever for more data. When the chunk-size is wrong (e.g., declared 4 but sent 5 bytes), the byte after the consumed data is not `\r` and will never become `\r\n`.

**Fix:** Before falling through to the wait-for-more-data path, check whether the available data can't possibly be the start of the expected CRLF separator. If we have enough bytes to determine the separator is wrong, raise `TransferEncodingError` immediately. The legitimate partial-separator case (received `\r` but not yet `\n`) is preserved.

**Changes:**
- `aiohttp/http_parser.py`: Add `elif` branch in `PARSE_CHUNKED_CHUNK_EOF` that raises `TransferEncodingError` when data doesn't match CRLF prefix
- `tests/test_http_parser.py`: Two regression tests — data too long (5 bytes for chunk-size 4) and data too short (5 bytes for chunk-size 6)
- `CHANGES/10596.bugfix.rst`: Changelog entry

## Test plan

- [x] Two new tests pass: `test_parse_chunked_payload_size_data_mismatch` and `test_parse_chunked_payload_size_data_mismatch_too_short`
- [x] All 14 existing chunked payload tests pass (including split-end tests that verify partial CRLF handling)
- [x] Full `test_http_parser.py` suite: 299 passed, 4 pre-existing failures (missing C extension/brotli)