### PR TITLE
fix(multipart): ensure BodyPartReader.read() returns bytes not bytearray

### DIFF
--- a/aiohttp/multipart.py
+++ b/aiohttp/multipart.py
@@ -322,8 +322,8 @@ class BodyPartReader:
                 decoded_data.extend(d)
                 if len(decoded_data) > self._client_max_size:
                     raise self._max_size_error_cls(self._client_max_size)
-            return decoded_data
-        return data
+            return bytes(decoded_data)
+        return bytes(data)
 
     async def read_chunk(self, size: int = chunk_size) -> bytes:
         """Reads body part content chunk of the specified size.


### PR DESCRIPTION
## Summary

BodyPartReader.read() accumulates data in an internal bytearray buffer but returns it directly without converting to bytes. This violates the documented return type annotation (bytes) and causes TypeError in downstream code that passes the result to json.dumps() or any API expecting bytes rather than bytearray.

The fix wraps both return paths with bytes() so the returned type always matches the annotation.

Fixes #12404