### PR TITLE
Make clear that regex is not affected by ReDoS

### DIFF
--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -115,7 +115,7 @@ SEPARATORS = {
 TOKEN = CHAR ^ CTL ^ SEPARATORS
 
 
-json_re = re.compile(r"(?:application/|[\w.-]+/[\w.+-]+?\+)json$", re.IGNORECASE)
+json_re = re.compile(r"^(?:application/|[\w.-]+/[\w.+-]+?\+)json$", re.IGNORECASE)
 
 
 class BasicAuth(namedtuple("BasicAuth", ["login", "password", "encoding"])):


### PR DESCRIPTION
codeql is highlighting this as vulnerable to ReDoS. It's not because it's used in re.match(), not re.search(). However, we can add `^` to this regex to make it safe in both situations and stop codeql thinking it's vulnerable.