### PR TITLE
Clarify `LineTooLong` error messages with context label

### DIFF
--- a/CHANGES/7177.bugfix.rst
+++ b/CHANGES/7177.bugfix.rst
@@ -1,0 +1,6 @@
+Improved the :exc:`~aiohttp.http_exceptions.LineTooLong` error message to
+describe which part of the HTTP message exceeded the limit (e.g. the request
+URL, status reason phrase, header field name/value, request/status line, or
+trailer). Previously, every overflow reported a generic ``"when reading:"``
+prefix, which was confusing when only the URL was too long but the message was
+historically labeled as a status-line overflow -- by :user:`Ricardo-M-L`.

--- a/CHANGES/7177.bugfix.rst
+++ b/CHANGES/7177.bugfix.rst
@@ -1,6 +1,6 @@
-Improved the :exc:`~aiohttp.http_exceptions.LineTooLong` error message to
-describe which part of the HTTP message exceeded the limit (e.g. the request
-URL, status reason phrase, header field name/value, request/status line, or
-trailer). Previously, every overflow reported a generic ``"when reading:"``
-prefix, which was confusing when only the URL was too long but the message was
-historically labeled as a status-line overflow -- by :user:`Ricardo-M-L`.
+Improved the ``LineTooLong`` error message to describe which part of the HTTP
+message exceeded the limit (e.g. the request URL, status reason phrase, header
+field name/value, request/status line, or trailer). Previously, every overflow
+reported a generic ``"when reading:"`` prefix, which was confusing when only
+the URL was too long but the message was historically labeled as a status-line
+overflow -- by :user:`Ricardo-M-L`.

--- a/aiohttp/_http_parser.pyx
+++ b/aiohttp/_http_parser.pyx
@@ -773,8 +773,10 @@ cdef int cb_on_url(cparser.llhttp_t* parser,
     cdef HttpParser pyparser = <HttpParser>parser.data
     try:
         if length > pyparser._max_line_size:
-            status = pyparser._buf + at[:length]
-            raise LineTooLong(status[:100] + b"...", pyparser._max_line_size)
+            url = pyparser._buf + at[:length]
+            raise LineTooLong(
+                url[:100] + b"...", pyparser._max_line_size, "request URL"
+            )
         extend(pyparser._buf, at, length)
     except BaseException as ex:
         pyparser._last_error = ex
@@ -789,7 +791,11 @@ cdef int cb_on_status(cparser.llhttp_t* parser,
     try:
         if length > pyparser._max_line_size:
             reason = pyparser._buf + at[:length]
-            raise LineTooLong(reason[:100] + b"...", pyparser._max_line_size)
+            raise LineTooLong(
+                reason[:100] + b"...",
+                pyparser._max_line_size,
+                "status reason phrase",
+            )
         extend(pyparser._buf, at, length)
     except BaseException as ex:
         pyparser._last_error = ex
@@ -807,7 +813,11 @@ cdef int cb_on_header_field(cparser.llhttp_t* parser,
         size = len(pyparser._raw_name) + length
         if size > pyparser._max_field_size:
             name = pyparser._raw_name + at[:length]
-            raise LineTooLong(name[:100] + b"...", pyparser._max_field_size)
+            raise LineTooLong(
+                name[:100] + b"...",
+                pyparser._max_field_size,
+                "header field name",
+            )
         pyparser._header_name_size = size
         pyparser._on_header_field(at, length)
     except BaseException as ex:
@@ -825,7 +835,11 @@ cdef int cb_on_header_value(cparser.llhttp_t* parser,
         size = len(pyparser._raw_value) + length
         if pyparser._header_name_size + size > pyparser._max_field_size:
             value = pyparser._raw_value + at[:length]
-            raise LineTooLong(value[:100] + b"...", pyparser._max_field_size)
+            raise LineTooLong(
+                value[:100] + b"...",
+                pyparser._max_field_size,
+                "header field value",
+            )
         pyparser._on_header_value(at, length)
     except BaseException as ex:
         pyparser._last_error = ex

--- a/aiohttp/http_exceptions.py
+++ b/aiohttp/http_exceptions.py
@@ -74,9 +74,13 @@ class ContentLengthError(PayloadEncodingError):
 
 
 class LineTooLong(BadHttpMessage):
-    def __init__(self, line: bytes, limit: int) -> None:
-        super().__init__(f"Got more than {limit} bytes when reading: {line!r}.")
-        self.args = (line, limit)
+    def __init__(
+        self, line: bytes, limit: int, context: str = "line"
+    ) -> None:
+        super().__init__(
+            f"Got more than {limit} bytes when reading {context}: {line!r}."
+        )
+        self.args = (line, limit, context)
 
 
 class InvalidHeader(BadHttpMessage):

--- a/aiohttp/http_exceptions.py
+++ b/aiohttp/http_exceptions.py
@@ -74,9 +74,7 @@ class ContentLengthError(PayloadEncodingError):
 
 
 class LineTooLong(BadHttpMessage):
-    def __init__(
-        self, line: bytes, limit: int, context: str = "line"
-    ) -> None:
+    def __init__(self, line: bytes, limit: int, context: str = "line") -> None:
         super().__init__(
             f"Got more than {limit} bytes when reading {context}: {line!r}."
         )

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -359,9 +359,7 @@ class HttpParser(abc.ABC, Generic[_MsgT]):
                         raise LineTooLong(
                             line[:100] + b"...",
                             max_line_length,
-                            "request/status line"
-                            if not self._lines
-                            else "header line",
+                            "request/status line" if not self._lines else "header line",
                         )
 
                     self._lines.append(line)
@@ -936,9 +934,11 @@ class HttpPayloadParser:
                         raise LineTooLong(
                             self._chunk_tail[:100] + b"...",
                             max_line_length,
-                            "chunk size line"
-                            if self._chunk != ChunkState.PARSE_TRAILERS
-                            else "trailer line",
+                            (
+                                "chunk size line"
+                                if self._chunk != ChunkState.PARSE_TRAILERS
+                                else "trailer line"
+                            ),
                         )
 
                 chunk = self._chunk_tail + chunk

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -207,7 +207,9 @@ class HeadersParser:
                     if header_length > self.max_field_size:
                         header_line = bname + b": " + b"".join(bvalue_lst)
                         raise LineTooLong(
-                            header_line[:100] + b"...", self.max_field_size
+                            header_line[:100] + b"...",
+                            self.max_field_size,
+                            "header line with continuations",
                         )
                     bvalue_lst.append(line)
 
@@ -354,7 +356,13 @@ class HttpParser(abc.ABC, Generic[_MsgT]):
                     if SEP == b"\n":  # For lax response parsing
                         line = line.rstrip(b"\r")
                     if len(line) > max_line_length:
-                        raise LineTooLong(line[:100] + b"...", max_line_length)
+                        raise LineTooLong(
+                            line[:100] + b"...",
+                            max_line_length,
+                            "request/status line"
+                            if not self._lines
+                            else "header line",
+                        )
 
                     self._lines.append(line)
                     # After processing the status/request line, everything is a header.
@@ -487,7 +495,11 @@ class HttpParser(abc.ABC, Generic[_MsgT]):
                 else:
                     self._tail = data[start_pos:]
                     if len(self._tail) > self.max_line_size:
-                        raise LineTooLong(self._tail[:100] + b"...", self.max_line_size)
+                        raise LineTooLong(
+                            self._tail[:100] + b"...",
+                            self.max_line_size,
+                            "request/status line",
+                        )
                     data = EMPTY
                     break
 
@@ -922,7 +934,11 @@ class HttpPayloadParser:
                         max_line_length = self._max_field_size
                     if len(self._chunk_tail) > max_line_length:
                         raise LineTooLong(
-                            self._chunk_tail[:100] + b"...", max_line_length
+                            self._chunk_tail[:100] + b"...",
+                            max_line_length,
+                            "chunk size line"
+                            if self._chunk != ChunkState.PARSE_TRAILERS
+                            else "trailer line",
                         )
 
                 chunk = self._chunk_tail + chunk
@@ -1020,7 +1036,11 @@ class HttpPayloadParser:
                         line = line.rstrip(b"\r")
 
                     if len(line) > self._max_field_size:
-                        raise LineTooLong(line[:100] + b"...", self._max_field_size)
+                        raise LineTooLong(
+                            line[:100] + b"...",
+                            self._max_field_size,
+                            "trailer line",
+                        )
 
                     self._trailer_lines.append(line)
 

--- a/aiohttp/streams.py
+++ b/aiohttp/streams.py
@@ -395,7 +395,9 @@ class StreamReader:
                     not_enough = False
 
                 if chunk_size > max_size:
-                    raise LineTooLong(chunk[:100] + b"...", max_size)
+                    raise LineTooLong(
+                        chunk[:100] + b"...", max_size, "stream until separator"
+                    )
 
             if self._eof:
                 break

--- a/tests/test_http_exceptions.py
+++ b/tests/test_http_exceptions.py
@@ -86,8 +86,7 @@ class TestLineTooLong:
         err = http_exceptions.LineTooLong(b"spam", 10, "request URL")
         assert err.code == 400
         assert (
-            err.message
-            == "Got more than 10 bytes when reading request URL: b'spam'."
+            err.message == "Got more than 10 bytes when reading request URL: b'spam'."
         )
         assert err.headers is None
 
@@ -105,9 +104,7 @@ class TestLineTooLong:
             assert err2.foo == "bar"
 
     def test_pickle_with_context(self) -> None:
-        err = http_exceptions.LineTooLong(
-            line=b"spam", limit=10, context="request URL"
-        )
+        err = http_exceptions.LineTooLong(line=b"spam", limit=10, context="request URL")
         for proto in range(pickle.HIGHEST_PROTOCOL + 1):
             pickled = pickle.dumps(err, proto)
             err2 = pickle.loads(pickled)
@@ -117,9 +114,7 @@ class TestLineTooLong:
 
     def test_str(self) -> None:
         err = http_exceptions.LineTooLong(line=b"spam", limit=10)
-        expected = (
-            "400, message:\n  Got more than 10 bytes when reading line: b'spam'."
-        )
+        expected = "400, message:\n  Got more than 10 bytes when reading line: b'spam'."
         assert str(err) == expected
 
     def test_repr(self) -> None:

--- a/tests/test_http_exceptions.py
+++ b/tests/test_http_exceptions.py
@@ -79,7 +79,16 @@ class TestLineTooLong:
     def test_ctor(self) -> None:
         err = http_exceptions.LineTooLong(b"spam", 10)
         assert err.code == 400
-        assert err.message == "Got more than 10 bytes when reading: b'spam'."
+        assert err.message == "Got more than 10 bytes when reading line: b'spam'."
+        assert err.headers is None
+
+    def test_ctor_with_context(self) -> None:
+        err = http_exceptions.LineTooLong(b"spam", 10, "request URL")
+        assert err.code == 400
+        assert (
+            err.message
+            == "Got more than 10 bytes when reading request URL: b'spam'."
+        )
         assert err.headers is None
 
     def test_pickle(self) -> None:
@@ -89,20 +98,35 @@ class TestLineTooLong:
             pickled = pickle.dumps(err, proto)
             err2 = pickle.loads(pickled)
             assert err2.code == 400
-            assert err2.message == ("Got more than 10 bytes when reading: b'spam'.")
+            assert err2.message == (
+                "Got more than 10 bytes when reading line: b'spam'."
+            )
             assert err2.headers is None
             assert err2.foo == "bar"
 
+    def test_pickle_with_context(self) -> None:
+        err = http_exceptions.LineTooLong(
+            line=b"spam", limit=10, context="request URL"
+        )
+        for proto in range(pickle.HIGHEST_PROTOCOL + 1):
+            pickled = pickle.dumps(err, proto)
+            err2 = pickle.loads(pickled)
+            assert err2.message == (
+                "Got more than 10 bytes when reading request URL: b'spam'."
+            )
+
     def test_str(self) -> None:
         err = http_exceptions.LineTooLong(line=b"spam", limit=10)
-        expected = "400, message:\n  Got more than 10 bytes when reading: b'spam'."
+        expected = (
+            "400, message:\n  Got more than 10 bytes when reading line: b'spam'."
+        )
         assert str(err) == expected
 
     def test_repr(self) -> None:
         err = http_exceptions.LineTooLong(line=b"spam", limit=10)
         assert repr(err) == (
             '<LineTooLong: 400, message="Got more than '
-            "10 bytes when reading: b'spam'.\">"
+            "10 bytes when reading line: b'spam'.\">"
         )
 
 

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -1552,6 +1552,20 @@ def test_http_request_max_status_line(parser: HttpRequestParser, size: int) -> N
         parser.feed_data(b"GET /path" + path + b" HTTP/1.1\r\n\r\n")
 
 
+def test_http_request_max_status_line_mentions_request_line(
+    parser: HttpRequestParser,
+) -> None:
+    path = b"t" * 8186
+    with pytest.raises(http_exceptions.LineTooLong) as exc_info:
+        parser.feed_data(b"GET /path" + path + b" HTTP/1.1\r\n\r\n")
+    # Error message must describe what overflowed (not "status line" when
+    # the request line is too long). See gh-7177.
+    assert (
+        "request URL" in exc_info.value.message
+        or "request/status line" in exc_info.value.message
+    )
+
+
 def test_http_request_max_status_line_under_limit(parser: HttpRequestParser) -> None:
     path = b"t" * 8172
     messages, upgraded, tail = parser.feed_data(


### PR DESCRIPTION
## What do these changes do?

Closes #7177.

The `LineTooLong` exception previously produced a generic error message:

```
Got more than 8190 bytes when reading: b'GET /pathttttt...'.
```

…regardless of which part of the HTTP message actually overflowed the
limit. That was especially confusing for long URLs, where older versions
labelled the overflow as a "Status line is too long" (see the logs in
#7177). Even after that text was removed, the resulting message still
gave no hint about whether the URL, the status reason, a header, or a
trailer was at fault.

This PR adds an optional `context` parameter to
`aiohttp.http_exceptions.LineTooLong` and wires it through every call
site so the message now looks like:

```
Got more than 8190 bytes when reading request URL: b'GET /pathttttt...'.
Got more than 8190 bytes when reading header field name: b'ttt...'.
Got more than 8190 bytes when reading request/status line: b'...'.
```

The addition is fully backwards-compatible: the parameter defaults to
`"line"`, so existing call-sites that have not been updated still
produce a coherent (if slightly less specific) message.

### Changes

- `aiohttp/http_exceptions.py` – accept and display `context` in `LineTooLong`.
- `aiohttp/_http_parser.pyx` – pass `"request URL"` / `"status reason phrase"` /
  `"header field name"` / `"header field value"` from the Cython callbacks.
- `aiohttp/http_parser.py` – pass `"request/status line"` /
  `"header line with continuations"` / `"chunk size line"` /
  `"trailer line"` from the pure-Python parser paths.
- `aiohttp/streams.py` – label `StreamReader.readuntil` overflows as
  `"stream until separator"`.

### Tests

- `tests/test_http_exceptions.py::TestLineTooLong` – added
  `test_ctor_with_context` and `test_pickle_with_context`, updated the
  existing message assertions for the new default label.
- `tests/test_http_parser.py::test_http_request_max_status_line_mentions_request_line`
  – new regression test asserting that a too-long request line is
  described as such in the error message.

All existing `match=...` regex assertions anchor on the prefix
`"Got more than N bytes when reading"` (no trailing colon), so they
continue to pass unchanged.

## Are there changes in behavior for the user?

The wording of the `LineTooLong` error message changes to include a
context label. Code that parses the message string could need updates;
code that catches the exception or reads `err.args = (line, limit, context)`
is unaffected.

## Related issue number

Closes #7177.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] Add a new news fragment into the `CHANGES/` folder
  * name it `<issue_id>.<type>.rst` (e.g. `588.bugfix.rst`)
  * if you don't have an `issue_id`, change it to the PR number after
    creating the PR
  * ensure type is one of the following:
    * `.feature`: Signifying a new feature.
    * `.bugfix`: Signifying a bug fix.
    * `.doc`: Signifying a documentation improvement.
    * `.removal`: Signifying a deprecation or removal of public API.
    * `.misc`: A ticket has been closed, but it is not of interest to users.
  * Make sure to use full sentences with correct case and punctuation,
    for example: "Fix issue with non-ascii contents in doctest text files."

## Disclosure

AI assistance (Claude) was used to draft these changes. I reviewed every
line and ran the relevant tests locally.