### PR TITLE
Security: Silent Exception Swallowing in Server Request Handler Factory

### DIFF
--- a/aiohttp/web_server.py
+++ b/aiohttp/web_server.py
@@ -117,6 +117,7 @@ class Server(Generic[_Request]):
         try:
             return RequestHandler(self, loop=self._loop, **self._kwargs)
         except TypeError:
+            # Failsafe creation: remove all custom handler_arg
             kwargs = {
                 k: v
                 for k, v in self._kwargs.items()

--- a/aiohttp/web_server.py
+++ b/aiohttp/web_server.py
@@ -1,6 +1,7 @@
 """Low level HTTP server."""
 
 import asyncio
+import logging
 import warnings
 from collections.abc import Awaitable, Callable
 from typing import Any, Generic, TypeVar, overload
@@ -13,6 +14,8 @@ from .web_request import BaseRequest
 from .web_response import StreamResponse
 
 __all__ = ("Server",)
+
+logger = logging.getLogger(__name__)
 
 _Request = TypeVar("_Request", bound=BaseRequest)
 _RequestFactory = Callable[
@@ -117,7 +120,12 @@ class Server(Generic[_Request]):
         try:
             return RequestHandler(self, loop=self._loop, **self._kwargs)
         except TypeError:
-            # Failsafe creation: remove all custom handler_args
+            logger.warning(
+                "Failed to create request handler with custom kwargs %r, "
+                "falling back to filtered kwargs. This may indicate a "
+                "misconfiguration.",
+                self._kwargs,
+            )
             kwargs = {
                 k: v
                 for k, v in self._kwargs.items()

--- a/aiohttp/web_server.py
+++ b/aiohttp/web_server.py
@@ -117,7 +117,7 @@ class Server(Generic[_Request]):
         try:
             return RequestHandler(self, loop=self._loop, **self._kwargs)
         except TypeError:
-            # Failsafe creation: remove all custom handler_arg
+            # Failsafe creation: remove all custom handler_args
             kwargs = {
                 k: v
                 for k, v in self._kwargs.items()

--- a/aiohttp/web_server.py
+++ b/aiohttp/web_server.py
@@ -1,7 +1,6 @@
 """Low level HTTP server."""
 
 import asyncio
-import logging
 import warnings
 from collections.abc import Awaitable, Callable
 from typing import Any, Generic, TypeVar, overload
@@ -14,8 +13,6 @@ from .web_request import BaseRequest
 from .web_response import StreamResponse
 
 __all__ = ("Server",)
-
-logger = logging.getLogger(__name__)
 
 _Request = TypeVar("_Request", bound=BaseRequest)
 _RequestFactory = Callable[
@@ -120,15 +117,16 @@ class Server(Generic[_Request]):
         try:
             return RequestHandler(self, loop=self._loop, **self._kwargs)
         except TypeError:
-            logger.warning(
-                "Failed to create request handler with custom kwargs %r, "
-                "falling back to filtered kwargs. This may indicate a "
-                "misconfiguration.",
-                self._kwargs,
-            )
             kwargs = {
                 k: v
                 for k, v in self._kwargs.items()
                 if k in ["debug", "access_log_class"]
             }
-            return RequestHandler(self, loop=self._loop, **kwargs)
+            handler = RequestHandler(self, loop=self._loop, **kwargs)
+            handler.logger.warning(
+                "Failed to create request handler with custom kwargs %r, "
+                "falling back to filtered kwargs. This may indicate a "
+                "misconfiguration.",
+                self._kwargs,
+            )
+            return handler


### PR DESCRIPTION
## Problem

The `Server.__call__` method catches `TypeError` broadly and silently retries handler creation with filtered kwargs. This could mask legitimate configuration errors or security-relevant misconfigurations, making debugging difficult and potentially allowing the server to start with an insecure or unexpected configuration.

**Severity**: `low`
**File**: `aiohttp/web_server.py`

## Solution

Log a warning when falling back to the failsafe creation path so that misconfiguration is visible to operators. Consider narrowing the exception handling or deprecating this failsafe behavior.

## Changes

- `aiohttp/web_server.py` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
