### PR TITLE
Optimise decompression size

### DIFF
--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -589,9 +589,6 @@ class ClientResponse(HeadersMixin):
         """Read response payload."""
         if self._body is None:
             try:
-                # Remove the decompression size limit since we are reading
-                # the entire body into memory anyway.
-                self.content.set_read_chunk_size(sys.maxsize)
                 self._body = await self.content.read()
                 for trace in self._traces:
                     await trace.send_response_chunk_received(

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -589,6 +589,9 @@ class ClientResponse(HeadersMixin):
         """Read response payload."""
         if self._body is None:
             try:
+                # Remove the decompression size limit since we are reading
+                # the entire body into memory anyway.
+                self.content.set_read_chunk_size(sys.maxsize)
                 self._body = await self.content.read()
                 for trace in self._traces:
                     await trace.send_response_chunk_received(

--- a/aiohttp/compression_utils.py
+++ b/aiohttp/compression_utils.py
@@ -329,9 +329,15 @@ class BrotliDecompressor(DecompressionBaseHandler):
     ) -> bytes:
         """Decompress the given data."""
         if hasattr(self._obj, "decompress"):
-            result = cast(bytes, self._obj.decompress(data, max_length))
+            if max_length == ZLIB_MAX_LENGTH_UNLIMITED:
+                result = cast(bytes, self._obj.decompress(data))
+            else:
+                result = cast(bytes, self._obj.decompress(data, max_length))
         else:
-            result = cast(bytes, self._obj.process(data, max_length))
+            if max_length == ZLIB_MAX_LENGTH_UNLIMITED:
+                result = cast(bytes, self._obj.process(data))
+            else:
+                result = cast(bytes, self._obj.process(data, max_length))
         # Only way to know that brotli has no further data is checking we get no output
         self._last_empty = result == b""
         return result

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -2,6 +2,7 @@ import abc
 import asyncio
 import re
 import string
+import sys
 from contextlib import suppress
 from enum import IntEnum
 from re import Pattern
@@ -1115,7 +1116,8 @@ class DeflateBuffer:
                 encoding=self.encoding, suppress_deflate_header=True
             )
 
-        max_length = max(self._max_decompress_size, self.out._low_water)
+        low_water = self.out._low_water
+        max_length = 0 if low_water >= sys.maxsize else max(self._max_decompress_size, low_water)
         try:
             chunk = self.decompressor.decompress_sync(chunk, max_length=max_length)
         except Exception:

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -1117,7 +1117,9 @@ class DeflateBuffer:
             )
 
         low_water = self.out._low_water
-        max_length = 0 if low_water >= sys.maxsize else max(self._max_decompress_size, low_water)
+        max_length = (
+            0 if low_water >= sys.maxsize else max(self._max_decompress_size, low_water)
+        )
         try:
             chunk = self.decompressor.decompress_sync(chunk, max_length=max_length)
         except Exception:

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -1115,10 +1115,9 @@ class DeflateBuffer:
                 encoding=self.encoding, suppress_deflate_header=True
             )
 
+        max_length = max(self._max_decompress_size, self.out._low_water)
         try:
-            chunk = self.decompressor.decompress_sync(
-                chunk, max_length=self._max_decompress_size
-            )
+            chunk = self.decompressor.decompress_sync(chunk, max_length=max_length)
         except Exception:
             raise ContentEncodingError(
                 "Can not decode content-encoding: %s" % self.encoding

--- a/aiohttp/streams.py
+++ b/aiohttp/streams.py
@@ -1,5 +1,6 @@
 import asyncio
 import collections
+import sys
 import warnings
 from collections.abc import Awaitable, Callable
 from typing import Final, Generic, TypeVar
@@ -411,10 +412,8 @@ class StreamReader:
             return b""
 
         if n < 0:
-            # This used to just loop creating a new waiter hoping to
-            # collect everything in self._buffer, but that would
-            # deadlock if the subprocess sends more than self.limit
-            # bytes.  So just call self.readany() until EOF.
+            # Reading everything — remove decompression chunk limit.
+            self.set_read_chunk_size(sys.maxsize)
             blocks = []
             while True:
                 block = await self.readany()
@@ -423,6 +422,7 @@ class StreamReader:
                 blocks.append(block)
             return b"".join(blocks)
 
+        self.set_read_chunk_size(n)
         # TODO: should be `if` instead of `while`
         # because waiter maybe triggered on chunk end,
         # without feeding any data

--- a/aiohttp/streams.py
+++ b/aiohttp/streams.py
@@ -596,6 +596,9 @@ class EmptyStreamReader(StreamReader):  # lgtm [py/missing-call-to-init]
     def feed_data(self, data: bytes) -> bool:
         return False
 
+    def set_read_chunk_size(self, n: int) -> None:
+        return
+
     async def readline(self, *, max_line_length: int | None = None) -> bytes:
         return b""
 

--- a/aiohttp/streams.py
+++ b/aiohttp/streams.py
@@ -66,31 +66,7 @@ class ChunkTupleAsyncStreamIterator:
         return rv
 
 
-class AsyncStreamReaderMixin:
-
-    __slots__ = ()
-
-    def __aiter__(self) -> AsyncStreamIterator[bytes]:
-        return AsyncStreamIterator(self.readline)  # type: ignore[attr-defined]
-
-    def iter_chunked(self, n: int) -> AsyncStreamIterator[bytes]:
-        """Returns an asynchronous iterator that yields chunks of size n."""
-        return AsyncStreamIterator(lambda: self.read(n))  # type: ignore[attr-defined]
-
-    def iter_any(self) -> AsyncStreamIterator[bytes]:
-        """Yield all available data as soon as it is received."""
-        return AsyncStreamIterator(self.readany)  # type: ignore[attr-defined]
-
-    def iter_chunks(self) -> ChunkTupleAsyncStreamIterator:
-        """Yield chunks of data as they are received by the server.
-
-        The yielded objects are tuples
-        of (bytes, bool) as returned by the StreamReader.readchunk method.
-        """
-        return ChunkTupleAsyncStreamIterator(self)  # type: ignore[arg-type]
-
-
-class StreamReader(AsyncStreamReaderMixin):
+class StreamReader:
     """An enhancement of asyncio.StreamReader.
 
     Supports asynchronous iteration by line, chunk or as available::
@@ -173,8 +149,34 @@ class StreamReader(AsyncStreamReaderMixin):
             info.append("e=%r" % self._exception)
         return "<%s>" % " ".join(info)
 
+    def __aiter__(self) -> AsyncStreamIterator[bytes]:
+        return AsyncStreamIterator(self.readline)
+
+    def iter_chunked(self, n: int) -> AsyncStreamIterator[bytes]:
+        """Returns an asynchronous iterator that yields chunks of size n."""
+        self.set_read_chunk_size(n)
+        return AsyncStreamIterator(lambda: self.read(n))
+
+    def iter_any(self) -> AsyncStreamIterator[bytes]:
+        """Yield all available data as soon as it is received."""
+        return AsyncStreamIterator(self.readany)
+
+    def iter_chunks(self) -> ChunkTupleAsyncStreamIterator:
+        """Yield chunks of data as they are received by the server.
+
+        The yielded objects are tuples
+        of (bytes, bool) as returned by the StreamReader.readchunk method.
+        """
+        return ChunkTupleAsyncStreamIterator(self)
+
     def get_read_buffer_limits(self) -> tuple[int, int]:
         return (self._low_water, self._high_water)
+
+    def set_read_chunk_size(self, n: int) -> None:
+        """Raise buffer limits to match the consumer's chunk size."""
+        if n > self._low_water:
+            self._low_water = n
+            self._high_water = n * 2
 
     def exception(self) -> type[BaseException] | BaseException | None:
         return self._exception

--- a/aiohttp/web_request.py
+++ b/aiohttp/web_request.py
@@ -627,6 +627,10 @@ class BaseRequest(MutableMapping[str | RequestKey[Any], Any], HeadersMixin):
         Returns bytes object with full request content.
         """
         if self._read_bytes is None:
+            # Raise the buffer limits so compressed payloads decompress in
+            # larger chunks instead of many small pause/resume cycles.
+            if self._client_max_size:
+                self._payload.set_read_chunk_size(self._client_max_size)
             body = bytearray()
             while True:
                 chunk = await self._payload.readany()

--- a/tests/test_flowcontrol_streams.py
+++ b/tests/test_flowcontrol_streams.py
@@ -77,7 +77,7 @@ class TestFlowControlStreamReader:
         stream.feed_data(b"data")
         res = await stream.readexactly(3)
         assert res == b"dat"
-        assert not stream._protocol.resume_reading.called  # type: ignore[attr-defined]
+        assert stream._protocol.resume_reading.called  # type: ignore[attr-defined]
 
     async def test_feed_data(self, stream: streams.StreamReader) -> None:
         stream._protocol._reading_paused = False


### PR DESCRIPTION
Raise the compression max_length if we know the user is going to allow a size larger than the default anyway.
Also get rid of AsyncStreamReaderMixin, which just doesn't make any sense.