### PR TITLE
fix(multipart): ensure BodyPartReader.read() returns bytes not bytearray

### DIFF
--- a/aiohttp/multipart.py
+++ b/aiohttp/multipart.py
@@ -322,8 +322,8 @@ class BodyPartReader:
                 decoded_data.extend(d)
                 if len(decoded_data) > self._client_max_size:
                     raise self._max_size_error_cls(self._client_max_size)
-            return decoded_data
-        return data
+            return bytes(decoded_data)
+        return bytes(data)
 
     async def read_chunk(self, size: int = chunk_size) -> bytes:
         """Reads body part content chunk of the specified size.


### PR DESCRIPTION
## Summary

 documents its return type as `bytes`, but internally builds the result in a `bytearray` and returns it directly. This means callers receive a `bytearray` instead of `bytes`, which breaks code that passes the result to `json.dumps()` or other APIs that don't accept `bytearray`.

## Reproduction

From #12404:

```python
reader = await request.multipart()
part = await reader.next()
data = await part.read(decode=True)
print(type(data))  # <class 'bytearray'>, should be <class 'bytes'>
json.dumps({"filename": data})  # TypeError!
```

## Fix

Convert the internal `bytearray` to `bytes` before returning from `read()`. This is a minimal, backward-compatible change — `bytes(bytearray)` is a no-op copy for the common case.

Fixes #12404