### PR TITLE
[3.14] Harden cookie file permissions in CookieJar.save()

### DIFF
--- a/CHANGES/12312.bugfix.rst
+++ b/CHANGES/12312.bugfix.rst
@@ -1,0 +1,1 @@
+``Cookiejar.save()`` now uses ``0x600`` permissions to better protect them from being read by other users -- by :user:`digiscrypt`.

--- a/aiohttp/cookiejar.py
+++ b/aiohttp/cookiejar.py
@@ -5,7 +5,7 @@ import datetime
 import heapq
 import itertools
 import json
-import os  # noqa
+import os
 import pathlib
 import pickle
 import re
@@ -174,7 +174,16 @@ class CookieJar(AbstractCookieJar):
                     if attr_val:
                         morsel_data[attr] = attr_val
                 data[key][name] = morsel_data
-        with file_path.open(mode="w", encoding="utf-8") as f:
+
+        # Cookie persistence may include authentication/session tokens.
+        # Use 0o600 at creation time to avoid umask-dependent overexposure
+        # and enforce least-privilege access to sensitive credential data.
+        with open(
+            file_path,
+            mode="w",
+            encoding="utf-8",
+            opener=lambda path, flags: os.open(path, flags, 0o600),
+        ) as f:
             json.dump(data, f, indent=2)
 
     def load(self, file_path: PathLike) -> None:

--- a/tests/test_cookiejar.py
+++ b/tests/test_cookiejar.py
@@ -1817,9 +1817,9 @@ async def test_save_load_json_secure_cookies(tmp_path: Path) -> None:
 @pytest.mark.skipif(
     os.name != "posix", reason="POSIX permission bits are required for this test"
 )
-def test_save_creates_private_cookie_file(tmp_path: Path) -> None:
+def test_save_creates_private_cookie_file(tmp_path: Path, loop) -> None:
     file_path = tmp_path / "private-cookies.json"
-    jar = CookieJar()
+    jar = CookieJar(loop=loop)
     jar.update_cookies_from_headers(
         ["token=abc123; Path=/"], URL("https://example.com/")
     )
@@ -1833,12 +1833,12 @@ def test_save_creates_private_cookie_file(tmp_path: Path) -> None:
 @pytest.mark.skipif(
     os.name != "posix", reason="POSIX permission bits are required for this test"
 )
-def test_save_preserves_existing_cookie_file_permissions(tmp_path: Path) -> None:
+def test_save_preserves_existing_cookie_file_permissions(tmp_path: Path, loop) -> None:
     file_path = tmp_path / "existing-cookies.json"
     file_path.write_text("{}", encoding="utf-8")
     file_path.chmod(0o644)
 
-    jar = CookieJar()
+    jar = CookieJar(loop=loop)
     jar.update_cookies_from_headers(
         ["token=abc123; Path=/"], URL("https://example.com/")
     )

--- a/tests/test_cookiejar.py
+++ b/tests/test_cookiejar.py
@@ -3,8 +3,10 @@ import datetime
 import heapq
 import itertools
 import logging
+import os
 import pathlib
 import pickle
+import stat
 import sys
 import unittest
 from http.cookies import BaseCookie, Morsel, SimpleCookie
@@ -1810,6 +1812,40 @@ async def test_save_load_json_secure_cookies(tmp_path: Path) -> None:
     assert cookie["secure"] is True
     assert cookie["httponly"] is True
     assert cookie["domain"] == "example.com"
+
+
+@pytest.mark.skipif(
+    os.name != "posix", reason="POSIX permission bits are required for this test"
+)
+def test_save_creates_private_cookie_file(tmp_path: Path) -> None:
+    file_path = tmp_path / "private-cookies.json"
+    jar = CookieJar()
+    jar.update_cookies_from_headers(
+        ["token=abc123; Path=/"], URL("https://example.com/")
+    )
+
+    jar.save(file_path=file_path)
+
+    assert file_path.exists()
+    assert stat.S_IMODE(file_path.stat().st_mode) == 0o600
+
+
+@pytest.mark.skipif(
+    os.name != "posix", reason="POSIX permission bits are required for this test"
+)
+def test_save_preserves_existing_cookie_file_permissions(tmp_path: Path) -> None:
+    file_path = tmp_path / "existing-cookies.json"
+    file_path.write_text("{}", encoding="utf-8")
+    file_path.chmod(0o644)
+
+    jar = CookieJar()
+    jar.update_cookies_from_headers(
+        ["token=abc123; Path=/"], URL("https://example.com/")
+    )
+
+    jar.save(file_path=file_path)
+
+    assert stat.S_IMODE(file_path.stat().st_mode) == 0o644
 
 
 async def test_cookie_jar_unsafe_property() -> None:


### PR DESCRIPTION
Backport of #12312 to the 3.14 branch.

This PR includes 3.14 conflict resolution and test adaptation for the 3.14 codebase.