### PR TITLE
docs: clarify query string requoting when using params

### DIFF
--- a/docs/client_quickstart.rst
+++ b/docs/client_quickstart.rst
@@ -122,12 +122,18 @@ that case you can specify multiple values for each key::
         expect = 'http://httpbin.org/get?key=value2&key=value1'
         assert str(r.url) == expect
 
-You can also pass :class:`str` content as param, but beware -- content
-is not encoded by library. Note that ``+`` is not encoded::
+You can also pass :class:`str` content as ``params``. The string is used as
+raw query data, so characters like ``+`` are not percent-encoded again by
+``aiohttp`` itself::
 
     async with session.get('http://httpbin.org/get',
                            params='key=value+1') as r:
             assert str(r.url) == 'http://httpbin.org/get?key=value+1'
+
+However, URL canonicalization still applies to the final URL. If you need to
+preserve an already-encoded query string exactly as-is, build the full
+:class:`yarl.URL` with ``encoded=True`` and pass it directly, without using
+``params``.
 
 If the URL already contains query string parameters, ``params`` will be
 appended to (not replace) the existing parameters::

--- a/docs/client_quickstart.rst
+++ b/docs/client_quickstart.rst
@@ -129,6 +129,15 @@ is not encoded by library. Note that ``+`` is not encoded::
                            params='key=value+1') as r:
             assert str(r.url) == 'http://httpbin.org/get?key=value+1'
 
+If the URL already contains query string parameters, ``params`` will be
+appended to (not replace) the existing parameters::
+
+    params = {'d': 'dog'}
+    async with session.get('http://httpbin.org/get?q=abc',
+                           params=params) as resp:
+        expect = 'http://httpbin.org/get?q=abc&d=dog'
+        assert str(resp.url) == expect
+
 .. note::
 
    *aiohttp* internally performs URL canonicalization before sending request.

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -428,8 +428,10 @@ The client session supports the context manager protocol for self closing.
 
       :param params: Mapping, iterable of tuple of *key*/*value* pairs or
                      string to be sent as parameters in the query
-                     string of the new request. Ignored for subsequent
-                     redirected requests (optional)
+                     string of the new request. If the *url* already
+                     contains query string parameters, *params* are
+                     appended to them (not replaced). Ignored for
+                     subsequent redirected requests (optional)
 
                      Allowed values are:
 
@@ -769,8 +771,10 @@ The client session supports the context manager protocol for self closing.
 
       :param params: Mapping, iterable of tuple of *key*/*value* pairs or
                      string to be sent as parameters in the query
-                     string of the new request. Ignored for subsequent
-                     redirected requests (optional)
+                     string of the new request. If the *url* already
+                     contains query string parameters, *params* are
+                     appended to them (not replaced). Ignored for
+                     subsequent redirected requests (optional)
 
                      Allowed values are:
 
@@ -926,8 +930,10 @@ certification chaining.
 
    :param params: Mapping, iterable of tuple of *key*/*value* pairs or
                   string to be sent as parameters in the query
-                  string of the new request. Ignored for subsequent
-                  redirected requests (optional)
+                  string of the new request. If the *url* already
+                  contains query string parameters, *params* are
+                  appended to them (not replaced). Ignored for
+                  subsequent redirected requests (optional)
 
                   Allowed values are:
 


### PR DESCRIPTION
Fixes #3689

Clarify that passing a string to `params` avoids re-encoding characters like `+`, but the final URL is still subject to canonicalization and requoting. Document that callers who need to preserve an already-encoded query string exactly should build a `yarl.URL(..., encoded=True)` and pass it directly without `params`.