### PR TITLE
fix: preserve public module paths for web re-exports

### DIFF
--- a/CHANGES/3714.bugfix.rst
+++ b/CHANGES/3714.bugfix.rst
@@ -1,0 +1,1 @@
+Updated the public ``aiohttp.web`` re-exports for ``Response`` and ``WebSocketResponse`` so autodoc and intersphinx resolve them under ``aiohttp.web``.

--- a/CHANGES/3714.bugfix.rst
+++ b/CHANGES/3714.bugfix.rst
@@ -1,1 +1,3 @@
-Updated the public ``aiohttp.web`` re-exports for ``Response`` and ``WebSocketResponse`` so autodoc and intersphinx resolve them under ``aiohttp.web``.
+Fixed the ``aiohttp.web`` re-exports for ``Response`` and ``WebSocketResponse`` so autodoc and intersphinx resolve them under the public module path.
+
+-- by :user:`nightcityblade`.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -341,6 +341,7 @@ Sergey Skripnick
 Serhii Charykov
 Serhii Kostel
 Serhiy Storchaka
+Shengsheng Shen
 Shensheng Shen
 Shubh Agarwal
 Simon Kennedy
@@ -433,5 +434,3 @@ Zlatan Sičanica
 Łukasz Setla
 Марк Коренберг
 Семён Марьясин
-
-nightcityblade

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -433,3 +433,5 @@ Zlatan Sičanica
 Łukasz Setla
 Марк Коренберг
 Семён Марьясин
+
+nightcityblade

--- a/aiohttp/web.py
+++ b/aiohttp/web.py
@@ -131,6 +131,9 @@ from .web_urldispatcher import (
 )
 from .web_ws import WebSocketReady, WebSocketResponse, WSMsgType
 
+Response.__module__ = "aiohttp.web"
+WebSocketResponse.__module__ = "aiohttp.web"
+
 __all__ = (
     # web_app
     "AppKey",

--- a/tests/test_web_public_api.py
+++ b/tests/test_web_public_api.py
@@ -1,0 +1,6 @@
+from aiohttp import web
+
+
+def test_reexported_classes_report_public_module() -> None:
+    assert web.Response.__module__ == "aiohttp.web"
+    assert web.WebSocketResponse.__module__ == "aiohttp.web"


### PR DESCRIPTION
## What do these changes do?

They preserve the public `aiohttp.web` module path for the re-exported `Response` and `WebSocketResponse` classes so autodoc and intersphinx resolve the public names instead of the internal implementation modules.

## Are there changes in behavior for the user?

No runtime behavior change. This only fixes how the public classes are reported for documentation and cross-reference generation.

## Is it a substantial burden for the maintainers to support this?

No.

## Related issue number

Closes #3714.

## Checklist

- [x] I think the code is well written
- [x] Tests for the changes exist
- [x] Documentation reflects the changes where applicable
- [x] Add a news fragment into the CHANGES folder if needed
- [x] I added my name to CONTRIBUTORS.txt
