### PR TITLE
[3.14 backport] Fix test_data_file race condition on Python 3.14 free-threaded

### DIFF
--- a/CHANGES/12170.misc.rst
+++ b/CHANGES/12170.misc.rst
@@ -1,0 +1,1 @@
+Fixed race condition in ``test_data_file`` on Python 3.14 free-threaded builds -- by :user:`rodrigobnogueira`.


### PR DESCRIPTION
<!-- Backport of #12170 to the 3.14 branch -->

## What do these changes do?

Backport of #12170 to the `3.14` release branch.

This fixes a flaky test (`test_data_file`) that fails on Python 3.14 free-threaded (`3.14t`) builds.

The test asserts `asyncio.isfuture(req._writer)` immediately after `await req.send(conn)`. On Python 3.12+, `asyncio.Task` accepts `eager_start=True`. Because the 2-byte file payload in the test is tiny, the task may complete synchronously during `send()`, leaving `req._writer` as `None`.

We mock `write_bytes` to execute `await asyncio.sleep(0)`, guaranteeing the task yields before the assertion.

## Are there changes in behavior for the user?

No user-facing changes. This strictly fixes test flakiness.

## Is it a substantial burden for the maintainers to support this?

No. This follows the exact same pattern already used in `test_data_stream`.

## Related issue number

Backport of #12170

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] Add a new news fragment into the `CHANGES/` folder