### PR TITLE
fix: Fix zstd decompression of multi-frame responses

### DIFF
--- a/CHANGES/12234.bugfix.rst
+++ b/CHANGES/12234.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed zstd decompression failing with ``ClientPayloadError`` when the server
+sends a response as multiple zstd frames -- by :user:`josu-moreno`.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -214,6 +214,7 @@ Jordan Borean
 Josep Cugat
 Josh Junon
 Joshu Coats
+Josu Moreno
 Julia Tsemusheva
 Julien Duponchelle
 Jungkook Park

--- a/aiohttp/compression_utils.py
+++ b/aiohttp/compression_utils.py
@@ -344,7 +344,8 @@ class ZSTDDecompressor(DecompressionBaseHandler):
         )
         result = self._obj.decompress(data, zstd_max_length)
 
-        # Handle multi-frame zstd streams (RFC 8878 §3.1.1):
+        # Handle multi-frame zstd streams.
+        # https://datatracker.ietf.org/doc/html/rfc8878#section-3.1.1
         # ZstdDecompressor handles one frame only. When a frame ends,
         # eof becomes True and any trailing data goes to unused_data.
         # We create a fresh decompressor to continue with the next frame.

--- a/aiohttp/compression_utils.py
+++ b/aiohttp/compression_utils.py
@@ -342,7 +342,28 @@ class ZSTDDecompressor(DecompressionBaseHandler):
             if max_length == ZLIB_MAX_LENGTH_UNLIMITED
             else max_length
         )
-        return self._obj.decompress(data, zstd_max_length)
+        result = self._obj.decompress(data, zstd_max_length)
+
+        # Handle multi-frame zstd streams (RFC 8878 §3.1.1):
+        # ZstdDecompressor handles one frame only. When a frame ends,
+        # eof becomes True and any trailing data goes to unused_data.
+        # We create a fresh decompressor to continue with the next frame.
+        while self._obj.eof and self._obj.unused_data:
+            unused = self._obj.unused_data
+            self._obj = ZstdDecompressor()
+            if zstd_max_length != ZSTD_MAX_LENGTH_UNLIMITED:
+                zstd_max_length -= len(result)
+                if zstd_max_length <= 0:
+                    break
+            result += self._obj.decompress(unused, zstd_max_length)
+
+        # Frame ended exactly at chunk boundary — no unused_data, but the
+        # next feed_data() call would fail on the spent decompressor.
+        # Prepare a fresh one for the next chunk.
+        if self._obj.eof:
+            self._obj = ZstdDecompressor()
+
+        return result
 
     def flush(self) -> bytes:
         return b""

--- a/aiohttp/compression_utils.py
+++ b/aiohttp/compression_utils.py
@@ -330,6 +330,7 @@ class ZSTDDecompressor(DecompressionBaseHandler):
                 "Please install `backports.zstd` module"
             )
         self._obj = ZstdDecompressor()
+        self._pending_unused_data: bytes | None = None
         super().__init__(executor=executor, max_sync_chunk_size=max_sync_chunk_size)
 
     def decompress_sync(
@@ -342,6 +343,9 @@ class ZSTDDecompressor(DecompressionBaseHandler):
             if max_length == ZLIB_MAX_LENGTH_UNLIMITED
             else max_length
         )
+        if self._pending_unused_data is not None:
+            data = self._pending_unused_data + data
+            self._pending_unused_data = None
         result = self._obj.decompress(data, zstd_max_length)
 
         # Handle multi-frame zstd streams.
@@ -350,13 +354,14 @@ class ZSTDDecompressor(DecompressionBaseHandler):
         # eof becomes True and any trailing data goes to unused_data.
         # We create a fresh decompressor to continue with the next frame.
         while self._obj.eof and self._obj.unused_data:
-            unused = self._obj.unused_data
+            unused_data = self._obj.unused_data
             self._obj = ZstdDecompressor()
             if zstd_max_length != ZSTD_MAX_LENGTH_UNLIMITED:
                 zstd_max_length -= len(result)
                 if zstd_max_length <= 0:
+                    self._pending_unused_data = unused_data
                     break
-            result += self._obj.decompress(unused, zstd_max_length)
+            result += self._obj.decompress(unused_data, zstd_max_length)
 
         # Frame ended exactly at chunk boundary — no unused_data, but the
         # next feed_data() call would fail on the spent decompressor.

--- a/tests/test_compression_utils.py
+++ b/tests/test_compression_utils.py
@@ -1,8 +1,23 @@
 """Tests for compression utils."""
 
+import sys
+
 import pytest
 
-from aiohttp.compression_utils import ZLibBackend, ZLibCompressor, ZLibDecompressor
+from aiohttp.compression_utils import (
+    ZLibBackend,
+    ZLibCompressor,
+    ZLibDecompressor,
+    ZSTDDecompressor,
+)
+
+try:
+    if sys.version_info >= (3, 14):
+        import compression.zstd as zstandard  # noqa: I900
+    else:
+        import backports.zstd as zstandard
+except ImportError:  # pragma: no cover
+    zstandard = None  # type: ignore[assignment]
 
 
 @pytest.mark.usefixtures("parametrize_zlib_backend")
@@ -33,3 +48,30 @@ async def test_compression_round_trip_in_event_loop() -> None:
     compressed_data = await compressor.compress(data) + compressor.flush()
     decompressed_data = await decompressor.decompress(compressed_data)
     assert data == decompressed_data
+
+
+@pytest.mark.skipif(zstandard is None, reason="zstandard is not installed")
+def test_zstd_multi_frame_unlimited() -> None:
+    d = ZSTDDecompressor()
+    frame1 = zstandard.compress(b"AAAA")
+    frame2 = zstandard.compress(b"BBBB")
+    result = d.decompress_sync(frame1 + frame2)
+    assert result == b"AAAABBBB"
+
+
+@pytest.mark.skipif(zstandard is None, reason="zstandard is not installed")
+def test_zstd_multi_frame_max_length_partial() -> None:
+    d = ZSTDDecompressor()
+    frame1 = zstandard.compress(b"AAAA")
+    frame2 = zstandard.compress(b"BBBB")
+    result = d.decompress_sync(frame1 + frame2, max_length=6)
+    assert result == b"AAAABB"
+
+
+@pytest.mark.skipif(zstandard is None, reason="zstandard is not installed")
+def test_zstd_multi_frame_max_length_exhausted() -> None:
+    d = ZSTDDecompressor()
+    frame1 = zstandard.compress(b"AAAA")
+    frame2 = zstandard.compress(b"BBBB")
+    result = d.decompress_sync(frame1 + frame2, max_length=4)
+    assert result == b"AAAA"

--- a/tests/test_compression_utils.py
+++ b/tests/test_compression_utils.py
@@ -75,3 +75,15 @@ def test_zstd_multi_frame_max_length_exhausted() -> None:
     frame2 = zstandard.compress(b"BBBB")
     result = d.decompress_sync(frame1 + frame2, max_length=4)
     assert result == b"AAAA"
+
+
+@pytest.mark.skipif(zstandard is None, reason="zstandard is not installed")
+def test_zstd_multi_frame_max_length_exhausted_preserves_unused_data() -> None:
+    d = ZSTDDecompressor()
+    frame1 = zstandard.compress(b"AAAA")
+    frame2 = zstandard.compress(b"BBBB")
+    frame3 = zstandard.compress(b"CCCC")
+    result1 = d.decompress_sync(frame1 + frame2, max_length=4)
+    assert result1 == b"AAAA"
+    result2 = d.decompress_sync(frame3)
+    assert result2 == b"BBBBCCCC"

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -2081,6 +2081,79 @@ class TestParsePayload:
         assert b"zstd data" == out._buffer[0]
         assert out.is_eof()
 
+    @pytest.mark.skipif(zstandard is None, reason="zstandard is not installed")
+    async def test_http_payload_zstandard_multi_frame(
+        self, protocol: BaseProtocol
+    ) -> None:
+        frame1 = zstandard.compress(b"first")
+        frame2 = zstandard.compress(b"second")
+        payload = frame1 + frame2
+        out = aiohttp.StreamReader(protocol, 2**16, loop=asyncio.get_running_loop())
+        p = HttpPayloadParser(
+            out,
+            length=len(payload),
+            compression="zstd",
+            headers_parser=HeadersParser(),
+        )
+        p.feed_data(payload)
+        assert b"firstsecond" == b"".join(out._buffer)
+        assert out.is_eof()
+
+    @pytest.mark.skipif(zstandard is None, reason="zstandard is not installed")
+    async def test_http_payload_zstandard_multi_frame_chunked(
+        self, protocol: BaseProtocol
+    ) -> None:
+        frame1 = zstandard.compress(b"chunk1")
+        frame2 = zstandard.compress(b"chunk2")
+        out = aiohttp.StreamReader(protocol, 2**16, loop=asyncio.get_running_loop())
+        p = HttpPayloadParser(
+            out,
+            length=len(frame1) + len(frame2),
+            compression="zstd",
+            headers_parser=HeadersParser(),
+        )
+        p.feed_data(frame1)
+        p.feed_data(frame2)
+        assert b"chunk1chunk2" == b"".join(out._buffer)
+        assert out.is_eof()
+
+    @pytest.mark.skipif(zstandard is None, reason="zstandard is not installed")
+    async def test_http_payload_zstandard_frame_split_mid_chunk(
+        self, protocol: BaseProtocol
+    ) -> None:
+        frame1 = zstandard.compress(b"AAAA")
+        frame2 = zstandard.compress(b"BBBB")
+        combined = frame1 + frame2
+        split_point = len(frame1) + 3  # 3 bytes into frame2
+        out = aiohttp.StreamReader(protocol, 2**16, loop=asyncio.get_running_loop())
+        p = HttpPayloadParser(
+            out,
+            length=len(combined),
+            compression="zstd",
+            headers_parser=HeadersParser(),
+        )
+        p.feed_data(combined[:split_point])
+        p.feed_data(combined[split_point:])
+        assert b"AAAABBBB" == b"".join(out._buffer)
+        assert out.is_eof()
+
+    @pytest.mark.skipif(zstandard is None, reason="zstandard is not installed")
+    async def test_http_payload_zstandard_many_small_frames(
+        self, protocol: BaseProtocol
+    ) -> None:
+        parts = [f"part{i}".encode() for i in range(10)]
+        payload = b"".join(zstandard.compress(p) for p in parts)
+        out = aiohttp.StreamReader(protocol, 2**16, loop=asyncio.get_running_loop())
+        p = HttpPayloadParser(
+            out,
+            length=len(payload),
+            compression="zstd",
+            headers_parser=HeadersParser(),
+        )
+        p.feed_data(payload)
+        assert b"".join(parts) == b"".join(out._buffer)
+        assert out.is_eof()
+
 
 class TestDeflateBuffer:
     async def test_feed_data(self, protocol: BaseProtocol) -> None:


### PR DESCRIPTION
ZstdDecompressor is one-shot-per-frame: once a frame ends, subsequent decompress() calls raise EOFError. This broke HTTP responses where the server sends multiple zstd frames (common with chunked transfer encoding).

Detect frame boundaries via eof/unused_data attributes and create fresh decompressor instances for subsequent frames.

<!-- Thank you for your contribution! -->

## What do these changes do?

Detect frame boundaries via eof/unused_data attributes and create fresh decompressor instances for subsequent frames.

## Are there changes in behavior for the user?

The change is seamless for the uses

## Is it a substantial burden for the maintainers to support this?

I think this is needed to cover multi-framed zstd responses. I tried to keep it simple but covering the cases that came to my mind.

## Related issue number

Fixes #12234 

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes - I don't think we need to update the docs in this case
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES/` folder
  * name it `<issue_or_pr_num>.<type>.rst` (e.g. `588.bugfix.rst`)
  * if you don't have an issue number, change it to the pull request
    number after creating the PR
    * `.bugfix`: A bug fix for something the maintainers deemed an
      improper undesired behavior that got corrected to match
      pre-agreed expectations.
    * `.feature`: A new behavior, public APIs. That sort of stuff.
    * `.deprecation`: A declaration of future API removals and breaking
      changes in behavior.
    * `.breaking`: When something public is removed in a breaking way.
      Could be deprecated in an earlier release.
    * `.doc`: Notable updates to the documentation structure or build
      process.
    * `.packaging`: Notes for downstreams about unobvious side effects
      and tooling. Changes in the test invocation considerations and
      runtime assumptions.
    * `.contrib`: Stuff that affects the contributor experience. e.g.
      Running tests, building the docs, setting up the development
      environment.
    * `.misc`: Changes that are hard to assign to any of the above
      categories.
  * Make sure to use full sentences with correct case and punctuation,
    for example:
    ```rst
    Fixed issue with non-ascii contents in doctest text files
    -- by :user:`contributor-gh-handle`.
    ```

    Use the past tense or the present tense a non-imperative mood,
    referring to what's changed compared to the last released version
    of this project.
