### PR TITLE
Fix spurious "Future exception was never retrieved" warning on disconnect during backpressure

### DIFF
--- a/CHANGES/12281.bugfix.rst
+++ b/CHANGES/12281.bugfix.rst
@@ -1,3 +1,1 @@
-Fixed spurious ``Future exception was never retrieved`` warnings logged by
-the asyncio event loop when a client disconnected while the server write
-buffer was paused due to TCP back-pressure -- by :user:`availov`.
+Fixed spurious ``Future exception was never retrieved`` warning on disconnect during backpressure -- by :user:`availov`.

--- a/CHANGES/12281.bugfix.rst
+++ b/CHANGES/12281.bugfix.rst
@@ -1,0 +1,3 @@
+Fixed spurious ``Future exception was never retrieved`` warnings logged by
+the asyncio event loop when a client disconnected while the server write
+buffer was paused due to TCP back-pressure -- by :user:`availov`.

--- a/CHANGES/12281.bugfix.rst
+++ b/CHANGES/12281.bugfix.rst
@@ -1,1 +1,1 @@
-Fixed spurious ``Future exception was never retrieved`` warning on disconnect during backpressure -- by :user:`availov`.
+Fixed spurious ``Future exception was never retrieved`` warning on disconnect during back-pressure -- by :user:`availov`.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -420,6 +420,7 @@ Yegor Roganov
 Yifei Kong
 Young-Ho Cha
 Yuriy Shatrov
+Yury Novikov
 Yury Pliner
 Yury Selivanov
 Yusuke Tsutsumi

--- a/aiohttp/base_protocol.py
+++ b/aiohttp/base_protocol.py
@@ -97,4 +97,4 @@ class BaseProtocol(asyncio.Protocol):
         if waiter is None:
             waiter = self._loop.create_future()
             self._drain_waiter = waiter
-        await asyncio.shield(waiter)
+        await waiter

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -8,7 +8,7 @@ import pytest
 
 from aiohttp import client, web
 from aiohttp.http_exceptions import BadHttpMethod, BadStatusLine
-from aiohttp.pytest_plugin import AiohttpClient, AiohttpRawServer
+from aiohttp.pytest_plugin import AiohttpClient, AiohttpRawServer, AiohttpServer
 
 
 async def test_simple_server(
@@ -454,3 +454,58 @@ async def test_no_handler_cancellation(unused_port_socket: socket.socket) -> Non
         assert done_event.is_set()
     finally:
         await asyncio.gather(runner.shutdown(), site.stop())
+
+
+async def test_no_future_warning_on_disconnect_during_backpressure(
+    aiohttp_server: AiohttpServer,
+) -> None:
+    import gc
+
+    loop = asyncio.get_event_loop()
+    exc_handler_calls: list[dict] = []
+    original_handler = loop.get_exception_handler()
+    loop.set_exception_handler(lambda _loop, ctx: exc_handler_calls.append(ctx))
+
+    protocol_holder: list[web.RequestHandler] = []
+
+    async def handler(request: web.Request) -> NoReturn:
+        protocol_holder.append(request.protocol)  # type: ignore[arg-type]
+        resp = web.StreamResponse()
+        await resp.prepare(request)
+        while True:
+            await resp.write(b"x" * 65536)
+
+    app = web.Application()
+    app.router.add_route("GET", "/", handler)
+    # aiohttp_server enables handler_cancellation by default so the handler
+    # task is cancelled when connection_lost() fires.
+    server = await aiohttp_server(app)
+
+    # Open a raw asyncio connection so we control exactly when the client
+    # side closes.
+    reader, writer = await asyncio.open_connection(server.host, server.port)
+    writer.write(b"GET / HTTP/1.1\r\nHost: localhost\r\n\r\n")
+    await writer.drain()
+
+    try:
+        # Poll until the server protocol reports that writing is paused.
+        async def wait_for_backpressure() -> None:
+            while not protocol_holder or not protocol_holder[0].writing_paused:
+                await asyncio.sleep(0.01)
+
+        await asyncio.wait_for(wait_for_backpressure(), timeout=5.0)
+
+        writer.close()
+        await asyncio.sleep(0.1)
+
+        gc.collect()
+        await asyncio.sleep(0)
+    finally:
+        loop.set_exception_handler(original_handler)
+
+    orphan_warnings = [
+        ctx
+        for ctx in exc_handler_calls
+        if "exception was never retrieved" in ctx.get("message", "").lower()
+    ]
+    assert not orphan_warnings, f"Unexpected asyncio warnings: {orphan_warnings}"

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -489,7 +489,7 @@ async def test_no_future_warning_on_disconnect_during_backpressure(
     try:
         # Poll until the server protocol reports that writing is paused.
         async def wait_for_backpressure() -> None:
-            while not protocol_holder or not protocol_holder[0].writing_paused:
+            while protocol is None or not protocol.writing_paused:
                 await asyncio.sleep(0.01)
 
         await asyncio.wait_for(wait_for_backpressure(), timeout=5.0)

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -1,7 +1,7 @@
 import asyncio
 import socket
 from contextlib import suppress
-from typing import NoReturn
+from typing import Any, NoReturn
 from unittest import mock
 
 import pytest
@@ -462,14 +462,14 @@ async def test_no_future_warning_on_disconnect_during_backpressure(
     import gc
 
     loop = asyncio.get_event_loop()
-    exc_handler_calls: list[dict] = []
+    exc_handler_calls: list[dict[str, Any]] = []
     original_handler = loop.get_exception_handler()
     loop.set_exception_handler(lambda _loop, ctx: exc_handler_calls.append(ctx))
 
-    protocol_holder: list[web.RequestHandler] = []
+    protocol_holder: list[web.RequestHandler[web.Request]] = []
 
     async def handler(request: web.Request) -> NoReturn:
-        protocol_holder.append(request.protocol)  # type: ignore[arg-type]
+        protocol_holder.append(request.protocol)
         resp = web.StreamResponse()
         await resp.prepare(request)
         while True:

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -1,4 +1,5 @@
 import asyncio
+import gc
 import socket
 from contextlib import suppress
 from typing import Any, NoReturn
@@ -459,17 +460,15 @@ async def test_no_handler_cancellation(unused_port_socket: socket.socket) -> Non
 async def test_no_future_warning_on_disconnect_during_backpressure(
     aiohttp_server: AiohttpServer,
 ) -> None:
-    import gc
-
-    loop = asyncio.get_event_loop()
+    loop = asyncio.get_running_loop()
     exc_handler_calls: list[dict[str, Any]] = []
     original_handler = loop.get_exception_handler()
     loop.set_exception_handler(lambda _loop, ctx: exc_handler_calls.append(ctx))
-
-    protocol_holder: list[web.RequestHandler[web.Request]] = []
+    protocol = None
 
     async def handler(request: web.Request) -> NoReturn:
-        protocol_holder.append(request.protocol)
+        nonlocal protocol
+        protocol = request.protocol
         resp = web.StreamResponse()
         await resp.prepare(request)
         while True:
@@ -503,9 +502,4 @@ async def test_no_future_warning_on_disconnect_during_backpressure(
     finally:
         loop.set_exception_handler(original_handler)
 
-    orphan_warnings = [
-        ctx
-        for ctx in exc_handler_calls
-        if "exception was never retrieved" in ctx.get("message", "").lower()
-    ]
-    assert not orphan_warnings, f"Unexpected asyncio warnings: {orphan_warnings}"
+    assert not exc_handler_calls


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

In `BaseProtocol._drain_helper()` we replaced `await asyncio.shield(waiter)` with plain `await waiter`.  
Since each connection is handled by a single task, the shield didn't provide any benefit and prevented proper cancellation of the waiter future.

Now the future is cancelled cleanly and no spurious warning is logged.

## Are there changes in behavior for the user?

No.

## Is it a substantial burden for the maintainers to support this?

No, this is a very small and localized change.

## Related issue number

Fixes #12281
