### PR TITLE
Security: Arbitrary Code Execution via exec() on File Content

### DIFF
--- a/tools/gen.py
+++ b/tools/gen.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+import ast
 import io
 import pathlib
 from collections import defaultdict
@@ -13,10 +14,20 @@ while ROOT.parent != ROOT and not (ROOT / "pyproject.toml").exists():
 
 def calc_headers(root):
     hdrs_file = root / "aiohttp/hdrs.py"
-    code = compile(hdrs_file.read_text(), str(hdrs_file), "exec")
-    globs = {}
-    exec(code, globs)
-    headers = [val for val in globs.values() if isinstance(val, multidict.istr)]
+    tree = ast.parse(hdrs_file.read_text())
+    headers = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign):
+            value = node.value
+            if (
+                isinstance(value, ast.Call)
+                and isinstance(value.func, ast.Name)
+                and value.func.id == "istr"
+                and len(value.args) == 1
+                and isinstance(value.args[0], ast.Constant)
+                and isinstance(value.args[0].value, str)
+            ):
+                headers.append(multidict.istr(value.args[0].value))
     return sorted(headers)
 
 


### PR DESCRIPTION
## Problem

The `calc_headers` function reads, compiles, and executes the content of `aiohttp/hdrs.py` using `exec(code, globs)`. If an attacker can modify `hdrs.py` (e.g., through a supply chain attack or compromised repository), arbitrary code would be executed when this tool script is run. The tool is used to generate C source files that get compiled into the library.

**Severity**: `medium`
**File**: `tools/gen.py`

## Solution

Instead of using `exec()`, parse `hdrs.py` with the `ast` module to safely extract the header constants: `import ast; tree = ast.parse(hdrs_file.read_text()); # extract string assignments from the AST`.

## Changes

- `tools/gen.py` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
