### PR TITLE
Replace deprecated ujson with orjson in documentation

### DIFF
--- a/docs/client_quickstart.rst
+++ b/docs/client_quickstart.rst
@@ -210,16 +210,20 @@ serialization.  But it is possible to use different
 ``serializer``. :class:`ClientSession` accepts ``json_serialize``
 parameter::
 
-  import ujson
+  import orjson
 
   async with aiohttp.ClientSession(
-          json_serialize=ujson.dumps) as session:
+          json_serialize=orjson.dumps) as session:
       await session.post(url, json={'test': 'object'})
 
 .. note::
 
-   ``ujson`` library is faster than standard :mod:`json` but slightly
-   incompatible.
+   ``orjson`` library is faster than standard :mod:`json`. Note that
+   ``orjson.dumps`` returns bytes, so you may need to decode::
+
+      json_serialize=lambda x: orjson.dumps(x).decode()
+
+   The older ``ujson`` library is deprecated and in maintenance-only mode.
 
 JSON Response Content
 =====================


### PR DESCRIPTION
Fixes #10795

## Problem
The documentation recommends using `ujson` for faster JSON serialization, but ujson is deprecated and in maintenance-only mode due to security concerns.

From the ujson PyPI page:
> UltraJSON's architecture is fundamentally ill-suited to making changes without risk of introducing new security vulnerabilities. As a result, this library has been put into a maintenance-only mode.

## Solution
Updated the documentation to recommend `orjson` instead, which:
- Is actively maintained
- Is faster than both ujson and standard json
- Is the recommended migration target from ujson

## Changes
- Replaced ujson example with orjson
- Added note about orjson.dumps returning bytes (may need .decode())
- Added note that ujson is deprecated