### PR TITLE
Avoid installation of backports.zstd on Python 3.14 in linting deps

### DIFF
--- a/CHANGES/12406.contrib.rst
+++ b/CHANGES/12406.contrib.rst
@@ -1,0 +1,2 @@
+Avoid installation of backports.zstd on Python 3.14 in linting dependency set
+-- by :user:`seifertm`.

--- a/requirements/lint.in
+++ b/requirements/lint.in
@@ -1,5 +1,5 @@
 aiodns
-backports.zstd; implementation_name == "cpython"
+backports.zstd; implementation_name == "cpython" and python_version < "3.14"
 blockbuster
 freezegun
 isal


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Avoid installation of *backports.zstd* in *lint.in* on Python 3.14 and newer.

Otherwise, `make test` results in the following error message:
```
ERROR: Ignored the following versions that require a different python version: 0.1.0 Requires-Python >=3.13,<3.14; 0.2.0 Requires-Python >=3.10,<3.14; 0.3.0 Requires-Python >=3.9,<3.14; 0.4.0 Requires-Python >=3.9,<3.14; 0.5.0 Requires-Python >=3.9,<3.14; 1.0.0 Requires-Python >=3.9,<3.14; 1.1.0 Requires-Python >=3.9,<3.14; 1.2.0 Requires-Python >=3.9,<3.14; 1.3.0 Requires-Python >=3.9,<3.14
ERROR: Could not find a version that satisfies the requirement backports.zstd (from versions: none)
ERROR: No matching distribution found for backports.zstd
```

## Are there changes in behavior for the user?

No

## Is it a substantial burden for the maintainers to support this?

No

## Related issue number

N/A

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES/` folder
  * name it `<issue_or_pr_num>.<type>.rst` (e.g. `588.bugfix.rst`)
  * if you don't have an issue number, change it to the pull request
    number after creating the PR
    * `.bugfix`: A bug fix for something the maintainers deemed an
      improper undesired behavior that got corrected to match
      pre-agreed expectations.
    * `.feature`: A new behavior, public APIs. That sort of stuff.
    * `.deprecation`: A declaration of future API removals and breaking
      changes in behavior.
    * `.breaking`: When something public is removed in a breaking way.
      Could be deprecated in an earlier release.
    * `.doc`: Notable updates to the documentation structure or build
      process.
    * `.packaging`: Notes for downstreams about unobvious side effects
      and tooling. Changes in the test invocation considerations and
      runtime assumptions.
    * `.contrib`: Stuff that affects the contributor experience. e.g.
      Running tests, building the docs, setting up the development
      environment.
    * `.misc`: Changes that are hard to assign to any of the above
      categories.
  * Make sure to use full sentences with correct case and punctuation,
    for example:
    ```rst
    Fixed issue with non-ascii contents in doctest text files
    -- by :user:`contributor-gh-handle`.
    ```

    Use the past tense or the present tense a non-imperative mood,
    referring to what's changed compared to the last released version
    of this project.
