### PR TITLE
fix: BodyPartReader.read() now returns bytes instead of bytearray

### DIFF
--- a/aiohttp/multipart.py
+++ b/aiohttp/multipart.py
@@ -318,8 +318,8 @@ class BodyPartReader:
             decoded_data = bytearray()
             async for d in self.decode_iter(data):
                 decoded_data.extend(d)
-            return decoded_data
-        return data
+            return bytes(decoded_data)
+        return bytes(data)
 
     async def read_chunk(self, size: int = chunk_size) -> bytes:
         """Reads body part content chunk of the specified size.

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -373,6 +373,21 @@ class TestPartReader:
             result = await obj.read(decode=True)
         assert thing[:-2] == result
 
+    async def test_read_returns_bytes_not_bytearray(self) -> None:
+        """Ensure read() and read(decode=True) always return bytes (GH#12404)."""
+        h = CIMultiDictProxy(CIMultiDict())
+        with Stream(b"Hello, World!\r\n--:--") as stream:
+            obj = aiohttp.BodyPartReader(BOUNDARY, h, stream)
+            result = await obj.read()
+        assert isinstance(result, bytes)
+        assert result == b"Hello, World!"
+
+        with Stream(b"Hello, World!\r\n--:--") as stream:
+            obj = aiohttp.BodyPartReader(BOUNDARY, h, stream)
+            result_decoded = await obj.read(decode=True)
+        assert isinstance(result_decoded, bytes)
+        assert result_decoded == b"Hello, World!"
+
     async def test_read_with_content_encoding_unknown(self) -> None:
         h = CIMultiDictProxy(CIMultiDict({CONTENT_ENCODING: "snappy"}))
         with Stream(b"\x0e4Time to Relax!\r\n--:--") as stream:


### PR DESCRIPTION
**What kind of change does this PR introduce?**

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Other, please describe:

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

**The PR fulfills these requirements:**
- [x] It's submitted to the `main` branch.
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] All tests are passing locally.
- [x] New tests have been added to cover the fix.

**Other information:**

`BodyPartReader.read()` and `read(decode=True)` were returning `bytearray` objects, violating the type hint promise of `-> bytes`. This caused `TypeError` when downstream code passed the result to `json.dumps` or other strict serializers (see #12404).

This fix wraps both return paths with `bytes(...)` to guarantee the correct return type. A regression test has been added to `tests/test_multipart.py`.