### PR TITLE
fix: ignore Content-Length/Transfer-Encoding in CONNECT 2xx proxy responses (RFC-9110)

### DIFF
--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -1532,9 +1532,13 @@ class TCPConnector(BaseConnector):
                 # read_until_eof=True will ensure the connection isn't closed
                 # once the response is received and processed allowing
                 # START_TLS to work on the connection below.
+                # skip_payload=True per RFC-9110 §9.3.6: a client MUST ignore
+                # any Content-Length or Transfer-Encoding header fields received
+                # in a successful response to CONNECT.
                 protocol.set_response_params(
                     read_until_eof=True,
                     timeout_ceil_threshold=self._timeout_ceil_threshold,
+                    skip_payload=True,
                 )
                 resp = await proxy_resp.start(conn)
             except BaseException:

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -10,6 +10,7 @@ from multidict import CIMultiDict
 from yarl import URL
 
 import aiohttp
+from aiohttp.client_proto import ResponseHandler
 from aiohttp.client_reqrep import (
     ClientRequest,
     ClientRequestArgs,
@@ -1184,8 +1185,14 @@ async def test_https_connect_skip_payload_on_200(  # type: ignore[misc]
 
     Per RFC-9110 §9.3.6 a client MUST ignore any Content-Length or
     Transfer-Encoding header fields in a successful response to CONNECT.
-    Verify that set_response_params is called with skip_payload=True so the
-    HTTP parser does not try to read a body from the 200 tunnel response.
+
+    This test uses a real ResponseHandler instance so we can assert that
+    ``_skip_payload`` is actually set to ``True`` on the protocol object
+    after the CONNECT 200 handshake.  ``_skip_payload=True`` causes the
+    underlying ``HttpResponseParser`` to be configured with
+    ``response_with_body=False``, which means any body bytes advertised
+    by Content-Length / Transfer-Encoding in the tunnel response are
+    silently discarded rather than blocking the TLS upgrade.
     """
     event_loop = asyncio.get_running_loop()
     proxy_req = ClientRequestBase(
@@ -1227,7 +1234,10 @@ async def test_https_connect_skip_payload_on_200(  # type: ignore[misc]
             with mock.patch.object(
                 connector, "_resolve_host", autospec=True, return_value=[r]
             ):
-                tr, proto = mock.Mock(), mock.Mock()
+                # Use a real ResponseHandler so we can assert its internal state
+                # rather than only checking that a mock method was called.
+                tr = mock.Mock()
+                proto = ResponseHandler(loop=event_loop)
                 with mock.patch.object(
                     event_loop,
                     "create_connection",
@@ -1250,13 +1260,15 @@ async def test_https_connect_skip_payload_on_200(  # type: ignore[misc]
                             req, [], aiohttp.ClientTimeout()
                         )
 
-                        # proto is the mock protocol returned by create_connection.
-                        # The connector calls protocol.set_response_params(...) on it
-                        # directly, so we assert on proto's auto-mock attribute.
-                        proto.set_response_params.assert_called_once_with(
-                            read_until_eof=True,
-                            timeout_ceil_threshold=mock.ANY,
-                            skip_payload=True,
+                        # Verify that the connector configured the real protocol
+                        # to skip the CONNECT response body.  This flag causes
+                        # HttpResponseParser to use response_with_body=False, so
+                        # any Content-Length / Transfer-Encoding bytes in the
+                        # tunnel handshake are not consumed before TLS is started.
+                        assert proto._skip_payload is True, (
+                            "ResponseHandler._skip_payload must be True after a "
+                            "CONNECT 200 so that proxy body bytes are not read "
+                            "before the TLS upgrade (RFC-9110 §9.3.6)"
                         )
 
                         proxy_resp.close()

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -1246,18 +1246,14 @@ async def test_https_connect_skip_payload_on_200(  # type: ignore[misc]
                             proxy=URL("http://proxy.example.com"),
                             loop=event_loop,
                         )
-                        # Capture the set_response_params call on the tunnel
-                        # protocol to verify skip_payload=True is passed.
-                        with mock.patch(
-                            "aiohttp.connector.ResponseHandler.set_response_params",
-                            autospec=True,
-                        ) as set_params_mock:
-                            await connector._create_connection(
-                                req, [], aiohttp.ClientTimeout()
-                            )
+                        await connector._create_connection(
+                            req, [], aiohttp.ClientTimeout()
+                        )
 
-                        set_params_mock.assert_called_once_with(
-                            mock.ANY,  # self
+                        # proto is the mock protocol returned by create_connection.
+                        # The connector calls protocol.set_response_params(...) on it
+                        # directly, so we assert on proto's auto-mock attribute.
+                        proto.set_response_params.assert_called_once_with(
                             read_until_eof=True,
                             timeout_ceil_threshold=mock.ANY,
                             skip_payload=True,

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -1167,3 +1167,102 @@ async def test_https_auth(  # type: ignore[misc]
                         proxy_resp.close()
                         await req._close()
             await connector.close()
+
+
+@mock.patch("aiohttp.connector.ClientRequestBase")
+@mock.patch(
+    "aiohttp.connector.aiohappyeyeballs.start_connection",
+    autospec=True,
+    spec_set=True,
+)
+async def test_https_connect_skip_payload_on_200(  # type: ignore[misc]
+    start_connection: mock.Mock,
+    ClientRequestMock: mock.Mock,
+    make_client_request: _RequestMaker,
+) -> None:
+    """Regression test for https://github.com/aio-libs/aiohttp/issues/8472.
+
+    Per RFC-9110 §9.3.6 a client MUST ignore any Content-Length or
+    Transfer-Encoding header fields in a successful response to CONNECT.
+    Verify that set_response_params is called with skip_payload=True so the
+    HTTP parser does not try to read a body from the 200 tunnel response.
+    """
+    event_loop = asyncio.get_running_loop()
+    proxy_req = ClientRequestBase(
+        "GET",
+        URL("http://proxy.example.com"),
+        auth=None,
+        loop=event_loop,
+        ssl=True,
+        headers=CIMultiDict({}),
+    )
+    ClientRequestMock.return_value = proxy_req
+
+    url = URL("http://proxy.example.com")
+    proxy_resp = ClientResponse(
+        "get",
+        url,
+        writer=None,
+        continue100=None,
+        timer=TimerNoop(),
+        traces=[],
+        loop=event_loop,
+        session=mock.Mock(),
+        request_headers=CIMultiDict[str](),
+        original_url=url,
+    )
+    with mock.patch.object(proxy_req, "_send", autospec=True, return_value=proxy_resp):
+        with mock.patch.object(proxy_resp, "start", autospec=True) as m:
+            m.return_value.status = 200
+
+            connector = aiohttp.TCPConnector()
+            r = {
+                "hostname": "hostname",
+                "host": "127.0.0.1",
+                "port": 80,
+                "family": socket.AF_INET,
+                "proto": 0,
+                "flags": 0,
+            }
+            with mock.patch.object(
+                connector, "_resolve_host", autospec=True, return_value=[r]
+            ):
+                tr, proto = mock.Mock(), mock.Mock()
+                with mock.patch.object(
+                    event_loop,
+                    "create_connection",
+                    autospec=True,
+                    return_value=(tr, proto),
+                ):
+                    with mock.patch.object(
+                        event_loop,
+                        "start_tls",
+                        autospec=True,
+                        return_value=mock.Mock(),
+                    ):
+                        req = make_client_request(
+                            "GET",
+                            URL("https://www.python.org"),
+                            proxy=URL("http://proxy.example.com"),
+                            loop=event_loop,
+                        )
+                        # Capture the set_response_params call on the tunnel
+                        # protocol to verify skip_payload=True is passed.
+                        with mock.patch(
+                            "aiohttp.connector.ResponseHandler.set_response_params",
+                            autospec=True,
+                        ) as set_params_mock:
+                            await connector._create_connection(
+                                req, [], aiohttp.ClientTimeout()
+                            )
+
+                        set_params_mock.assert_called_once_with(
+                            mock.ANY,  # self
+                            read_until_eof=True,
+                            timeout_ceil_threshold=mock.ANY,
+                            skip_payload=True,
+                        )
+
+                        proxy_resp.close()
+                        await req._close()
+            await connector.close()


### PR DESCRIPTION
## Summary

Per RFC-9110 §9.3.6:
> A client MUST ignore any Content-Length or Transfer-Encoding header fields received in a successful response to CONNECT.

When a proxy server returns a `200 Connection established` response with a `Content-Length` header, aiohttp's HTTP parser attempts to read that many bytes as a response body. This corrupts the tunnel and causes the subsequent TLS handshake to fail.

The fix adds `skip_payload=True` to the `set_response_params` call used when reading the CONNECT response, which instructs the HTTP parser to treat the response as having no body regardless of any framing headers.

## Changes
- `aiohttp/connector.py`: add `skip_payload=True` to CONNECT response parsing
- `tests/test_proxy.py`: add regression test (`test_https_connect_skip_payload_on_200`) that verifies `set_response_params` is called with `skip_payload=True`

Fixes #8472