### PR TITLE
Add progress callback support to Payload

### DIFF
--- a/CHANGES/12340.feature.rst
+++ b/CHANGES/12340.feature.rst
@@ -1,0 +1,3 @@
+Added the possibility to provide a callback to the ``Payload``,
+which is used by their writer methods to report back the already written bytes.
+-- by :user:`mib1185`.

--- a/aiohttp/payload.py
+++ b/aiohttp/payload.py
@@ -918,15 +918,15 @@ class BytesIOPayload(IOBasePayload):
                 await asyncio.sleep(0)
             if remaining_bytes is None:
                 await writer.write(chunk)
+                total_written_len += chunk_len
+                self._report_progress(total_written_len)
             else:
                 await writer.write(chunk[:remaining_bytes])
+                total_written_len += remaining_bytes
                 remaining_bytes -= chunk_len
-
-            total_written_len += chunk_len
-            self._report_progress(total_written_len)
-
-            if remaining_bytes is not None and remaining_bytes <= 0:
-                return
+                self._report_progress(total_written_len)
+                if remaining_bytes <= 0:
+                    return
 
             loop_count += 1
 

--- a/aiohttp/payload.py
+++ b/aiohttp/payload.py
@@ -1071,7 +1071,7 @@ class AsyncIterablePayload(Payload):
                 elif remaining_bytes > 0:
                     await writer.write(chunk[:remaining_bytes])
                     remaining_bytes -= chunk_len
-                    total_written_len += chunk_len
+                    total_written_len += remaining_bytes
                     self._report_progress(total_written_len)
                 else:
                     break
@@ -1096,7 +1096,7 @@ class AsyncIterablePayload(Payload):
                 elif remaining_bytes > 0:
                     await writer.write(chunk[:remaining_bytes])
                     remaining_bytes -= chunk_len
-                    total_written_len += chunk_len
+                    total_written_len += remaining_bytes
                     self._report_progress(total_written_len)
                 # We still want to exhaust the iterator even
                 # if we have reached the content length limit

--- a/aiohttp/payload.py
+++ b/aiohttp/payload.py
@@ -634,13 +634,13 @@ class IOBasePayload(Payload):
             # Write data with or without length constraint
             if remaining_content_len is None:
                 await writer.write(chunk)
+                total_written_len += chunk_len
             else:
                 await writer.write(chunk[:remaining_content_len])
+                total_written_len += min(remaining_content_len, chunk_len)
                 remaining_content_len -= chunk_len
 
-            total_written_len += chunk_len
             self._report_progress(total_written_len)
-
             # Check if we're done writing
             if self._should_stop_writing(
                 available_len, total_written_len, remaining_content_len
@@ -922,9 +922,9 @@ class BytesIOPayload(IOBasePayload):
                 self._report_progress(total_written_len)
             else:
                 await writer.write(chunk[:remaining_bytes])
-                total_written_len += remaining_bytes
-                remaining_bytes -= chunk_len
+                total_written_len += min(remaining_bytes, chunk_len)
                 self._report_progress(total_written_len)
+                remaining_bytes -= chunk_len
                 if remaining_bytes <= 0:
                     return
 
@@ -1070,9 +1070,9 @@ class AsyncIterablePayload(Payload):
                     self._report_progress(total_written_len)
                 elif remaining_bytes > 0:
                     await writer.write(chunk[:remaining_bytes])
-                    remaining_bytes -= chunk_len
-                    total_written_len += remaining_bytes
+                    total_written_len += min(remaining_bytes, chunk_len)
                     self._report_progress(total_written_len)
+                    remaining_bytes -= chunk_len
                 else:
                     break
             return
@@ -1095,9 +1095,9 @@ class AsyncIterablePayload(Payload):
                 # If we have a content length limit
                 elif remaining_bytes > 0:
                     await writer.write(chunk[:remaining_bytes])
-                    remaining_bytes -= chunk_len
-                    total_written_len += remaining_bytes
+                    total_written_len += min(remaining_bytes, chunk_len)
                     self._report_progress(total_written_len)
+                    remaining_bytes -= chunk_len
                 # We still want to exhaust the iterator even
                 # if we have reached the content length limit
                 # since the file handle may not get closed by

--- a/aiohttp/payload.py
+++ b/aiohttp/payload.py
@@ -7,7 +7,7 @@ import os
 import sys
 import warnings
 from abc import ABC, abstractmethod
-from collections.abc import AsyncIterable, AsyncIterator, Iterable
+from collections.abc import AsyncIterable, AsyncIterator, Callable, Iterable
 from itertools import chain
 from typing import IO, Any, Final, TextIO
 
@@ -151,11 +151,13 @@ class Payload(ABC):
         content_type: None | str | _SENTINEL = sentinel,
         filename: str | None = None,
         encoding: str | None = None,
+        progress: Callable[[int], None] | None = None,
         **kwargs: Any,
     ) -> None:
         self._encoding = encoding
         self._filename = filename
         self._headers = CIMultiDict[str]()
+        self._progress = progress
         self._value = value
         if content_type is not sentinel and content_type is not None:
             assert isinstance(content_type, str)
@@ -239,6 +241,19 @@ class Payload(ABC):
         self._headers[hdrs.CONTENT_DISPOSITION] = content_disposition_header(
             disptype, quote_fields=quote_fields, _charset=_charset, params=params
         )
+
+    def set_progress_callback(
+        self, callback: Callable[[int], None] | None = None
+    ) -> None:
+        """
+        Set a callback function to be called with the total number of bytes written so far.
+
+        Args:
+            callback: A callable that takes an integer representing the total number of bytes written so far.
+                When set to `None`, it will clear any existing progress callback.
+
+        """
+        self._progress = callback
 
     @abstractmethod
     def decode(self, encoding: str = "utf-8", errors: str = "strict") -> str:
@@ -334,6 +349,11 @@ class Payload(ABC):
         """
         self._close()
 
+    def _report_progress(self, total_written_len: int) -> None:
+        """Call the progress callback if it is set, with the total number of bytes written so far."""
+        if self._progress:
+            self._progress(total_written_len)
+
 
 class BytesPayload(Payload):
     _value: bytes
@@ -408,10 +428,13 @@ class BytesPayload(Payload):
         is performed efficiently using array slicing.
 
         """
+        self._report_progress(0)
         if content_length is not None:
             await writer.write(self._value[:content_length])
+            self._report_progress(content_length)
         else:
             await writer.write(self._value)
+            self._report_progress(len(self._value))
 
 
 class StringPayload(BytesPayload):
@@ -598,6 +621,8 @@ class IOBasePayload(Payload):
         total_written_len = 0
         remaining_content_len = content_length
 
+        self._report_progress(total_written_len)
+
         # Get initial data and available length
         available_len, chunk = await loop.run_in_executor(
             None, self._read_and_available_len, remaining_content_len
@@ -614,6 +639,7 @@ class IOBasePayload(Payload):
                 remaining_content_len -= chunk_len
 
             total_written_len += chunk_len
+            self._report_progress(total_written_len)
 
             # Check if we're done writing
             if self._should_stop_writing(
@@ -877,8 +903,13 @@ class BytesIOPayload(IOBasePayload):
         """
         self._set_or_restore_start_position()
         loop_count = 0
+        total_written_len = 0
         remaining_bytes = content_length
+
+        self._report_progress(total_written_len)
+
         while chunk := self._value.read(READ_SIZE):
+            chunk_len = len(chunk)
             if loop_count > 0:
                 # Avoid blocking the event loop
                 # if they pass a large BytesIO object
@@ -889,9 +920,14 @@ class BytesIOPayload(IOBasePayload):
                 await writer.write(chunk)
             else:
                 await writer.write(chunk[:remaining_bytes])
-                remaining_bytes -= len(chunk)
-                if remaining_bytes <= 0:
-                    return
+                remaining_bytes -= chunk_len
+
+            total_written_len += chunk_len
+            self._report_progress(total_written_len)
+
+            if remaining_bytes is not None and remaining_bytes <= 0:
+                return
+
             loop_count += 1
 
     async def as_bytes(self, encoding: str = "utf-8", errors: str = "strict") -> bytes:
@@ -1020,15 +1056,23 @@ class AsyncIterablePayload(Payload):
         4. Does NOT generate cache - that's done by as_bytes()
 
         """
+        total_written_len = 0
+        self._report_progress(total_written_len)
+
         # If we have cached chunks, use them
         if self._cached_chunks is not None:
             remaining_bytes = content_length
             for chunk in self._cached_chunks:
+                chunk_len = len(chunk)
                 if remaining_bytes is None:
                     await writer.write(chunk)
+                    total_written_len += chunk_len
+                    self._report_progress(total_written_len)
                 elif remaining_bytes > 0:
                     await writer.write(chunk[:remaining_bytes])
-                    remaining_bytes -= len(chunk)
+                    remaining_bytes -= chunk_len
+                    total_written_len += chunk_len
+                    self._report_progress(total_written_len)
                 else:
                     break
             return
@@ -1043,12 +1087,17 @@ class AsyncIterablePayload(Payload):
         try:
             while True:
                 chunk = await anext(self._iter)
+                chunk_len = len(chunk)
                 if remaining_bytes is None:
                     await writer.write(chunk)
+                    total_written_len += chunk_len
+                    self._report_progress(total_written_len)
                 # If we have a content length limit
                 elif remaining_bytes > 0:
                     await writer.write(chunk[:remaining_bytes])
-                    remaining_bytes -= len(chunk)
+                    remaining_bytes -= chunk_len
+                    total_written_len += chunk_len
+                    self._report_progress(total_written_len)
                 # We still want to exhaust the iterator even
                 # if we have reached the content length limit
                 # since the file handle may not get closed by

--- a/tests/test_payload.py
+++ b/tests/test_payload.py
@@ -232,6 +232,27 @@ async def test_bytes_payload_write_with_length_truncated() -> None:
     assert len(writer.get_written_bytes()) == 5
 
 
+async def test_bytes_payload_write_progress_callback() -> None:
+    """Test BytesPayload writing with progress callback."""
+    progress_callback = unittest.mock.Mock()
+    p = payload.BytesPayload(b"0123456789")
+    p.set_progress_callback(progress_callback)
+    writer = MockStreamWriter()
+
+    await p.write_with_length(writer, 5)
+    assert progress_callback.call_args_list == [
+        unittest.mock.call(0),
+        unittest.mock.call(5),
+    ]
+    progress_callback.call_args_list.clear()
+
+    await p.write_with_length(writer, None)
+    assert progress_callback.call_args_list == [
+        unittest.mock.call(0),
+        unittest.mock.call(10),
+    ]
+
+
 async def test_iobase_payload_write_with_length_no_limit() -> None:
     """Test IOBasePayload writing with no content length limit."""
     data = b"0123456789"
@@ -263,6 +284,69 @@ async def test_iobase_payload_write_with_length_truncated() -> None:
     await p.write_with_length(writer, 5)
     assert writer.get_written_bytes() == b"01234"
     assert len(writer.get_written_bytes()) == 5
+
+
+async def test_iobase_payload_write_progress_callback() -> None:
+    """Test IOBasePayload writing with progress callback."""
+    progress_callback = unittest.mock.Mock()
+    p = payload.IOBasePayload(io.BytesIO(b"0123456789"))
+    p.set_progress_callback(progress_callback)
+    writer = MockStreamWriter()
+
+    await p.write_with_length(writer, 5)
+    assert progress_callback.call_args_list == [
+        unittest.mock.call(0),
+        unittest.mock.call(5),
+    ]
+    progress_callback.call_args_list.clear()
+
+    await p.write_with_length(writer, None)
+    assert progress_callback.call_args_list == [
+        unittest.mock.call(0),
+        unittest.mock.call(10),
+    ]
+
+
+@pytest.mark.parametrize(
+    ("content_length", "expected_calls"),
+    [
+        (
+            6,
+            [
+                unittest.mock.call(0),
+                unittest.mock.call(4),
+                unittest.mock.call(6),
+            ],
+        ),
+        (
+            10,
+            [
+                unittest.mock.call(0),
+                unittest.mock.call(4),
+                unittest.mock.call(8),
+                unittest.mock.call(10),
+            ],
+        ),
+    ],
+)
+async def test_iobase_payload_write_chunked_progress_callback(
+    content_length, expected_calls
+) -> None:
+    """Test IOBasePayload writing in chunks with progress callback."""
+
+    # Mock the file-like object to track read calls
+    mock_file = unittest.mock.Mock(spec=io.BytesIO)
+    mock_file.tell.return_value = 0
+    mock_file.fileno.side_effect = AttributeError  # Make size return None
+    mock_file.read.side_effect = [b"0123", b"4567", b"89"]
+
+    progress_callback = unittest.mock.Mock()
+    p = payload.IOBasePayload(mock_file)
+    writer = MockStreamWriter()
+    p.set_progress_callback(progress_callback)
+
+    await p.write_with_length(writer, content_length)
+    assert progress_callback.call_args_list == expected_calls
 
 
 async def test_bytesio_payload_write_with_length_no_limit() -> None:
@@ -348,6 +432,27 @@ async def test_bytesio_payload_remaining_bytes_exhausted() -> None:
     written = writer.get_written_bytes()
     assert len(written) == 8000
     assert written == data[:8000]
+
+
+async def test_bytesio_payload_write_progress_callback() -> None:
+    """Test BytesIOPayload writing with progress callback."""
+    progress_callback = unittest.mock.Mock()
+    p = payload.BytesIOPayload(io.BytesIO(b"0123456789abcdef" * 1000))
+    p.set_progress_callback(progress_callback)
+    writer = MockStreamWriter()
+
+    await p.write_with_length(writer, 5)
+    assert progress_callback.call_args_list == [
+        unittest.mock.call(0),
+        unittest.mock.call(5),
+    ]
+    progress_callback.call_args_list.clear()
+
+    await p.write_with_length(writer, None)
+    assert progress_callback.call_args_list == [
+        unittest.mock.call(0),
+        unittest.mock.call(16000),
+    ]
 
 
 async def test_iobase_payload_exact_chunk_size_limit() -> None:
@@ -574,6 +679,47 @@ async def test_async_iterable_payload_write_with_length_truncated_at_chunk() -> 
     await p.write_with_length(writer, 4)
     assert writer.get_written_bytes() == b"0123"
     assert len(writer.get_written_bytes()) == 4
+
+
+@pytest.mark.parametrize(
+    ("content_length", "expected_calls"),
+    [
+        (
+            6,
+            [
+                unittest.mock.call(0),
+                unittest.mock.call(4),
+                unittest.mock.call(6),
+            ],
+        ),
+        (
+            None,
+            [
+                unittest.mock.call(0),
+                unittest.mock.call(4),
+                unittest.mock.call(8),
+                unittest.mock.call(10),
+            ],
+        ),
+    ],
+)
+async def test_async_iterable_payload_write_chunked_progress_callback(
+    content_length, expected_calls
+) -> None:
+    """Test AsyncIterablePayload writing with content length truncating mid-chunk."""
+
+    async def gen() -> AsyncIterator[bytes]:
+        yield b"0123"
+        yield b"4567"
+        yield b"89"
+
+    progress_callback = unittest.mock.Mock()
+    p = payload.AsyncIterablePayload(gen())
+    p.set_progress_callback(progress_callback)
+    writer = MockStreamWriter()
+
+    await p.write_with_length(writer, content_length)
+    assert progress_callback.call_args_list == expected_calls
 
 
 async def test_bytes_payload_backwards_compatibility() -> None:

--- a/tests/test_payload.py
+++ b/tests/test_payload.py
@@ -333,7 +333,6 @@ async def test_iobase_payload_write_chunked_progress_callback(
     content_length: int, expected_calls: list[unittest.mock._Call]
 ) -> None:
     """Test IOBasePayload writing in chunks with progress callback."""
-
     # Mock the file-like object to track read calls
     mock_file = unittest.mock.Mock(spec=io.BytesIO)
     mock_file.tell.return_value = 0

--- a/tests/test_payload.py
+++ b/tests/test_payload.py
@@ -330,7 +330,7 @@ async def test_iobase_payload_write_progress_callback() -> None:
     ],
 )
 async def test_iobase_payload_write_chunked_progress_callback(
-    content_length, expected_calls
+    content_length: int, expected_calls: list[unittest.mock._Call]
 ) -> None:
     """Test IOBasePayload writing in chunks with progress callback."""
 
@@ -704,7 +704,7 @@ async def test_async_iterable_payload_write_with_length_truncated_at_chunk() -> 
     ],
 )
 async def test_async_iterable_payload_write_chunked_progress_callback(
-    content_length, expected_calls
+    content_length: int | None, expected_calls: list[unittest.mock._Call]
 ) -> None:
     """Test AsyncIterablePayload writing with content length truncating mid-chunk."""
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

This adds the possibility to provide a callback to the `Payload` class, which is used by their writer methods to report back the already written bytes. The intention is, that a consuming application can get a progress indication - in my specific case, I want to add the [backup upload progress](https://developers.home-assistant.io/blog/2026/03/11/backup-upload-progress/) to the Synology DSM integration in Home Assistant. The Synology DSM uses the aiohttp client with the [MultipartWriter](https://github.com/mib1185/py-synologydsm-api/blob/e8a6a2460c5e8b316b0b64e2ae11972110904aff/src/synology_dsm/synology_dsm.py#L391) to perform the upload. The goal is to provide the callback like:

```python
  with MultipartWriter("form-data", boundary=boundary) as mp:
      part = mp.append(path)

      if progress_callback is not None:
          part.set_progress_callback(progress_callback)
```

todo:
- [x] add tests
- [ ] add docs

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

No, as the callback is set to `None` by default

<!-- Outline any notable behaviour for the end users. -->

## Is it a substantial burden for the maintainers to support this?

I don't think so.

<!--
Stop right there! Pause. Just for a minute... Can you think of anything
obvious that would complicate the ongoing development of this project?

Try to consider if you'd be able to maintain it throughout the next
5 years. Does it seem viable? Tell us your thoughts! We'd very much
love to hear what the consequences of merging this patch might be...

This will help us assess if your change is something we'd want to
entertain early in the review process. Thank you in advance!
-->

## Related issue number

<!-- Will this resolve any open issues? -->
<!-- Remember to prefix with 'Fixes' if it closes an issue (e.g. 'Fixes #123'). -->

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES/` folder
  * name it `<issue_or_pr_num>.<type>.rst` (e.g. `588.bugfix.rst`)
  * if you don't have an issue number, change it to the pull request
    number after creating the PR
    * `.bugfix`: A bug fix for something the maintainers deemed an
      improper undesired behavior that got corrected to match
      pre-agreed expectations.
    * `.feature`: A new behavior, public APIs. That sort of stuff.
    * `.deprecation`: A declaration of future API removals and breaking
      changes in behavior.
    * `.breaking`: When something public is removed in a breaking way.
      Could be deprecated in an earlier release.
    * `.doc`: Notable updates to the documentation structure or build
      process.
    * `.packaging`: Notes for downstreams about unobvious side effects
      and tooling. Changes in the test invocation considerations and
      runtime assumptions.
    * `.contrib`: Stuff that affects the contributor experience. e.g.
      Running tests, building the docs, setting up the development
      environment.
    * `.misc`: Changes that are hard to assign to any of the above
      categories.
  * Make sure to use full sentences with correct case and punctuation,
    for example:
    ```rst
    Fixed issue with non-ascii contents in doctest text files
    -- by :user:`contributor-gh-handle`.
    ```

    Use the past tense or the present tense a non-imperative mood,
    referring to what's changed compared to the last released version
    of this project.
