### PR TITLE
Raise ConnectionResetError if transport is None (#11761)

### DIFF
--- a/CHANGES/11761.bugfix.rst
+++ b/CHANGES/11761.bugfix.rst
@@ -1,0 +1,4 @@
+Fixed ``AssertionError`` when the transport is ``None`` during WebSocket
+preparation or file response sending (e.g. when a client disconnects
+immediately after connecting). A ``ConnectionResetError`` is now raised
+instead -- by :user:`agners`.

--- a/aiohttp/web_fileresponse.py
+++ b/aiohttp/web_fileresponse.py
@@ -141,7 +141,8 @@ class FileResponse(StreamResponse):
 
         loop = request._loop
         transport = request.transport
-        assert transport is not None
+        if transport is None:
+            raise ConnectionResetError("Connection lost")
 
         try:
             await loop.sendfile(transport, fobj, offset, count)

--- a/aiohttp/web_ws.py
+++ b/aiohttp/web_ws.py
@@ -358,7 +358,8 @@ class WebSocketResponse(StreamResponse, Generic[_DecodeText]):
         self.force_close()
         self._compress = compress
         transport = request._protocol.transport
-        assert transport is not None
+        if transport is None:
+            raise ConnectionResetError("Connection lost")
         writer = WebSocketWriter(
             request._protocol,
             transport,

--- a/tests/test_web_sendfile_functional.py
+++ b/tests/test_web_sendfile_functional.py
@@ -1,5 +1,6 @@
 import asyncio
 import bz2
+import contextlib
 import gzip
 import pathlib
 import socket
@@ -13,6 +14,7 @@ import aiohttp
 from aiohttp import web
 from aiohttp.compression_utils import ZLibBackend
 from aiohttp.pytest_plugin import AiohttpClient
+from aiohttp.web_fileresponse import NOSENDFILE
 
 try:
     import brotlicffi as brotli
@@ -1151,3 +1153,64 @@ async def test_static_file_huge_error(aiohttp_client, tmp_path) -> None:
 
     await resp.release()
     await client.close()
+
+
+@pytest.mark.skipif(NOSENDFILE, reason="OS sendfile not available")
+async def test_sendfile_after_client_disconnect(
+    aiohttp_client: AiohttpClient, tmp_path: pathlib.Path
+) -> None:
+    """Test ConnectionResetError when client disconnects before sendfile.
+
+    Reproduces the race condition where:
+    - Client sends a GET request for a file
+    - Handler does async work (e.g. auth check) before returning a FileResponse
+    - Client disconnects while the handler is busy
+    - Server then calls sendfile() → ConnectionResetError (not AssertionError)
+
+    _send_headers_immediately is set to False so that super().prepare()
+    only buffers the headers without writing to the transport. Otherwise
+    _write() raises ClientConnectionResetError first and _sendfile()'s own
+    transport check is never reached.
+    """
+    filepath = tmp_path / "test.txt"
+    filepath.write_bytes(b"x" * 1024)
+
+    handler_started = asyncio.Event()
+    prepare_done = asyncio.Event()
+    captured_protocol = None
+
+    async def handler(request: web.Request) -> web.Response:
+        nonlocal captured_protocol
+        resp = web.FileResponse(filepath)
+        resp._send_headers_immediately = False
+        captured_protocol = request._protocol
+        handler_started.set()
+        # Simulate async work (e.g., auth check) during which client disconnects.
+        await asyncio.sleep(0)
+        with pytest.raises(ConnectionResetError, match="Connection lost"):
+            await resp.prepare(request)
+        prepare_done.set()
+        return web.Response(status=503)
+
+    app = web.Application()
+    app.router.add_get("/", handler)
+    client = await aiohttp_client(app)
+
+    request_task = asyncio.create_task(client.get("/"))
+
+    # Wait until the handler is running but has not yet returned the response.
+    await handler_started.wait()
+    assert captured_protocol is not None
+
+    # Simulate the client disconnecting by setting transport to None directly.
+    # We cannot use force_close() because closing the TCP transport triggers
+    # connection_lost() which cancels the handler task before it can call
+    # prepare() and hit the ConnectionResetError in _sendfile().
+    captured_protocol.transport = None
+
+    # Wait for the handler to resume, call prepare(), and hit ConnectionResetError.
+    await asyncio.wait_for(prepare_done.wait(), timeout=1)
+
+    request_task.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await request_task

--- a/tests/test_web_websocket_functional.py
+++ b/tests/test_web_websocket_functional.py
@@ -11,7 +11,7 @@ from unittest import mock
 import pytest
 
 import aiohttp
-from aiohttp import web
+from aiohttp import hdrs, web
 from aiohttp.http import WSCloseCode, WSMsgType
 from aiohttp.pytest_plugin import AiohttpClient
 
@@ -1608,3 +1608,58 @@ async def test_server_receive_json_with_orjson_style_loads(
     assert msg.type is aiohttp.WSMsgType.TEXT
     assert msg.data == "success"
     await ws.close()
+
+
+async def test_prepare_after_client_disconnect(aiohttp_client: AiohttpClient) -> None:
+    """Test ConnectionResetError when client disconnects before ws.prepare().
+
+    Reproduces the race condition where:
+    - Client connects and sends a WebSocket upgrade request
+    - Handler starts async work (e.g. authentication) before calling ws.prepare()
+    - Client disconnects while the handler is busy
+    - Handler then calls ws.prepare() → ConnectionResetError (not AssertionError)
+    """
+    handler_started = asyncio.Event()
+    captured_protocol = None
+
+    async def handler(request: web.Request) -> web.Response:
+        nonlocal captured_protocol
+        ws = web.WebSocketResponse()
+        captured_protocol = request._protocol
+        handler_started.set()
+        # Simulate async work (e.g., auth check) during which client disconnects.
+        await asyncio.sleep(0)
+        with pytest.raises(ConnectionResetError, match="Connection lost"):
+            await ws.prepare(request)
+        return web.Response(status=503)
+
+    app = web.Application()
+    app.router.add_route("GET", "/", handler)
+    client = await aiohttp_client(app)
+
+    request_task = asyncio.create_task(
+        client.session.get(
+            client.make_url("/"),
+            headers={
+                hdrs.UPGRADE: "websocket",
+                hdrs.CONNECTION: "Upgrade",
+                hdrs.SEC_WEBSOCKET_KEY: "dGhlIHNhbXBsZSBub25jZQ==",
+                hdrs.SEC_WEBSOCKET_VERSION: "13",
+            },
+        )
+    )
+
+    # Wait until the handler is running but has not yet called ws.prepare().
+    await handler_started.wait()
+    assert captured_protocol is not None
+
+    # Simulate the client disconnecting abruptly.
+    captured_protocol.force_close()
+
+    # Yield so the handler can resume and hit the ConnectionResetError.
+    await asyncio.sleep(0)
+
+    with contextlib.suppress(
+        aiohttp.ServerDisconnectedError, aiohttp.ClientConnectionResetError
+    ):
+        await request_task


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Backport cherry picked from commit b26c9aee4cf1cb280fa771855ab7be95f1ae1d22

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->

## Is it a substantial burden for the maintainers to support this?

<!--
Stop right there! Pause. Just for a minute... Can you think of anything
obvious that would complicate the ongoing development of this project?

Try to consider if you'd be able to maintain it throughout the next
5 years. Does it seem viable? Tell us your thoughts! We'd very much
love to hear what the consequences of merging this patch might be...

This will help us assess if your change is something we'd want to
entertain early in the review process. Thank you in advance!
-->

## Related issue number

<!-- Will this resolve any open issues? -->
<!-- Remember to prefix with 'Fixes' if it closes an issue (e.g. 'Fixes #123'). -->

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES/` folder
  * name it `<issue_or_pr_num>.<type>.rst` (e.g. `588.bugfix.rst`)
  * if you don't have an issue number, change it to the pull request
    number after creating the PR
    * `.bugfix`: A bug fix for something the maintainers deemed an
      improper undesired behavior that got corrected to match
      pre-agreed expectations.
    * `.feature`: A new behavior, public APIs. That sort of stuff.
    * `.deprecation`: A declaration of future API removals and breaking
      changes in behavior.
    * `.breaking`: When something public is removed in a breaking way.
      Could be deprecated in an earlier release.
    * `.doc`: Notable updates to the documentation structure or build
      process.
    * `.packaging`: Notes for downstreams about unobvious side effects
      and tooling. Changes in the test invocation considerations and
      runtime assumptions.
    * `.contrib`: Stuff that affects the contributor experience. e.g.
      Running tests, building the docs, setting up the development
      environment.
    * `.misc`: Changes that are hard to assign to any of the above
      categories.
  * Make sure to use full sentences with correct case and punctuation,
    for example:
    ```rst
    Fixed issue with non-ascii contents in doctest text files
    -- by :user:`contributor-gh-handle`.
    ```

    Use the past tense or the present tense a non-imperative mood,
    referring to what's changed compared to the last released version
    of this project.
