### PR TITLE
Fix TypeError when access_logger.enabled changes after RequestHandler init

### DIFF
--- a/aiohttp/web_protocol.py
+++ b/aiohttp/web_protocol.py
@@ -503,9 +503,11 @@ class RequestHandler(BaseProtocol, Generic[_Request]):
         response: StreamResponse,
         request_start: float | None,
     ) -> None:
-        if self._logging_enabled and self.access_logger is not None:
-            if TYPE_CHECKING:
-                assert request_start is not None
+        if (
+            self.access_logger is not None
+            and self.access_logger.enabled
+            and request_start is not None
+        ):
             await self.access_logger.log(request, response, request_start)
 
     def log_debug(self, *args: Any, **kw: Any) -> None:


### PR DESCRIPTION
## Problem

When `_logging_enabled` is `False` at `RequestHandler` init time, `start_time` is set to `None`. If the log level changes later (e.g. in unit tests using `assertLogs()`), `log_access()` still runs because the check uses the cached `_logging_enabled` flag instead of the current `access_logger.enabled` state.

This causes `TypeError` from `self._loop.time() - None`.

## Root Cause

```python
# init: _logging_enabled = False → start_time = None
start = loop.time() if self._logging_enabled else None

# log_access: uses cached _logging_enabled which may be stale
if self._logging_enabled and self.access_logger is not None:
    await self.access_logger.log(request, response, request_start)  # request_start is None!
```

## Fix

1. Check `access_logger.enabled` directly instead of the cached `_logging_enabled`
2. Add `request_start is not None` guard to prevent TypeError

```python
if (
    self.access_logger is not None
    and self.access_logger.enabled
    and request_start is not None
):
    await self.access_logger.log(request, response, request_start)
```

Closes #11778