### PR TITLE
[PR #12231/7043bc56 backport][3.13] Adjust header value character checks to RFC 9110

### DIFF
--- a/CHANGES/12231.bugfix.rst
+++ b/CHANGES/12231.bugfix.rst
@@ -1,0 +1,2 @@
+Adjusted pure-Python request header value validation to align with RFC 9110 control-character handling, while preserving lax response parser behavior, and added regression tests for Host/header control-character cases.
+-- by :user:`rodrigobnogueira`.

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -81,6 +81,10 @@ ASCIISET: Final[Set[str]] = set(string.printable)
 #     token = 1*tchar
 _TCHAR_SPECIALS: Final[str] = re.escape("!#$%&'*+-.^_`|~")
 TOKENRE: Final[Pattern[str]] = re.compile(f"[0-9A-Za-z{_TCHAR_SPECIALS}]+")
+# https://www.rfc-editor.org/rfc/rfc9110#section-5.5-5
+_FIELD_VALUE_FORBIDDEN_CTL_RE: Final[Pattern[str]] = re.compile(
+    r"[\x00-\x08\x0a-\x1f\x7f]"
+)
 VERSRE: Final[Pattern[str]] = re.compile(r"HTTP/(\d)\.(\d)", re.ASCII)
 DIGITS: Final[Pattern[str]] = re.compile(r"\d+", re.ASCII)
 HEXDIGITS: Final[Pattern[bytes]] = re.compile(rb"[0-9a-fA-F]+")
@@ -208,7 +212,10 @@ class HeadersParser:
             value = bvalue.decode("utf-8", "surrogateescape")
 
             # https://www.rfc-editor.org/rfc/rfc9110.html#section-5.5-5
-            if "\n" in value or "\r" in value or "\x00" in value:
+            if self._lax:
+                if "\n" in value or "\r" in value or "\x00" in value:
+                    raise InvalidHeader(bvalue)
+            elif _FIELD_VALUE_FORBIDDEN_CTL_RE.search(value):
                 raise InvalidHeader(bvalue)
 
             headers.add(name, value)

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -221,10 +221,20 @@ def test_bad_header_name(parser: Any, rfc9110_5_6_2_token_delim: str) -> None:
         "Foo : bar",  # https://www.rfc-editor.org/rfc/rfc9112.html#section-5.1-2
         "Foo\t: bar",
         "\xffoo: bar",
+        "Foo: abc\x01def",  # CTL bytes forbidden per RFC 9110 §5.5
+        "Foo: abc\x7fdef",  # DEL is also a CTL byte
+        "Foo: abc\x1fdef",
     ),
 )
 def test_bad_headers(parser: Any, hdr: str) -> None:
     text = f"POST / HTTP/1.1\r\n{hdr}\r\n\r\n".encode()
+    with pytest.raises(http_exceptions.BadHttpMessage):
+        parser.feed_data(text)
+
+
+def test_ctl_host_header_bad_characters(parser: HttpRequestParser) -> None:
+    """CTL byte in Host header must be rejected."""
+    text = b"GET /test HTTP/1.1\r\nHost: trusted.example\x01@bad.test\r\n\r\n"
     with pytest.raises(http_exceptions.BadHttpMessage):
         parser.feed_data(text)
 


### PR DESCRIPTION
## What do these changes do?

Backport of #12231 to the 3.13 branch.

Adjusts the pure-Python header parser to align request header-value character handling with RFC 9110 §5.5 by rejecting control characters (except HTAB) on the strict request path. Response parsing in lax mode retains the previous, looser check.

Adds regression coverage for control characters in header values, including a Host header case.

## Are there changes in behavior for the user?

Yes. Malformed request headers containing forbidden control characters in header values are now rejected by the pure-Python request parser path. Response parsing behavior remains unchanged in lax mode.

## Is it a substantial burden for the maintainers to support this?

No. The change is localized to existing parser validation logic with targeted test coverage. It does not add new APIs or maintenance-heavy abstractions.

## Related issue number

Backport of #12231.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
- [x] Add a new news fragment into the `CHANGES/` folder
