### PR TITLE
Fix Response.text failing when body is set to a string

### DIFF
--- a/CHANGES/2928.bugfix.rst
+++ b/CHANGES/2928.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed ``Response.text`` raising ``AttributeError`` when ``Response.body`` was set to a string -- by :user:`dhruvildarji`.

--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -612,6 +612,12 @@ class Response(StreamResponse):
             self._body = None
         elif isinstance(body, (bytes, bytearray)):
             self._body = body
+        elif isinstance(body, str):
+            self._body = body.encode(self.charset or "utf-8")
+            if self.content_type == "application/octet-stream":
+                self.content_type = "text/plain"
+            if self.charset is None:
+                self.charset = "utf-8"
         else:
             try:
                 self._body = body = payload.PAYLOAD_REGISTRY.get(body)

--- a/tests/test_web_response.py
+++ b/tests/test_web_response.py
@@ -1191,6 +1191,48 @@ def test_payload_body_get_text(payload: object, expected: str | None) -> None:
         assert resp.text == expected
 
 
+def test_body_setter_with_str_stores_bytes() -> None:
+    """Setting body to a str should encode it to bytes (issue #2928)."""
+    resp = web.Response()
+    resp.body = "hello"
+    assert resp.body == b"hello"
+    assert isinstance(resp.body, bytes)
+    assert resp.text == "hello"
+
+
+def test_body_setter_with_str_sets_content_type() -> None:
+    """Setting body to a str should set content_type to text/plain."""
+    resp = web.Response()
+    resp.body = "hello"
+    assert resp.content_type == "text/plain"
+    assert resp.charset == "utf-8"
+
+
+def test_body_setter_with_str_preserves_existing_content_type() -> None:
+    """Setting body to str should not override an existing non-default content_type."""
+    resp = web.Response(content_type="text/html")
+    resp.body = "hello"
+    assert resp.content_type == "text/html"
+
+
+def test_body_setter_with_str_uses_existing_charset() -> None:
+    """Setting body to str should use existing charset for encoding."""
+    resp = web.Response(charset="latin-1", content_type="text/plain")
+    resp.body = "caf\u00e9"
+    assert resp.body == "caf\u00e9".encode("latin-1")
+    assert resp.text == "caf\u00e9"
+
+
+def test_body_setter_str_then_text_roundtrip() -> None:
+    """body = str -> text -> body roundtrip should be consistent."""
+    resp = web.Response()
+    resp.body = "test string"
+    text = resp.text
+    assert text == "test string"
+    resp.text = text
+    assert resp.body == b"test string"
+
+
 def test_response_set_content_length() -> None:
     resp = web.Response()
     with pytest.raises(RuntimeError):


### PR DESCRIPTION
## Summary

Setting `Response.body` to a string and then accessing `Response.text` would fail with an `AttributeError` because the body setter created a `StringPayload` wrapper that didn't always have a compatible `decode` method.

The fix handles `str` explicitly in the body setter by encoding it directly to bytes, consistent with how the `text` setter works. It also sets sensible defaults for `content_type` and `charset` when they haven't been configured.

## What's Changed

- Added `str` handling in `Response.body` setter that encodes to bytes using the configured charset
- Sets `content_type` to `text/plain` if it was the default `application/octet-stream`
- Sets `charset` to `utf-8` if not already set
- Added tests for the new behavior

## Test Plan

- [x] Setting body to str stores bytes and text property works
- [x] Content-type defaults are set correctly
- [x] Existing content-type is preserved
- [x] Existing charset is used for encoding
- [x] Roundtrip body→text→body is consistent
- [x] All existing tests pass

Fixes #2928