### PR TITLE
docs: fix minor grammar issues in reference docs

### DIFF
--- a/CHANGES/12400.doc.rst
+++ b/CHANGES/12400.doc.rst
@@ -1,0 +1,3 @@
+Fixed minor grammatical issues in the documentation for
+:meth:`~aiohttp.StreamReader.exception`, the WebSocket response
+``exception()`` method, and the certifi example in client advanced usage.

--- a/CHANGES/12400.doc.rst
+++ b/CHANGES/12400.doc.rst
@@ -1,3 +1,0 @@
-Fixed minor grammatical issues in the documentation for
-:meth:`~aiohttp.StreamReader.exception`, the WebSocket response
-``exception()`` method, and the certifi example in client advanced usage.

--- a/docs/client_advanced.rst
+++ b/docs/client_advanced.rst
@@ -644,7 +644,7 @@ Example: Use certifi
 ^^^^^^^^^^^^^^^^^^^^
 
 By default, Python uses the system CA certificates. In rare cases, these may not be
-installed or Python is unable to find them, resulting in a error like
+installed or Python is unable to find them, resulting in an error like
 `ssl.SSLCertVerificationError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate`
 
 One way to work around this problem is to use the `certifi` package::

--- a/docs/streams.rst
+++ b/docs/streams.rst
@@ -180,7 +180,7 @@ Helpers
 
 .. method:: StreamReader.exception()
 
-   Get the exception occurred on data reading.
+   Get the exception that occurred on data reading.
 
 .. method:: is_eof()
 

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -1099,7 +1099,7 @@ and :ref:`aiohttp-web-signals` handlers::
 
    .. method:: exception()
 
-      Returns last occurred exception or None.
+      Returns the last exception that occurred, or None.
 
    .. method:: ping(message=b'')
       :async:


### PR DESCRIPTION

**Repo:** aio-libs/aiohttp (⭐ 15000)
**Type:** docs
**Files changed:** 4
**Lines:** +6/-3

## What
Fixes three small grammatical issues in the documentation:
- `docs/streams.rst`: "Get the exception occurred on data reading" → "Get the exception that occurred on data reading".
- `docs/web_reference.rst`: "Returns last occurred exception or None" → "Returns the last exception that occurred, or None".
- `docs/client_advanced.rst`: "resulting in a error like" → "resulting in an error like".

Adds a CHANGES fragment (`CHANGES/12400.doc.rst`) following the repo's towncrier conventions.

## Why
These are minor readability issues in public-facing Sphinx reference docs. They're the kind of polish that reviewers are happy to merge and add up over time. No code behavior changes.

## Testing
Pure docs changes — no code paths touched. Visual review of the three hunks; the wording now reads as grammatical English. A full docs build would confirm no RST syntax errors, but the edits are minimal text substitutions in stable paragraphs.

## Risk
Low — docs-only, three small text changes.
