### PR TITLE
Harden Transfer-Encoding parsing and unify validation logic

### DIFF
--- a/CHANGES/12499.bugfix.rst
+++ b/CHANGES/12499.bugfix.rst
@@ -1,0 +1,1 @@
+Hardened HTTP parser ``Transfer-Encoding`` handling by validating coding tokens as ASCII/token syntax and applying strict ``chunked`` ordering/duplication checks consistently for both request and response parsers.

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -291,7 +291,28 @@ class HttpParser(abc.ABC, Generic[_MsgT]):
     def parse_message(self, lines: list[bytes]) -> _MsgT: ...
 
     @abc.abstractmethod
-    def _is_chunked_te(self, te: str) -> bool: ...
+    def _is_chunked_te(self, codings: tuple[str, ...]) -> bool: ...
+
+    def _parse_transfer_encoding(self, te: str) -> tuple[str, ...]:
+        codings = []
+        for item in te.split(","):
+            item = item.strip(" \t")
+            # Reject empty, non-ASCII, or invalid coding tokens.
+            if not item or not item.isascii():
+                raise BadHttpMessage("Invalid `Transfer-Encoding` header value")
+
+            coding, has_params, _params = item.partition(";")
+            coding = coding.strip(" \t")
+            if not coding or not TOKENRE.fullmatch(coding):
+                raise BadHttpMessage("Invalid `Transfer-Encoding` header value")
+
+            coding = coding.lower()
+            # RFC 9112 section 7.1 does not define chunk-ext for TE.
+            if has_params and coding == "chunked":
+                raise BadHttpMessage("Invalid `Transfer-Encoding` header value")
+            codings.append(coding)
+
+        return tuple(codings)
 
     def pause_reading(self) -> None:
         assert self._payload_parser is not None
@@ -585,7 +606,8 @@ class HttpParser(abc.ABC, Generic[_MsgT]):
         # chunking
         te = headers.get(hdrs.TRANSFER_ENCODING)
         if te is not None:
-            if self._is_chunked_te(te):
+            codings = self._parse_transfer_encoding(te)
+            if self._is_chunked_te(codings):
                 chunked = True
 
             if hdrs.CONTENT_LENGTH in headers:
@@ -694,17 +716,14 @@ class HttpRequestParser(HttpParser[RawRequestMessage]):
             url,
         )
 
-    def _is_chunked_te(self, te: str) -> bool:
+    def _is_chunked_te(self, codings: tuple[str, ...]) -> bool:
         # https://www.rfc-editor.org/rfc/rfc9112#section-7.1-3
         # "A sender MUST NOT apply the chunked transfer coding more
         #  than once to a message body"
-        parts = [p.strip(" \t") for p in te.split(",")]
-        chunked_count = sum(1 for p in parts if p.isascii() and p.lower() == "chunked")
+        chunked_count = sum(1 for p in codings if p == "chunked")
         if chunked_count > 1:
             raise BadHttpMessage("Request has duplicate `chunked` Transfer-Encoding")
-        last = parts[-1]
-        # .lower() transforms some non-ascii chars, so must check first.
-        if last.isascii() and last.lower() == "chunked":
+        if codings[-1] == "chunked":
             return True
         # https://www.rfc-editor.org/rfc/rfc9112#section-6.3-2.4.3
         raise BadHttpMessage("Request has invalid `Transfer-Encoding`")
@@ -791,9 +810,14 @@ class HttpResponseParser(HttpParser[RawResponseMessage]):
             chunked,
         )
 
-    def _is_chunked_te(self, te: str) -> bool:
+    def _is_chunked_te(self, codings: tuple[str, ...]) -> bool:
         # https://www.rfc-editor.org/rfc/rfc9112#section-6.3-2.4.2
-        return te.rsplit(",", maxsplit=1)[-1].strip(" \t").lower() == "chunked"
+        chunked_count = sum(1 for p in codings if p == "chunked")
+        if chunked_count > 1:
+            raise BadHttpMessage("Response has duplicate `chunked` Transfer-Encoding")
+        if chunked_count and codings[-1] != "chunked":
+            raise BadHttpMessage("Response has invalid `Transfer-Encoding`")
+        return codings[-1] == "chunked"
 
 
 class HttpPayloadParser:

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -760,6 +760,20 @@ def test_request_te_duplicate_chunked(parser: HttpRequestParser) -> None:
         parser.feed_data(text)
 
 
+def test_request_te_mixed_non_ascii_and_chunked(parser: HttpRequestParser) -> None:
+    text = (
+        "GET /test HTTP/1.1\r\n"
+        "Host: a\r\n"
+        "Transfer-Encoding: a\N{KELVIN SIGN}, chunked\r\n"
+        "\r\n"
+    )
+    with pytest.raises(
+        http_exceptions.BadHttpMessage,
+        match="Invalid `Transfer-Encoding`|nvalid `Transfer-Encoding`",
+    ):
+        parser.feed_data(text.encode())
+
+
 def test_conn_upgrade(parser: HttpRequestParser) -> None:
     text = (
         b"GET /test HTTP/1.1\r\n"
@@ -1773,6 +1787,22 @@ async def test_http_response_parser_notchunked(
     assert await messages[0][1].read() == b"1\r\nT\r\n3\r\nest\r\n0\r\n\r\n"
 
 
+async def test_http_response_te_header_non_ascii(
+    response: HttpResponseParser,
+) -> None:
+    # Kelvin sign is not ASCII and must not be treated as 'k'.
+    text = (
+        "HTTP/1.1 200 OK\r\n"
+        "Transfer-Encoding: chun\N{KELVIN SIGN}ed\r\n"
+        "\r\n1\r\nT\r\n3\r\nest\r\n0\r\n\r\n"
+    )
+    with pytest.raises(
+        http_exceptions.BadHttpMessage,
+        match="Invalid `Transfer-Encoding`|invalid transfer encoding",
+    ):
+        response.feed_data(text.encode())
+
+
 async def test_http_response_parser_last_chunked(
     response: HttpResponseParser,
 ) -> None:
@@ -1781,6 +1811,51 @@ async def test_http_response_parser_last_chunked(
 
     # https://www.rfc-editor.org/rfc/rfc9112#section-6.3-2.4.2
     assert await messages[0][1].read() == b"Test"
+
+
+def test_http_response_parser_te_chunked_not_last(
+    response: HttpResponseParser,
+) -> None:
+    text = (
+        b"HTTP/1.1 200 OK\r\n"
+        b"Transfer-Encoding: chunked, gzip\r\n"
+        b"\r\n"
+    )
+    with pytest.raises(
+        http_exceptions.BadHttpMessage,
+        match="Response has invalid `Transfer-Encoding`|invalid transfer encoding",
+    ):
+        response.feed_data(text)
+
+
+def test_http_response_parser_te_duplicate_chunked(
+    response: HttpResponseParser,
+) -> None:
+    text = (
+        b"HTTP/1.1 200 OK\r\n"
+        b"Transfer-Encoding: gzip, chunked, chunked\r\n"
+        b"\r\n"
+    )
+    with pytest.raises(
+        http_exceptions.BadHttpMessage,
+        match="duplicate `chunked` Transfer-Encoding|invalid transfer encoding",
+    ):
+        response.feed_data(text)
+
+
+def test_http_response_parser_te_non_ascii_with_chunked(
+    response: HttpResponseParser,
+) -> None:
+    text = (
+        "HTTP/1.1 200 OK\r\n"
+        "Transfer-Encoding: a\N{KELVIN SIGN}, chunked\r\n"
+        "\r\n"
+    )
+    with pytest.raises(
+        http_exceptions.BadHttpMessage,
+        match="Invalid `Transfer-Encoding`|invalid transfer encoding",
+    ):
+        response.feed_data(text.encode())
 
 
 def test_http_response_parser_bad(response: HttpResponseParser) -> None:

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -1816,11 +1816,7 @@ async def test_http_response_parser_last_chunked(
 def test_http_response_parser_te_chunked_not_last(
     response: HttpResponseParser,
 ) -> None:
-    text = (
-        b"HTTP/1.1 200 OK\r\n"
-        b"Transfer-Encoding: chunked, gzip\r\n"
-        b"\r\n"
-    )
+    text = b"HTTP/1.1 200 OK\r\n" b"Transfer-Encoding: chunked, gzip\r\n" b"\r\n"
     with pytest.raises(
         http_exceptions.BadHttpMessage,
         match="Response has invalid `Transfer-Encoding`|invalid transfer encoding",
@@ -1832,9 +1828,7 @@ def test_http_response_parser_te_duplicate_chunked(
     response: HttpResponseParser,
 ) -> None:
     text = (
-        b"HTTP/1.1 200 OK\r\n"
-        b"Transfer-Encoding: gzip, chunked, chunked\r\n"
-        b"\r\n"
+        b"HTTP/1.1 200 OK\r\n" b"Transfer-Encoding: gzip, chunked, chunked\r\n" b"\r\n"
     )
     with pytest.raises(
         http_exceptions.BadHttpMessage,
@@ -1847,9 +1841,7 @@ def test_http_response_parser_te_non_ascii_with_chunked(
     response: HttpResponseParser,
 ) -> None:
     text = (
-        "HTTP/1.1 200 OK\r\n"
-        "Transfer-Encoding: a\N{KELVIN SIGN}, chunked\r\n"
-        "\r\n"
+        "HTTP/1.1 200 OK\r\n" "Transfer-Encoding: a\N{KELVIN SIGN}, chunked\r\n" "\r\n"
     )
     with pytest.raises(
         http_exceptions.BadHttpMessage,


### PR DESCRIPTION
**What do these changes do?**

This change improves how aiohttp handles Transfer-Encoding headers by making parsing stricter and more consistent across request and response processing.

A shared parsing function is introduced to validate and normalize Transfer-Encoding values in one place. This ensures both request and response parsers follow the same rules and handle invalid input consistently.

The updated logic rejects malformed or ambiguous headers such as non-ASCII values, duplicate chunked codings, and invalid token formats.

**Are there changes in behavior for the user?**

Yes, but only for invalid or non-standard Transfer-Encoding headers.

Valid and RFC-compliant headers continue to work as before.

The main differences are:

- Non-ASCII Transfer-Encoding values are now rejected
- Duplicate chunked codings are no longer accepted
- Invalid or malformed encoding values raise BadHttpMessage instead of being partially accepted
- Request and response parsing now behave consistently

These changes improve correctness and reduce ambiguity in HTTP message parsing.

**Is it a substantial burden for the maintainers to support this?**

This change reduces long-term maintenance complexity by removing duplicated parsing logic and centralizing Transfer-Encoding validation.

It also improves consistency between request and response parsers, reducing the risk of future divergence.

The change does not introduce new dependencies or public API changes.

Because this tightens validation rules, it may require careful review of edge cases, but overall it simplifies and stabilizes the parsing logic.

This PR addresses inconsistencies in Transfer-Encoding parsing between request and response handling.