### PR TITLE
Fix GunicornWebWorker failing to reset SIGCHLD handler

### DIFF
--- a/aiohttp/worker.py
+++ b/aiohttp/worker.py
@@ -179,12 +179,11 @@ class GunicornWebWorker(base.Worker):  # type: ignore[misc,no-any-unimported]
         # by interrupting system calls
         signal.siginterrupt(signal.SIGTERM, False)
         signal.siginterrupt(signal.SIGUSR1, False)
+
         # Reset SIGCHLD to default so Gunicorn doesn't swallow subprocess
         # return codes. Without this, workers inherit the master arbiter's
         # SIGCHLD handler, causing spurious "Worker exited" errors when
         # application code spawns subprocesses.
-        # See: https://github.com/aio-libs/aiohttp/issues/6130
-        # See: https://github.com/aio-libs/aiohttp/issues/12327
         signal.signal(signal.SIGCHLD, signal.SIG_DFL)
 
     def handle_quit(self, sig: int, frame: FrameType | None) -> None:

--- a/aiohttp/worker.py
+++ b/aiohttp/worker.py
@@ -179,8 +179,13 @@ class GunicornWebWorker(base.Worker):  # type: ignore[misc,no-any-unimported]
         # by interrupting system calls
         signal.siginterrupt(signal.SIGTERM, False)
         signal.siginterrupt(signal.SIGUSR1, False)
-        # Reset signals so Gunicorn doesn't swallow subprocess return codes
+        # Reset SIGCHLD to default so Gunicorn doesn't swallow subprocess
+        # return codes. Without this, workers inherit the master arbiter's
+        # SIGCHLD handler, causing spurious "Worker exited" errors when
+        # application code spawns subprocesses.
         # See: https://github.com/aio-libs/aiohttp/issues/6130
+        # See: https://github.com/aio-libs/aiohttp/issues/12327
+        signal.signal(signal.SIGCHLD, signal.SIG_DFL)
 
     def handle_quit(self, sig: int, frame: FrameType | None) -> None:
         self.alive = False


### PR DESCRIPTION
Fixes #12327

## Problem

`GunicornWebWorker.init_signals()` had a comment about resetting SIGCHLD but **no actual implementation**. Workers inherit the Gunicorn master arbiter's SIGCHLD handler, causing spurious "Worker exited" errors when application code spawns subprocesses.

The comment on lines 183-184 said:
```python
# Reset signals so Gunicorn doesn't swallow subprocess return codes
# See: https://github.com/aio-libs/aiohttp/issues/6130
```

But no code followed.

## Fix

Add `signal.signal(signal.SIGCHLD, signal.SIG_DFL)` to reset the handler, consistent with gunicorn's base `Worker` class which resets all signals including CHLD.

## Evidence

gunicorn's `base.Worker.init_signals()` properly resets SIGCHLD:
```python
SIGNALS = ["ABRT", "HUP", "QUIT", "INT", "TERM", "USR1", "USR2", "WINCH", "CHLD"]
def init_signals(self):
    for s in self.SIGNALS:
        signal.signal(s, signal.SIG_DFL)
```

aiohttp's override doesn't call `super()` and was missing the CHLD reset.

## Changes

```diff
+ signal.signal(signal.SIGCHLD, signal.SIG_DFL)
```