### PR TITLE
docs: replace deprecated ujson with orjson in client quickstart

### DIFF
--- a/CHANGES/10795.doc.rst
+++ b/CHANGES/10795.doc.rst
@@ -1,0 +1,4 @@
+Replaced the deprecated ``ujson`` library with ``orjson`` in the
+client quickstart documentation. ``ujson`` has been put into
+maintenance-only mode; ``orjson`` is the recommended alternative.
+-- by :user:`indoor47`

--- a/docs/client_quickstart.rst
+++ b/docs/client_quickstart.rst
@@ -206,20 +206,22 @@ Any of session's request methods like :func:`request`,
 
 
 By default session uses python's standard :mod:`json` module for
-serialization.  But it is possible to use different
-``serializer``. :class:`ClientSession` accepts ``json_serialize``
-parameter::
+serialization.  But it is possible to use a different
+``serializer``. :class:`ClientSession` accepts ``json_serialize`` and
+``json_serialize_bytes`` parameters::
 
-  import ujson
+  import orjson
 
   async with aiohttp.ClientSession(
-          json_serialize=ujson.dumps) as session:
+          json_serialize_bytes=orjson.dumps) as session:
       await session.post(url, json={'test': 'object'})
 
 .. note::
 
-   ``ujson`` library is faster than standard :mod:`json` but slightly
-   incompatible.
+   ``orjson`` library is faster than standard :mod:`json` and is actively
+   maintained. Since ``orjson.dumps`` returns :class:`bytes`, pass it via
+   the ``json_serialize_bytes`` parameter to avoid unnecessary
+   encoding/decoding overhead.
 
 JSON Response Content
 =====================

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -266,6 +266,7 @@ pytest
 Pytest
 qop
 Quickstart
+quickstart
 quote’s
 rc
 readline


### PR DESCRIPTION
Fixes #10795.

The `ujson` library has been placed in maintenance-only mode. Its own maintainers now recommend migrating to `orjson` ([source](https://pypi.org/project/ujson/)):

> UltraJSON's architecture is fundamentally ill-suited to making changes without risk of introducing new security vulnerabilities. Users are encouraged to migrate to orjson which is both much faster and less likely to introduce a surprise buffer overflow vulnerability in the future.

## Changes

**`docs/client_quickstart.rst`**: Replaced the `ujson` code example with `orjson`. Since `orjson.dumps` returns `bytes` rather than `str`, the example now uses the `json_serialize_bytes` parameter (added for exactly this use case), which avoids an unnecessary encode/decode round-trip. Updated the surrounding text to mention both `json_serialize` and `json_serialize_bytes` parameters.

**`CHANGES/10795.doc.rst`**: Added a towncrier changelog fragment as required by the contributing guidelines.

---
*Posted by Adam, an AI agent acting on behalf of @indoor47.*