### PR TITLE
fix: handle missing event loop in GunicornWebWorker.init_process on Python 3.14+

### DIFF
--- a/CHANGES/11701.bugfix.rst
+++ b/CHANGES/11701.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed :class:`~aiohttp.GunicornWebWorker` crashing on init with Python 3.14+ due to :func:`asyncio.get_event_loop` raising :exc:`RuntimeError` when no event loop exists -- by :user:`tysoncung`.

--- a/aiohttp/worker.py
+++ b/aiohttp/worker.py
@@ -49,7 +49,12 @@ class GunicornWebWorker(base.Worker):  # type: ignore[misc,no-any-unimported]
 
     def init_process(self) -> None:
         # create new event_loop after fork
-        asyncio.get_event_loop().close()
+        try:
+            loop = asyncio.get_event_loop()
+            if not loop.is_closed():
+                loop.close()
+        except RuntimeError:
+            pass  # No running event loop (Python 3.14+)
 
         self.loop = asyncio.new_event_loop()
         asyncio.set_event_loop(self.loop)

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -65,12 +65,31 @@ def worker(
 
 def test_init_process(worker: base_worker.GunicornWebWorker) -> None:
     with mock.patch("aiohttp.worker.asyncio") as m_asyncio:
+        m_asyncio.get_event_loop.return_value.is_closed.return_value = False
         try:
             worker.init_process()
         except TypeError:
             pass
 
         assert m_asyncio.get_event_loop.return_value.close.called
+        assert m_asyncio.new_event_loop.called
+        assert m_asyncio.set_event_loop.called
+
+
+def test_init_process_no_event_loop(
+    worker: base_worker.GunicornWebWorker,
+) -> None:
+    """Test that init_process handles missing event loop (Python 3.14+)."""
+    with mock.patch("aiohttp.worker.asyncio") as m_asyncio:
+        m_asyncio.get_event_loop.side_effect = RuntimeError(
+            "There is no current event loop in thread 'MainThread'."
+        )
+        try:
+            worker.init_process()
+        except TypeError:
+            pass
+
+        assert m_asyncio.get_event_loop.called
         assert m_asyncio.new_event_loop.called
         assert m_asyncio.set_event_loop.called
 


### PR DESCRIPTION
## Summary

Fixes #11701

On Python 3.14, `asyncio.get_event_loop()` raises `RuntimeError` when no current event loop exists in the thread (instead of implicitly creating one, as in Python ≤3.13). This causes `GunicornWebWorker.init_process()` to crash immediately on startup:

```
RuntimeError: There is no current event loop in thread 'MainThread'.
```

## Fix

Wrap the existing `asyncio.get_event_loop().close()` call in a try/except block that:

1. Catches `RuntimeError` (no event loop exists — Python 3.14+ behavior)
2. Also checks `is_closed()` before calling `close()` for extra safety

This matches the approach already used on the main branch, where this code was removed entirely in PR #3580.

## Changes

- **`aiohttp/worker.py`**: Wrapped `get_event_loop().close()` in try/except RuntimeError
- **`tests/test_worker.py`**: Updated existing test to explicitly set `is_closed=False`, added new `test_init_process_no_event_loop` test covering the Python 3.14+ code path
- **`CHANGES/11701.bugfix.rst`**: Changelog entry

## Testing

- Existing `test_init_process` updated to work with new code (explicitly sets `is_closed=False`)
- New `test_init_process_no_event_loop` test: simulates Python 3.14+ by making `get_event_loop` raise `RuntimeError`, verifies `new_event_loop` and `set_event_loop` are still called