### PR TITLE
ci: skip backport label job by default

### DIFF
--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -9,16 +9,19 @@ jobs:
   backport:
     runs-on: ubuntu-latest
     name: Backport label added
-    if: ${{ github.event.pull_request.user.type != 'Bot' }}
+    if: >-
+      ${{
+        github.event.pull_request.user.type != 'Bot' &&
+        contains(join(github.event.pull_request.labels.*.name, ','), 'backport-')
+      }}
     steps:
       - uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const pr = await github.rest.pulls.get({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              pull_number: context.payload.pull_request.number
-            });
-            if (!pr.data.labels.find(l => l.name.startsWith("backport")))
-              process.exit(1);
+            const hasBackportLabel = context.payload.pull_request.labels.some(
+              label => label.name.startsWith("backport"),
+            );
+            if (!hasBackportLabel) {
+              core.notice("No backport label present, skipping.");
+            }

--- a/CHANGES/12169.contrib.rst
+++ b/CHANGES/12169.contrib.rst
@@ -1,0 +1,1 @@
+Adjusted the GitHub Actions backport-label check so ordinary pull requests without ``backport-*`` labels are skipped instead of reported as failed -- by :user:`1ort`.


### PR DESCRIPTION
## Summary
- make the backport label job skip on normal PRs instead of failing
- gate the job on PRs that already carry a backport label
- keep the workflow green unless a real backport check should run

## Related
- Ref: #12168

## Testing
- not run locally (GitHub Actions workflow change)
- draft PR opened to validate the job is skipped on a normal PR and runs when a backport label is added