### PR TITLE
Replace unintentional except BaseException with except Exception

### DIFF
--- a/aiohttp/client_proto.py
+++ b/aiohttp/client_proto.py
@@ -325,7 +325,7 @@ class ResponseHandler(BaseProtocol, DataQueue[tuple[RawResponseMessage, StreamRe
         # parse http messages
         try:
             messages, upgraded, tail = self._parser.feed_data(data)
-        except BaseException as underlying_exc:
+        except Exception as underlying_exc:
             if self.transport is not None:
                 # connection.release() could be called BEFORE
                 # data_received(), the transport is already

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -446,7 +446,7 @@ class HttpParser(abc.ABC, Generic[_MsgT]):
                 assert self._payload_parser is not None
                 try:
                     eof, data = self._payload_parser.feed_data(data[start_pos:], SEP)
-                except BaseException as underlying_exc:
+                except Exception as underlying_exc:
                     reraised_exc = underlying_exc
                     if self.payload_exception is not None:
                         reraised_exc = self.payload_exception(str(underlying_exc))

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -447,7 +447,7 @@ class HttpParser(abc.ABC, Generic[_MsgT]):
                 try:
                     eof, data = self._payload_parser.feed_data(data[start_pos:], SEP)
                 except Exception as underlying_exc:
-                    reraised_exc = underlying_exc
+                    reraised_exc: BaseException = underlying_exc
                     if self.payload_exception is not None:
                         reraised_exc = self.payload_exception(str(underlying_exc))
 

--- a/aiohttp/worker.py
+++ b/aiohttp/worker.py
@@ -122,7 +122,7 @@ class GunicornWebWorker(base.Worker):  # type: ignore[misc,no-any-unimported]
                     self.log.info("Parent changed, shutting down: %s", self)
                 else:
                     await self._wait_next_notify()
-        except BaseException:
+        except Exception:
             pass
 
         await runner.cleanup()


### PR DESCRIPTION
## Summary

Fixes #2444.

`BaseException` catches `SystemExit`, `KeyboardInterrupt`, and `GeneratorExit` in addition to normal exceptions. Using it unintentionally in application-level error handling silently swallows shutdown signals and process control exceptions, which can cause hangs or other unexpected behavior.

This PR replaces three `except BaseException` clauses that were **catching-and-handling** (not catching-and-re-raising) with `except Exception`.

## Changes

### `aiohttp/worker.py` (line 125)

```python
# Before
except BaseException:
    pass
```

The gunicorn worker's main loop swallowed **all** exceptions with `pass`, including `KeyboardInterrupt` and `SystemExit`. This means shutdown signals sent to the worker process would be silently ignored. Changed to `except Exception: pass`.

### `aiohttp/client_proto.py` (line 328)

```python
# Before
except BaseException as underlying_exc:
    ...
    self.set_exception(exc, underlying_exc)
    return  # no re-raise
```

The HTTP `data_received()` handler converted all exceptions — including `KeyboardInterrupt` — into an `HttpProcessingError` via `set_exception()` and returned without re-raising. A `KeyboardInterrupt` during HTTP data parsing would be silently converted into a protocol error instead of propagating up. Changed to `except Exception`.

### `aiohttp/http_parser.py` (line 449)

```python
# Before
except BaseException as underlying_exc:
    ...
    set_exception(self._payload_parser.payload, reraised_exc, underlying_exc)
    eof = True
    data = b""
    if isinstance(underlying_exc, (InvalidHeader, TransferEncodingError)):
        raise  # only re-raises for specific types
```

The payload parser fed all exceptions into the payload exception handler and only re-raised for `InvalidHeader` / `TransferEncodingError`. All other exceptions — including `KeyboardInterrupt` — were silently swallowed into the payload. Changed to `except Exception`.

## What was NOT changed

All other `except BaseException` occurrences in the codebase are intentional. They follow the correct pattern of performing resource cleanup (closing transports, releasing connections, cancelling timers) and then **immediately re-raising** the exception. This is the standard pattern for ensuring cleanup under `asyncio.CancelledError` and other system exceptions in async code.

The `.pyx` Cython callback functions also intentionally use `BaseException` because they are C-level callbacks that must catch any Python exception to return an error code (`-1`) — they cannot propagate Python exceptions through the C call stack.