### PR TITLE
Fix digest authentication for URLs with reserved characters

### DIFF
--- a/CHANGES/12436.bugfix.rst
+++ b/CHANGES/12436.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed digest authentication failing for requests whose path or query string contains percent-encoded reserved characters; the digest signature now uses the encoded request-target that is sent on the wire instead of the decoded form -- by :user:`bdraco`.

--- a/aiohttp/client_middleware_digest_auth.py
+++ b/aiohttp/client_middleware_digest_auth.py
@@ -246,7 +246,11 @@ class DigestAuthMiddleware:
         # Convert string values to bytes once
         nonce_bytes = nonce.encode("utf-8")
         realm_bytes = realm.encode("utf-8")
-        path = URL(url).path_qs
+        # Use the encoded request-target (raw_path_qs) since that is what is
+        # transmitted on the wire and what the server signs against. Using the
+        # decoded form would cause digest verification to fail when the path
+        # or query string contains percent-encoded reserved characters.
+        path = URL(url).raw_path_qs
 
         # Process QoP
         qop = ""

--- a/tests/test_client_middleware_digest_auth.py
+++ b/tests/test_client_middleware_digest_auth.py
@@ -190,6 +190,47 @@ async def test_encode_digest_with_md5(
 
 
 @pytest.mark.parametrize(
+    ("url", "expected_uri"),
+    [
+        (
+            URL("http://example.com/axis-cgi/io/port.cgi?action=9:\\"),
+            "/axis-cgi/io/port.cgi?action=9:%5C",
+        ),
+        (
+            URL("http://example.com/path with space/file"),
+            "/path%20with%20space/file",
+        ),
+        (
+            URL("http://example.com/p?q=a&b=1+2"),
+            "/p?q=a&b=1+2",
+        ),
+        (
+            URL.build(
+                scheme="http",
+                host="example.com",
+                path="/p",
+                query={"x": "[]"},
+            ),
+            "/p?x=%5B%5D",
+        ),
+    ],
+    ids=["backslash-and-colon", "space-in-path", "ampersand-and-plus", "brackets"],
+)
+async def test_encode_uri_uses_wire_encoded_request_target(
+    auth_mw_with_challenge: DigestAuthMiddleware,
+    url: URL,
+    expected_uri: str,
+) -> None:
+    """The digest uri/A2 must use the encoded request-target sent on the wire.
+
+    Servers compute the digest signature against the encoded request-target
+    they actually receive, so the client must sign the same encoded form.
+    """
+    header = await auth_mw_with_challenge._encode("GET", url, b"")
+    assert f'uri="{expected_uri}"' in header
+
+
+@pytest.mark.parametrize(
     "algorithm", ["MD5-SESS", "SHA-SESS", "SHA-256-SESS", "SHA-512-SESS"]
 )
 async def test_encode_digest_with_sess_algorithms(


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

The digest middleware was computing the signature using yarl's `path_qs`, which returns the decoded form of the path and query string; aiohttp sends the encoded form (`raw_path_qs`) on the wire, so the server signed a different request-target than the client and rejected the response with 401. This switches the digest A2 and the Authorization `uri` field to `raw_path_qs` so the signed value matches what is sent on the wire.

## Are there changes in behavior for the user?

Digest auth now works against servers when the request path or query string contains percent-encoded reserved characters, for example `?action=9:\` on Axis VAPIX endpoints. Requests that previously worked are unaffected since the encoded and decoded forms are identical when no reserved characters are present.

## Is it a substantial burden for the maintainers to support this?

No, the change is a single attribute swap on a yarl URL plus a parametrized test covering the encoded-vs-decoded mismatch.

## Related issue number

Reported in https://github.com/Kane610/axis/pull/774, where the downstream library had to ship its own digest-signing fallback to work around this.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES/` folder
  * name it `<issue_or_pr_num>.<type>.rst` (e.g. `588.bugfix.rst`)
  * if you don't have an issue number, change it to the pull request
    number after creating the PR
    * `.bugfix`: A bug fix for something the maintainers deemed an
      improper undesired behavior that got corrected to match
      pre-agreed expectations.
    * `.feature`: A new behavior, public APIs. That sort of stuff.
    * `.deprecation`: A declaration of future API removals and breaking
      changes in behavior.
    * `.breaking`: When something public is removed in a breaking way.
      Could be deprecated in an earlier release.
    * `.doc`: Notable updates to the documentation structure or build
      process.
    * `.packaging`: Notes for downstreams about unobvious side effects
      and tooling. Changes in the test invocation considerations and
      runtime assumptions.
    * `.contrib`: Stuff that affects the contributor experience. e.g.
      Running tests, building the docs, setting up the development
      environment.
    * `.misc`: Changes that are hard to assign to any of the above
      categories.
  * Make sure to use full sentences with correct case and punctuation,
    for example:
    ```rst
    Fixed issue with non-ascii contents in doctest text files
    -- by :user:`contributor-gh-handle`.
    ```

    Use the past tense or the present tense a non-imperative mood,
    referring to what's changed compared to the last released version
    of this project.