### PR TITLE
Validate Content-Length format in ClientRequest

### DIFF
--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -78,6 +78,7 @@ if TYPE_CHECKING:
 
 _CONNECTION_CLOSED_EXCEPTION = ClientConnectionError("Connection closed")
 _CONTAINS_CONTROL_CHAR_RE = re.compile(r"[^-!#$%&'*+.^_`|~0-9a-zA-Z]")
+_DIGITS_RE = re.compile(r"\d+", re.ASCII)
 
 
 def _gen_default_accept_encoding() -> str:
@@ -753,12 +754,11 @@ class ClientRequestBase:
             return None
 
         content_length_hdr = self.headers[hdrs.CONTENT_LENGTH]
-        try:
-            return int(content_length_hdr)
-        except ValueError:
+        if not _DIGITS_RE.fullmatch(content_length_hdr):
             raise ValueError(
-                f"Invalid Content-Length header: {content_length_hdr}"
-            ) from None
+                f"Invalid Content-Length header: {content_length_hdr!r}"
+            )
+        return int(content_length_hdr)
 
     @property
     def _writer(self) -> asyncio.Task[None] | None:

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -755,9 +755,7 @@ class ClientRequestBase:
 
         content_length_hdr = self.headers[hdrs.CONTENT_LENGTH]
         if not _DIGITS_RE.fullmatch(content_length_hdr):
-            raise ValueError(
-                f"Invalid Content-Length header: {content_length_hdr!r}"
-            )
+            raise ValueError(f"Invalid Content-Length header: {content_length_hdr!r}")
         return int(content_length_hdr)
 
     @property

--- a/tests/test_client_request.py
+++ b/tests/test_client_request.py
@@ -1911,7 +1911,24 @@ async def test_get_content_length(make_client_request: _RequestMaker) -> None:
 
     # Invalid Content-Length header
     req.headers["Content-Length"] = "invalid"
-    with pytest.raises(ValueError, match="Invalid Content-Length header: invalid"):
+    with pytest.raises(ValueError, match="Invalid Content-Length header"):
+        req._get_content_length()
+
+
+async def test_get_content_length_invalid_formats(
+    make_client_request: _RequestMaker,
+) -> None:
+    req = make_client_request("get", URL("http://python.org/"))
+
+    req.headers["Content-Length"] = "100"
+    assert req._get_content_length() == 100
+
+    req.headers["Content-Length"] = "-100"
+    with pytest.raises(ValueError, match="Invalid Content-Length header"):
+        req._get_content_length()
+
+    req.headers["Content-Length"] = " 100"
+    with pytest.raises(ValueError, match="Invalid Content-Length header"):
         req._get_content_length()
 
 

--- a/tests/test_client_request.py
+++ b/tests/test_client_request.py
@@ -1822,7 +1822,24 @@ async def test_get_content_length(make_client_request: _RequestMaker) -> None:
 
     # Invalid Content-Length header
     req.headers["Content-Length"] = "invalid"
-    with pytest.raises(ValueError, match="Invalid Content-Length header: invalid"):
+    with pytest.raises(ValueError, match="Invalid Content-Length header"):
+        req._get_content_length()
+
+
+async def test_get_content_length_invalid_formats(
+    make_client_request: _RequestMaker,
+) -> None:
+    req = make_client_request("get", URL("http://python.org/"))
+
+    req.headers["Content-Length"] = "100"
+    assert req._get_content_length() == 100
+
+    req.headers["Content-Length"] = "-100"
+    with pytest.raises(ValueError, match="Invalid Content-Length header"):
+        req._get_content_length()
+
+    req.headers["Content-Length"] = "abc"
+    with pytest.raises(ValueError, match="Invalid Content-Length header"):
         req._get_content_length()
 
 

--- a/tests/test_client_request.py
+++ b/tests/test_client_request.py
@@ -1838,7 +1838,7 @@ async def test_get_content_length_invalid_formats(
     with pytest.raises(ValueError, match="Invalid Content-Length header"):
         req._get_content_length()
 
-    req.headers["Content-Length"] = "abc"
+    req.headers["Content-Length"] = "५"  # Devengali number 5
     with pytest.raises(ValueError, match="Invalid Content-Length header"):
         req._get_content_length()
 

--- a/tests/test_web_functional.py
+++ b/tests/test_web_functional.py
@@ -196,29 +196,6 @@ async def test_response_before_complete(aiohttp_client: AiohttpClient) -> None:
     resp.release()
 
 
-async def test_content_length_invalid(
-    aiohttp_client: AiohttpClient,
-) -> None:
-    async def handler(request: web.Request) -> web.Response:
-        body = await request.read()
-        return web.Response(body=body)
-
-    app = web.Application()
-    app.router.add_post("/", handler)
-    client = await aiohttp_client(app)
-
-    resp = await client.post("/", data=b"hello world", headers={CONTENT_LENGTH: "11"})
-    assert resp.status == 200
-    assert await resp.read() == b"hello world"
-    resp.release()
-
-    with pytest.raises(ValueError, match="Invalid Content-Length header"):
-        await client.post("/", data=b"hello world", headers={CONTENT_LENGTH: "-100"})
-
-    with pytest.raises(ValueError, match="Invalid Content-Length header"):
-        await client.post("/", data=b"hello world", headers={CONTENT_LENGTH: " 100"})
-
-
 @pytest.mark.skipif(sys.version_info < (3, 11), reason="Needs Task.cancelling()")
 async def test_cancel_shutdown(aiohttp_client: AiohttpClient) -> None:
     async def handler(request: web.Request) -> web.Response:

--- a/tests/test_web_functional.py
+++ b/tests/test_web_functional.py
@@ -196,6 +196,29 @@ async def test_response_before_complete(aiohttp_client: AiohttpClient) -> None:
     resp.release()
 
 
+async def test_content_length_invalid(
+    aiohttp_client: AiohttpClient,
+) -> None:
+    async def handler(request: web.Request) -> web.Response:
+        body = await request.read()
+        return web.Response(body=body)
+
+    app = web.Application()
+    app.router.add_post("/", handler)
+    client = await aiohttp_client(app)
+
+    resp = await client.post("/", data=b"hello world", headers={CONTENT_LENGTH: "11"})
+    assert resp.status == 200
+    assert await resp.read() == b"hello world"
+    resp.release()
+
+    with pytest.raises(ValueError, match="Invalid Content-Length header"):
+        await client.post("/", data=b"hello world", headers={CONTENT_LENGTH: "-100"})
+
+    with pytest.raises(ValueError, match="Invalid Content-Length header"):
+        await client.post("/", data=b"hello world", headers={CONTENT_LENGTH: " 100"})
+
+
 @pytest.mark.skipif(sys.version_info < (3, 11), reason="Needs Task.cancelling()")
 async def test_cancel_shutdown(aiohttp_client: AiohttpClient) -> None:
     async def handler(request: web.Request) -> web.Response:


### PR DESCRIPTION
## What do these changes do?

This change adds strict validation for the `Content-Length` header in `ClientRequest`.

Currently, `_get_content_length()` uses Python’s `int()` for parsing, which accepts non-RFC-compliant values such as negative numbers or values with whitespace. This patch introduces a DIGITS-only validation to ensure the header follows the same format already enforced by the HTTP parser.

## Are there changes in behavior for the user?

Yes, but only for invalid inputs.

- Valid `Content-Length` values (e.g., `"0"`, `"100"`) are unaffected.
- Non-compliant values (e.g., `"-100"`, `" 100"`, `"+100"`) will now raise a `ValueError` instead of being accepted.

This aligns behavior across send and receive paths and avoids unexpected behavior when invalid values are provided.

## Is it a substantial burden for the maintainers to support this?

No.

- The change is minimal and localized to a single method.
- It reuses the same validation approach already used in the HTTP parser.
- No new abstractions or dependencies are introduced.
- The behavior is consistent with existing expectations for header validation.

This should not increase maintenance overhead.

## Related issue number

N/A

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
- [ ] Add a new news fragment into the `CHANGES/` folder