### PR TITLE
Fix zstd decompression for multi-frame responses

### DIFF
--- a/aiohttp/compression_utils.py
+++ b/aiohttp/compression_utils.py
@@ -342,7 +342,20 @@ class ZSTDDecompressor(DecompressionBaseHandler):
             if max_length == ZLIB_MAX_LENGTH_UNLIMITED
             else max_length
         )
-        return self._obj.decompress(data, zstd_max_length)
+        try:
+            result = self._obj.decompress(data, zstd_max_length)
+        except EOFError:
+            # ZstdDecompressor cannot handle multiple compressed frames.
+            # When a frame ends, create a new decompressor for the next frame.
+            self._obj = ZstdDecompressor()
+            return self._obj.decompress(data, zstd_max_length)
+
+        # Handle multiple frames arriving in a single chunk
+        while self._obj.unused_data:
+            unused = self._obj.unused_data
+            self._obj = ZstdDecompressor()
+            result += self._obj.decompress(unused, zstd_max_length)
+        return result
 
     def flush(self) -> bytes:
         return b""

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -2081,6 +2081,26 @@ class TestParsePayload:
         assert b"zstd data" == out._buffer[0]
         assert out.is_eof()
 
+    @pytest.mark.skipif(zstandard is None, reason="zstandard is not installed")
+    async def test_http_payload_zstandard_multi_frame(
+        self, protocol: BaseProtocol
+    ) -> None:
+        """Test that zstd decompression handles multiple compressed frames."""
+        frame1 = zstandard.compress(b"frame1 data")
+        frame2 = zstandard.compress(b"frame2 data")
+        combined = frame1 + frame2
+
+        out = aiohttp.StreamReader(protocol, 2**16, loop=asyncio.get_running_loop())
+        p = HttpPayloadParser(
+            out,
+            length=len(combined),
+            compression="zstd",
+            headers_parser=HeadersParser(),
+        )
+        p.feed_data(combined)
+        assert b"frame1 dataframe2 data" == out._buffer[0]
+        assert out.is_eof()
+
 
 class TestDeflateBuffer:
     async def test_feed_data(self, protocol: BaseProtocol) -> None:


### PR DESCRIPTION
## What do these changes do?

Fix zstd decompression failing with `ClientPayloadError` when a server sends zstd-encoded data in multiple frames (e.g., chunked transfer encoding with separate flushes per chunk).

The root cause is that `compression.zstd.ZstdDecompressor` cannot handle inputs containing multiple compressed frames — it raises `EOFError: Already at the end of a Zstandard frame` when encountering a second frame after the first one ends.

This fix:
- Catches `EOFError` when a frame ends and creates a new `ZstdDecompressor` for the next frame
- Handles multiple frames arriving in a single chunk by checking `unused_data`
- Adds a regression test for multi-frame zstd decompression

## Are there changes in behavior for the user?

Servers that send zstd responses in multiple frames (which is valid per the zstd spec) will now work correctly instead of raising `ClientPayloadError`.

## Related issue number

Fixes #12234

## Checklist

- [x] Tests added
- [x] Changes described in `CHANGES/12234.bugfix.rst` (if applicable)