### PR TITLE
fix: ensure BodyPartReader.read() returns bytes instead of bytearray

### DIFF
--- a/aiohttp/multipart.py
+++ b/aiohttp/multipart.py
@@ -322,8 +322,8 @@ class BodyPartReader:
                 decoded_data.extend(d)
                 if len(decoded_data) > self._client_max_size:
                     raise self._max_size_error_cls(self._client_max_size)
-            return decoded_data
-        return data
+            return bytes(decoded_data)
+        return bytes(data)
 
     async def read_chunk(self, size: int = chunk_size) -> bytes:
         """Reads body part content chunk of the specified size.


### PR DESCRIPTION
## Summary

BodyPartReader.read() documents its return type as `bytes`, but both the decoded and raw code paths returned the internal `bytearray` buffer unchanged. This caused `TypeError: Object of type bytearray is not JSON serializable` when piping multipart data into json.dumps, msgpack, or any other serializer with strict type requirements.

## Changes

- Convert `decoded_data` (decode=True path) to `bytes()` before returning
- Convert `data` (raw path) to `bytes()` before returning

Both are 2-line changes in `aiohttp/multipart.py` that make the return values match the documented API contract.

Fixes #12404