### PR TITLE
Fix _sendfile_fallback over-reading beyond requested count (#12096)

### DIFF
--- a/CHANGES/12096.bugfix.rst
+++ b/CHANGES/12096.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed _sendfile_fallback over-reading beyond requested count -- by :user:`bysiber`.

--- a/aiohttp/web_fileresponse.py
+++ b/aiohttp/web_fileresponse.py
@@ -118,11 +118,11 @@ class FileResponse(StreamResponse):
         chunk_size = self._chunk_size
         loop = asyncio.get_event_loop()
         chunk = await loop.run_in_executor(
-            None, self._seek_and_read, fobj, offset, chunk_size
+            None, self._seek_and_read, fobj, offset, min(chunk_size, count)
         )
         while chunk:
             await writer.write(chunk)
-            count = count - chunk_size
+            count = count - len(chunk)
             if count <= 0:
                 break
             chunk = await loop.run_in_executor(None, fobj.read, min(chunk_size, count))


### PR DESCRIPTION
(cherry picked from commit 291d969ec2806b9b920ee48c761a4c9310b13300)