### PR TITLE
Reject duplicate singleton headers in C extension parser

### DIFF
--- a/CHANGES/12240.bugfix.rst
+++ b/CHANGES/12240.bugfix.rst
@@ -1,0 +1,5 @@
+Rejected duplicate singleton headers (``Host``, ``Content-Type``,
+``Content-Length``, etc.) in the C extension HTTP parser to match
+the pure Python parser behavior, preventing potential host-based
+access control bypasses via parser differentials
+-- by :user:`rodrigobnogueira`.

--- a/aiohttp/_http_parser.pyx
+++ b/aiohttp/_http_parser.pyx
@@ -71,6 +71,20 @@ cdef object StreamReader = _StreamReader
 cdef object DeflateBuffer = _DeflateBuffer
 cdef bytes EMPTY_BYTES = b""
 
+# https://www.rfc-editor.org/rfc/rfc9110.html#section-5.5-6
+cdef tuple SINGLETON_HEADERS = (
+    hdrs.CONTENT_LENGTH,
+    hdrs.CONTENT_LOCATION,
+    hdrs.CONTENT_RANGE,
+    hdrs.CONTENT_TYPE,
+    hdrs.ETAG,
+    hdrs.HOST,
+    hdrs.MAX_FORWARDS,
+    hdrs.SERVER,
+    hdrs.TRANSFER_ENCODING,
+    hdrs.USER_AGENT,
+)
+
 cdef inline object extend(object buf, const char* at, size_t length):
     cdef Py_ssize_t s
     cdef char* ptr
@@ -429,6 +443,14 @@ cdef class HttpParser:
 
         raw_headers = tuple(self._raw_headers)
         headers = CIMultiDictProxy(CIMultiDict(self._headers))
+
+        # https://www.rfc-editor.org/rfc/rfc9110.html#name-collected-abnf
+        bad_hdr = next(
+            (h for h in SINGLETON_HEADERS if len(headers.getall(h, ())) > 1),
+            None,
+        )
+        if bad_hdr is not None:
+            raise BadHttpMessage(f"Duplicate '{bad_hdr}' header found.")
 
         if self._cparser.type == cparser.HTTP_REQUEST:
             h_upg = headers.get("upgrade", "")

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -281,6 +281,47 @@ def test_content_length_transfer_encoding(parser: HttpRequestParser) -> None:
         parser.feed_data(text)
 
 
+@pytest.mark.parametrize(
+    "hdr",
+    (
+        "Content-Length",
+        "Content-Location",
+        "Content-Range",
+        "Content-Type",
+        "ETag",
+        "Host",
+        "Max-Forwards",
+        "Server",
+        "Transfer-Encoding",
+        "User-Agent",
+    ),
+)
+def test_duplicate_singleton_header_rejected(
+    parser: HttpRequestParser, hdr: str
+) -> None:
+    val1, val2 = ("1", "2") if hdr == "Content-Length" else ("value1", "value2")
+    text = (
+        f"GET /test HTTP/1.1\r\n"
+        f"Host: example.com\r\n"
+        f"{hdr}: {val1}\r\n"
+        f"{hdr}: {val2}\r\n"
+        f"\r\n"
+    ).encode()
+    with pytest.raises(http_exceptions.BadHttpMessage, match="Duplicate"):
+        parser.feed_data(text)
+
+
+def test_duplicate_host_header_rejected(parser: HttpRequestParser) -> None:
+    text = (
+        b"GET /admin HTTP/1.1\r\n"
+        b"Host: admin.example\r\n"
+        b"Host: public.example\r\n"
+        b"\r\n"
+    )
+    with pytest.raises(http_exceptions.BadHttpMessage, match="Duplicate.*Host"):
+        parser.feed_data(text)
+
+
 def test_bad_chunked(parser: HttpRequestParser) -> None:
     """Test that invalid chunked encoding doesn't allow content-length to be used."""
     text = (


### PR DESCRIPTION
## What do these changes do?

Add duplicate singleton header validation to the C extension HTTP parser (`_http_parser.pyx`) to match the existing pure Python parser behavior.

The C extension parser now rejects requests containing duplicate RFC 9110 singleton headers (`Host`, `Content-Type`, `Content-Length`, `Content-Location`, `Content-Range`, `ETag`, `Max-Forwards`, `Server`, `Transfer-Encoding`, `User-Agent`) with a `BadHttpMessage` error, just as the pure Python parser already does.

## Are there changes in behavior for the user?

Yes. HTTP requests with duplicate singleton headers that were previously accepted (and silently used the first value) are now rejected with a `400 Bad Request`. This is the **correct behavior** per RFC 9110 §5.5 and matches what the pure Python parser already enforces.

## Is it a substantial burden for the maintainers to support this?

No. The change mirrors existing logic from the pure Python parser (`http_parser.py:500-514`) into the C extension parser. It is a small, focused security fix with no new dependencies or architectural changes.

## Related issue number

Align C and python implementations

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
- [x] Add a new news fragment into the `CHANGES/` folder
