### PR TITLE
docs: clarify params query canonicalization behavior

### DIFF
--- a/docs/client_quickstart.rst
+++ b/docs/client_quickstart.rst
@@ -122,8 +122,9 @@ that case you can specify multiple values for each key::
         expect = 'http://httpbin.org/get?key=value2&key=value1'
         assert str(r.url) == expect
 
-You can also pass :class:`str` content as param, but beware -- content
-is not encoded by library. Note that ``+`` is not encoded::
+You can also pass :class:`str` content as param. The value is used as a
+query string, but passing ``params`` does not disable URL
+canonicalization. Note that ``+`` is not encoded::
 
     async with session.get('http://httpbin.org/get',
                            params='key=value+1') as r:
@@ -149,7 +150,9 @@ is not encoded by library. Note that ``+`` is not encoded::
 
 .. warning::
 
-   Passing *params* overrides ``encoded=True``, never use both options.
+   Passing *params* overrides ``encoded=True``. Never use both options
+   if you need to preserve exact query-string bytes.
+   Build the full URL (including query) instead.
 
 Response Content and Status Code
 ================================


### PR DESCRIPTION
## What do these changes do?
This updates the client quickstart docs around `params` with string values.

The previous wording suggested that string params are "not encoded by library". The updated text clarifies that using `params` does **not** disable URL canonicalization/requoting, and keeps the existing `+` example.

I also expanded the warning for `encoded=True` to make it explicit that `params` overrides it, and that preserving exact query-string bytes requires building the full URL (including query) without `params`.

## Are there changes in behavior for the user?
No runtime behavior changes. This is a documentation-only clarification.

## Is it a substantial burden for the maintainers to support this?
No. This is a small wording change in one doc section.

## Related issue number
Fixes #3689

## Checklist
- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
- [ ] Add a new news fragment into the `CHANGES/` folder