### PR TITLE
fix: ensure BodyPartReader.read() returns bytes, not bytearray

### DIFF
--- a/CHANGES/12404.bugfix.rst
+++ b/CHANGES/12404.bugfix.rst
@@ -1,0 +1,3 @@
+BodyPartReader.read() now correctly returns ``bytes`` instead of ``bytearray``,
+matching the type annotation and preventing ``TypeError`` in downstream code
+that expects ``bytes`` (e.g. ``json.dumps``).

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -286,6 +286,7 @@ Navid Sheikhol
 Nicolas Braem
 Nikolay Kim
 Nikolay Novik
+Nikita Zamuldinov
 Nikolay Tiunov
 Nándor Mátravölgyi
 Oisin Aylward

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -284,9 +284,9 @@ Moss Collum
 Mun Gwan-gyeong
 Navid Sheikhol
 Nicolas Braem
+Nikita Zamuldinov
 Nikolay Kim
 Nikolay Novik
-Nikita Zamuldinov
 Nikolay Tiunov
 Nándor Mátravölgyi
 Oisin Aylward

--- a/aiohttp/multipart.py
+++ b/aiohttp/multipart.py
@@ -322,8 +322,8 @@ class BodyPartReader:
                 decoded_data.extend(d)
                 if len(decoded_data) > self._client_max_size:
                     raise self._max_size_error_cls(self._client_max_size)
-            return decoded_data
-        return data
+            return bytes(decoded_data)
+        return bytes(data)
 
     async def read_chunk(self, size: int = chunk_size) -> bytes:
         """Reads body part content chunk of the specified size.

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -185,6 +185,27 @@ class TestPartReader:
             assert b"Hello, world!" == result
             assert obj.at_eof()
 
+    async def test_read_returns_bytes_not_bytearray(self) -> None:
+        """BodyPartReader.read() must return bytes, not bytearray (#12404)."""
+        with Stream(b"Hello, world!\r\n--:") as stream:
+            d = CIMultiDictProxy[str](CIMultiDict())
+            obj = aiohttp.BodyPartReader(BOUNDARY, d, stream)
+            result = await obj.read()
+            assert isinstance(result, bytes), f"Expected bytes, got {type(result)}"
+            assert result == b"Hello, world!"
+
+    async def test_read_decode_returns_bytes_not_bytearray(self) -> None:
+        """BodyPartReader.read(decode=True) must return bytes, not bytearray (#12404)."""
+        data = gzip.compress(b"Hello, world!")
+        headers = CIMultiDictProxy[str](
+            CIMultiDict({CONTENT_ENCODING: "gzip"})
+        )
+        with Stream(data + b"\r\n--:") as stream:
+            obj = aiohttp.BodyPartReader(BOUNDARY, headers, stream, subtype="mixed")
+            result = await obj.read(decode=True)
+            assert isinstance(result, bytes), f"Expected bytes, got {type(result)}"
+            assert result == b"Hello, world!"
+
     async def test_read_chunk_at_eof(self) -> None:
         with Stream(b"--:") as stream:
             d = CIMultiDictProxy[str](CIMultiDict())

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -197,9 +197,7 @@ class TestPartReader:
     async def test_read_decode_returns_bytes_not_bytearray(self) -> None:
         """BodyPartReader.read(decode=True) must return bytes, not bytearray (#12404)."""
         data = gzip.compress(b"Hello, world!")
-        headers = CIMultiDictProxy[str](
-            CIMultiDict({CONTENT_ENCODING: "gzip"})
-        )
+        headers = CIMultiDictProxy[str](CIMultiDict({CONTENT_ENCODING: "gzip"}))
         with Stream(data + b"\r\n--:") as stream:
             obj = aiohttp.BodyPartReader(BOUNDARY, headers, stream, subtype="mixed")
             result = await obj.read(decode=True)


### PR DESCRIPTION
## What do these changes do?

`BodyPartReader.read()` internally accumulates data into a `bytearray` for efficient concatenation, but returns it directly, violating the annotated return type of `bytes`. This causes downstream code that expects `bytes` (e.g. `json.dumps`) to fail with `TypeError: Object of type bytearray is not JSON serializable`.

This PR wraps both return paths (raw and decoded) with `bytes()` to ensure the returned value always matches the type annotation.

## Are there changes in behavior for the user?

Yes — `read()` and `read(decode=True)` now return `bytes` instead of `bytearray`. This is a fix to match the documented type; code that already treated the return as `bytes` will see no difference. Code that relied on the mutable `bytearray` (unlikely given the type hints) would need adjustment.

## Is it a substantial burden for the maintainers to support this?

No. The change is minimal (two `bytes()` calls) and does not introduce new API surface or complexity.

## Related issue number

Fixes #12404

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes (no doc changes needed — behavior now matches docs)
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
- [x] Add a new news fragment into the `CHANGES/` folder