### PR TITLE
Fix AttributeError when accessing Response.text with Payload body

### DIFF
--- a/CHANGES/2928.bugfix.rst
+++ b/CHANGES/2928.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed ``AttributeError`` when accessing ``Response.text`` after setting ``body`` to a value that becomes a ``Payload`` without a ``decode`` method. Now raises a clear ``TypeError`` with guidance on using the ``text`` setter instead.

--- a/CHANGES/2928.bugfix.rst
+++ b/CHANGES/2928.bugfix.rst
@@ -1,1 +1,1 @@
-Fixed ``AttributeError`` when accessing ``Response.text`` after setting ``body`` to a value that becomes a ``Payload`` without a ``decode`` method. Now raises a clear ``TypeError`` with guidance on using the ``text`` setter instead.
+Changed ``AttributeError`` to ``TypeError`` when accessing ``Response.text`` after setting ``body`` to a value that becomes a ``Payload`` without a ``decode`` method.

--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -636,10 +636,15 @@ class Response(StreamResponse):
     def text(self) -> str | None:
         if self._body is None:
             return None
-        # Note: When _body is a Payload (e.g. FilePayload), this may do blocking I/O
-        # This is generally safe as most common payloads (BytesPayload, StringPayload)
-        # don't do blocking I/O, but be careful with file-based payloads
-        return self._body.decode(self.charset or "utf-8")
+        if isinstance(self._body, (bytes, bytearray)):
+            return self._body.decode(self.charset or "utf-8")
+        # For Payload objects, check if decode method exists (BytesPayload and subclasses)
+        if hasattr(self._body, "decode"):
+            return self._body.decode(self.charset or "utf-8")
+        raise TypeError(
+            f"Unable to get text from body type {type(self._body).__name__}. "
+            f"Use the text setter or pass text= to Response() for string content."
+        )
 
     @text.setter
     def text(self, text: str) -> None:

--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -636,15 +636,13 @@ class Response(StreamResponse):
     def text(self) -> str | None:
         if self._body is None:
             return None
-        if isinstance(self._body, (bytes, bytearray)):
+        try:
             return self._body.decode(self.charset or "utf-8")
-        # For Payload objects, check if decode method exists (BytesPayload and subclasses)
-        if hasattr(self._body, "decode"):
-            return self._body.decode(self.charset or "utf-8")
-        raise TypeError(
-            f"Unable to get text from body type {type(self._body).__name__}. "
-            f"Use the text setter or pass text= to Response() for string content."
-        )
+        except AttributeError:
+            raise TypeError(
+                f"Unable to get text from body type {type(self._body).__name__}. "
+                f"Use the text setter or pass text= to Response() for string content."
+            )
 
     @text.setter
     def text(self, text: str) -> None:


### PR DESCRIPTION
## Summary

When `Response.body` is set to a value that gets converted to a `Payload` without a `decode` method (e.g., `AsyncIterablePayload`, `BodyPartReader`), accessing `Response.text` would raise an unhelpful `AttributeError`:

```python
>>> from aiohttp.web_response import Response
>>> r = Response()
>>> r.body = some_async_iterator
>>> r.text
AttributeError: 'AsyncIterablePayload' object has no attribute 'decode'
```

## Changes

- Modified `Response.text` property to check for `bytes`/`bytearray` first
- For `Payload` objects, checks if `decode` method exists before calling it
- Raises a clear `TypeError` with guidance when the body type doesn't support text access

## Test Plan

- Existing tests in `test_payload_body_get_text` already cover this case
- The test expects `TypeError` for payloads like `async_iter()` and `BodyPartReader`

Fixes #2928