### PR TITLE
Drop version from autobahn config

### DIFF
--- a/tests/autobahn/server/fuzzingclient.json
+++ b/tests/autobahn/server/fuzzingclient.json
@@ -10,4 +10,3 @@
     "exclude-cases": [],
     "exclude-agent-cases": {}
 }
-

--- a/tests/autobahn/server/fuzzingclient.json
+++ b/tests/autobahn/server/fuzzingclient.json
@@ -3,14 +3,11 @@
     "outdir": "./reports/servers",
 
     "servers": [
-        {
-            "agent": "AutobahnServer",
-            "url": "ws://localhost:9001",
-            "options": {"version": 18}
-        }
+        {"agent": "AutobahnServer", "url": "ws://localhost:9001"}
     ],
 
     "cases": ["*"],
     "exclude-cases": [],
     "exclude-agent-cases": {}
 }
+


### PR DESCRIPTION
This is apparently not needed and will ensure we're not testing against on outdated protocol version.