### PR TITLE
[3.13 backport] Fix test_data_file race condition on Python 3.14 free-threaded

### DIFF
--- a/CHANGES/12170.misc.rst
+++ b/CHANGES/12170.misc.rst
@@ -1,0 +1,1 @@
+Fixed race condition in ``test_data_file`` on Python 3.14 free-threaded builds -- by :user:`rodrigobnogueira`.

--- a/tests/test_client_request.py
+++ b/tests/test_client_request.py
@@ -1173,7 +1173,18 @@ async def test_data_file(loop, buf, conn) -> None:
         assert isinstance(req.body, payload.BufferedReaderPayload)
         assert req.headers["TRANSFER-ENCODING"] == "chunked"
 
-        resp = await req.send(conn)
+        original_write_bytes = req.write_bytes
+
+        async def _mock_write_bytes(
+            writer: AbstractStreamWriter, conn: mock.Mock, content_length: Optional[int]
+        ) -> None:
+            # Ensure the task is scheduled so _writer isn't None
+            await asyncio.sleep(0)
+            await original_write_bytes(writer, conn, content_length)
+
+        with mock.patch.object(req, "write_bytes", _mock_write_bytes):
+            resp = await req.send(conn)
+
         assert asyncio.isfuture(req._writer)
         await resp.wait_for_close()
 


### PR DESCRIPTION
<!-- Backport of #12170 to the 3.13 branch -->

## What do these changes do?

Backport of #12170 to the `3.13` release branch.

This fixes a flaky test (`test_data_file`) that fails on Python 3.14 free-threaded (`3.14t`) builds.

The test asserts `asyncio.isfuture(req._writer)` immediately after `await req.send(conn)`. On Python 3.12+, `asyncio.Task` accepts `eager_start=True`. Because the 2-byte file payload in the test is tiny, the task may complete synchronously during `send()`, leaving `req._writer` as `None`.

We mock `write_bytes` to execute `await asyncio.sleep(0)`, guaranteeing the task yields before the assertion.

## Are there changes in behavior for the user?

No user-facing changes. This strictly fixes test flakiness.

## Is it a substantial burden for the maintainers to support this?

No. This follows the exact same pattern already used in `test_data_stream`.

## Related issue number

Backport of #12170

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] Add a new news fragment into the `CHANGES/` folder