### PR TITLE
[3.13] Fix test_invalid_idna for idna 3.11 compatibility (#12036)

### DIFF
--- a/CHANGES/12027.misc.rst
+++ b/CHANGES/12027.misc.rst
@@ -1,0 +1,1 @@
+Fixed ``test_invalid_idna`` to work with ``idna`` 3.11 by using an invalid character (``\u0080``) that is rejected by ``yarl`` during URL construction -- by :user:`rodrigobnogueira`.

--- a/requirements/base-ft.txt
+++ b/requirements/base-ft.txt
@@ -24,7 +24,7 @@ frozenlist==1.8.0
     #   aiosignal
 gunicorn==23.0.0
     # via -r requirements/base-ft.in
-idna==3.10
+idna==3.11
     # via yarl
 multidict==6.6.4
     # via

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -24,7 +24,7 @@ frozenlist==1.8.0
     #   aiosignal
 gunicorn==23.0.0
     # via -r requirements/base.in
-idna==3.4
+idna==3.11
     # via yarl
 multidict==6.6.4
     # via

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -90,7 +90,7 @@ gunicorn==23.0.0
     # via -r requirements/base.in
 identify==2.6.15
     # via pre-commit
-idna==3.3
+idna==3.11
     # via
     #   requests
     #   trustme

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -88,7 +88,7 @@ gunicorn==23.0.0
     # via -r requirements/base.in
 identify==2.6.15
     # via pre-commit
-idna==3.4
+idna==3.11
     # via
     #   requests
     #   trustme

--- a/requirements/doc-spelling.txt
+++ b/requirements/doc-spelling.txt
@@ -18,7 +18,7 @@ click==8.1.8
     # via towncrier
 docutils==0.21.2
     # via sphinx
-idna==3.4
+idna==3.11
     # via requests
 imagesize==1.4.1
     # via sphinx

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -18,7 +18,7 @@ click==8.1.8
     # via towncrier
 docutils==0.21.2
     # via sphinx
-idna==3.10
+idna==3.11
     # via requests
 imagesize==1.4.1
     # via sphinx

--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -35,7 +35,7 @@ freezegun==1.5.5
     # via -r requirements/lint.in
 identify==2.6.15
     # via pre-commit
-idna==3.7
+idna==3.11
     # via trustme
 iniconfig==2.1.0
     # via pytest

--- a/requirements/runtime-deps.txt
+++ b/requirements/runtime-deps.txt
@@ -22,7 +22,7 @@ frozenlist==1.8.0
     # via
     #   -r requirements/runtime-deps.in
     #   aiosignal
-idna==3.10
+idna==3.11
     # via yarl
 multidict==6.6.4
     # via

--- a/requirements/test-common.txt
+++ b/requirements/test-common.txt
@@ -28,7 +28,7 @@ forbiddenfruit==0.1.4
     # via blockbuster
 freezegun==1.5.5
     # via -r requirements/test-common.in
-idna==3.10
+idna==3.11
     # via trustme
 iniconfig==2.1.0
     # via pytest

--- a/requirements/test-ft.txt
+++ b/requirements/test-ft.txt
@@ -47,7 +47,7 @@ frozenlist==1.8.0
     #   aiosignal
 gunicorn==23.0.0
     # via -r requirements/base-ft.in
-idna==3.10
+idna==3.11
     # via
     #   trustme
     #   yarl

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -47,7 +47,7 @@ frozenlist==1.8.0
     #   aiosignal
 gunicorn==23.0.0
     # via -r requirements/base.in
-idna==3.4
+idna==3.11
     # via
     #   trustme
     #   yarl

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -3319,7 +3319,7 @@ async def test_invalid_idna() -> None:
     session = aiohttp.ClientSession()
     try:
         with pytest.raises(aiohttp.InvalidURL):
-            await session.get("http://\u2061owhefopw.com")
+            await session.get("http://\u0080owhefopw.com")
     finally:
         await session.close()
 


### PR DESCRIPTION
Backport of #12036 to `3.13`.