### PR TITLE
Tokenize Connection header values in Python HTTP parser

### DIFF
--- a/CHANGES/12249.bugfix.rst
+++ b/CHANGES/12249.bugfix.rst
@@ -1,0 +1,3 @@
+Aligned the pure-Python HTTP request parser with the C parser by tokenizing
+comma-separated and repeated ``Connection`` header values for keep-alive,
+close, and upgrade handling -- by :user:`rodrigobnogueira`.

--- a/CHANGES/12249.bugfix.rst
+++ b/CHANGES/12249.bugfix.rst
@@ -1,3 +1,3 @@
-Aligned the pure-Python HTTP request parser with the C parser by tokenizing
+Aligned the pure-Python HTTP request parser with the C parser by splitting
 comma-separated and repeated ``Connection`` header values for keep-alive,
 close, and upgrade handling -- by :user:`rodrigobnogueira`.

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -520,16 +520,24 @@ class HttpParser(abc.ABC, Generic[_MsgT]):
         if bad_hdr is not None:
             raise BadHttpMessage(f"Duplicate '{bad_hdr}' header found.")
 
-        # keep-alive
-        conn = headers.get(hdrs.CONNECTION)
-        if conn:
-            v = conn.lower()
-            if v == "close":
+        # keep-alive and protocol switching
+        # RFC 9110 section 7.6.1 defines Connection as a comma-separated list.
+        conn_values = headers.getall(hdrs.CONNECTION, ())
+        if conn_values:
+            conn_tokens = {
+                token.lower()
+                for conn_value in conn_values
+                for token in (part.strip(" \t") for part in conn_value.split(","))
+                if token and token.isascii()
+            }
+
+            if "close" in conn_tokens:
                 close_conn = True
-            elif v == "keep-alive":
+            elif "keep-alive" in conn_tokens:
                 close_conn = False
+
             # https://www.rfc-editor.org/rfc/rfc9110.html#name-101-switching-protocols
-            elif v == "upgrade" and headers.get(hdrs.UPGRADE):
+            if "upgrade" in conn_tokens and headers.get(hdrs.UPGRADE):
                 upgrade = True
 
         # encoding

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -513,6 +513,24 @@ def test_conn_keep_alive_1_1(parser: HttpRequestParser) -> None:
     assert not msg.should_close
 
 
+def test_conn_close_comma_list(parser: HttpRequestParser) -> None:
+    text = b"GET /test HTTP/1.1\r\nconnection: close, keep-alive\r\n\r\n"
+    messages, upgrade, tail = parser.feed_data(text)
+    msg = messages[0][0]
+    assert msg.should_close
+
+
+def test_conn_close_multiple_headers(parser: HttpRequestParser) -> None:
+    text = (
+        b"GET /test HTTP/1.1\r\n"
+        b"connection: keep-alive\r\n"
+        b"connection: close\r\n\r\n"
+    )
+    messages, upgrade, tail = parser.feed_data(text)
+    msg = messages[0][0]
+    assert msg.should_close
+
+
 def test_conn_other_1_0(parser: HttpRequestParser) -> None:
     text = b"GET /test HTTP/1.0\r\nconnection: test\r\n\r\n"
     messages, upgrade, tail = parser.feed_data(text)
@@ -603,6 +621,33 @@ def test_request_te_duplicate_chunked(parser: HttpRequestParser) -> None:
 def test_conn_upgrade(parser: HttpRequestParser) -> None:
     text = (
         b"GET /test HTTP/1.1\r\n"
+        b"connection: upgrade\r\n"
+        b"upgrade: websocket\r\n\r\n"
+    )
+    messages, upgrade, tail = parser.feed_data(text)
+    msg = messages[0][0]
+    assert not msg.should_close
+    assert msg.upgrade
+    assert upgrade
+
+
+def test_conn_upgrade_comma_list(parser: HttpRequestParser) -> None:
+    text = (
+        b"GET /test HTTP/1.1\r\n"
+        b"connection: keep-alive, upgrade\r\n"
+        b"upgrade: websocket\r\n\r\n"
+    )
+    messages, upgrade, tail = parser.feed_data(text)
+    msg = messages[0][0]
+    assert not msg.should_close
+    assert msg.upgrade
+    assert upgrade
+
+
+def test_conn_upgrade_multiple_headers(parser: HttpRequestParser) -> None:
+    text = (
+        b"GET /test HTTP/1.1\r\n"
+        b"connection: keep-alive\r\n"
         b"connection: upgrade\r\n"
         b"upgrade: websocket\r\n\r\n"
     )
@@ -982,6 +1027,14 @@ def test_http_request_bad_status_line_whitespace(parser: HttpRequestParser) -> N
 
 def test_http_request_message_after_close(parser: HttpRequestParser) -> None:
     text = b"GET / HTTP/1.1\r\nConnection: close\r\n\r\nInvalid\r\n\r\n"
+    with pytest.raises(
+        http_exceptions.BadHttpMessage, match="Data after `Connection: close`"
+    ):
+        parser.feed_data(text)
+
+
+def test_http_request_message_after_close_comma_list(parser: HttpRequestParser) -> None:
+    text = b"GET / HTTP/1.1\r\nConnection: close, keep-alive\r\n\r\nInvalid\r\n\r\n"
     with pytest.raises(
         http_exceptions.BadHttpMessage, match="Data after `Connection: close`"
     ):


### PR DESCRIPTION
## What do these changes do?

Align the pure-Python HTTP request parser with the C parser for `Connection` handling.

- Parse `Connection` from all field lines (`getall`) instead of only the first value.
- Split comma-separated values into tokens and compare case-insensitively.
- Apply token-based semantics for `close`, `keep-alive`, and `upgrade`.
- Add regression tests for comma-separated and repeated `Connection` values.

## Are there changes in behavior for the user?

Yes, for requests with multi-value/repeated `Connection` headers.

- `Connection: keep-alive, upgrade` + `Upgrade: websocket` now upgrades in the Python parser.
- `Connection: close, keep-alive` now results in `should_close=True` in the Python parser.
- Single-token behavior is unchanged.

## Is it a substantial burden for the maintainers to support this?

No. This is a small parser-consistency fix with focused regression coverage and no new dependencies.

## Related issue number

N/A (security report).

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
- [x] Add a new news fragment into the `CHANGES/` folder
