### PR TITLE
Copy unsafe setting from session cookie jar to ad-hoc request cookie jar

### DIFF
--- a/CHANGES/12011.bugfix.rst
+++ b/CHANGES/12011.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed ad-hoc cookies passed to individual requests not being sent when the session's cookie jar has ``unsafe=True`` and the target URL uses an IP address, by copying the ``unsafe`` setting from the session's cookie jar to the temporary cookie jar -- by :user:`Krishnachaitanyakc`.

--- a/aiohttp/abc.py
+++ b/aiohttp/abc.py
@@ -155,6 +155,11 @@ class AbstractCookieJar(Sized, Iterable[Morsel[str]]):
 
     @property
     @abstractmethod
+    def unsafe(self) -> bool:
+        """Return True if cookies can be used with IP addresses."""
+
+    @property
+    @abstractmethod
     def quote_cookie(self) -> bool:
         """Return True if cookies should be quoted."""
 

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -670,7 +670,8 @@ class ClientSession:
 
                     if cookies is not None:
                         tmp_cookie_jar = CookieJar(
-                            quote_cookie=self._cookie_jar.quote_cookie
+                            unsafe=self._cookie_jar.unsafe,
+                            quote_cookie=self._cookie_jar.quote_cookie,
                         )
                         tmp_cookie_jar.update_cookies(cookies)
                         req_cookies = tmp_cookie_jar.filter_cookies(url)

--- a/aiohttp/cookiejar.py
+++ b/aiohttp/cookiejar.py
@@ -144,6 +144,10 @@ class CookieJar(AbstractCookieJar):
         self._expirations: dict[tuple[str, str, str], float] = {}
 
     @property
+    def unsafe(self) -> bool:
+        return self._unsafe
+
+    @property
     def quote_cookie(self) -> bool:
         return self._quote_cookie
 
@@ -593,6 +597,10 @@ class DummyCookieJar(AbstractCookieJar):
 
     def __len__(self) -> int:
         return 0
+
+    @property
+    def unsafe(self) -> bool:
+        return False
 
     @property
     def quote_cookie(self) -> bool:

--- a/tests/test_client_session.py
+++ b/tests/test_client_session.py
@@ -776,6 +776,10 @@ async def test_cookie_jar_usage(
             self._items: list[Any] = []
 
         @property
+        def unsafe(self) -> bool:
+            return False
+
+        @property
         def quote_cookie(self) -> bool:
             return True
 
@@ -855,6 +859,25 @@ async def test_cookies_with_not_quoted_cookie_jar(
     async with aiohttp.ClientSession(cookie_jar=jar) as sess:
         resp = await sess.request("GET", server.make_url("/"), cookies=cookies)
     assert resp.request_info.headers.get("Cookie", "") == "name=val=foobar"
+
+
+async def test_cookies_with_unsafe_cookie_jar(
+    aiohttp_server: AiohttpServer,
+) -> None:
+    async def handler(request: web.Request) -> web.Response:
+        return web.Response(text=request.headers.get("Cookie", ""))
+
+    app = web.Application()
+    app.router.add_route("GET", "/", handler)
+    server = await aiohttp_server(app)
+    jar = CookieJar(unsafe=True)
+    # Use an IP-based URL to verify that ad-hoc cookies are sent
+    # when the session cookie jar has unsafe=True.
+    ip_url = server.make_url("/")
+    cookies = {"adhoc": "value"}
+    async with aiohttp.ClientSession(cookie_jar=jar) as sess:
+        resp = await sess.request("GET", ip_url, cookies=cookies)
+    assert "adhoc=value" in resp.request_info.headers.get("Cookie", "")
 
 
 async def test_session_default_version(loop: asyncio.AbstractEventLoop) -> None:

--- a/tests/test_client_session.py
+++ b/tests/test_client_session.py
@@ -875,6 +875,7 @@ async def test_cookies_with_unsafe_cookie_jar(
     # Use an IP-based URL to verify that ad-hoc cookies are sent
     # when the session cookie jar has unsafe=True.
     ip_url = server.make_url("/")
+    assert ip_url.host is not None
     assert ip_url.host.count(".") == 3  # Sanity check it looks like an IP address
     cookies = {"adhoc": "value"}
     async with aiohttp.ClientSession(cookie_jar=jar) as sess:

--- a/tests/test_client_session.py
+++ b/tests/test_client_session.py
@@ -804,6 +804,7 @@ async def test_cookie_jar_usage(
     jar = MockCookieJar()
 
     assert jar.quote_cookie is True
+    assert jar.unsafe is False
     assert len(jar) == 0
     assert list(jar) == []
     jar.clear()
@@ -865,7 +866,7 @@ async def test_cookies_with_unsafe_cookie_jar(
     aiohttp_server: AiohttpServer,
 ) -> None:
     async def handler(request: web.Request) -> web.Response:
-        return web.Response(text=request.headers.get("Cookie", ""))
+        return web.Response()
 
     app = web.Application()
     app.router.add_route("GET", "/", handler)
@@ -874,10 +875,11 @@ async def test_cookies_with_unsafe_cookie_jar(
     # Use an IP-based URL to verify that ad-hoc cookies are sent
     # when the session cookie jar has unsafe=True.
     ip_url = server.make_url("/")
+    assert str(ip_url).count(".") == 3
     cookies = {"adhoc": "value"}
     async with aiohttp.ClientSession(cookie_jar=jar) as sess:
-        resp = await sess.request("GET", ip_url, cookies=cookies)
-    assert "adhoc=value" in resp.request_info.headers.get("Cookie", "")
+        async with sess.request("GET", ip_url, cookies=cookies) as resp:
+            assert "adhoc=value" in resp.request_info.headers.get("Cookie", "")
 
 
 async def test_session_default_version(loop: asyncio.AbstractEventLoop) -> None:

--- a/tests/test_client_session.py
+++ b/tests/test_client_session.py
@@ -875,7 +875,7 @@ async def test_cookies_with_unsafe_cookie_jar(
     # Use an IP-based URL to verify that ad-hoc cookies are sent
     # when the session cookie jar has unsafe=True.
     ip_url = server.make_url("/")
-    assert str(ip_url).count(".") == 3
+    assert ip_url.host.count(".") == 3  # Sanity check it looks like an IP address
     cookies = {"adhoc": "value"}
     async with aiohttp.ClientSession(cookie_jar=jar) as sess:
         async with sess.request("GET", ip_url, cookies=cookies) as resp:

--- a/tests/test_cookiejar.py
+++ b/tests/test_cookiejar.py
@@ -1761,4 +1761,3 @@ async def test_cookie_jar_unsafe_property() -> None:
 
     jar_unsafe = CookieJar(unsafe=True)
     assert jar_unsafe.unsafe is True
-

--- a/tests/test_cookiejar.py
+++ b/tests/test_cookiejar.py
@@ -770,6 +770,7 @@ class TestCookieJarSafe:
 async def test_dummy_cookie_jar() -> None:
     cookie = SimpleCookie("foo=bar; Domain=example.com;")
     dummy_jar = DummyCookieJar()
+    assert dummy_jar.unsafe is False
     assert dummy_jar.quote_cookie is True
     assert len(dummy_jar) == 0
     dummy_jar.update_cookies(cookie)
@@ -1752,3 +1753,12 @@ def test_save_load_json_secure_cookies(tmp_path: Path) -> None:
     assert cookie["secure"] is True
     assert cookie["httponly"] is True
     assert cookie["domain"] == "example.com"
+
+
+async def test_cookie_jar_unsafe_property() -> None:
+    jar_safe = CookieJar()
+    assert jar_safe.unsafe is False
+
+    jar_unsafe = CookieJar(unsafe=True)
+    assert jar_unsafe.unsafe is True
+


### PR DESCRIPTION
## Summary

Fixes #12011

When ad-hoc cookies are passed to individual requests via the `cookies` parameter, a temporary `CookieJar` is created to filter them. Previously, only the `quote_cookie` setting was copied from the session's cookie jar. This meant that if the session's cookie jar had `unsafe=True` (to allow cookies with IP addresses), the ad-hoc cookies would still be filtered out by the temporary jar's default `unsafe=False` setting.

This change:
- Copies the `unsafe` setting from the session's cookie jar to the temporary cookie jar used for ad-hoc request cookies
- Exposes `unsafe` as a public abstract property on `AbstractCookieJar` (mirroring the existing `quote_cookie` property)
- Implements the `unsafe` property on `CookieJar` and `DummyCookieJar`

This approach was explicitly approved by maintainers @Dreamsorcerer and @bdraco in the issue discussion.

## Test plan

- [x] Added `test_cookies_with_unsafe_cookie_jar` in `test_client_session.py` verifying ad-hoc cookies are sent when the session cookie jar has `unsafe=True` and the target URL uses an IP address
- [x] Added `test_cookie_jar_unsafe_property` in `test_cookiejar.py` verifying the new `unsafe` property on `CookieJar`
- [x] Added assertion for `DummyCookieJar.unsafe` in the existing `test_dummy_cookie_jar` test
- [x] Updated `MockCookieJar` in test suite to implement the new abstract `unsafe` property
- [x] All existing cookie jar tests pass (84/84)
- [x] All existing client session tests pass (86/86, 1 skipped)