### PR TITLE
Fix test_data_file race condition on Python 3.14 free-threaded

### DIFF
--- a/CHANGES/12170.misc.rst
+++ b/CHANGES/12170.misc.rst
@@ -1,0 +1,1 @@
+Fixed race condition in ``test_data_file`` on Python 3.14 free-threaded builds -- by :user:`rodrigobnogueira`.

--- a/CHANGES/test_data_file_314t_fix.misc
+++ b/CHANGES/test_data_file_314t_fix.misc
@@ -1,0 +1,1 @@
+Fix race condition in `test_data_file` on Python 3.14 free-threaded.

--- a/CHANGES/test_data_file_314t_fix.misc
+++ b/CHANGES/test_data_file_314t_fix.misc
@@ -1,1 +1,0 @@
-Fix race condition in `test_data_file` on Python 3.14 free-threaded.

--- a/tests/test_client_request.py
+++ b/tests/test_client_request.py
@@ -1363,7 +1363,7 @@ async def test_data_file(
 
         with mock.patch.object(req, "_write_bytes", _mock_write_bytes):
             resp = await req._send(conn)
-        
+
         assert asyncio.isfuture(req._writer)
         await resp.wait_for_close()
 

--- a/tests/test_client_request.py
+++ b/tests/test_client_request.py
@@ -1352,7 +1352,18 @@ async def test_data_file(
         assert isinstance(req.body, payload.BufferedReaderPayload)
         assert req.headers["TRANSFER-ENCODING"] == "chunked"
 
-        resp = await req._send(conn)
+        original_write_bytes = req._write_bytes
+
+        async def _mock_write_bytes(
+            writer: AbstractStreamWriter, conn: mock.Mock, content_length: int | None
+        ) -> None:
+            # Ensure the task is scheduled so _writer isn't None
+            await asyncio.sleep(0)
+            await original_write_bytes(writer, conn, content_length)
+
+        with mock.patch.object(req, "_write_bytes", _mock_write_bytes):
+            resp = await req._send(conn)
+        
         assert asyncio.isfuture(req._writer)
         await resp.wait_for_close()
 


### PR DESCRIPTION
## What do these changes do?

This PR fixes a flaky test (`test_data_file`) that fails on Python 3.14 free-threaded (`3.14t`) builds.

The test asserts `asyncio.isfuture(req._writer)` immediately after `await req._send(conn)`. However, on Python 3.12+, `asyncio.Task` accepts `eager_start=True`. Because the 2-byte file payload in this test is exceptionally small, the eagerly-started task completes *synchronously* during `_send()`.

When `task.done()` handles this, `req._writer` is left as `None`, causing the assertion to fail (e.g. `assert False + where False = asyncio.isfuture(None)`).

This PR applies the exact same mock strategy used by the sibling test `test_data_stream`. We mock the `_write_bytes` method to execute `await asyncio.sleep(0)`, guaranteeing the task yields back to the event loop. This ensures `req._writer` holds a pending Future when the assertion fires.

The fixed test has failed in PRs #12089 and #12153, for example.

## Are there changes in behavior for the user?

No user-facing changes. This strictly addresses test flakiness in the CI environment.

## Is it a substantial burden for the maintainers to support this?

No. This follows the exact same pattern already used in the same test file.

## Related issue number

N/A.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
- [x] Add a new news fragment into the `CHANGES/` folder