### PR TITLE
perf: use deque for FormData.add_fields() queue

### DIFF
--- a/aiohttp/formdata.py
+++ b/aiohttp/formdata.py
@@ -1,4 +1,5 @@
 import io
+from collections import deque
 from collections.abc import Iterable
 from typing import Any
 from urllib.parse import urlencode
@@ -81,10 +82,10 @@ class FormData:
         self._fields.append((type_options, headers, value))
 
     def add_fields(self, *fields: Any) -> None:
-        to_add = list(fields)
+        to_add: deque[Any] = deque(fields)
 
         while to_add:
-            rec = to_add.pop(0)
+            rec = to_add.popleft()
 
             if isinstance(rec, io.IOBase):
                 k = guess_filename(rec, "unknown")


### PR DESCRIPTION
## Summary

Replace `list.pop(0)` with `collections.deque.popleft()` in `FormData.add_fields()`.

## Problem

`add_fields()` uses a work-list that drains from the front via `.pop(0)` and may grow via `.extend()` when `MultiDict` entries are encountered (BFS pattern). Each `list.pop(0)` is **O(n)** because CPython must shift all remaining elements.

## Solution

Switch from `list` to `collections.deque` and use `.popleft()` for **O(1)** front removal.

## Compatibility

- `.extend()`, truthiness, and iteration are identical on `deque`
- No API surface changes; purely internal optimisation
- Zero behaviour change

## Complexity

| Operation | Before | After |
|-----------|--------|-------|
| pop front | O(n) | O(1) |