### PR TITLE
Remove asyncio.shield in _drain_helper to fix unhandled future warnings

### DIFF
--- a/CHANGES/12281.bugfix.rst
+++ b/CHANGES/12281.bugfix.rst
@@ -1,4 +1,4 @@
 Fixed "Future exception was never retrieved" warning when a request handler
-is cancelled during TCP write backpressure. ``_drain_helper`` now awaits the
+is cancelled during TCP write back-pressure. ``_drain_helper`` now awaits the
 drain waiter directly instead of wrapping it in :func:`asyncio.shield`
 -- by :user:`joaquinhuigomez`.

--- a/CHANGES/12281.bugfix.rst
+++ b/CHANGES/12281.bugfix.rst
@@ -1,0 +1,4 @@
+Fixed "Future exception was never retrieved" warning when a request handler
+is cancelled during TCP write backpressure. ``_drain_helper`` now awaits the
+drain waiter directly instead of wrapping it in :func:`asyncio.shield`
+-- by :user:`joaquinhuigomez`.

--- a/aiohttp/base_protocol.py
+++ b/aiohttp/base_protocol.py
@@ -97,4 +97,4 @@ class BaseProtocol(asyncio.Protocol):
         if waiter is None:
             waiter = self._loop.create_future()
             self._drain_waiter = waiter
-        await asyncio.shield(waiter)
+        await waiter

--- a/tests/test_base_protocol.py
+++ b/tests/test_base_protocol.py
@@ -242,6 +242,50 @@ async def test_resume_drain_cancelled() -> None:
     assert pr._drain_waiter is None
 
 
+async def test_cancelled_drain_no_unhandled_future_warning() -> None:
+    """Cancelling a task during backpressure must not leave an orphaned future.
+
+    When the handler task is cancelled while awaiting _drain_helper and
+    connection_lost fires with an exception afterward, the waiter should
+    already be done (cancelled) so set_exception is skipped. No "Future
+    exception was never retrieved" warning should appear.
+
+    Regression test for https://github.com/aio-libs/aiohttp/issues/12281
+    """
+    loop = asyncio.get_event_loop()
+    pr = BaseProtocol(loop=loop)
+    tr = mock.Mock()
+    pr.connection_made(tr)
+    pr.pause_writing()
+
+    fut = loop.create_future()
+
+    async def wait() -> None:
+        fut.set_result(None)
+        await pr._drain_helper()
+
+    t = loop.create_task(wait())
+    await fut
+    t.cancel()
+    with suppress(asyncio.CancelledError):
+        await t
+
+    # After cancellation the waiter should be done (cancelled), so
+    # connection_lost with an exception must not call set_exception.
+    assert pr._drain_waiter is not None
+    waiter = pr._drain_waiter
+    assert waiter.done(), "waiter must be cancelled when task is cancelled"
+
+    # This previously left an orphaned future with an unhandled exception
+    # because asyncio.shield kept the original waiter alive and uncancelled.
+    exc = RuntimeError("connection died")
+    pr.connection_lost(exc)
+    assert pr._drain_waiter is None
+
+    # Verify the waiter is cancelled, not set with an exception.
+    assert waiter.cancelled()
+
+
 async def test_parallel_drain_race_condition() -> None:
     loop = asyncio.get_event_loop()
     pr = BaseProtocol(loop=loop)

--- a/tests/test_base_protocol.py
+++ b/tests/test_base_protocol.py
@@ -283,7 +283,7 @@ async def test_cancelled_drain_no_unhandled_future_warning() -> None:
     assert pr._drain_waiter is None
 
     # Verify the waiter is cancelled, not set with an exception.
-    assert waiter.cancelled()
+    assert waiter.cancelled()  # type: ignore[unreachable]
 
 
 async def test_parallel_drain_race_condition() -> None:


### PR DESCRIPTION
Replace `asyncio.shield(waiter)` with direct `await waiter` in `_drain_helper`.

HTTP/1.1 has a single consumer per drain waiter, so the shield is unnecessary. When a handler task is cancelled during write backpressure, `asyncio.shield` keeps the original waiter alive and uncancelled. `connection_lost` then calls `set_exception` on it, but nobody is awaiting it anymore, producing noisy "Future exception was never retrieved" warnings.

Without the shield, cancellation propagates directly to the waiter. `connection_lost` finds `waiter.done() == True` and skips `set_exception`.

Includes a regression test that verifies the waiter is properly cancelled (not left with an unhandled exception) when the task is cancelled during backpressure and `connection_lost` fires afterward.

Closes #12281