### PR TITLE
[3.14] Fix test_invalid_idna for idna 3.11 compatibility (#12036)

### DIFF
--- a/CHANGES/12027.misc.rst
+++ b/CHANGES/12027.misc.rst
@@ -1,0 +1,1 @@
+Fixed ``test_invalid_idna`` to work with ``idna`` 3.11 by using an invalid character (``\u0080``) that is rejected by ``yarl`` during URL construction -- by :user:`rodrigobnogueira`.

--- a/requirements/base-ft.txt
+++ b/requirements/base-ft.txt
@@ -26,7 +26,7 @@ frozenlist==1.8.0
     #   aiosignal
 gunicorn==25.1.0
     # via -r requirements/base-ft.in
-idna==3.10
+idna==3.11
     # via yarl
 multidict==6.7.0
     # via

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -26,7 +26,7 @@ frozenlist==1.8.0
     #   aiosignal
 gunicorn==25.1.0
     # via -r requirements/base.in
-idna==3.10
+idna==3.11
     # via yarl
 multidict==6.7.0
     # via

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -89,7 +89,7 @@ gunicorn==25.1.0
     # via -r requirements/base.in
 identify==2.6.16
     # via pre-commit
-idna==3.10
+idna==3.11
     # via
     #   requests
     #   trustme

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -87,7 +87,7 @@ gunicorn==25.1.0
     # via -r requirements/base.in
 identify==2.6.16
     # via pre-commit
-idna==3.10
+idna==3.11
     # via
     #   requests
     #   trustme

--- a/requirements/doc-spelling.txt
+++ b/requirements/doc-spelling.txt
@@ -18,7 +18,7 @@ click==8.3.1
     # via towncrier
 docutils==0.21.2
     # via sphinx
-idna==3.10
+idna==3.11
     # via requests
 imagesize==1.4.1
     # via sphinx

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -18,7 +18,7 @@ click==8.3.1
     # via towncrier
 docutils==0.21.2
     # via sphinx
-idna==3.10
+idna==3.11
     # via requests
 imagesize==1.4.1
     # via sphinx

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -39,7 +39,7 @@ freezegun==1.5.5
     # via -r requirements/lint.in
 identify==2.6.16
     # via pre-commit
-idna==3.10
+idna==3.11
     # via trustme
 iniconfig==2.3.0
     # via pytest

--- a/requirements/runtime-deps.txt
+++ b/requirements/runtime-deps.txt
@@ -24,7 +24,7 @@ frozenlist==1.8.0
     # via
     #   -r requirements/runtime-deps.in
     #   aiosignal
-idna==3.10
+idna==3.11
     # via yarl
 multidict==6.7.0
     # via

--- a/requirements/test-common.txt
+++ b/requirements/test-common.txt
@@ -28,7 +28,7 @@ forbiddenfruit==0.1.4
     # via blockbuster
 freezegun==1.5.5
     # via -r requirements/test-common.in
-idna==3.10
+idna==3.11
     # via trustme
 iniconfig==2.3.0
     # via pytest

--- a/requirements/test-ft.txt
+++ b/requirements/test-ft.txt
@@ -49,7 +49,7 @@ frozenlist==1.8.0
     #   aiosignal
 gunicorn==25.1.0
     # via -r requirements/base-ft.in
-idna==3.10
+idna==3.11
     # via
     #   trustme
     #   yarl

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -49,7 +49,7 @@ frozenlist==1.8.0
     #   aiosignal
 gunicorn==25.1.0
     # via -r requirements/base.in
-idna==3.10
+idna==3.11
     # via
     #   trustme
     #   yarl

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -3332,7 +3332,7 @@ async def test_invalid_idna() -> None:
     session = aiohttp.ClientSession()
     try:
         with pytest.raises(aiohttp.InvalidURL):
-            await session.get("http://\u2061owhefopw.com")
+            await session.get("http://\u0080owhefopw.com")
     finally:
         await session.close()
 


### PR DESCRIPTION
Backport of #12036 to `3.14`.