### PR TITLE
Fix AttributeError: 'ClientConnectorCertificateError' object has no attribute '_os_error'.

### DIFF
--- a/CHANGES/12136.bugfix.rst
+++ b/CHANGES/12136.bugfix.rst
@@ -1,0 +1,2 @@
+``ClientConnectorCertificateError.os_error`` no longer raises :exc:`AttributeError`
+-- by :user:`themylogin`.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -392,6 +392,7 @@ Vladimir Kamarzin
 Vladimir Kozlovski
 Vladimir Rutsky
 Vladimir Shulyak
+Vladimir Vinogradenko
 Vladimir Zakharov
 Vladyslav Bohaichuk
 Vladyslav Bondar

--- a/aiohttp/client_exceptions.py
+++ b/aiohttp/client_exceptions.py
@@ -346,7 +346,9 @@ class ClientConnectorCertificateError(*cert_errors_bases):  # type: ignore[misc]
 
     def __init__(
         # TODO: If we require ssl in future, this can become ssl.CertificateError
-        self, connection_key: ConnectionKey, certificate_error: Exception
+        self,
+        connection_key: ConnectionKey,
+        certificate_error: Exception,
     ) -> None:
         if isinstance(certificate_error, cert_errors + (OSError,)):
             # ssl.CertificateError has errno and strerror, so we should be fine

--- a/aiohttp/client_exceptions.py
+++ b/aiohttp/client_exceptions.py
@@ -345,6 +345,7 @@ class ClientConnectorCertificateError(*cert_errors_bases):  # type: ignore[misc]
     _conn_key: ConnectionKey
 
     def __init__(
+        # TODO: If we require ssl in future, this can become ssl.CertificateError
         self, connection_key: ConnectionKey, certificate_error: Exception
     ) -> None:
         if isinstance(certificate_error, cert_errors + (OSError,)):

--- a/tests/test_client_exceptions.py
+++ b/tests/test_client_exceptions.py
@@ -201,6 +201,15 @@ class TestClientConnectorCertificateError:
             " [Exception: ('Bad certificate',)]"
         )
 
+    def test_oserror(self) -> None:
+        certificate_error = OSError(1, "Bad certificate")
+        err = client.ClientConnectorCertificateError(
+            connection_key=self.connection_key, certificate_error=certificate_error
+        )
+        assert err.os_error == certificate_error
+        assert err.errno == 1
+        assert err.strerror == "Bad certificate"
+
 
 class TestServerDisconnectedError:
     def test_ctor(self) -> None:


### PR DESCRIPTION

<!-- Thank you for your contribution! -->

## What do these changes do?

`ClientConnectorCertificateError` is a subclass of `ClientConnectorError` and should have all of its attributes (Liskov substitution principle). However, when I try to access the `os_error` attribute in my exception handler, I get the following exception:

```
AttributeError: 'ClientConnectorCertificateError' object has no attribute '_os_error'.
```

## Are there changes in behavior for the user?

Users that use `hasattr(e, 'os_error')` to ensure that `e` is not an instance of `ClientConnectorCertificateError` (or its subclasses), will have their code broken.

## Is it a substantial burden for the maintainers to support this?

There should be none.

## Checklist

- [X] I think the code is well written
- [X] Unit tests for the changes exist
- [X] Documentation reflects the changes
- [X] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [X] Add a new news fragment into the `CHANGES/` folder
  * name it `<issue_or_pr_num>.<type>.rst` (e.g. `588.bugfix.rst`)
  * if you don't have an issue number, change it to the pull request
    number after creating the PR
    * `.bugfix`: A bug fix for something the maintainers deemed an
      improper undesired behavior that got corrected to match
      pre-agreed expectations.
    * `.feature`: A new behavior, public APIs. That sort of stuff.
    * `.deprecation`: A declaration of future API removals and breaking
      changes in behavior.
    * `.breaking`: When something public is removed in a breaking way.
      Could be deprecated in an earlier release.
    * `.doc`: Notable updates to the documentation structure or build
      process.
    * `.packaging`: Notes for downstreams about unobvious side effects
      and tooling. Changes in the test invocation considerations and
      runtime assumptions.
    * `.contrib`: Stuff that affects the contributor experience. e.g.
      Running tests, building the docs, setting up the development
      environment.
    * `.misc`: Changes that are hard to assign to any of the above
      categories.
  * Make sure to use full sentences with correct case and punctuation,
    for example:
    ```rst
    Fixed issue with non-ascii contents in doctest text files
    -- by :user:`contributor-gh-handle`.
    ```

    Use the past tense or the present tense a non-imperative mood,
    referring to what's changed compared to the last released version
    of this project.
