### PR TITLE
Avoid accessing Py_buffer after release in HTTP parser

### DIFF
--- a/aiohttp/_http_parser.pyx
+++ b/aiohttp/_http_parser.pyx
@@ -556,20 +556,23 @@ cdef class HttpParser:
         cdef:
             size_t data_len
             size_t nb
+            char* base
             cdef cparser.llhttp_errno_t errno
 
         PyObject_GetBuffer(data, &self.py_buf, PyBUF_SIMPLE)
+        # Cache buffer pointer before PyBuffer_Release to avoid use-after-release.
+        base = <char*>self.py_buf.buf
         data_len = <size_t>self.py_buf.len
 
         errno = cparser.llhttp_execute(
             self._cparser,
-            <char*>self.py_buf.buf,
+            base,
             data_len)
 
         if errno is cparser.HPE_PAUSED_UPGRADE:
             cparser.llhttp_resume_after_upgrade(self._cparser)
 
-            nb = cparser.llhttp_get_error_pos(self._cparser) - <char*>self.py_buf.buf
+            nb = cparser.llhttp_get_error_pos(self._cparser) - base
 
         PyBuffer_Release(&self.py_buf)
 
@@ -580,7 +583,7 @@ cdef class HttpParser:
                     self._last_error = None
                 else:
                     after = cparser.llhttp_get_error_pos(self._cparser)
-                    before = data[:after - <char*>self.py_buf.buf]
+                    before = data[:after - base]
                     after_b = after.split(b"\r\n", 1)[0]
                     before = before.rsplit(b"\r\n", 1)[-1]
                     data = before + after_b


### PR DESCRIPTION
## What do these changes do?

This PR fixes a small memory-safety issue in the Cython HTTP parser.  
It caches the buffer pointer before releasing the buffer view, then uses that cached pointer for later offset math.  
This avoids accessing released buffer state.

## Are there changes in behavior for the user?

No user-facing behavior change is expected.  
This is an internal correctness/safety fix only.

## Is it a substantial burden for the maintainers to support this?

No.  
The change is small, localized, and does not introduce new behavior.

## Related issue number

N/A

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to CONTRIBUTORS.txt
- [ ] Add a new news fragment into the CHANGES/ folder