### PR TITLE
Disable cov/xdist by default

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -237,7 +237,8 @@ jobs:
         PIP_USER: 1
       run: >-
         PATH="${HOME}/Library/Python/3.11/bin:${HOME}/.local/bin:${PATH}"
-        pytest --junitxml=junit.xml -m 'not dev_mode and not autobahn'
+        pytest --junitxml=junit.xml --numprocesses=auto --cov=aiohttp/ --cov=tests/
+        -m 'not dev_mode and not autobahn'
       shell: bash
     - name: Re-run the failing tests with maximum verbosity
       if: failure()
@@ -245,7 +246,7 @@ jobs:
         COLOR: yes
         AIOHTTP_NO_EXTENSIONS: ${{ matrix.no-extensions }}
       run: >-  # `exit 1` makes sure that the job remains red with flaky runs
-        pytest --no-cov --numprocesses=0 -vvvvv --lf && exit 1
+        pytest --no-cov -vvvvv --lf && exit 1
       shell: bash
     - name: Run dev_mode tests
       env:
@@ -253,7 +254,7 @@ jobs:
         AIOHTTP_NO_EXTENSIONS: ${{ matrix.no-extensions }}
         PIP_USER: 1
         PYTHONDEVMODE: 1
-      run: pytest -m dev_mode --cov-append --numprocesses=0
+      run: pytest -m dev_mode --cov=aiohttp/ --cov=tests/ --cov-append
       shell: bash
     - name: Turn coverage into xml
       env:
@@ -345,7 +346,7 @@ jobs:
         PIP_USER: 1
       run: >-
         PATH="${HOME}/Library/Python/3.11/bin:${HOME}/.local/bin:${PATH}"
-        pytest --junitxml=junit.xml --numprocesses=0 -m autobahn
+        pytest --junitxml=junit.xml --numprocesses=auto --cov=aiohttp/ --cov=tests/ -m autobahn
       shell: bash
     - name: Turn coverage into xml
       env:
@@ -413,7 +414,7 @@ jobs:
       uses: CodSpeedHQ/action@v4
       with:
         mode: instrumentation
-        run: python -Im pytest --no-cov --numprocesses=0 -vvvvv --codspeed
+        run: python -Im pytest --no-cov -vvvvv --codspeed
 
 
   cython-coverage:
@@ -462,7 +463,7 @@ jobs:
         PIP_USER: 1
       run: >-
         pytest tests/test_client_functional.py tests/test_http_parser.py tests/test_http_writer.py tests/test_web_functional.py tests/test_web_response.py tests/test_websocket_parser.py
-        --cov-config=.coveragerc-cython.toml
+        --cov-config=.coveragerc-cython.toml --cov=aiohttp/ --cov=tests/ --numprocesses=auto
         -m 'not dev_mode and not autobahn'
       shell: bash
     - name: Turn coverage into xml

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -346,7 +346,7 @@ jobs:
         PIP_USER: 1
       run: >-
         PATH="${HOME}/Library/Python/3.11/bin:${HOME}/.local/bin:${PATH}"
-        pytest --junitxml=junit.xml --numprocesses=auto --cov=aiohttp/ --cov=tests/ -m autobahn
+        pytest --junitxml=junit.xml --cov=aiohttp/ --cov=tests/ -m autobahn
       shell: bash
     - name: Turn coverage into xml
       env:

--- a/CHANGES/12364.contrib.rst
+++ b/CHANGES/12364.contrib.rst
@@ -1,0 +1,1 @@
+Disabled ``coverage`` and ``xdist`` by default to ease local development -- by :user:`Dreamsorcerer`.

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,9 +41,6 @@ exclude_lines =
 
 [tool:pytest]
 addopts =
-    # `pytest-xdist`:
-    --numprocesses=auto
-
     # show 10 slowest invocations:
     --durations=10
 
@@ -55,11 +52,6 @@ addopts =
 
     # show values of the local vars in errors:
     --showlocals
-
-    # `pytest-cov`:
-    -p pytest_cov
-    --cov=aiohttp
-    --cov=tests/
 
     -m "not dev_mode and not autobahn and not internal"
 filterwarnings =


### PR DESCRIPTION
Enabling these by default can be frustrating to local development.

pytest-cov adds several seconds to the end of every pytest run. When trying to run a single test, this is obviously longer than the test run itself.

pytest-xdist silently loses all stdout making it impossible to debug with print() etc. There's nothing obvious to tell you that xdist is the cause either, leading to a lot of frustrated time trying to understand why you can't even get a simple print() to work.