### PR TITLE
Reject duplicate Content-Length headers

### DIFF
--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -374,9 +374,15 @@ class HttpParser(abc.ABC, Generic[_MsgT]):
 
                         def get_content_length() -> int | None:
                             # payload length
-                            length_hdr = msg.headers.get(CONTENT_LENGTH)
-                            if length_hdr is None:
+                            length_values = msg.headers.getall(CONTENT_LENGTH, [])
+
+                            if len(length_values) > 1:
+                                raise BadHttpMessage("Duplicate Content-Length headers")
+
+                            if not length_values:
                                 return None
+
+                            length_hdr = length_values[0]
 
                             # Shouldn't allow +/- or other number formats.
                             # https://www.rfc-editor.org/rfc/rfc9110#section-8.6-2


### PR DESCRIPTION
**What do these changes do?**

This change makes the Python HTTP response parser reject responses with multiple `Content-Length` headers by using `headers.getall()` and raising `BadHttpMessage`. This aligns behavior with the C parser and removes ambiguity in message framing.

**Are there changes in behavior for the user?**

Yes. Previously only the first `Content-Length` header was used. Now, responses with more than one `Content-Length` header will be rejected with `BadHttpMessage`.

**Is it a substantial burden for the maintainers to support this?**

No. The change is small, localized, and improves correctness and consistency without adding maintenance complexity.