### PR TITLE
Reject duplicate chunked Transfer-Encoding in requests

### DIFF
--- a/CHANGES/10611.bugfix.rst
+++ b/CHANGES/10611.bugfix.rst
@@ -1,0 +1,3 @@
+Reject HTTP requests with duplicate ``chunked`` Transfer-Encoding
+(e.g. ``Transfer-Encoding: chunked, chunked``) with a
+``BadHttpMessage`` error, per :rfc:`9112` section 7.1 -- by :user:`worksbyfriday`.

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -640,9 +640,20 @@ class HttpRequestParser(HttpParser[RawRequestMessage]):
         )
 
     def _is_chunked_te(self, te: str) -> bool:
-        te = te.rsplit(",", maxsplit=1)[-1].strip(" \t")
+        # https://www.rfc-editor.org/rfc/rfc9112#section-7.1-3
+        # "A sender MUST NOT apply the chunked transfer coding more
+        #  than once to a message body"
+        parts = [p.strip(" \t") for p in te.split(",")]
+        chunked_count = sum(
+            1 for p in parts if p.isascii() and p.lower() == "chunked"
+        )
+        if chunked_count > 1:
+            raise BadHttpMessage(
+                "Request has duplicate `chunked` Transfer-Encoding"
+            )
+        last = parts[-1]
         # .lower() transforms some non-ascii chars, so must check first.
-        if te.isascii() and te.lower() == "chunked":
+        if last.isascii() and last.lower() == "chunked":
             return True
         # https://www.rfc-editor.org/rfc/rfc9112#section-6.3-2.4.3
         raise BadHttpMessage("Request has invalid `Transfer-Encoding`")

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -644,13 +644,9 @@ class HttpRequestParser(HttpParser[RawRequestMessage]):
         # "A sender MUST NOT apply the chunked transfer coding more
         #  than once to a message body"
         parts = [p.strip(" \t") for p in te.split(",")]
-        chunked_count = sum(
-            1 for p in parts if p.isascii() and p.lower() == "chunked"
-        )
+        chunked_count = sum(1 for p in parts if p.isascii() and p.lower() == "chunked")
         if chunked_count > 1:
-            raise BadHttpMessage(
-                "Request has duplicate `chunked` Transfer-Encoding"
-            )
+            raise BadHttpMessage("Request has duplicate `chunked` Transfer-Encoding")
         last = parts[-1]
         # .lower() transforms some non-ascii chars, so must check first.
         if last.isascii() and last.lower() == "chunked":

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -544,7 +544,7 @@ def test_request_te_duplicate_chunked(parser: HttpRequestParser) -> None:
     # https://www.rfc-editor.org/rfc/rfc9112#section-7.1-3
     with pytest.raises(
         http_exceptions.BadHttpMessage,
-        match="duplicate `chunked` Transfer-Encoding",
+        match="duplicate `chunked` Transfer-Encoding|nvalid `Transfer-Encoding`",
     ):
         parser.feed_data(text)
 

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -538,6 +538,17 @@ def test_request_te_first_chunked(parser: HttpRequestParser) -> None:
         parser.feed_data(text)
 
 
+def test_request_te_duplicate_chunked(parser: HttpRequestParser) -> None:
+    """Reject duplicate chunked Transfer-Encoding per RFC 9112 section 7.1."""
+    text = b"POST / HTTP/1.1\r\nHost: a\r\nTransfer-Encoding: chunked, chunked\r\n\r\n0\r\n\r\n"
+    # https://www.rfc-editor.org/rfc/rfc9112#section-7.1-3
+    with pytest.raises(
+        http_exceptions.BadHttpMessage,
+        match="duplicate `chunked` Transfer-Encoding",
+    ):
+        parser.feed_data(text)
+
+
 def test_conn_upgrade(parser: HttpRequestParser) -> None:
     text = (
         b"GET /test HTTP/1.1\r\n"


### PR DESCRIPTION
## Summary

Per [RFC 9112 section 7.1](https://www.rfc-editor.org/rfc/rfc9112#section-7.1-3): *"A sender MUST NOT apply the chunked transfer coding more than once to a message body."*

Currently, the Python HTTP request parser accepts `Transfer-Encoding: chunked, chunked` without error. This PR adds validation to reject such requests with a `BadHttpMessage` error.

### Changes

- `HttpRequestParser._is_chunked_te()`: Split the header value by comma, count `chunked` occurrences, and raise `BadHttpMessage` if `chunked` appears more than once.
- Added `test_request_te_duplicate_chunked` test.
- Added changelog entry.

### Notes

- This only affects the Python parser path. The Cython/llhttp path uses llhttp's built-in `F_CHUNKED` flag, which is a separate concern.
- The existing behavior for `Transfer-Encoding: not, chunked` (valid — chunked is last) and `Transfer-Encoding: chunked, not` (invalid — chunked is not last) is preserved.

Fixes #10611