### PR TITLE
Skip TLS-in-TLS warning when proxy is not HTTPS

### DIFF
--- a/CHANGES/10683.bugfix.rst
+++ b/CHANGES/10683.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed misleading TLS-in-TLS warning being emitted when sending HTTPS requests through an HTTP proxy. The warning now only fires when the proxy itself uses HTTPS, which is the only case where TLS-in-TLS actually applies -- by :user:`wavebyrd`.

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -1275,6 +1275,12 @@ class TCPConnector(BaseConnector):
         if req.url.scheme != "https":
             return
 
+        # TLS-in-TLS only applies when the proxy itself is HTTPS.
+        # When the proxy is HTTP, start_tls upgrades a plain TCP connection,
+        # which is standard TLS and works on all event loops and Python versions.
+        if req.proxy is None or req.proxy.scheme != "https":
+            return
+
         # Check if uvloop is being used, which supports TLS in TLS,
         # otherwise assume that asyncio's native transport is being used.
         if type(underlying_transport).__module__.startswith("uvloop"):


### PR DESCRIPTION
## Summary

- The `_warn_about_tls_in_tls` warning was firing for all HTTPS requests through any proxy, but TLS-in-TLS only applies when the proxy itself uses HTTPS.
- When the proxy is HTTP, `start_tls` upgrades a plain TCP connection, which is not TLS-in-TLS and works fine everywhere.
- Added a check for `req.proxy.scheme` so the warning is only emitted when the proxy is actually HTTPS.

Fixes #10683

## Test plan

- Existing `test_https_proxy_unsupported_tls_in_tls` covers the HTTPS-proxy case and should still pass (warning still fires for HTTPS proxies on old Python).
- HTTPS requests through an HTTP proxy no longer produce the misleading warning.