### PR TITLE
fix(tests): use .invalid TLD for unresolvable DNS test

### DIFF
--- a/CHANGES/11293.misc.rst
+++ b/CHANGES/11293.misc.rst
@@ -1,0 +1,4 @@
+Fixed flaky ``test_aiohttp_request_ctx_manager_not_found`` by switching the
+unresolvable hostname to use the reserved ``.invalid`` TLD (RFC 2606), which is
+guaranteed not to resolve, instead of relying on a real domain that could be
+hijacked or unexpectedly resolved by some networks -- by :user:`copilot`.

--- a/CHANGES/11293.misc.rst
+++ b/CHANGES/11293.misc.rst
@@ -1,4 +1,0 @@
-Fixed flaky ``test_aiohttp_request_ctx_manager_not_found`` by switching the
-unresolvable hostname to use the reserved ``.invalid`` TLD (:rfc:`2606`),
-which is guaranteed not to resolve, instead of relying on a real domain that
-could be hijacked or unexpectedly resolved by some networks.

--- a/CHANGES/11293.misc.rst
+++ b/CHANGES/11293.misc.rst
@@ -1,4 +1,4 @@
 Fixed flaky ``test_aiohttp_request_ctx_manager_not_found`` by switching the
-unresolvable hostname to use the reserved ``.invalid`` TLD (RFC 2606), which is
-guaranteed not to resolve, instead of relying on a real domain that could be
-hijacked or unexpectedly resolved by some networks -- by :user:`copilot`.
+unresolvable hostname to use the reserved ``.invalid`` TLD (:rfc:`2606`),
+which is guaranteed not to resolve, instead of relying on a real domain that
+could be hijacked or unexpectedly resolved by some networks.

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -3753,13 +3753,9 @@ async def test_aiohttp_request_ctx_manager_close_sess_on_error(
 
 
 async def test_aiohttp_request_ctx_manager_not_found() -> None:
-    # Use the reserved ``.invalid`` TLD (RFC 2606) so DNS resolution is
-    # guaranteed to fail, instead of relying on a real domain name which
-    # may unexpectedly resolve on some networks (e.g. ISP NXDOMAIN
-    # hijacking) and make this test flaky. See #11293.
     with pytest.raises(aiohttp.ClientConnectionError):
         async with aiohttp.request("GET", "http://wrong-dns-name.invalid"):
-            assert False, "never executed"
+            assert False
 
 
 async def test_raising_client_connector_dns_error_on_dns_failure() -> None:

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -3753,9 +3753,13 @@ async def test_aiohttp_request_ctx_manager_close_sess_on_error(
 
 
 async def test_aiohttp_request_ctx_manager_not_found() -> None:
+    # Use the reserved ``.invalid`` TLD (RFC 2606) so DNS resolution is
+    # guaranteed to fail, instead of relying on a real domain name which
+    # may unexpectedly resolve on some networks (e.g. ISP NXDOMAIN
+    # hijacking) and make this test flaky. See #11293.
     with pytest.raises(aiohttp.ClientConnectionError):
-        async with aiohttp.request("GET", "http://wrong-dns-name.com"):
-            assert False
+        async with aiohttp.request("GET", "http://wrong-dns-name.invalid"):
+            assert False, "never executed"
 
 
 async def test_raising_client_connector_dns_error_on_dns_failure() -> None:


### PR DESCRIPTION
Closes #11293

<!-- Drafted by an agent run; please review carefully before merging. -->

## What do these changes do?

Switch the unresolvable-DNS test hostname from `wrong-dns-name.com` to `wrong-dns-name.invalid`, using the reserved `.invalid` TLD (RFC 2606), so the test cannot be flaked by NXDOMAIN hijacking, parking pages, or cached records on networks that opportunistically resolve `.com` typos.

Also added a `"never executed"` message to the inner `assert False` to match the sibling test and aid debugging when something does enter the body.

## Are there changes in behavior for the user?

No — test-only change. No public API or runtime behavior is affected.

## Is it a substantial burden for the maintainers to support this?

No — single hostname swap in one test, no new dependencies, and `.invalid` is guaranteed unresolvable by RFC 2606, so there is no new infrastructure to maintain.

## Related issue number

Fixes #11293

## Root cause

`test_aiohttp_request_ctx_manager_not_found` relied on `http://wrong-dns-name.com` failing DNS resolution, but on some networks (notably macOS / certain ISPs) that domain can intermittently resolve. When it resolves, the request proceeds past the `async with`, the inner `assert False` trips, and the outer `pytest.raises(ClientConnectionError)` fails.

## Regression test

`tests/test_client_functional.py::test_aiohttp_request_ctx_manager_not_found` — same test, now deterministic; it asserts that entering an `aiohttp.request` context manager for an unresolvable host raises `ClientConnectionError` and never enters the body.

## Verification

Manually verified via `socket.getaddrinfo('wrong-dns-name.invalid', 80)` raises `gaierror`, confirming `.invalid` is unresolvable and the test will reliably hit the `ClientConnectionError` path. Local pytest env was missing some required plugins (`textual`), so the in-tree run is left to CI.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist (the existing test, now deterministic)
- [x] Documentation reflects the changes (N/A — test-only)
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
- [x] Add a new news fragment into the `CHANGES/` folder (`CHANGES/11293.misc.rst` is included in this PR)
