### PR TITLE
[3.14] Validate Content-Length format in ClientRequest (backport of #12385)

### DIFF
--- a/.coveragerc-cython.toml
+++ b/.coveragerc-cython.toml
@@ -1,0 +1,17 @@
+[run]
+branch = true
+plugins = [
+  'Cython.Coverage',
+]
+omit = [
+  'site-packages',
+]
+
+[report]
+exclude_also = [
+  'if TYPE_CHECKING',
+  'assert False',
+  ': \.\.\.(\s*#.*)?$',
+  '^ +\.\.\.$',
+  'pytest.fail\('
+]

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -407,7 +407,10 @@ jobs:
 
     name: Cython coverage
     needs: gen_llhttp
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu, windows]
+    runs-on: ${{ matrix.os }}-latest
     steps:
     - name: Checkout
       uses: actions/checkout@v6

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -552,7 +552,7 @@ jobs:
       run: |
         make cythonize
     - name: Build wheels
-      uses: pypa/cibuildwheel@v3.4.0
+      uses: pypa/cibuildwheel@v3.4.1
       env:
         CIBW_SKIP: pp* ${{ matrix.musl == 'musllinux' && '*manylinux*' || '*musllinux*' }}
         CIBW_ARCHS_MACOS: x86_64 arm64 universal2

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -401,6 +401,64 @@ jobs:
         run: python -Im pytest --no-cov --numprocesses=0 -vvvvv --codspeed
 
 
+  cython-coverage:
+    permissions:
+      contents: read # to fetch code (actions/checkout)
+
+    name: Cython coverage
+    needs: gen_llhttp
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v6
+      with:
+        submodules: true
+    - name: Setup Python
+      id: python-install
+      uses: actions/setup-python@v6
+      with:
+        python-version: '3.12'
+    - name: Update pip, wheel, setuptools, build, twine
+      run: |
+        python -m pip install -U pip wheel setuptools build twine
+    - name: Install dependencies
+      run: |
+        python -Im pip install -r requirements/test.in -c requirements/test.txt
+    - name: Uninstall blocbuster
+      run: python -m pip uninstall blockbuster -y
+    - name: Restore llhttp generated files
+      uses: actions/download-artifact@v8
+      with:
+        name: llhttp
+        path: vendor/llhttp/build/
+    - name: Cythonize with linetrace
+      run: |
+        make cythonize CYTHON_EXTRA="-X linetrace=True"
+    - name: Install self
+      env:
+        AIOHTTP_CYTHON_TRACE: 1
+      run: python -m pip install -e .
+    - name: Run tests with Cython tracing
+      env:
+        COLOR: yes
+        PIP_USER: 1
+      run: >-
+        pytest tests/test_client_functional.py tests/test_http_parser.py tests/test_http_writer.py tests/test_web_functional.py tests/test_web_response.py tests/test_websocket_parser.py
+        --cov-config=.coveragerc-cython.toml
+        -m 'not dev_mode and not autobahn'
+      shell: bash
+    - name: Turn coverage into xml
+      run: |
+        python -m coverage xml -o cython-coverage.xml --rcfile=.coveragerc-cython.toml
+    - name: Upload coverage
+      uses: codecov/codecov-action@v6
+      with:
+        files: ./cython-coverage.xml
+        disable_search: true
+        flags: cython-coverage
+        token: ${{ secrets.CODECOV_TOKEN }}
+        fail_ci_if_error: true
+
   check:  # This job does nothing and is only used for the branch protection
     if: always()
 

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -222,7 +222,8 @@ jobs:
         PIP_USER: 1
       run: >-
         PATH="${HOME}/Library/Python/3.11/bin:${HOME}/.local/bin:${PATH}"
-        pytest --junitxml=junit.xml -m 'not dev_mode and not autobahn'
+        pytest --junitxml=junit.xml --numprocesses=auto --cov=aiohttp/ --cov=tests/
+        -m 'not dev_mode and not autobahn'
       shell: bash
     - name: Re-run the failing tests with maximum verbosity
       if: failure()
@@ -230,7 +231,7 @@ jobs:
         COLOR: yes
         AIOHTTP_NO_EXTENSIONS: ${{ matrix.no-extensions }}
       run: >-  # `exit 1` makes sure that the job remains red with flaky runs
-        pytest --no-cov --numprocesses=0 -vvvvv --lf && exit 1
+        pytest --no-cov -vvvvv --lf && exit 1
       shell: bash
     - name: Run dev_mode tests
       env:
@@ -238,7 +239,7 @@ jobs:
         AIOHTTP_NO_EXTENSIONS: ${{ matrix.no-extensions }}
         PIP_USER: 1
         PYTHONDEVMODE: 1
-      run: pytest -m dev_mode --cov-append --numprocesses=0
+      run: pytest -m dev_mode --cov=aiohttp/ --cov=tests/ --cov-append
       shell: bash
     - name: Turn coverage into xml
       env:
@@ -330,7 +331,7 @@ jobs:
         PIP_USER: 1
       run: >-
         PATH="${HOME}/Library/Python/3.11/bin:${HOME}/.local/bin:${PATH}"
-        pytest --junitxml=junit.xml --numprocesses=0 -m autobahn
+        pytest --junitxml=junit.xml --cov=aiohttp/ --cov=tests/ -m autobahn
       shell: bash
     - name: Turn coverage into xml
       env:
@@ -398,7 +399,7 @@ jobs:
       uses: CodSpeedHQ/action@v4
       with:
         mode: instrumentation
-        run: python -Im pytest --no-cov --numprocesses=0 -vvvvv --codspeed
+        run: python -Im pytest --no-cov -vvvvv --codspeed
 
 
   cython-coverage:
@@ -447,7 +448,7 @@ jobs:
         PIP_USER: 1
       run: >-
         pytest tests/test_client_functional.py tests/test_http_parser.py tests/test_http_writer.py tests/test_web_functional.py tests/test_web_response.py tests/test_websocket_parser.py
-        --cov-config=.coveragerc-cython.toml
+        --cov-config=.coveragerc-cython.toml --cov=aiohttp/ --cov=tests/ --numprocesses=auto
         -m 'not dev_mode and not autobahn'
       shell: bash
     - name: Turn coverage into xml

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -71,7 +71,7 @@ jobs:
       with:
         python-version: 3.11
     - name: Cache PyPI
-      uses: actions/cache@v5.0.4
+      uses: actions/cache@v5.0.5
       with:
         key: pip-lint-${{ hashFiles('requirements/*.txt') }}
         path: ~/.cache/pip
@@ -120,7 +120,7 @@ jobs:
       with:
         submodules: true
     - name: Cache llhttp generated files
-      uses: actions/cache@v5.0.4
+      uses: actions/cache@v5.0.5
       id: cache
       with:
         key: llhttp-${{ hashFiles('vendor/llhttp/package*.json', 'vendor/llhttp/src/**/*') }}
@@ -184,7 +184,7 @@ jobs:
         echo "dir=$(pip cache dir)" >> "${GITHUB_OUTPUT}"
       shell: bash
     - name: Cache PyPI
-      uses: actions/cache@v5.0.4
+      uses: actions/cache@v5.0.5
       with:
         key: pip-ci-${{ runner.os }}-${{ matrix.pyver }}-${{ matrix.no-extensions }}-${{ hashFiles('requirements/*.txt') }}
         path: ${{ steps.pip-cache.outputs.dir }}
@@ -296,7 +296,7 @@ jobs:
         echo "dir=$(pip cache dir)" >> "${GITHUB_OUTPUT}"
       shell: bash
     - name: Cache PyPI
-      uses: actions/cache@v5.0.4
+      uses: actions/cache@v5.0.5
       with:
         key: pip-ci-${{ runner.os }}-${{ matrix.pyver }}-${{ matrix.no-extensions }}-${{ hashFiles('requirements/*.txt') }}
         path: ${{ steps.pip-cache.outputs.dir }}

--- a/CHANGES/10600.bugfix.rst
+++ b/CHANGES/10600.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed http parser not rejecting HTTP/1.1 requests that do not have valid Host header.
+-- by :user:`Cycloctane`.

--- a/CHANGES/11966.feature.rst
+++ b/CHANGES/11966.feature.rst
@@ -1,0 +1,8 @@
+Large overhaul of parser/decompression code.
+
+The zip bomb security fix in 3.13 stopped highly compressed payloads
+from being decompressed, regardless of validity. Now aiohttp will
+decompress such payloads in chunks of 256+ KiB, allowing safe decompression
+of such payloads.
+
+-- by :user:`Dreamsorcerer`.

--- a/CHANGES/12281.bugfix.rst
+++ b/CHANGES/12281.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed spurious ``Future exception was never retrieved`` warning on disconnect during back-pressure -- by :user:`availov`.

--- a/CHANGES/12312.bugfix.rst
+++ b/CHANGES/12312.bugfix.rst
@@ -1,0 +1,1 @@
+``Cookiejar.save()`` now uses ``0x600`` permissions to better protect them from being read by other users -- by :user:`digiscrypt`.

--- a/CHANGES/12349.contrib.rst
+++ b/CHANGES/12349.contrib.rst
@@ -1,0 +1,1 @@
+Added a CI job to measure Cython coverage -- by :user:`Dreamsorcerer`.

--- a/CHANGES/12358.misc.rst
+++ b/CHANGES/12358.misc.rst
@@ -1,0 +1,1 @@
+Changed ``zlib_executor_size`` default so compressed payloads are async by default -- by :user:`Dreamsorcerer`.

--- a/CHANGES/12364.contrib.rst
+++ b/CHANGES/12364.contrib.rst
@@ -1,0 +1,1 @@
+Disabled ``coverage`` and ``xdist`` by default to ease local development -- by :user:`Dreamsorcerer`.

--- a/CHANGES/12406.contrib.rst
+++ b/CHANGES/12406.contrib.rst
@@ -1,0 +1,2 @@
+Avoid installation of backports.zstd on Python 3.14 in linting dependency set
+-- by :user:`seifertm`.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -410,6 +410,7 @@ Yegor Roganov
 Yifei Kong
 Young-Ho Cha
 Yuriy Shatrov
+Yury Novikov
 Yury Pliner
 Yury Selivanov
 Yusuke Tsutsumi

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@
 to-hash-one = $(dir $1).hash/$(addsuffix .hash,$(notdir $1))
 to-hash = $(foreach fname,$1,$(call to-hash-one,$(fname)))
 
+CYTHON_EXTRA ?=
 CYS := $(wildcard aiohttp/*.pyx) $(wildcard aiohttp/*.pyi)  $(wildcard aiohttp/*.pxd) $(wildcard aiohttp/_websocket/*.pyx) $(wildcard aiohttp/_websocket/*.pyi) $(wildcard aiohttp/_websocket/*.pxd)
 PYXS := $(wildcard aiohttp/*.pyx) $(wildcard aiohttp/_websocket/*.pyx)
 CS := $(wildcard aiohttp/*.c) $(wildcard aiohttp/_websocket/*.c)
@@ -59,14 +60,14 @@ aiohttp/_find_header.c: $(call to-hash,aiohttp/hdrs.py ./tools/gen.py)
 # Special case for reader since we want to be able to disable
 # the extension with AIOHTTP_NO_EXTENSIONS
 aiohttp/_websocket/reader_c.c: aiohttp/_websocket/reader_c.py
-	cython -3 -X freethreading_compatible=True -o $@ $< -I aiohttp -Werror
+	cython -3 -X freethreading_compatible=True $(CYTHON_EXTRA) -o $@ $< -I aiohttp -Werror
 
 # _find_headers generator creates _headers.pyi as well
 aiohttp/%.c: aiohttp/%.pyx $(call to-hash,$(CYS)) aiohttp/_find_header.c
-	cython -3 -X freethreading_compatible=True -o $@ $< -I aiohttp -Werror
+	cython -3 -X freethreading_compatible=True $(CYTHON_EXTRA) -o $@ $< -I aiohttp -Werror
 
 aiohttp/_websocket/%.c: aiohttp/_websocket/%.pyx $(call to-hash,$(CYS))
-	cython -3 -X freethreading_compatible=True -o $@ $< -I aiohttp -Werror
+	cython -3 -X freethreading_compatible=True $(CYTHON_EXTRA) -o $@ $< -I aiohttp -Werror
 
 vendor/llhttp/node_modules: vendor/llhttp/package.json
 	cd vendor/llhttp; npm ci

--- a/aiohttp/_cparser.pxd
+++ b/aiohttp/_cparser.pxd
@@ -145,6 +145,7 @@ cdef extern from "llhttp.h":
 
     int llhttp_should_keep_alive(const llhttp_t* parser)
 
+    void llhttp_resume(llhttp_t* parser)
     void llhttp_resume_after_upgrade(llhttp_t* parser)
 
     llhttp_errno_t llhttp_get_errno(const llhttp_t* parser)

--- a/aiohttp/_http_parser.pyx
+++ b/aiohttp/_http_parser.pyx
@@ -46,7 +46,8 @@ include "_headers.pxi"
 
 from aiohttp cimport _find_header
 
-ALLOWED_UPGRADES = frozenset({"websocket"})
+
+cdef frozenset ALLOWED_UPGRADES = frozenset({"websocket"})
 DEF DEFAULT_FREELIST_SIZE = 250
 
 cdef extern from "Python.h":
@@ -69,7 +70,7 @@ cdef object CONTENT_ENCODING = hdrs.CONTENT_ENCODING
 cdef object EMPTY_PAYLOAD = _EMPTY_PAYLOAD
 cdef object StreamReader = _StreamReader
 cdef object DeflateBuffer = _DeflateBuffer
-cdef bytes EMPTY_BYTES = b""
+cdef tuple EMPTY_FEED_DATA_RESULT = ((), False, b"")
 
 # RFC 9110 singleton headers — duplicates are rejected in strict mode.
 # In lax mode (response parser default), the check is skipped entirely
@@ -298,7 +299,7 @@ cdef class HttpParser:
         bint      _has_value
         int _header_name_size
 
-        object _protocol
+        readonly object protocol
         object _loop
         object _timer
 
@@ -309,6 +310,7 @@ cdef class HttpParser:
         bint _read_until_eof
         bint _lax
 
+        bytes   _tail
         bint    _started
         object  _url
         bytearray   _buf
@@ -319,6 +321,9 @@ cdef class HttpParser:
         list    _raw_headers
         bint    _upgraded
         list    _messages
+        bint    _more_data_available
+        bint    _paused
+        bint    _eof_pending
         object  _payload
         bint    _payload_error
         object  _payload_exception
@@ -359,18 +364,22 @@ cdef class HttpParser:
         self._cparser.data = <void*>self
         self._cparser.content_length = 0
 
-        self._protocol = protocol
+        self.protocol = protocol
         self._loop = loop
         self._timer = timer
 
         self._buf = bytearray()
+        self._more_data_available = False
+        self._paused = False
+        self._eof_pending = False
         self._payload = None
         self._payload_error = 0
         self._payload_exception = payload_exception
         self._messages = []
 
-        self._raw_name = EMPTY_BYTES
-        self._raw_value = EMPTY_BYTES
+        self._raw_name = b""
+        self._raw_value = b""
+        self._tail = b""
         self._has_value = False
         self._header_name_size = 0
 
@@ -401,7 +410,7 @@ cdef class HttpParser:
 
     cdef _process_header(self):
         cdef str value
-        if self._raw_name is not EMPTY_BYTES:
+        if self._raw_name != b"":
             name = find_header(self._raw_name)
             value = self._raw_value.decode('utf-8', 'surrogateescape')
 
@@ -426,20 +435,20 @@ cdef class HttpParser:
             self._has_value = False
             self._header_name_size = 0
             self._raw_headers.append((self._raw_name, self._raw_value))
-            self._raw_name = EMPTY_BYTES
-            self._raw_value = EMPTY_BYTES
+            self._raw_name = b""
+            self._raw_value = b""
 
     cdef _on_header_field(self, char* at, size_t length):
         if self._has_value:
             self._process_header()
 
-        if self._raw_name is EMPTY_BYTES:
+        if self._raw_name == b"":
             self._raw_name = at[:length]
         else:
             self._raw_name += at[:length]
 
     cdef _on_header_value(self, char* at, size_t length):
-        if self._raw_value is EMPTY_BYTES:
+        if self._raw_value == b"":
             self._raw_value = at[:length]
         else:
             self._raw_value += at[:length]
@@ -495,14 +504,14 @@ cdef class HttpParser:
              self._read_until_eof)
         ):
             payload = StreamReader(
-                self._protocol, timer=self._timer, loop=self._loop,
+                self.protocol, timer=self._timer, loop=self._loop,
                 limit=self._limit)
         else:
             payload = EMPTY_PAYLOAD
 
         self._payload = payload
         if encoding is not None and self._auto_decompress:
-            self._payload = DeflateBuffer(payload, encoding)
+            self._payload = DeflateBuffer(payload, encoding, max_decompress_size=self._limit)
 
         if not self._response_with_body:
             payload = EMPTY_PAYLOAD
@@ -535,6 +544,10 @@ cdef class HttpParser:
 
     ### Public API ###
 
+    def pause_reading(self):
+        assert self._payload is not None
+        self._paused = True
+
     def feed_eof(self):
         cdef bytes desc
 
@@ -549,18 +562,52 @@ cdef class HttpParser:
                 desc = cparser.llhttp_get_error_reason(self._cparser)
                 raise PayloadEncodingError(desc.decode('latin-1'))
             else:
+                self._eof_pending = True
+                while self._more_data_available:
+                    if self._paused:
+                        self._paused = False
+                        return  # Will resume via feed_data(b"") later
+                    self._more_data_available = self._payload.feed_data(b"", 0)
                 self._payload.feed_eof()
+                self._payload = None
+                self._more_data_available = False
+                self._eof_pending = False
         elif self._started:
             self._on_headers_complete()
             if self._messages:
                 return self._messages[-1][0]
 
-    def feed_data(self, data):
+    def feed_data(self, incoming_data):
         cdef:
             size_t data_len
             size_t nb
             char* base
             cdef cparser.llhttp_errno_t errno
+            cdef bytes data
+
+        # Proactor loop sends bytearray.
+        # Ensure cython sees `data` as bytes
+        if type(incoming_data) is not bytes:
+            data = bytes(incoming_data)
+        else:
+            data = incoming_data
+
+        if self._tail:
+            data, self._tail = self._tail + data, b""
+
+        if self._more_data_available:
+            result = cb_on_body(self._cparser, b"", 0)
+            if result is cparser.HPE_PAUSED:
+                self._tail = data
+                return EMPTY_FEED_DATA_RESULT
+
+        if self._eof_pending:
+            self._payload.feed_eof()
+            self._payload = None
+            self._eof_pending = False
+            # We can't have new messages here, otherwise we wouldn't have
+            # received EOF.
+            return EMPTY_FEED_DATA_RESULT
 
         PyObject_GetBuffer(data, &self.py_buf, PyBUF_SIMPLE)
         # Cache buffer pointer before PyBuffer_Release to avoid use-after-release.
@@ -574,12 +621,15 @@ cdef class HttpParser:
 
         if errno is cparser.HPE_PAUSED_UPGRADE:
             cparser.llhttp_resume_after_upgrade(self._cparser)
-
             nb = cparser.llhttp_get_error_pos(self._cparser) - base
+        elif errno is cparser.HPE_PAUSED:
+            cparser.llhttp_resume(self._cparser)
+            pos = cparser.llhttp_get_error_pos(self._cparser) - base
+            self._tail = data[pos:]
 
         PyBuffer_Release(&self.py_buf)
 
-        if errno not in (cparser.HPE_OK, cparser.HPE_PAUSED_UPGRADE):
+        if errno not in (cparser.HPE_OK, cparser.HPE_PAUSED, cparser.HPE_PAUSED_UPGRADE):
             if self._payload_error == 0:
                 if self._last_error is not None:
                     ex = self._last_error
@@ -603,8 +653,9 @@ cdef class HttpParser:
 
         if self._upgraded:
             return messages, True, data[nb:]
-        else:
-            return messages, False, b""
+        if not messages:  # Shortcut to reduce Python overhead
+            return EMPTY_FEED_DATA_RESULT
+        return messages, False, b""
 
     def set_upgraded(self, val):
         self._upgraded = val
@@ -799,19 +850,27 @@ cdef int cb_on_body(cparser.llhttp_t* parser,
                     const char *at, size_t length) except -1:
     cdef HttpParser pyparser = <HttpParser>parser.data
     cdef bytes body = at[:length]
-    try:
-        pyparser._payload.feed_data(body, length)
-    except BaseException as underlying_exc:
-        reraised_exc = underlying_exc
-        if pyparser._payload_exception is not None:
-            reraised_exc = pyparser._payload_exception(str(underlying_exc))
+    while body or pyparser._more_data_available:
+        try:
+            pyparser._more_data_available = pyparser._payload.feed_data(body, length)
+        except BaseException as underlying_exc:
+            reraised_exc = underlying_exc
+            if pyparser._payload_exception is not None:
+                reraised_exc = pyparser._payload_exception(str(underlying_exc))
 
-        set_exception(pyparser._payload, reraised_exc, underlying_exc)
+            set_exception(pyparser._payload, reraised_exc, underlying_exc)
 
-        pyparser._payload_error = 1
-        return -1
-    else:
-        return 0
+            pyparser._payload_error = 1
+            pyparser._paused = False
+            return -1
+        body = b""
+        length = 0
+
+        if pyparser._paused:
+            pyparser._paused = False
+            return cparser.HPE_PAUSED
+    pyparser._paused = False
+    return 0
 
 
 cdef int cb_on_message_complete(cparser.llhttp_t* parser) except -1:

--- a/aiohttp/_http_parser.pyx
+++ b/aiohttp/_http_parser.pyx
@@ -457,6 +457,7 @@ cdef class HttpParser:
     cdef _on_headers_complete(self):
         self._process_header()
 
+        http_version = self.http_version()
         should_close = not cparser.llhttp_should_keep_alive(self._cparser)
         upgrade = self._cparser.upgrade
         chunked = self._cparser.flags & cparser.F_CHUNKED
@@ -465,6 +466,8 @@ cdef class HttpParser:
         headers = CIMultiDictProxy(CIMultiDict(self._headers))
 
         if self._cparser.type == cparser.HTTP_REQUEST:
+            if http_version == HttpVersion11 and hdrs.HOST not in headers:
+                raise BadHttpMessage("Missing 'Host' header in request.")
             h_upg = headers.get("upgrade", "")
             allowed = upgrade and h_upg.isascii() and h_upg.lower() in ALLOWED_UPGRADES
             if allowed or self._cparser.method == cparser.HTTP_CONNECT:
@@ -488,11 +491,11 @@ cdef class HttpParser:
             method = http_method_str(self._cparser.method)
             msg = _new_request_message(
                 method, self._path,
-                self.http_version(), headers, raw_headers,
+                http_version, headers, raw_headers,
                 should_close, encoding, upgrade, chunked, self._url)
         else:
             msg = _new_response_message(
-                self.http_version(), self._cparser.status_code, self._reason,
+                http_version, self._cparser.status_code, self._reason,
                 headers, raw_headers, should_close, encoding,
                 upgrade, chunked)
 

--- a/aiohttp/_websocket/writer.py
+++ b/aiohttp/_websocket/writer.py
@@ -9,6 +9,7 @@ from typing import Final, Optional, Set
 from ..base_protocol import BaseProtocol
 from ..client_exceptions import ClientConnectionResetError
 from ..compression_utils import ZLibBackend, ZLibCompressor
+from ..helpers import DEFAULT_CHUNK_SIZE
 from .helpers import (
     MASK_LEN,
     MSG_SIZE,
@@ -20,8 +21,6 @@ from .helpers import (
     websocket_mask,
 )
 from .models import WS_DEFLATE_TRAILING, WSMsgType
-
-DEFAULT_LIMIT: Final[int] = 2**18
 
 # WebSocket opcode boundary: opcodes 0-7 are data frames, 8-15 are control frames
 # Control frames (ping, pong, close) are never compressed
@@ -52,7 +51,7 @@ class WebSocketWriter:
         transport: asyncio.Transport,
         *,
         use_mask: bool = False,
-        limit: int = DEFAULT_LIMIT,
+        limit: int = DEFAULT_CHUNK_SIZE,
         random: random.Random = random.Random(),
         compress: int = 0,
         notakeover: bool = False,

--- a/aiohttp/_websocket/writer.py
+++ b/aiohttp/_websocket/writer.py
@@ -21,7 +21,7 @@ from .helpers import (
 )
 from .models import WS_DEFLATE_TRAILING, WSMsgType
 
-DEFAULT_LIMIT: Final[int] = 2**16
+DEFAULT_LIMIT: Final[int] = 2**18
 
 # WebSocket opcode boundary: opcodes 0-7 are data frames, 8-15 are control frames
 # Control frames (ping, pong, close) are never compressed

--- a/aiohttp/base_protocol.py
+++ b/aiohttp/base_protocol.py
@@ -97,4 +97,4 @@ class BaseProtocol(asyncio.Protocol):
         if waiter is None:
             waiter = self._loop.create_future()
             self._drain_waiter = waiter
-        await asyncio.shield(waiter)
+        await waiter

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -91,6 +91,7 @@ from .cookiejar import CookieJar
 from .helpers import (
     _SENTINEL,
     DEBUG,
+    DEFAULT_CHUNK_SIZE,
     EMPTY_BODY_METHODS,
     BasicAuth,
     TimeoutHandle,
@@ -333,7 +334,7 @@ class ClientSession:
         trust_env: bool = False,
         requote_redirect_url: bool = True,
         trace_configs: list[TraceConfig] | None = None,
-        read_bufsize: int = 2**18,
+        read_bufsize: int = DEFAULT_CHUNK_SIZE,
         max_line_size: int = 8190,
         max_field_size: int = 8190,
         max_headers: int = 128,
@@ -1294,7 +1295,7 @@ class ClientSession:
 
             transport = conn.transport
             assert transport is not None
-            reader = WebSocketDataQueue(conn_proto, 2**18, loop=self._loop)
+            reader = WebSocketDataQueue(conn_proto, DEFAULT_CHUNK_SIZE, loop=self._loop)
             writer = WebSocketWriter(
                 conn_proto,
                 transport,

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -333,7 +333,7 @@ class ClientSession:
         trust_env: bool = False,
         requote_redirect_url: bool = True,
         trace_configs: list[TraceConfig] | None = None,
-        read_bufsize: int = 2**16,
+        read_bufsize: int = 2**18,
         max_line_size: int = 8190,
         max_field_size: int = 8190,
         max_headers: int = 128,
@@ -1294,7 +1294,7 @@ class ClientSession:
 
             transport = conn.transport
             assert transport is not None
-            reader = WebSocketDataQueue(conn_proto, 2**16, loop=self._loop)
+            reader = WebSocketDataQueue(conn_proto, 2**18, loop=self._loop)
             writer = WebSocketWriter(
                 conn_proto,
                 transport,

--- a/aiohttp/client_proto.py
+++ b/aiohttp/client_proto.py
@@ -12,6 +12,7 @@ from .client_exceptions import (
 )
 from .helpers import (
     _EXC_SENTINEL,
+    DEFAULT_CHUNK_SIZE,
     EMPTY_BODY_STATUS_CODES,
     BaseTimerContext,
     set_exception,
@@ -230,7 +231,7 @@ class ResponseHandler(BaseProtocol, DataQueue[tuple[RawResponseMessage, StreamRe
         read_until_eof: bool = False,
         auto_decompress: bool = True,
         read_timeout: float | None = None,
-        read_bufsize: int = 2**18,
+        read_bufsize: int = DEFAULT_CHUNK_SIZE,
         timeout_ceil_threshold: float = 5,
         max_line_size: int = 8190,
         max_field_size: int = 8190,

--- a/aiohttp/client_proto.py
+++ b/aiohttp/client_proto.py
@@ -26,7 +26,7 @@ class ResponseHandler(BaseProtocol, DataQueue[tuple[RawResponseMessage, StreamRe
     """Helper class to adapt between Protocol and StreamReader."""
 
     def __init__(self, loop: asyncio.AbstractEventLoop) -> None:
-        BaseProtocol.__init__(self, loop=loop)
+        BaseProtocol.__init__(self, loop=loop, parser=None)
         DataQueue.__init__(self, loop)
 
         self._should_close = False
@@ -37,10 +37,7 @@ class ResponseHandler(BaseProtocol, DataQueue[tuple[RawResponseMessage, StreamRe
         self._data_received_cb: Callable[[], None] | None = None
 
         self._timer = None
-
         self._tail = b""
-        self._upgraded = False
-        self._parser: HttpResponseParser | None = None
 
         self._read_timeout: float | None = None
         self._read_timeout_handle: asyncio.TimerHandle | None = None
@@ -191,8 +188,8 @@ class ResponseHandler(BaseProtocol, DataQueue[tuple[RawResponseMessage, StreamRe
         super().pause_reading()
         self._drop_timeout()
 
-    def resume_reading(self) -> None:
-        super().resume_reading()
+    def resume_reading(self, resume_parser: bool = True) -> None:
+        super().resume_reading(resume_parser)
         self._reschedule_timeout()
 
     def set_exception(
@@ -233,7 +230,7 @@ class ResponseHandler(BaseProtocol, DataQueue[tuple[RawResponseMessage, StreamRe
         read_until_eof: bool = False,
         auto_decompress: bool = True,
         read_timeout: float | None = None,
-        read_bufsize: int = 2**16,
+        read_bufsize: int = 2**18,
         timeout_ceil_threshold: float = 5,
         max_line_size: int = 8190,
         max_field_size: int = 8190,
@@ -298,10 +295,10 @@ class ResponseHandler(BaseProtocol, DataQueue[tuple[RawResponseMessage, StreamRe
             set_exception(self._payload, exc)
 
     def data_received(self, data: bytes) -> None:
-        self._reschedule_timeout()
-
-        if not data:
-            return
+        # If no data, then we are resuming decompression. We haven't received
+        # data from the socket, so we can avoid the reschedule overhead.
+        if data:
+            self._reschedule_timeout()
 
         # custom payload parser - currently always WebSocketReader
         if self._payload_parser is not None:

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -87,6 +87,7 @@ if TYPE_CHECKING:
 _CONNECTION_CLOSED_EXCEPTION = ClientConnectionError("Connection closed")
 _CONTAINS_CONTROL_CHAR_RE = re.compile(r"[^-!#$%&'*+.^_`|~0-9a-zA-Z]")
 json_re = re.compile(r"^application/(?:[\w.+-]+?\+)?json")
+_DIGITS_RE = re.compile(r"\d+", re.ASCII)
 
 
 def _gen_default_accept_encoding() -> str:
@@ -903,12 +904,11 @@ class ClientRequest:
             return None
 
         content_length_hdr = self.headers[hdrs.CONTENT_LENGTH]
-        try:
-            return int(content_length_hdr)
-        except ValueError:
+        if not _DIGITS_RE.fullmatch(content_length_hdr):
             raise ValueError(
-                f"Invalid Content-Length header: {content_length_hdr}"
-            ) from None
+                f"Invalid Content-Length header: {content_length_hdr!r}"
+            )
+        return int(content_length_hdr)
 
     @property
     def skip_auto_headers(self) -> CIMultiDict[None]:

--- a/aiohttp/compression_utils.py
+++ b/aiohttp/compression_utils.py
@@ -34,7 +34,9 @@ except ImportError:
 
 
 MAX_SYNC_CHUNK_SIZE = 4096
-DEFAULT_MAX_DECOMPRESS_SIZE = 2**25  # 32MiB
+# Matches the max size we receive from sockets:
+# https://github.com/python/cpython/blob/1857a40807daeae3a1bf5efb682de9c9ae6df845/Lib/asyncio/selector_events.py#L766
+DEFAULT_MAX_DECOMPRESS_SIZE = 256 * 1024
 
 # Unlimited decompression constants - different libraries use different conventions
 ZLIB_MAX_LENGTH_UNLIMITED = 0  # zlib uses 0 to mean unlimited
@@ -52,6 +54,9 @@ class ZLibDecompressObjProtocol(Protocol):
 
     @property
     def eof(self) -> bool: ...
+
+    @property
+    def unconsumed_tail(self) -> bytes: ...
 
 
 class ZLibBackendProtocol(Protocol):
@@ -179,6 +184,11 @@ class DecompressionBaseHandler(ABC):
             )
         return self.decompress_sync(data, max_length)
 
+    @property
+    @abstractmethod
+    def data_available(self) -> bool:
+        """Return True if more output is available by passing b""."""
+
 
 class ZLibCompressor:
     def __init__(
@@ -267,11 +277,17 @@ class ZLibDecompressor(DecompressionBaseHandler):
         self._mode = encoding_to_mode(encoding, suppress_deflate_header)
         self._zlib_backend: Final = ZLibBackendWrapper(ZLibBackend._zlib_backend)
         self._decompressor = self._zlib_backend.decompressobj(wbits=self._mode)
+        self._last_empty = False
 
     def decompress_sync(
         self, data: Buffer, max_length: int = ZLIB_MAX_LENGTH_UNLIMITED
     ) -> bytes:
-        return self._decompressor.decompress(data, max_length)
+        result = self._decompressor.decompress(
+            self._decompressor.unconsumed_tail + data, max_length
+        )
+        # Only way to know that isal has no further data is checking we get no output
+        self._last_empty = result == b""
+        return result
 
     def flush(self, length: int = 0) -> bytes:
         return (
@@ -279,6 +295,10 @@ class ZLibDecompressor(DecompressionBaseHandler):
             if length > 0
             else self._decompressor.flush()
         )
+
+    @property
+    def data_available(self) -> bool:
+        return bool(self._decompressor.unconsumed_tail) or not self._last_empty
 
     @property
     def eof(self) -> bool:
@@ -301,6 +321,7 @@ class BrotliDecompressor(DecompressionBaseHandler):
                 "Please install `Brotli` module"
             )
         self._obj = brotli.Decompressor()
+        self._last_empty = False
         super().__init__(executor=executor, max_sync_chunk_size=max_sync_chunk_size)
 
     def decompress_sync(
@@ -308,14 +329,22 @@ class BrotliDecompressor(DecompressionBaseHandler):
     ) -> bytes:
         """Decompress the given data."""
         if hasattr(self._obj, "decompress"):
-            return cast(bytes, self._obj.decompress(data, max_length))
-        return cast(bytes, self._obj.process(data, max_length))
+            result = cast(bytes, self._obj.decompress(data, max_length))
+        else:
+            result = cast(bytes, self._obj.process(data, max_length))
+        # Only way to know that brotli has no further data is checking we get no output
+        self._last_empty = result == b""
+        return result
 
     def flush(self) -> bytes:
         """Flush the decompressor."""
         if hasattr(self._obj, "flush"):
             return cast(bytes, self._obj.flush())
         return b""
+
+    @property
+    def data_available(self) -> bool:
+        return not self._obj.is_finished() and not self._last_empty
 
 
 class ZSTDDecompressor(DecompressionBaseHandler):
@@ -373,3 +402,9 @@ class ZSTDDecompressor(DecompressionBaseHandler):
 
     def flush(self) -> bytes:
         return b""
+
+    @property
+    def data_available(self) -> bool:
+        return (
+            not self._obj.needs_input and not self._obj.eof
+        ) or self._pending_unused_data is not None

--- a/aiohttp/compression_utils.py
+++ b/aiohttp/compression_utils.py
@@ -326,9 +326,15 @@ class BrotliDecompressor(DecompressionBaseHandler):
     ) -> bytes:
         """Decompress the given data."""
         if hasattr(self._obj, "decompress"):
-            result = cast(bytes, self._obj.decompress(data, max_length))
+            if max_length == ZLIB_MAX_LENGTH_UNLIMITED:
+                result = cast(bytes, self._obj.decompress(data))
+            else:
+                result = cast(bytes, self._obj.decompress(data, max_length))
         else:
-            result = cast(bytes, self._obj.process(data, max_length))
+            if max_length == ZLIB_MAX_LENGTH_UNLIMITED:
+                result = cast(bytes, self._obj.process(data))
+            else:
+                result = cast(bytes, self._obj.process(data, max_length))
         # Only way to know that brotli has no further data is checking we get no output
         self._last_empty = result == b""
         return result

--- a/aiohttp/compression_utils.py
+++ b/aiohttp/compression_utils.py
@@ -34,9 +34,6 @@ except ImportError:
 
 
 MAX_SYNC_CHUNK_SIZE = 4096
-# Matches the max size we receive from sockets:
-# https://github.com/python/cpython/blob/1857a40807daeae3a1bf5efb682de9c9ae6df845/Lib/asyncio/selector_events.py#L766
-DEFAULT_MAX_DECOMPRESS_SIZE = 256 * 1024
 
 # Unlimited decompression constants - different libraries use different conventions
 ZLIB_MAX_LENGTH_UNLIMITED = 0  # zlib uses 0 to mean unlimited

--- a/aiohttp/cookiejar.py
+++ b/aiohttp/cookiejar.py
@@ -5,7 +5,7 @@ import datetime
 import heapq
 import itertools
 import json
-import os  # noqa
+import os
 import pathlib
 import pickle
 import re
@@ -174,7 +174,16 @@ class CookieJar(AbstractCookieJar):
                     if attr_val:
                         morsel_data[attr] = attr_val
                 data[key][name] = morsel_data
-        with file_path.open(mode="w", encoding="utf-8") as f:
+
+        # Cookie persistence may include authentication/session tokens.
+        # Use 0o600 at creation time to avoid umask-dependent overexposure
+        # and enforce least-privilege access to sensitive credential data.
+        with open(
+            file_path,
+            mode="w",
+            encoding="utf-8",
+            opener=lambda path, flags: os.open(path, flags, 0o600),
+        ) as f:
             json.dump(data, f, indent=2)
 
     def load(self, file_path: PathLike) -> None:

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -58,6 +58,10 @@ IS_WINDOWS = platform.system() == "Windows"
 
 PY_311 = sys.version_info >= (3, 11)
 
+# This is the default size/limit for several operations.
+# Matches the max size we receive from sockets:
+# https://github.com/python/cpython/blob/1857a40807daeae3a1bf5efb682de9c9ae6df845/Lib/asyncio/selector_events.py#L766
+DEFAULT_CHUNK_SIZE = 2**18  # 256 KiB
 
 _T = TypeVar("_T")
 _S = TypeVar("_S")

--- a/aiohttp/http_exceptions.py
+++ b/aiohttp/http_exceptions.py
@@ -74,7 +74,7 @@ class ContentLengthError(PayloadEncodingError):
 
 
 class DecompressSizeError(PayloadEncodingError):
-    """Decompressed size exceeds the configured limit."""
+    """Deprecated. Removed in v4."""
 
 
 class LineTooLong(BadHttpMessage):

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -49,7 +49,7 @@ from .http_exceptions import (
     LineTooLong,
     TransferEncodingError,
 )
-from .http_writer import HttpVersion, HttpVersion10
+from .http_writer import HttpVersion, HttpVersion10, HttpVersion11
 from .streams import EMPTY_PAYLOAD, StreamReader
 from .typedefs import RawHeaders
 
@@ -685,6 +685,9 @@ class HttpRequestParser(HttpParser[RawRequestMessage]):
             upgrade,
             chunked,
         ) = self.parse_headers(lines[1:])
+
+        if version_o == HttpVersion11 and hdrs.HOST not in headers:
+            raise BadHttpMessage("Missing 'Host' header in request.")
 
         if close is None:  # then the headers weren't set in the request
             if version_o <= HttpVersion10:  # HTTP 1.0 must asks to not close

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -2,6 +2,7 @@ import abc
 import asyncio
 import re
 import string
+import sys
 from contextlib import suppress
 from enum import IntEnum
 from re import Pattern
@@ -1130,10 +1131,12 @@ class DeflateBuffer:
                 encoding=self.encoding, suppress_deflate_header=True
             )
 
+        low_water = self.out._low_water
+        max_length = (
+            0 if low_water >= sys.maxsize else max(self._max_decompress_size, low_water)
+        )
         try:
-            chunk = self.decompressor.decompress_sync(
-                chunk, max_length=self._max_decompress_size
-            )
+            chunk = self.decompressor.decompress_sync(chunk, max_length=max_length)
         except Exception:
             raise ContentEncodingError(
                 "Can not decode content-encoding: %s" % self.encoding

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -5,7 +5,16 @@ import string
 from contextlib import suppress
 from enum import IntEnum
 from re import Pattern
-from typing import Any, ClassVar, Final, Generic, Literal, NamedTuple, TypeVar
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    ClassVar,
+    Final,
+    Generic,
+    Literal,
+    NamedTuple,
+    TypeVar,
+)
 
 from multidict import CIMultiDict, CIMultiDictProxy, istr
 from yarl import URL
@@ -35,7 +44,6 @@ from .http_exceptions import (
     BadStatusLine,
     ContentEncodingError,
     ContentLengthError,
-    DecompressSizeError,
     InvalidHeader,
     InvalidURLError,
     LineTooLong,
@@ -44,6 +52,9 @@ from .http_exceptions import (
 from .http_writer import HttpVersion, HttpVersion10
 from .streams import EMPTY_PAYLOAD, StreamReader
 from .typedefs import RawHeaders
+
+if TYPE_CHECKING:
+    from .client_proto import ResponseHandler
 
 __all__ = (
     "HeadersParser",
@@ -122,6 +133,12 @@ class RawResponseMessage(NamedTuple):
 
 
 _MsgT = TypeVar("_MsgT", RawRequestMessage, RawResponseMessage)
+
+
+class PayloadState(IntEnum):
+    PAYLOAD_COMPLETE = 0
+    PAYLOAD_NEEDS_INPUT = 1
+    PAYLOAD_HAS_PENDING_INPUT = 2
 
 
 class ParseState(IntEnum):
@@ -276,6 +293,7 @@ class HttpParser(abc.ABC, Generic[_MsgT]):
         self._upgraded = False
         self._payload = None
         self._payload_parser: HttpPayloadParser | None = None
+        self._payload_has_more_data = False
         self._auto_decompress = auto_decompress
         self._limit = limit
         self._headers_parser = HeadersParser(
@@ -288,10 +306,15 @@ class HttpParser(abc.ABC, Generic[_MsgT]):
     @abc.abstractmethod
     def _is_chunked_te(self, te: str) -> bool: ...
 
+    def pause_reading(self) -> None:
+        assert self._payload_parser is not None
+        self._payload_parser.pause_reading()
+
     def feed_eof(self) -> _MsgT | None:
         if self._payload_parser is not None:
             self._payload_parser.feed_eof()
-            self._payload_parser = None
+            if self._payload_parser.done:
+                self._payload_parser = None
         else:
             # try to extract partial message
             if self._tail:
@@ -325,8 +348,7 @@ class HttpParser(abc.ABC, Generic[_MsgT]):
         max_line_length = self.max_line_size
 
         should_close = False
-        while start_pos < data_len:
-
+        while start_pos < data_len or self._payload_has_more_data:
             # read HTTP message (request/response line + headers), \r\n\r\n
             # and split by lines
             if self._payload_parser is None and not self._upgraded:
@@ -420,6 +442,7 @@ class HttpParser(abc.ABC, Generic[_MsgT]):
                                 max_line_size=self.max_line_size,
                                 max_field_size=self.max_field_size,
                                 max_trailers=max_trailers,
+                                limit=self._limit,
                             )
                             if not payload_parser.done:
                                 self._payload_parser = payload_parser
@@ -442,6 +465,7 @@ class HttpParser(abc.ABC, Generic[_MsgT]):
                                 max_line_size=self.max_line_size,
                                 max_field_size=self.max_field_size,
                                 max_trailers=max_trailers,
+                                limit=self._limit,
                             )
                         elif not empty_body and length is None and self.read_until_eof:
                             payload = StreamReader(
@@ -464,6 +488,7 @@ class HttpParser(abc.ABC, Generic[_MsgT]):
                                 max_line_size=self.max_line_size,
                                 max_field_size=self.max_field_size,
                                 max_trailers=max_trailers,
+                                limit=self._limit,
                             )
                             if not payload_parser.done:
                                 self._payload_parser = payload_parser
@@ -485,11 +510,13 @@ class HttpParser(abc.ABC, Generic[_MsgT]):
                 break
 
             # feed payload
-            elif data and start_pos < data_len:
+            else:
                 assert not self._lines
                 assert self._payload_parser is not None
                 try:
-                    eof, data = self._payload_parser.feed_data(data[start_pos:], SEP)
+                    payload_state, data = self._payload_parser.feed_data(
+                        data[start_pos:], SEP
+                    )
                 except Exception as underlying_exc:
                     reraised_exc: BaseException = underlying_exc
                     if self.payload_exception is not None:
@@ -501,20 +528,25 @@ class HttpParser(abc.ABC, Generic[_MsgT]):
                         underlying_exc,
                     )
 
-                    eof = True
+                    payload_state = PayloadState.PAYLOAD_COMPLETE
                     data = b""
                     if isinstance(
                         underlying_exc, (InvalidHeader, TransferEncodingError)
                     ):
                         raise
 
-                if eof:
-                    start_pos = 0
-                    data_len = len(data)
-                    self._payload_parser = None
-                    continue
-            else:
-                break
+                self._payload_has_more_data = (
+                    payload_state == PayloadState.PAYLOAD_HAS_PENDING_INPUT
+                )
+
+                if payload_state is not PayloadState.PAYLOAD_COMPLETE:
+                    # We've either consumed all available data, or we're pausing
+                    # until the reader buffer is freed up.
+                    break
+
+                start_pos = 0
+                data_len = len(data)
+                self._payload_parser = None
 
         if data and start_pos < data_len:
             data = data[start_pos:]
@@ -689,6 +721,8 @@ class HttpResponseParser(HttpParser[RawResponseMessage]):
     Returns RawResponseMessage.
     """
 
+    protocol: "ResponseHandler"
+
     # Lax mode should only be enabled on response parser.
     lax = not DEBUG
 
@@ -783,8 +817,10 @@ class HttpPayloadParser:
         max_line_size: int = 8190,
         max_field_size: int = 8190,
         max_trailers: int = 128,
+        limit: int = DEFAULT_MAX_DECOMPRESS_SIZE,
     ) -> None:
         self._length = 0
+        self._paused = False
         self._type = ParseState.PARSE_UNTIL_EOF
         self._chunk = ChunkState.PARSE_CHUNKED_SIZE
         self._chunk_size = 0
@@ -795,13 +831,15 @@ class HttpPayloadParser:
         self._max_line_size = max_line_size
         self._max_field_size = max_field_size
         self._max_trailers = max_trailers
+        self._more_data_available = False
         self._trailer_lines: list[bytes] = []
         self.done = False
+        self._eof_pending = False
 
         # payload decompression wrapper
         if response_with_body and compression and self._auto_decompress:
             real_payload: StreamReader | DeflateBuffer = DeflateBuffer(
-                payload, compression
+                payload, compression, max_decompress_size=limit
             )
         else:
             real_payload = payload
@@ -823,9 +861,20 @@ class HttpPayloadParser:
 
         self.payload = real_payload
 
+    def pause_reading(self) -> None:
+        self._paused = True
+
     def feed_eof(self) -> None:
         if self._type == ParseState.PARSE_UNTIL_EOF:
+            self._eof_pending = True
+            while self._more_data_available:
+                if self._paused:
+                    self._paused = False
+                    return  # Will resume via feed_data(b"") later
+                self._more_data_available = self.payload.feed_data(b"", 0)
             self.payload.feed_eof()
+            self.done = True
+            self._eof_pending = False
         elif self._type == ParseState.PARSE_LENGTH:
             raise ContentLengthError(
                 "Not enough data to satisfy content length header."
@@ -837,41 +886,54 @@ class HttpPayloadParser:
 
     def feed_data(
         self, chunk: bytes, SEP: _SEP = b"\r\n", CHUNK_EXT: bytes = b";"
-    ) -> tuple[bool, bytes]:
+    ) -> tuple[PayloadState, bytes]:
+        """Receive a chunk of data to process.
+
+        Return:
+            PayloadState - The current state of payload processing.
+                           This function may be called with empty bytes after returning
+                           PAYLOAD_HAS_PENDING_INPUT to continue processing after a pause.
+            bytes - If payload is complete, this is the unconsumed bytes intended for the
+                    next message/payload, b"" otherwise.
+        """
         # Read specified amount of bytes
         if self._type == ParseState.PARSE_LENGTH:
+            if self._chunk_tail:
+                chunk = self._chunk_tail + chunk
+                self._chunk_tail = b""
+
             required = self._length
-            chunk_len = len(chunk)
+            self._length = max(required - len(chunk), 0)
+            self._more_data_available = self.payload.feed_data(
+                chunk[:required], required
+            )
+            while self._more_data_available:
+                if self._paused:
+                    self._paused = False
+                    self._chunk_tail = chunk[required:]
+                    return PayloadState.PAYLOAD_HAS_PENDING_INPUT, b""
+                self._more_data_available = self.payload.feed_data(b"", 0)
 
-            if required >= chunk_len:
-                self._length = required - chunk_len
-                self.payload.feed_data(chunk, chunk_len)
-                if self._length == 0:
-                    self.payload.feed_eof()
-                    return True, b""
-            else:
-                self._length = 0
-                self.payload.feed_data(chunk[:required], required)
+            if self._length == 0:
                 self.payload.feed_eof()
-                return True, chunk[required:]
-
+                return PayloadState.PAYLOAD_COMPLETE, chunk[required:]
         # Chunked transfer encoding parser
         elif self._type == ParseState.PARSE_CHUNKED:
             if self._chunk_tail:
-                # We should never have a tail if we're inside the payload body.
-                assert self._chunk != ChunkState.PARSE_CHUNKED_CHUNK
-                # We should check the length is sane.
-                max_line_length = self._max_line_size
-                if self._chunk == ChunkState.PARSE_TRAILERS:
-                    max_line_length = self._max_field_size
-                if len(self._chunk_tail) > max_line_length:
-                    raise LineTooLong(self._chunk_tail[:100] + b"...", max_line_length)
+                # We should check the length is sane when not processing payload body.
+                if self._chunk != ChunkState.PARSE_CHUNKED_CHUNK:
+                    max_line_length = self._max_line_size
+                    if self._chunk == ChunkState.PARSE_TRAILERS:
+                        max_line_length = self._max_field_size
+                    if len(self._chunk_tail) > max_line_length:
+                        raise LineTooLong(
+                            self._chunk_tail[:100] + b"...", max_line_length
+                        )
 
                 chunk = self._chunk_tail + chunk
                 self._chunk_tail = b""
 
-            while chunk:
-
+            while chunk or self._more_data_available:
                 # read next chunk size
                 if self._chunk == ChunkState.PARSE_CHUNKED_SIZE:
                     pos = chunk.find(SEP)
@@ -911,23 +973,30 @@ class HttpPayloadParser:
                             self.payload.begin_http_chunk_receiving()
                     else:
                         self._chunk_tail = chunk
-                        return False, b""
+                        return PayloadState.PAYLOAD_NEEDS_INPUT, b""
 
                 # read chunk and feed buffer
                 if self._chunk == ChunkState.PARSE_CHUNKED_CHUNK:
-                    required = self._chunk_size
-                    chunk_len = len(chunk)
+                    if self._paused:
+                        self._paused = False
+                        self._chunk_tail = chunk
+                        return PayloadState.PAYLOAD_HAS_PENDING_INPUT, b""
 
-                    if required > chunk_len:
-                        self._chunk_size = required - chunk_len
-                        self.payload.feed_data(chunk, chunk_len)
-                        return False, b""
-                    else:
-                        self._chunk_size = 0
-                        self.payload.feed_data(chunk[:required], required)
-                        chunk = chunk[required:]
-                        self._chunk = ChunkState.PARSE_CHUNKED_CHUNK_EOF
-                        self.payload.end_http_chunk_receiving()
+                    required = self._chunk_size
+                    self._chunk_size = max(required - len(chunk), 0)
+                    self._more_data_available = self.payload.feed_data(
+                        chunk[:required], required
+                    )
+                    chunk = chunk[required:]
+
+                    if self._more_data_available:
+                        continue
+
+                    if self._chunk_size:
+                        self._paused = False
+                        return PayloadState.PAYLOAD_NEEDS_INPUT, b""
+                    self._chunk = ChunkState.PARSE_CHUNKED_CHUNK_EOF
+                    self.payload.end_http_chunk_receiving()
 
                 # toss the CRLF at the end of the chunk
                 if self._chunk == ChunkState.PARSE_CHUNKED_CHUNK_EOF:
@@ -944,13 +1013,13 @@ class HttpPayloadParser:
                         raise exc
                     else:
                         self._chunk_tail = chunk
-                        return False, b""
+                        return PayloadState.PAYLOAD_NEEDS_INPUT, b""
 
                 if self._chunk == ChunkState.PARSE_TRAILERS:
                     pos = chunk.find(SEP)
                     if pos < 0:  # No line found
                         self._chunk_tail = chunk
-                        return False, b""
+                        return PayloadState.PAYLOAD_NEEDS_INPUT, b""
 
                     line = chunk[:pos]
                     chunk = chunk[pos + len(SEP) :]
@@ -976,13 +1045,24 @@ class HttpPayloadParser:
                         finally:
                             self._trailer_lines.clear()
                         self.payload.feed_eof()
-                        return True, chunk
+                        return PayloadState.PAYLOAD_COMPLETE, chunk
 
         # Read all bytes until eof
         elif self._type == ParseState.PARSE_UNTIL_EOF:
-            self.payload.feed_data(chunk, len(chunk))
+            self._more_data_available = self.payload.feed_data(chunk, len(chunk))
+            while self._more_data_available:
+                if self._paused:
+                    self._paused = False
+                    return PayloadState.PAYLOAD_HAS_PENDING_INPUT, b""
+                self._more_data_available = self.payload.feed_data(b"", 0)
 
-        return False, b""
+            if self._eof_pending:
+                self.payload.feed_eof()
+                self.done = True
+                self._eof_pending = False
+                return PayloadState.PAYLOAD_COMPLETE, b""
+
+        return PayloadState.PAYLOAD_NEEDS_INPUT, b""
 
 
 class DeflateBuffer:
@@ -1029,10 +1109,7 @@ class DeflateBuffer:
     ) -> None:
         set_exception(self.out, exc, exc_cause)
 
-    def feed_data(self, chunk: bytes, size: int) -> None:
-        if not size:
-            return
-
+    def feed_data(self, chunk: bytes, size: int) -> bool:
         self.size += size
         self.out.total_compressed_bytes = self.size
 
@@ -1051,9 +1128,8 @@ class DeflateBuffer:
             )
 
         try:
-            # Decompress with limit + 1 so we can detect if output exceeds limit
             chunk = self.decompressor.decompress_sync(
-                chunk, max_length=self._max_decompress_size + 1
+                chunk, max_length=self._max_decompress_size
             )
         except Exception:
             raise ContentEncodingError(
@@ -1062,21 +1138,18 @@ class DeflateBuffer:
 
         self._started_decoding = True
 
-        # Check if decompression limit was exceeded
-        if len(chunk) > self._max_decompress_size:
-            raise DecompressSizeError(
-                "Decompressed data exceeds the configured limit of %d bytes"
-                % self._max_decompress_size
-            )
-
         if chunk:
             self.out.feed_data(chunk, len(chunk))
+        return self.decompressor.data_available  # type: ignore[no-any-return]
 
     def feed_eof(self) -> None:
         chunk = self.decompressor.flush()
+        # This should never contain data as we defer the call until exhausting
+        # the decompression. If .flush() is returning data, this may indicate a
+        # zip bomb vulnerability as it will decompress all remaining data at once.
+        assert not chunk
 
-        if chunk or self.size > 0:
-            self.out.feed_data(chunk, len(chunk))
+        if self.size > 0:
             if self.encoding == "deflate" and not self.decompressor.eof:
                 raise ContentEncodingError("deflate")
 

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -22,7 +22,6 @@ from yarl import URL
 from . import hdrs
 from .base_protocol import BaseProtocol
 from .compression_utils import (
-    DEFAULT_MAX_DECOMPRESS_SIZE,
     HAS_BROTLI,
     HAS_ZSTD,
     BrotliDecompressor,
@@ -32,6 +31,7 @@ from .compression_utils import (
 from .helpers import (
     _EXC_SENTINEL,
     DEBUG,
+    DEFAULT_CHUNK_SIZE,
     EMPTY_BODY_METHODS,
     EMPTY_BODY_STATUS_CODES,
     NO_EXTENSIONS,
@@ -817,7 +817,7 @@ class HttpPayloadParser:
         max_line_size: int = 8190,
         max_field_size: int = 8190,
         max_trailers: int = 128,
-        limit: int = DEFAULT_MAX_DECOMPRESS_SIZE,
+        limit: int = DEFAULT_CHUNK_SIZE,
     ) -> None:
         self._length = 0
         self._paused = False
@@ -1074,7 +1074,7 @@ class DeflateBuffer:
         self,
         out: StreamReader,
         encoding: str | None,
-        max_decompress_size: int = DEFAULT_MAX_DECOMPRESS_SIZE,
+        max_decompress_size: int = DEFAULT_CHUNK_SIZE,
     ) -> None:
         self.out = out
         self.size = 0

--- a/aiohttp/multipart.py
+++ b/aiohttp/multipart.py
@@ -14,11 +14,7 @@ from urllib.parse import parse_qsl, unquote, urlencode
 from multidict import CIMultiDict, CIMultiDictProxy
 
 from .abc import AbstractStreamWriter
-from .compression_utils import (
-    DEFAULT_MAX_DECOMPRESS_SIZE,
-    ZLibCompressor,
-    ZLibDecompressor,
-)
+from .compression_utils import ZLibCompressor, ZLibDecompressor
 from .hdrs import (
     CONTENT_DISPOSITION,
     CONTENT_ENCODING,
@@ -26,7 +22,7 @@ from .hdrs import (
     CONTENT_TRANSFER_ENCODING,
     CONTENT_TYPE,
 )
-from .helpers import CHAR, TOKEN, parse_mimetype, reify
+from .helpers import CHAR, DEFAULT_CHUNK_SIZE, TOKEN, parse_mimetype, reify
 from .http import HeadersParser
 from .http_exceptions import BadHttpMessage
 from .log import internal_logger
@@ -267,7 +263,7 @@ class BodyPartReader:
         *,
         subtype: str = "mixed",
         default_charset: str | None = None,
-        max_decompress_size: int = DEFAULT_MAX_DECOMPRESS_SIZE,
+        max_decompress_size: int = DEFAULT_CHUNK_SIZE,
         client_max_size: int = sys.maxsize,
         max_size_error_cls: type[Exception] = ValueError,
     ) -> None:
@@ -640,7 +636,7 @@ class BodyPartReaderPayload(Payload):
 
     async def write(self, writer: AbstractStreamWriter) -> None:
         field = self._value
-        while chunk := await field.read_chunk(size=2**18):
+        while chunk := await field.read_chunk(size=DEFAULT_CHUNK_SIZE):
             async for d in field.decode_iter(chunk):
                 await writer.write(d)
 

--- a/aiohttp/multipart.py
+++ b/aiohttp/multipart.py
@@ -268,6 +268,8 @@ class BodyPartReader:
         subtype: str = "mixed",
         default_charset: str | None = None,
         max_decompress_size: int = DEFAULT_MAX_DECOMPRESS_SIZE,
+        client_max_size: int = sys.maxsize,
+        max_size_error_cls: type[Exception] = ValueError,
     ) -> None:
         self.headers = headers
         self._boundary = boundary
@@ -285,6 +287,8 @@ class BodyPartReader:
         self._content_eof = 0
         self._cache: dict[str, Any] = {}
         self._max_decompress_size = max_decompress_size
+        self._client_max_size = client_max_size
+        self._max_size_error_cls = max_size_error_cls
 
     def __aiter__(self: Self) -> Self:
         return self
@@ -313,10 +317,14 @@ class BodyPartReader:
         data = bytearray()
         while not self._at_eof:
             data.extend(await self.read_chunk(self.chunk_size))
+            if len(data) > self._client_max_size:
+                raise self._max_size_error_cls(self._client_max_size)
         if decode:
             decoded_data = bytearray()
             async for d in self.decode_iter(data):
                 decoded_data.extend(d)
+                if len(decoded_data) > self._client_max_size:
+                    raise self._max_size_error_cls(self._client_max_size)
             return decoded_data
         return data
 
@@ -558,6 +566,8 @@ class BodyPartReader:
                 suppress_deflate_header=True,
             )
             yield await d.decompress(data, max_length=self._max_decompress_size)
+            while d.data_available:
+                yield await d.decompress(b"", max_length=self._max_decompress_size)
         else:
             raise RuntimeError(f"unknown content encoding: {encoding}")
 
@@ -651,8 +661,10 @@ class MultipartReader:
         headers: Mapping[str, str],
         content: StreamReader,
         *,
+        client_max_size: int = sys.maxsize,
         max_field_size: int = 8190,
         max_headers: int = 128,
+        max_size_error_cls: type[Exception] = ValueError,
     ) -> None:
         self._mimetype = parse_mimetype(headers[CONTENT_TYPE])
         assert self._mimetype.type == "multipart", "multipart/* content type expected"
@@ -663,11 +675,13 @@ class MultipartReader:
 
         self.headers = headers
         self._boundary = ("--" + self._get_boundary()).encode()
+        self._client_max_size = client_max_size
         self._content = content
         self._default_charset: str | None = None
         self._last_part: MultipartReader | BodyPartReader | None = None
         self._max_field_size = max_field_size
         self._max_headers = max_headers
+        self._max_size_error_cls = max_size_error_cls
         self._at_eof = False
         self._at_bof = True
         self._unread: list[bytes] = []
@@ -766,12 +780,21 @@ class MultipartReader:
 
         if mimetype.type == "multipart":
             if self.multipart_reader_cls is None:
-                return type(self)(headers, self._content)
+                return type(self)(
+                    headers,
+                    self._content,
+                    client_max_size=self._client_max_size,
+                    max_field_size=self._max_field_size,
+                    max_headers=self._max_headers,
+                    max_size_error_cls=self._max_size_error_cls,
+                )
             return self.multipart_reader_cls(
                 headers,
                 self._content,
+                client_max_size=self._client_max_size,
                 max_field_size=self._max_field_size,
                 max_headers=self._max_headers,
+                max_size_error_cls=self._max_size_error_cls,
             )
         else:
             return self.part_reader_cls(
@@ -780,6 +803,8 @@ class MultipartReader:
                 self._content,
                 subtype=self._mimetype.subtype,
                 default_charset=self._default_charset,
+                client_max_size=self._client_max_size,
+                max_size_error_cls=self._max_size_error_cls,
             )
 
     def _get_boundary(self) -> str:

--- a/aiohttp/payload.py
+++ b/aiohttp/payload.py
@@ -43,7 +43,7 @@ __all__ = (
 )
 
 TOO_LARGE_BYTES_BODY: Final[int] = 2**20  # 1 MB
-READ_SIZE: Final[int] = 2**16  # 64 KB
+READ_SIZE: Final[int] = 2**18  # 256 KiB
 _CLOSE_FUTURES: set[asyncio.Future[None]] = set()
 
 

--- a/aiohttp/payload.py
+++ b/aiohttp/payload.py
@@ -17,6 +17,7 @@ from . import hdrs
 from .abc import AbstractStreamWriter
 from .helpers import (
     _SENTINEL,
+    DEFAULT_CHUNK_SIZE,
     content_disposition_header,
     guess_filename,
     parse_mimetype,
@@ -43,7 +44,6 @@ __all__ = (
 )
 
 TOO_LARGE_BYTES_BODY: Final[int] = 2**20  # 1 MB
-READ_SIZE: Final[int] = 2**18  # 256 KiB
 _CLOSE_FUTURES: set[asyncio.Future[None]] = set()
 
 
@@ -491,7 +491,7 @@ class IOBasePayload(Payload):
 
         Args:
             remaining_content_len: Optional limit on how many bytes to read in this operation.
-                If None, READ_SIZE will be used as the default chunk size.
+                If None, DEFAULT_CHUNK_SIZE will be used as the default chunk size.
 
         Returns:
             A tuple containing:
@@ -506,7 +506,11 @@ class IOBasePayload(Payload):
         self._set_or_restore_start_position()
         size = self.size  # Call size only once since it does I/O
         return size, self._value.read(
-            min(READ_SIZE, size or READ_SIZE, remaining_content_len or READ_SIZE)
+            min(
+                DEFAULT_CHUNK_SIZE,
+                size or DEFAULT_CHUNK_SIZE,
+                remaining_content_len or DEFAULT_CHUNK_SIZE,
+            )
         )
 
     def _read(self, remaining_content_len: int | None) -> bytes:
@@ -515,7 +519,7 @@ class IOBasePayload(Payload):
 
         Args:
             remaining_content_len: Optional maximum number of bytes to read.
-                If None, READ_SIZE will be used as the default chunk size.
+                If None, DEFAULT_CHUNK_SIZE will be used as the default chunk size.
 
         Returns:
             A chunk of bytes read from the file object, respecting the
@@ -525,7 +529,7 @@ class IOBasePayload(Payload):
         the initial _read_and_available_len call has been made.
 
         """
-        return self._value.read(remaining_content_len or READ_SIZE)  # type: ignore[no-any-return]
+        return self._value.read(remaining_content_len or DEFAULT_CHUNK_SIZE)  # type: ignore[no-any-return]
 
     @property
     def size(self) -> int | None:
@@ -628,9 +632,9 @@ class IOBasePayload(Payload):
                 None,
                 self._read,
                 (
-                    min(READ_SIZE, remaining_content_len)
+                    min(DEFAULT_CHUNK_SIZE, remaining_content_len)
                     if remaining_content_len is not None
-                    else READ_SIZE
+                    else DEFAULT_CHUNK_SIZE
                 ),
             )
 
@@ -756,7 +760,7 @@ class TextIOPayload(IOBasePayload):
 
         Args:
             remaining_content_len: Optional limit on how many bytes to read in this operation.
-                If None, READ_SIZE will be used as the default chunk size.
+                If None, DEFAULT_CHUNK_SIZE will be used as the default chunk size.
 
         Returns:
             A tuple containing:
@@ -775,7 +779,11 @@ class TextIOPayload(IOBasePayload):
         self._set_or_restore_start_position()
         size = self.size
         chunk = self._value.read(
-            min(READ_SIZE, size or READ_SIZE, remaining_content_len or READ_SIZE)
+            min(
+                DEFAULT_CHUNK_SIZE,
+                size or DEFAULT_CHUNK_SIZE,
+                remaining_content_len or DEFAULT_CHUNK_SIZE,
+            )
         )
         return size, chunk.encode(self._encoding) if self._encoding else chunk.encode()
 
@@ -785,7 +793,7 @@ class TextIOPayload(IOBasePayload):
 
         Args:
             remaining_content_len: Optional maximum number of bytes to read.
-                If None, READ_SIZE will be used as the default chunk size.
+                If None, DEFAULT_CHUNK_SIZE will be used as the default chunk size.
 
         Returns:
             A chunk of bytes read from the file object and encoded using the payload's
@@ -797,7 +805,7 @@ class TextIOPayload(IOBasePayload):
         the specified encoding (or UTF-8 if none was provided).
 
         """
-        chunk = self._value.read(remaining_content_len or READ_SIZE)
+        chunk = self._value.read(remaining_content_len or DEFAULT_CHUNK_SIZE)
         return chunk.encode(self._encoding) if self._encoding else chunk.encode()
 
     def decode(self, encoding: str = "utf-8", errors: str = "strict") -> str:
@@ -881,7 +889,7 @@ class BytesIOPayload(IOBasePayload):
         self._set_or_restore_start_position()
         loop_count = 0
         remaining_bytes = content_length
-        while chunk := self._value.read(READ_SIZE):
+        while chunk := self._value.read(DEFAULT_CHUNK_SIZE):
             if loop_count > 0:
                 # Avoid blocking the event loop
                 # if they pass a large BytesIO object

--- a/aiohttp/streams.py
+++ b/aiohttp/streams.py
@@ -1,5 +1,6 @@
 import asyncio
 import collections
+import sys
 import warnings
 from collections.abc import Awaitable, Callable
 from typing import Final, Generic, TypeVar
@@ -67,31 +68,7 @@ class ChunkTupleAsyncStreamIterator:
         return rv
 
 
-class AsyncStreamReaderMixin:
-
-    __slots__ = ()
-
-    def __aiter__(self) -> AsyncStreamIterator[bytes]:
-        return AsyncStreamIterator(self.readline)  # type: ignore[attr-defined]
-
-    def iter_chunked(self, n: int) -> AsyncStreamIterator[bytes]:
-        """Returns an asynchronous iterator that yields chunks of size n."""
-        return AsyncStreamIterator(lambda: self.read(n))  # type: ignore[attr-defined]
-
-    def iter_any(self) -> AsyncStreamIterator[bytes]:
-        """Yield all available data as soon as it is received."""
-        return AsyncStreamIterator(self.readany)  # type: ignore[attr-defined]
-
-    def iter_chunks(self) -> ChunkTupleAsyncStreamIterator:
-        """Yield chunks of data as they are received by the server.
-
-        The yielded objects are tuples
-        of (bytes, bool) as returned by the StreamReader.readchunk method.
-        """
-        return ChunkTupleAsyncStreamIterator(self)  # type: ignore[arg-type]
-
-
-class StreamReader(AsyncStreamReaderMixin):
+class StreamReader:
     """An enhancement of asyncio.StreamReader.
 
     Supports asynchronous iteration by line, chunk or as available::
@@ -176,8 +153,34 @@ class StreamReader(AsyncStreamReaderMixin):
             info.append("e=%r" % self._exception)
         return "<%s>" % " ".join(info)
 
+    def __aiter__(self) -> AsyncStreamIterator[bytes]:
+        return AsyncStreamIterator(self.readline)
+
+    def iter_chunked(self, n: int) -> AsyncStreamIterator[bytes]:
+        """Returns an asynchronous iterator that yields chunks of size n."""
+        self.set_read_chunk_size(n)
+        return AsyncStreamIterator(lambda: self.read(n))
+
+    def iter_any(self) -> AsyncStreamIterator[bytes]:
+        """Yield all available data as soon as it is received."""
+        return AsyncStreamIterator(self.readany)
+
+    def iter_chunks(self) -> ChunkTupleAsyncStreamIterator:
+        """Yield chunks of data as they are received by the server.
+
+        The yielded objects are tuples
+        of (bytes, bool) as returned by the StreamReader.readchunk method.
+        """
+        return ChunkTupleAsyncStreamIterator(self)
+
     def get_read_buffer_limits(self) -> tuple[int, int]:
         return (self._low_water, self._high_water)
+
+    def set_read_chunk_size(self, n: int) -> None:
+        """Raise buffer limits to match the consumer's chunk size."""
+        if n > self._low_water:
+            self._low_water = n
+            self._high_water = n * 2
 
     def exception(self) -> BaseException | None:
         return self._exception
@@ -427,10 +430,8 @@ class StreamReader(AsyncStreamReaderMixin):
             return b""
 
         if n < 0:
-            # This used to just loop creating a new waiter hoping to
-            # collect everything in self._buffer, but that would
-            # deadlock if the subprocess sends more than self.limit
-            # bytes.  So just call self.readany() until EOF.
+            # Reading everything — remove decompression chunk limit.
+            self.set_read_chunk_size(sys.maxsize)
             blocks = []
             while True:
                 block = await self.readany()
@@ -439,6 +440,7 @@ class StreamReader(AsyncStreamReaderMixin):
                 blocks.append(block)
             return b"".join(blocks)
 
+        self.set_read_chunk_size(n)
         # TODO: should be `if` instead of `while`
         # because waiter maybe triggered on chunk end,
         # without feeding any data
@@ -611,6 +613,9 @@ class EmptyStreamReader(StreamReader):  # lgtm [py/missing-call-to-init]
 
     def feed_data(self, data: bytes, n: int = 0) -> bool:
         return False
+
+    def set_read_chunk_size(self, n: int) -> None:
+        return
 
     async def readline(self, *, max_line_length: int | None = None) -> bytes:
         return b""

--- a/aiohttp/streams.py
+++ b/aiohttp/streams.py
@@ -7,6 +7,7 @@ from typing import Final, Generic, TypeVar
 from .base_protocol import BaseProtocol
 from .helpers import (
     _EXC_SENTINEL,
+    DEFAULT_CHUNK_SIZE,
     BaseTimerContext,
     TimerNoop,
     set_exception,
@@ -167,7 +168,7 @@ class StreamReader(AsyncStreamReaderMixin):
             info.append("%d bytes" % self._size)
         if self._eof:
             info.append("eof")
-        if self._low_water != 2**18:  # default limit
+        if self._low_water != DEFAULT_CHUNK_SIZE:
             info.append("low=%d high=%d" % (self._low_water, self._high_water))
         if self._waiter:
             info.append("w=%r" % self._waiter)

--- a/aiohttp/streams.py
+++ b/aiohttp/streams.py
@@ -140,11 +140,11 @@ class StreamReader(AsyncStreamReaderMixin):
         self._high_water = limit * 2
         if loop is None:
             loop = asyncio.get_event_loop()
-        # Ensure high_water_chunks >= 3 so it's always > low_water_chunks.
-        self._high_water_chunks = max(3, limit // 4)
-        # Use max(2, ...) because there's always at least 1 chunk split remaining
+        # Use max(4, ...) because there's always at least 1 chunk split remaining
         # (the current position), so we need low_water >= 2 to allow resume.
-        self._low_water_chunks = max(2, self._high_water_chunks // 2)
+        # limit // 16 gets us a reasonable value of 16k with default 256KiB limit.
+        self._high_water_chunks = max(4, limit // 16)
+        self._low_water_chunks = self._high_water_chunks // 2
         self._loop = loop
         self._size = 0
         self._cursor = 0
@@ -167,7 +167,7 @@ class StreamReader(AsyncStreamReaderMixin):
             info.append("%d bytes" % self._size)
         if self._eof:
             info.append("eof")
-        if self._low_water != 2**16:  # default limit
+        if self._low_water != 2**18:  # default limit
             info.append("low=%d high=%d" % (self._low_water, self._high_water))
         if self._waiter:
             info.append("w=%r" % self._waiter)
@@ -221,8 +221,8 @@ class StreamReader(AsyncStreamReaderMixin):
             self._eof_waiter = None
             set_result(waiter, None)
 
-        if self._protocol._reading_paused:
-            self._protocol.resume_reading()
+        # At EOF the parser is done, there won't be unprocessed data.
+        self._protocol.resume_reading(resume_parser=False)
 
         for cb in self._eof_callbacks:
             try:
@@ -277,11 +277,11 @@ class StreamReader(AsyncStreamReaderMixin):
         self._eof_counter = 0
 
     # TODO: size is ignored, remove the param later
-    def feed_data(self, data: bytes, size: int = 0) -> None:
+    def feed_data(self, data: bytes, size: int = 0) -> bool:
         assert not self._eof, "feed_data after feed_eof"
 
         if not data:
-            return
+            return False
 
         data_len = len(data)
         self._size += data_len
@@ -293,8 +293,9 @@ class StreamReader(AsyncStreamReaderMixin):
             self._waiter = None
             set_result(waiter, None)
 
-        if self._size > self._high_water and not self._protocol._reading_paused:
+        if self._size > self._high_water:
             self._protocol.pause_reading()
+        return False
 
     def begin_http_chunk_receiving(self) -> None:
         if self._http_chunk_splits is None:
@@ -331,10 +332,7 @@ class StreamReader(AsyncStreamReaderMixin):
         # If we get too many small chunks before self._high_water is reached, then any
         # .read() call becomes computationally expensive, and could block the event loop
         # for too long, hence an additional self._high_water_chunks here.
-        if (
-            len(self._http_chunk_splits) > self._high_water_chunks
-            and not self._protocol._reading_paused
-        ):
+        if len(self._http_chunk_splits) > self._high_water_chunks:
             self._protocol.pause_reading()
 
         # wake up readchunk when end of http chunk received
@@ -548,13 +546,9 @@ class StreamReader(AsyncStreamReaderMixin):
         while chunk_splits and chunk_splits[0] < self._cursor:
             chunk_splits.popleft()
 
-        if (
-            self._protocol._reading_paused
-            and self._size < self._low_water
-            and (
-                self._http_chunk_splits is None
-                or len(self._http_chunk_splits) < self._low_water_chunks
-            )
+        if self._size < self._low_water and (
+            self._http_chunk_splits is None
+            or len(self._http_chunk_splits) < self._low_water_chunks
         ):
             self._protocol.resume_reading()
         return data
@@ -614,8 +608,8 @@ class EmptyStreamReader(StreamReader):  # lgtm [py/missing-call-to-init]
     async def wait_eof(self) -> None:
         return
 
-    def feed_data(self, data: bytes, n: int = 0) -> None:
-        pass
+    def feed_data(self, data: bytes, n: int = 0) -> bool:
+        return False
 
     async def readline(self, *, max_line_length: int | None = None) -> bytes:
         return b""

--- a/aiohttp/web_exceptions.py
+++ b/aiohttp/web_exceptions.py
@@ -315,12 +315,8 @@ class HTTPPreconditionFailed(HTTPClientError):
 class HTTPRequestEntityTooLarge(HTTPClientError):
     status_code = 413
 
-    def __init__(self, max_size: float, actual_size: float, **kwargs: Any) -> None:
-        kwargs.setdefault(
-            "text",
-            f"Maximum request body size {max_size} exceeded, "
-            f"actual body size {actual_size}",
-        )
+    def __init__(self, max_size: float, actual_size: float = 0, **kwargs: Any) -> None:
+        kwargs.setdefault("text", f"Maximum request body size {max_size} exceeded.")
         super().__init__(**kwargs)
 
 

--- a/aiohttp/web_fileresponse.py
+++ b/aiohttp/web_fileresponse.py
@@ -26,7 +26,7 @@ from typing import (  # noqa
 
 from . import hdrs
 from .abc import AbstractStreamWriter
-from .helpers import ETAG_ANY, ETag, must_be_empty_body
+from .helpers import DEFAULT_CHUNK_SIZE, ETAG_ANY, ETag, must_be_empty_body
 from .typedefs import LooseHeaders, PathLike
 from .web_exceptions import (
     HTTPForbidden,
@@ -95,7 +95,7 @@ class FileResponse(StreamResponse):
     def __init__(
         self,
         path: PathLike,
-        chunk_size: int = 256 * 1024,
+        chunk_size: int = DEFAULT_CHUNK_SIZE,
         status: int = 200,
         reason: str | None = None,
         headers: LooseHeaders | None = None,

--- a/aiohttp/web_protocol.py
+++ b/aiohttp/web_protocol.py
@@ -24,6 +24,7 @@ from .http import (
     HttpVersion10,
     RawRequestMessage,
     StreamWriter,
+    WebSocketReader,
 )
 from .http_exceptions import BadHttpMethod
 from .log import access_logger, server_logger
@@ -149,11 +150,8 @@ class RequestHandler(BaseProtocol):
         "_handler_waiter",
         "_waiter",
         "_task_handler",
-        "_upgrade",
         "_payload_parser",
         "_data_received_cb",
-        "_request_parser",
-        "_reading_paused",
         "logger",
         "debug",
         "access_log",
@@ -184,11 +182,21 @@ class RequestHandler(BaseProtocol):
         max_headers: int = 128,
         max_field_size: int = 8190,
         lingering_time: float = 10.0,
-        read_bufsize: int = 2**16,
+        read_bufsize: int = 2**18,
         auto_decompress: bool = True,
         timeout_ceil_threshold: float = 5,
     ):
-        super().__init__(loop)
+        parser = HttpRequestParser(
+            self,
+            loop,
+            read_bufsize,
+            max_line_size=max_line_size,
+            max_field_size=max_field_size,
+            max_headers=max_headers,
+            payload_exception=RequestPayloadError,
+            auto_decompress=auto_decompress,
+        )
+        super().__init__(loop, parser)
 
         # _request_count is the number of requests processed with the same connection.
         self._request_count = 0
@@ -216,19 +224,7 @@ class RequestHandler(BaseProtocol):
         self._waiter: asyncio.Future[None] | None = None
         self._handler_waiter: asyncio.Future[None] | None = None
         self._task_handler: asyncio.Task[None] | None = None
-
-        self._upgrade = False
         self._payload_parser: Any = None
-        self._request_parser: HttpRequestParser | None = HttpRequestParser(
-            self,
-            loop,
-            read_bufsize,
-            max_line_size=max_line_size,
-            max_field_size=max_field_size,
-            max_headers=max_headers,
-            payload_exception=RequestPayloadError,
-            auto_decompress=auto_decompress,
-        )
 
         self._timeout_ceil_threshold: float = 5
         try:
@@ -363,7 +359,7 @@ class RequestHandler(BaseProtocol):
         self._manager = None
         self._request_factory = None
         self._request_handler = None
-        self._request_parser = None
+        self._parser = None
 
         if self._keepalive_handle is not None:
             self._keepalive_handle.cancel()
@@ -383,9 +379,10 @@ class RequestHandler(BaseProtocol):
             self._payload_parser = None
 
     def set_parser(
-        self, parser: Any, data_received_cb: Callable[[], None] | None = None
+        self,
+        parser: WebSocketReader,
+        data_received_cb: Callable[[], None] | None = None,
     ) -> None:
-        # Actual type is WebReader
         assert self._payload_parser is None
 
         self._payload_parser = parser
@@ -403,10 +400,10 @@ class RequestHandler(BaseProtocol):
             return
         # parse http messages
         messages: Sequence[_MsgType]
-        if self._payload_parser is None and not self._upgrade:
-            assert self._request_parser is not None
+        if self._payload_parser is None and not self._upgraded:
+            assert self._parser is not None
             try:
-                messages, upgraded, tail = self._request_parser.feed_data(data)
+                messages, upgraded, tail = self._parser.feed_data(data)
             except HttpProcessingError as exc:
                 messages = [
                     (_ErrInfo(status=400, exc=exc, message=exc.message), EMPTY_PAYLOAD)
@@ -423,12 +420,12 @@ class RequestHandler(BaseProtocol):
                 # don't set result twice
                 waiter.set_result(None)
 
-            self._upgrade = upgraded
+            self._upgraded = upgraded
             if upgraded and tail:
                 self._message_tail = tail
 
         # no parser, just store
-        elif self._payload_parser is None and self._upgrade and data:
+        elif self._payload_parser is None and self._upgraded and data:
             self._message_tail += data
 
         # feed payload
@@ -691,11 +688,11 @@ class RequestHandler(BaseProtocol):
         prematurely.
         """
         request._finish()
-        if self._request_parser is not None:
-            self._request_parser.set_upgraded(False)
-            self._upgrade = False
+        if self._parser is not None:
+            self._parser.set_upgraded(False)
+            self._upgraded = False
             if self._message_tail:
-                self._request_parser.feed_data(self._message_tail)
+                self._parser.feed_data(self._message_tail)
                 self._message_tail = b""
         try:
             prepare_meth = resp.prepare

--- a/aiohttp/web_protocol.py
+++ b/aiohttp/web_protocol.py
@@ -17,7 +17,7 @@ from propcache import under_cached_property
 
 from .abc import AbstractAccessLogger, AbstractStreamWriter
 from .base_protocol import BaseProtocol
-from .helpers import ceil_timeout
+from .helpers import DEFAULT_CHUNK_SIZE, ceil_timeout
 from .http import (
     HttpProcessingError,
     HttpRequestParser,
@@ -182,7 +182,7 @@ class RequestHandler(BaseProtocol):
         max_headers: int = 128,
         max_field_size: int = 8190,
         lingering_time: float = 10.0,
-        read_bufsize: int = 2**18,
+        read_bufsize: int = DEFAULT_CHUNK_SIZE,
         auto_decompress: bool = True,
         timeout_ceil_threshold: float = 5,
     ):

--- a/aiohttp/web_request.py
+++ b/aiohttp/web_request.py
@@ -678,6 +678,10 @@ class BaseRequest(MutableMapping[str | RequestKey[Any], Any], HeadersMixin):
         Returns bytes object with full request content.
         """
         if self._read_bytes is None:
+            # Raise the buffer limits so compressed payloads decompress in
+            # larger chunks instead of many small pause/resume cycles.
+            if self._client_max_size:
+                self._payload.set_read_chunk_size(self._client_max_size)
             body = bytearray()
             while True:
                 chunk = await self._payload.readany()

--- a/aiohttp/web_request.py
+++ b/aiohttp/web_request.py
@@ -29,6 +29,7 @@ from .abc import AbstractStreamWriter
 from .helpers import (
     _SENTINEL,
     DEBUG,
+    DEFAULT_CHUNK_SIZE,
     ETAG_ANY,
     LIST_QUOTED_ETAG_RE,
     ChainMapProxy,
@@ -752,7 +753,7 @@ class BaseRequest(MutableMapping[str | RequestKey[Any], Any], HeadersMixin):
                         tmp = await self._loop.run_in_executor(
                             None, tempfile.TemporaryFile
                         )
-                        while chunk := await field.read_chunk(size=2**18):
+                        while chunk := await field.read_chunk(size=DEFAULT_CHUNK_SIZE):
                             async for decoded_chunk in field.decode_iter(chunk):
                                 await self._loop.run_in_executor(
                                     None, tmp.write, decoded_chunk

--- a/aiohttp/web_request.py
+++ b/aiohttp/web_request.py
@@ -683,10 +683,8 @@ class BaseRequest(MutableMapping[str | RequestKey[Any], Any], HeadersMixin):
                 body.extend(chunk)
                 if self._client_max_size:
                     body_size = len(body)
-                    if body_size >= self._client_max_size:
-                        raise HTTPRequestEntityTooLarge(
-                            max_size=self._client_max_size, actual_size=body_size
-                        )
+                    if body_size > self._client_max_size:
+                        raise HTTPRequestEntityTooLarge(self._client_max_size)
                 if not chunk:
                     break
             self._read_bytes = bytes(body)
@@ -708,8 +706,10 @@ class BaseRequest(MutableMapping[str | RequestKey[Any], Any], HeadersMixin):
         return MultipartReader(
             self._headers,
             self._payload,
+            client_max_size=self._client_max_size,
             max_field_size=self._protocol.max_field_size,
             max_headers=self._protocol.max_headers,
+            max_size_error_cls=HTTPRequestEntityTooLarge,
         )
 
     async def post(self) -> "MultiDictProxy[str | bytes | FileField]":
@@ -760,9 +760,7 @@ class BaseRequest(MutableMapping[str | RequestKey[Any], Any], HeadersMixin):
                                 size += len(decoded_chunk)
                                 if 0 < max_size < size:
                                     await self._loop.run_in_executor(None, tmp.close)
-                                    raise HTTPRequestEntityTooLarge(
-                                        max_size=max_size, actual_size=size
-                                    )
+                                    raise HTTPRequestEntityTooLarge(max_size)
                         await self._loop.run_in_executor(None, tmp.seek, 0)
 
                         if field_ct is None:
@@ -782,9 +780,7 @@ class BaseRequest(MutableMapping[str | RequestKey[Any], Any], HeadersMixin):
                         while chunk := await field.read_chunk():
                             size += len(chunk)
                             if 0 < max_size < size:
-                                raise HTTPRequestEntityTooLarge(
-                                    max_size=max_size, actual_size=size
-                                )
+                                raise HTTPRequestEntityTooLarge(max_size)
                             raw_data.extend(chunk)
 
                         value = bytearray()

--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -16,7 +16,7 @@ from multidict import CIMultiDict, istr
 
 from . import hdrs, payload
 from .abc import AbstractStreamWriter
-from .compression_utils import ZLibCompressor
+from .compression_utils import MAX_SYNC_CHUNK_SIZE, ZLibCompressor
 from .helpers import (
     ETAG_ANY,
     QUOTED_ETAG_RE,
@@ -35,7 +35,6 @@ from .payload import Payload
 from .typedefs import JSONBytesEncoder, JSONEncoder, LooseHeaders
 
 REASON_PHRASES = {http_status.value: http_status.phrase for http_status in HTTPStatus}
-LARGE_BODY_SIZE = 1024**2
 
 __all__ = (
     "ContentCoding",
@@ -665,7 +664,7 @@ class Response(StreamResponse):
         headers: LooseHeaders | None = None,
         content_type: str | None = None,
         charset: str | None = None,
-        zlib_executor_size: int | None = None,
+        zlib_executor_size: int = MAX_SYNC_CHUNK_SIZE,
         zlib_executor: Executor | None = None,
     ) -> None:
         if body is not None and text is not None:
@@ -846,13 +845,6 @@ class Response(StreamResponse):
             executor=self._zlib_executor,
         )
         assert self._body is not None
-        if self._zlib_executor_size is None and len(self._body) > LARGE_BODY_SIZE:
-            warnings.warn(
-                "Synchronous compression of large response bodies "
-                f"({len(self._body)} bytes) might block the async event loop. "
-                "Consider providing a custom value to zlib_executor_size/"
-                "zlib_executor response properties or disabling compression on it."
-            )
         self._compressed_body = (
             await compressor.compress(self._body) + compressor.flush()
         )

--- a/aiohttp/web_server.py
+++ b/aiohttp/web_server.py
@@ -81,4 +81,11 @@ class Server:
                 for k, v in self._kwargs.items()
                 if k in ["debug", "access_log_class"]
             }
-            return RequestHandler(self, loop=self._loop, **kwargs)
+            handler = RequestHandler(self, loop=self._loop, **kwargs)
+            handler.logger.warning(
+                "Failed to create request handler with custom kwargs %r, "
+                "falling back to filtered kwargs. This may indicate a "
+                "misconfiguration.",
+                self._kwargs,
+            )
+            return handler

--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -31,7 +31,7 @@ from yarl import URL, __version__ as yarl_version
 
 from . import hdrs
 from .abc import AbstractMatchInfo, AbstractRouter, AbstractView
-from .helpers import DEBUG
+from .helpers import DEBUG, DEFAULT_CHUNK_SIZE
 from .http import HttpVersion11
 from .typedefs import Handler, PathLike
 from .web_exceptions import (
@@ -536,7 +536,7 @@ class StaticResource(PrefixResource):
         *,
         name: str | None = None,
         expect_handler: _ExpectHandler | None = None,
-        chunk_size: int = 256 * 1024,
+        chunk_size: int = DEFAULT_CHUNK_SIZE,
         show_index: bool = False,
         follow_symlinks: bool = False,
         append_version: bool = False,
@@ -1166,7 +1166,7 @@ class UrlDispatcher(AbstractRouter, Mapping[str, AbstractResource]):
         *,
         name: str | None = None,
         expect_handler: _ExpectHandler | None = None,
-        chunk_size: int = 256 * 1024,
+        chunk_size: int = DEFAULT_CHUNK_SIZE,
         show_index: bool = False,
         follow_symlinks: bool = False,
         append_version: bool = False,

--- a/aiohttp/web_ws.py
+++ b/aiohttp/web_ws.py
@@ -12,10 +12,14 @@ from multidict import CIMultiDict
 
 from . import hdrs
 from ._websocket.reader import WebSocketDataQueue
-from ._websocket.writer import DEFAULT_LIMIT
 from .abc import AbstractStreamWriter
 from .client_exceptions import WSMessageTypeError
-from .helpers import calculate_timeout_when, set_exception, set_result
+from .helpers import (
+    DEFAULT_CHUNK_SIZE,
+    calculate_timeout_when,
+    set_exception,
+    set_result,
+)
 from .http import (
     WS_CLOSED_MESSAGE,
     WS_CLOSING_MESSAGE,
@@ -104,7 +108,7 @@ class WebSocketResponse(StreamResponse, Generic[_DecodeText]):
         protocols: Iterable[str] = (),
         compress: bool = True,
         max_msg_size: int = 4 * 1024 * 1024,
-        writer_limit: int = DEFAULT_LIMIT,
+        writer_limit: int = DEFAULT_CHUNK_SIZE,
         decode_text: bool = True,
     ) -> None:
         super().__init__(status=101)
@@ -380,7 +384,9 @@ class WebSocketResponse(StreamResponse, Generic[_DecodeText]):
 
         loop = self._loop
         assert loop is not None
-        self._reader = WebSocketDataQueue(request._protocol, 2**18, loop=loop)
+        self._reader = WebSocketDataQueue(
+            request._protocol, DEFAULT_CHUNK_SIZE, loop=loop
+        )
         parser = WebSocketReader(
             self._reader,
             self._max_msg_size,

--- a/aiohttp/web_ws.py
+++ b/aiohttp/web_ws.py
@@ -380,7 +380,7 @@ class WebSocketResponse(StreamResponse, Generic[_DecodeText]):
 
         loop = self._loop
         assert loop is not None
-        self._reader = WebSocketDataQueue(request._protocol, 2**16, loop=loop)
+        self._reader = WebSocketDataQueue(request._protocol, 2**18, loop=loop)
         parser = WebSocketReader(
             self._reader,
             self._max_msg_size,

--- a/aiohttp/worker.py
+++ b/aiohttp/worker.py
@@ -191,8 +191,12 @@ class GunicornWebWorker(base.Worker):  # type: ignore[misc,no-any-unimported]
         # by interrupting system calls
         signal.siginterrupt(signal.SIGTERM, False)
         signal.siginterrupt(signal.SIGUSR1, False)
-        # Reset signals so Gunicorn doesn't swallow subprocess return codes
-        # See: https://github.com/aio-libs/aiohttp/issues/6130
+
+        # Reset SIGCHLD to default so Gunicorn doesn't swallow subprocess
+        # return codes. Without this, workers inherit the master arbiter's
+        # SIGCHLD handler, causing spurious "Worker exited" errors when
+        # application code spawns subprocesses.
+        signal.signal(signal.SIGCHLD, signal.SIG_DFL)
 
     def handle_quit(self, sig: int, frame: FrameType | None) -> None:
         self.alive = False

--- a/docs/client_quickstart.rst
+++ b/docs/client_quickstart.rst
@@ -119,8 +119,9 @@ that case you can specify multiple values for each key::
         expect = 'http://httpbin.org/get?key=value2&key=value1'
         assert str(r.url) == expect
 
-You can also pass :class:`str` content as param, but beware -- content
-is not encoded by library. Note that ``+`` is not encoded::
+You can also pass :class:`str` content as param. The value is used as a
+query string, but passing ``params`` does not disable URL
+canonicalization. Note that ``+`` is not encoded::
 
     async with session.get('http://httpbin.org/get',
                            params='key=value+1') as r:
@@ -146,7 +147,9 @@ is not encoded by library. Note that ``+`` is not encoded::
 
 .. warning::
 
-   Passing *params* overrides ``encoded=True``, never use both options.
+   Passing *params* overrides ``encoded=True``. Never use both options
+   if you need to preserve exact query-string bytes.
+   Build the full URL (including query) instead.
 
 Response Content and Status Code
 ================================

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -490,6 +490,12 @@ basis, the TestClient object can be used directly::
 A full list of the utilities provided can be found at the
 :mod:`api reference <aiohttp.test_utils>`
 
+For end-to-end client code that talks to an external service, it is
+recommended to run a small fake server rather than patching private aiohttp
+internals. The ``examples/fake_server.py`` demo shows such an approach: start
+a local :class:`~aiohttp.web.Application`, point a custom resolver at it, and
+exercise the client against that controlled endpoint.
+
 
 Testing API Reference
 ---------------------

--- a/requirements/lint.in
+++ b/requirements/lint.in
@@ -1,5 +1,5 @@
 aiodns
-backports.zstd; implementation_name == "cpython"
+backports.zstd; implementation_name == "cpython" and python_version < "3.14"
 blockbuster
 freezegun
 isal

--- a/setup.cfg
+++ b/setup.cfg
@@ -86,6 +86,8 @@ filterwarnings =
     # https://github.com/spulec/freezegun/issues/508
     # https://github.com/spulec/freezegun/pull/511
     ignore:datetime.*utcnow\(\) is deprecated and scheduled for removal:DeprecationWarning:freezegun.api
+    # Weird issue in Python 3.13+ triggered in test_multipart.py
+    ignore:coroutine method 'aclose' of 'BodyPartReader._decode_content_async' was never awaited:RuntimeWarning
 junit_suite_name = aiohttp_test_suite
 norecursedirs = dist docs build .tox .eggs
 minversion = 3.8.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,9 +41,6 @@ exclude_lines =
 
 [tool:pytest]
 addopts =
-    # `pytest-xdist`:
-    --numprocesses=auto
-
     # show 10 slowest invocations:
     --durations=10
 
@@ -55,11 +52,6 @@ addopts =
 
     # show values of the local vars in errors:
     --showlocals
-
-    # `pytest-cov`:
-    -p pytest_cov
-    --cov=aiohttp
-    --cov=tests/
 
     -m "not dev_mode and not autobahn and not internal"
 filterwarnings =

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ USE_SYSTEM_DEPS = bool(
     os.environ.get("AIOHTTP_USE_SYSTEM_DEPS", os.environ.get("USE_SYSTEM_DEPS"))
 )
 NO_EXTENSIONS: bool = bool(os.environ.get("AIOHTTP_NO_EXTENSIONS"))
+CYTHON_TRACING: bool = bool(os.environ.get("AIOHTTP_CYTHON_TRACE"))
 HERE = pathlib.Path(__file__).parent
 IS_GIT_REPO = (HERE / ".git").exists()
 
@@ -54,8 +55,16 @@ else:
         "include_dirs": ["vendor/llhttp/build"],
     }
 
+cython_trace_macros = [("CYTHON_TRACE", 1)] if CYTHON_TRACING else []
+if cython_trace_macros:
+    llhttp_kwargs.setdefault("define_macros", []).extend(cython_trace_macros)
+
 extensions = [
-    Extension("aiohttp._websocket.mask", ["aiohttp/_websocket/mask.c"]),
+    Extension(
+        "aiohttp._websocket.mask",
+        ["aiohttp/_websocket/mask.c"],
+        define_macros=cython_trace_macros,
+    ),
     Extension(
         "aiohttp._http_parser",
         [
@@ -65,8 +74,16 @@ extensions = [
         ],
         **llhttp_kwargs,
     ),
-    Extension("aiohttp._http_writer", ["aiohttp/_http_writer.c"]),
-    Extension("aiohttp._websocket.reader_c", ["aiohttp/_websocket/reader_c.c"]),
+    Extension(
+        "aiohttp._http_writer",
+        ["aiohttp/_http_writer.c"],
+        define_macros=cython_trace_macros,
+    ),
+    Extension(
+        "aiohttp._websocket.reader_c",
+        ["aiohttp/_websocket/reader_c.c"],
+        define_macros=cython_trace_macros,
+    ),
 ]
 
 

--- a/tests/test_base_protocol.py
+++ b/tests/test_base_protocol.py
@@ -5,6 +5,7 @@ from unittest import mock
 import pytest
 
 from aiohttp.base_protocol import BaseProtocol
+from aiohttp.http_parser import HttpParser
 
 
 async def test_loop() -> None:
@@ -26,33 +27,28 @@ async def test_pause_writing() -> None:
 
 async def test_pause_reading_no_transport() -> None:
     loop = asyncio.get_event_loop()
-    pr = BaseProtocol(loop)
-    assert not pr._reading_paused
+    parser = mock.create_autospec(HttpParser, spec_set=True, instance=True)
+    pr = BaseProtocol(loop, parser=parser)
     pr.pause_reading()
-    assert not pr._reading_paused
+    parser.pause_reading.assert_called_once()
 
 
 async def test_pause_reading_stub_transport() -> None:
     loop = asyncio.get_event_loop()
-    pr = BaseProtocol(loop)
+    parser = mock.create_autospec(HttpParser, spec_set=True, instance=True)
+    pr = BaseProtocol(loop, parser=parser)
     tr = asyncio.Transport()
     pr.transport = tr
     assert not pr._reading_paused
     pr.pause_reading()
     assert pr._reading_paused
-
-
-async def test_resume_reading_no_transport() -> None:
-    loop = asyncio.get_event_loop()
-    pr = BaseProtocol(loop)
-    pr._reading_paused = True
-    pr.resume_reading()
-    assert pr._reading_paused
+    parser.pause_reading.assert_called_once()  # type: ignore[unreachable]
 
 
 async def test_resume_reading_stub_transport() -> None:
     loop = asyncio.get_event_loop()
-    pr = BaseProtocol(loop)
+    parser = mock.create_autospec(HttpParser, spec_set=True, instance=True)
+    pr = BaseProtocol(loop, parser=parser)
     tr = asyncio.Transport()
     pr.transport = tr
     pr._reading_paused = True

--- a/tests/test_benchmarks_client.py
+++ b/tests/test_benchmarks_client.py
@@ -504,6 +504,36 @@ def test_ten_streamed_responses_iter_chunked_1mb(
         loop.run_until_complete(run_client_benchmark())
 
 
+@pytest.mark.usefixtures("parametrize_zlib_backend")
+def test_ten_compressed_responses_iter_chunked_1mb(
+    loop: asyncio.AbstractEventLoop,
+    aiohttp_client: AiohttpClient,
+    benchmark: BenchmarkFixture,
+) -> None:
+    """Benchmark compressed GET request read via large iter_chunked."""
+    MB = 2**20
+    data = b"x" * 10 * MB
+
+    async def handler(request: web.Request) -> web.Response:
+        resp = web.Response(body=data)
+        resp.enable_compression()
+        return resp
+
+    app = web.Application()
+    app.router.add_route("GET", "/", handler)
+
+    async def run_client_benchmark() -> None:
+        client = await aiohttp_client(app)
+        resp = await client.get("/")
+        async for _ in resp.content.iter_chunked(MB):
+            pass
+        await client.close()
+
+    @benchmark
+    def _run() -> None:
+        loop.run_until_complete(run_client_benchmark())
+
+
 def test_ten_streamed_responses_iter_chunks(
     loop: asyncio.AbstractEventLoop,
     aiohttp_client: AiohttpClient,

--- a/tests/test_benchmarks_client.py
+++ b/tests/test_benchmarks_client.py
@@ -177,14 +177,14 @@ def test_one_hundred_get_requests_with_30000_chunked_payload(
         loop.run_until_complete(run_client_benchmark())
 
 
-def test_one_hundred_get_requests_with_512kib_chunked_payload(
+def test_one_hundred_get_requests_with_10mb_chunked_payload(
     loop: asyncio.AbstractEventLoop,
     aiohttp_client: AiohttpClient,
     benchmark: BenchmarkFixture,
 ) -> None:
-    """Benchmark 100 GET requests with a payload of 512KiB using read."""
+    """Benchmark 100 GET requests with a payload of 10 MiB using read."""
     message_count = 100
-    payload = b"a" * (2**19)
+    payload = b"a" * (10 * 2**20)
 
     async def handler(request: web.Request) -> web.Response:
         resp = web.Response(body=payload)
@@ -206,14 +206,14 @@ def test_one_hundred_get_requests_with_512kib_chunked_payload(
         loop.run_until_complete(run_client_benchmark())
 
 
-def test_one_hundred_get_requests_iter_chunks_on_512kib_chunked_payload(
+def test_one_hundred_get_requests_iter_chunks_on_10mb_chunked_payload(
     loop: asyncio.AbstractEventLoop,
     aiohttp_client: AiohttpClient,
     benchmark: BenchmarkFixture,
 ) -> None:
-    """Benchmark 100 GET requests with a payload of 512KiB using iter_chunks."""
+    """Benchmark 100 GET requests with a payload of 10 MiB using iter_chunks."""
     message_count = 100
-    payload = b"a" * (2**19)
+    payload = b"a" * (10 * 2**20)
 
     async def handler(request: web.Request) -> web.Response:
         resp = web.Response(body=payload)
@@ -327,14 +327,14 @@ def test_one_hundred_get_requests_with_30000_content_length_payload(
         loop.run_until_complete(run_client_benchmark())
 
 
-def test_one_hundred_get_requests_with_512kib_content_length_payload(
+def test_one_hundred_get_requests_with_10mb_content_length_payload(
     loop: asyncio.AbstractEventLoop,
     aiohttp_client: AiohttpClient,
     benchmark: BenchmarkFixture,
 ) -> None:
-    """Benchmark 100 GET requests with a payload of 512KiB."""
+    """Benchmark 100 GET requests with a payload of 10 MiB."""
     message_count = 100
-    payload = b"a" * (2**19)
+    payload = b"a" * (10 * 2**20)
     headers = {hdrs.CONTENT_LENGTH: str(len(payload))}
 
     async def handler(request: web.Request) -> web.Response:
@@ -471,14 +471,15 @@ def test_ten_streamed_responses_iter_chunked_4096(
         loop.run_until_complete(run_client_benchmark())
 
 
-def test_ten_streamed_responses_iter_chunked_65536(
+def test_ten_streamed_responses_iter_chunked_1mb(
     loop: asyncio.AbstractEventLoop,
     aiohttp_client: AiohttpClient,
     benchmark: BenchmarkFixture,
 ) -> None:
-    """Benchmark 10 streamed responses using iter_chunked 65536."""
+    """Benchmark 10 streamed responses using iter_chunked 1 MiB."""
     message_count = 10
-    data = b"x" * 65536  # 64 KiB chunk size, 64 KiB iter_chunked
+    MB = 2**20
+    data = b"x" * 10 * MB
 
     async def handler(request: web.Request) -> web.StreamResponse:
         resp = web.StreamResponse()
@@ -494,7 +495,7 @@ def test_ten_streamed_responses_iter_chunked_65536(
         client = await aiohttp_client(app)
         for _ in range(message_count):
             resp = await client.get("/")
-            async for _ in resp.content.iter_chunked(65536):
+            async for _ in resp.content.iter_chunked(MB):
                 pass
         await client.close()
 
@@ -510,7 +511,7 @@ def test_ten_streamed_responses_iter_chunks(
 ) -> None:
     """Benchmark 10 streamed responses using iter_chunks."""
     message_count = 10
-    data = b"x" * 65536  # 64 KiB chunk size
+    data = b"x" * 2**20
 
     async def handler(request: web.Request) -> web.StreamResponse:
         resp = web.StreamResponse()

--- a/tests/test_benchmarks_http_websocket.py
+++ b/tests/test_benchmarks_http_websocket.py
@@ -36,8 +36,8 @@ def test_read_one_hundred_websocket_text_messages(
     loop: asyncio.AbstractEventLoop, benchmark: BenchmarkFixture
 ) -> None:
     """Benchmark reading 100 WebSocket text messages."""
-    queue = WebSocketDataQueue(BaseProtocol(loop), 2**16, loop=loop)
-    reader = WebSocketReader(queue, max_msg_size=2**16)
+    queue = WebSocketDataQueue(BaseProtocol(loop), 2**18, loop=loop)
+    reader = WebSocketReader(queue, max_msg_size=2**18)
     raw_message = (
         b'\x81~\x01!{"id":1,"src":"shellyplugus-c049ef8c30e4","dst":"aios-1453812500'
         b'8","result":{"name":null,"id":"shellyplugus-c049ef8c30e4","mac":"C049EF8C30E'

--- a/tests/test_benchmarks_http_websocket.py
+++ b/tests/test_benchmarks_http_websocket.py
@@ -8,6 +8,7 @@ from pytest_codspeed import BenchmarkFixture
 from aiohttp._websocket.helpers import MSG_SIZE, PACK_LEN3
 from aiohttp._websocket.reader import WebSocketDataQueue
 from aiohttp.base_protocol import BaseProtocol
+from aiohttp.helpers import DEFAULT_CHUNK_SIZE
 from aiohttp.http_websocket import WebSocketReader, WebSocketWriter, WSMsgType
 
 
@@ -15,8 +16,8 @@ def test_read_large_binary_websocket_messages(
     loop: asyncio.AbstractEventLoop, benchmark: BenchmarkFixture
 ) -> None:
     """Read one hundred large binary websocket messages."""
-    queue = WebSocketDataQueue(BaseProtocol(loop), 2**16, loop=loop)
-    reader = WebSocketReader(queue, max_msg_size=2**18)
+    queue = WebSocketDataQueue(BaseProtocol(loop), DEFAULT_CHUNK_SIZE, loop=loop)
+    reader = WebSocketReader(queue, max_msg_size=DEFAULT_CHUNK_SIZE)
 
     # PACK3 has a minimum message length of 2**16 bytes.
     message = b"x" * ((2**16) + 1)
@@ -36,8 +37,8 @@ def test_read_one_hundred_websocket_text_messages(
     loop: asyncio.AbstractEventLoop, benchmark: BenchmarkFixture
 ) -> None:
     """Benchmark reading 100 WebSocket text messages."""
-    queue = WebSocketDataQueue(BaseProtocol(loop), 2**18, loop=loop)
-    reader = WebSocketReader(queue, max_msg_size=2**18)
+    queue = WebSocketDataQueue(BaseProtocol(loop), DEFAULT_CHUNK_SIZE, loop=loop)
+    reader = WebSocketReader(queue, max_msg_size=DEFAULT_CHUNK_SIZE)
     raw_message = (
         b'\x81~\x01!{"id":1,"src":"shellyplugus-c049ef8c30e4","dst":"aios-1453812500'
         b'8","result":{"name":null,"id":"shellyplugus-c049ef8c30e4","mac":"C049EF8C30E'

--- a/tests/test_benchmarks_web_request.py
+++ b/tests/test_benchmarks_web_request.py
@@ -1,0 +1,42 @@
+"""codspeed benchmarks for web request reading."""
+
+import asyncio
+import zlib
+
+import pytest
+from pytest_codspeed import BenchmarkFixture
+
+from aiohttp import web
+from aiohttp.pytest_plugin import AiohttpClient
+
+
+@pytest.mark.usefixtures("parametrize_zlib_backend")
+def test_read_compressed_post_body(
+    loop: asyncio.AbstractEventLoop,
+    aiohttp_client: AiohttpClient,
+    benchmark: BenchmarkFixture,
+) -> None:
+    """Benchmark server Request.read() with a compressed POST body."""
+    original = b"B" * (5 * 2**20)
+    compressed = zlib.compress(original)
+
+    async def handler(request: web.Request) -> web.Response:
+        body = await request.read()
+        return web.Response(text=str(len(body)))
+
+    app = web.Application(client_max_size=10 * 2**20)
+    app.router.add_post("/", handler)
+
+    async def run_benchmark() -> None:
+        client = await aiohttp_client(app)
+        resp = await client.post(
+            "/",
+            data=compressed,
+            headers={"Content-Encoding": "deflate"},
+        )
+        assert int(await resp.read()) == len(original)
+        await client.close()
+
+    @benchmark
+    def _run() -> None:
+        loop.run_until_complete(run_benchmark())

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -53,7 +53,6 @@ from aiohttp.client_exceptions import (
 from aiohttp.client_reqrep import ClientRequest
 from aiohttp.compression_utils import DEFAULT_MAX_DECOMPRESS_SIZE
 from aiohttp.connector import Connection
-from aiohttp.http_exceptions import DecompressSizeError
 from aiohttp.http_writer import StreamWriter
 from aiohttp.payload import (
     AsyncIterablePayload,
@@ -2454,10 +2453,9 @@ async def test_payload_decompress_size_limit(aiohttp_client: AiohttpClient) -> N
     When a compressed payload expands beyond the configured limit,
     we raise DecompressSizeError.
     """
-    # Create a highly compressible payload that exceeds the decompression limit.
-    # 64MiB of repeated bytes compresses to ~32KB but expands beyond the
-    # 32MiB per-call limit.
-    original = b"A" * (64 * 2**20)
+    # Create a highly compressible payload.
+    payload_size = 64 * 2**20
+    original = b"A" * payload_size
     compressed = zlib.compress(original)
     assert len(original) > DEFAULT_MAX_DECOMPRESS_SIZE
 
@@ -2474,11 +2472,11 @@ async def test_payload_decompress_size_limit(aiohttp_client: AiohttpClient) -> N
     async with client.get("/") as resp:
         assert resp.status == 200
 
-        with pytest.raises(aiohttp.ClientPayloadError) as exc_info:
-            await resp.read()
+        received = 0
+        async for chunk in resp.content.iter_chunked(1024):
+            received += len(chunk)
 
-        assert isinstance(exc_info.value.__cause__, DecompressSizeError)
-        assert "Decompressed data exceeds" in str(exc_info.value.__cause__)
+        assert received == payload_size
 
 
 @pytest.mark.skipif(brotli is None, reason="brotli is not installed")
@@ -2487,8 +2485,9 @@ async def test_payload_decompress_size_limit_brotli(
 ) -> None:
     """Test that brotli decompression size limit triggers DecompressSizeError."""
     assert brotli is not None
-    # Create a highly compressible payload that exceeds the decompression limit.
-    original = b"A" * (64 * 2**20)
+    # Create a highly compressible payload
+    payload_size = 64 * 2**20
+    original = b"A" * payload_size
     compressed = brotli.compress(original)
     assert len(original) > DEFAULT_MAX_DECOMPRESS_SIZE
 
@@ -2504,11 +2503,11 @@ async def test_payload_decompress_size_limit_brotli(
     async with client.get("/") as resp:
         assert resp.status == 200
 
-        with pytest.raises(aiohttp.ClientPayloadError) as exc_info:
-            await resp.read()
+        received = 0
+        async for chunk in resp.content.iter_chunked(1024):
+            received += len(chunk)
 
-        assert isinstance(exc_info.value.__cause__, DecompressSizeError)
-        assert "Decompressed data exceeds" in str(exc_info.value.__cause__)
+        assert received == payload_size
 
 
 @pytest.mark.skipif(ZstdCompressor is None, reason="backports.zstd is not installed")
@@ -2517,8 +2516,9 @@ async def test_payload_decompress_size_limit_zstd(
 ) -> None:
     """Test that zstd decompression size limit triggers DecompressSizeError."""
     assert ZstdCompressor is not None
-    # Create a highly compressible payload that exceeds the decompression limit.
-    original = b"A" * (64 * 2**20)
+    # Create a highly compressible payload.
+    payload_size = 64 * 2**20
+    original = b"A" * payload_size
     compressor = ZstdCompressor()
     compressed = compressor.compress(original) + compressor.flush()
     assert len(original) > DEFAULT_MAX_DECOMPRESS_SIZE
@@ -2535,11 +2535,11 @@ async def test_payload_decompress_size_limit_zstd(
     async with client.get("/") as resp:
         assert resp.status == 200
 
-        with pytest.raises(aiohttp.ClientPayloadError) as exc_info:
-            await resp.read()
+        received = 0
+        async for chunk in resp.content.iter_chunked(1024):
+            received += len(chunk)
 
-        assert isinstance(exc_info.value.__cause__, DecompressSizeError)
-        assert "Decompressed data exceeds" in str(exc_info.value.__cause__)
+        assert received == payload_size
 
 
 async def test_bad_payload_chunked_encoding(aiohttp_client: AiohttpClient) -> None:

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -51,8 +51,8 @@ from aiohttp.client_exceptions import (
     TooManyRedirects,
 )
 from aiohttp.client_reqrep import ClientRequest
-from aiohttp.compression_utils import DEFAULT_MAX_DECOMPRESS_SIZE
 from aiohttp.connector import Connection
+from aiohttp.helpers import DEFAULT_CHUNK_SIZE
 from aiohttp.http_writer import StreamWriter
 from aiohttp.payload import (
     AsyncIterablePayload,
@@ -2457,7 +2457,7 @@ async def test_payload_decompress_size_limit(aiohttp_client: AiohttpClient) -> N
     payload_size = 64 * 2**20
     original = b"A" * payload_size
     compressed = zlib.compress(original)
-    assert len(original) > DEFAULT_MAX_DECOMPRESS_SIZE
+    assert len(original) > DEFAULT_CHUNK_SIZE
 
     async def handler(request: web.Request) -> web.Response:
         # Send compressed data with Content-Encoding header
@@ -2489,7 +2489,7 @@ async def test_payload_decompress_size_limit_brotli(
     payload_size = 64 * 2**20
     original = b"A" * payload_size
     compressed = brotli.compress(original)
-    assert len(original) > DEFAULT_MAX_DECOMPRESS_SIZE
+    assert len(original) > DEFAULT_CHUNK_SIZE
 
     async def handler(request: web.Request) -> web.Response:
         resp = web.Response(body=compressed)
@@ -2521,7 +2521,7 @@ async def test_payload_decompress_size_limit_zstd(
     original = b"A" * payload_size
     compressor = ZstdCompressor()
     compressed = compressor.compress(original) + compressor.flush()
-    assert len(original) > DEFAULT_MAX_DECOMPRESS_SIZE
+    assert len(original) > DEFAULT_CHUNK_SIZE
 
     async def handler(request: web.Request) -> web.Response:
         resp = web.Response(body=compressed)

--- a/tests/test_client_proto.py
+++ b/tests/test_client_proto.py
@@ -8,6 +8,7 @@ from aiohttp.client_exceptions import ClientOSError, ServerDisconnectedError
 from aiohttp.client_proto import ResponseHandler
 from aiohttp.client_reqrep import ClientResponse
 from aiohttp.helpers import TimerNoop
+from aiohttp.http_parser import HttpParser
 
 
 async def test_force_close(loop: asyncio.AbstractEventLoop) -> None:
@@ -31,8 +32,10 @@ async def test_oserror(loop: asyncio.AbstractEventLoop) -> None:
     assert isinstance(proto.exception(), ClientOSError)
 
 
-async def test_pause_resume_on_error(loop) -> None:
+async def test_pause_resume_on_error(loop: asyncio.AbstractEventLoop) -> None:
+    parser = mock.create_autospec(HttpParser, spec_set=True, instance=True)
     proto = ResponseHandler(loop=loop)
+    proto._parser = parser
     transport = mock.Mock()
     proto.connection_made(transport)
 

--- a/tests/test_client_request.py
+++ b/tests/test_client_request.py
@@ -1667,7 +1667,24 @@ def test_get_content_length(make_request: _RequestMaker) -> None:
 
     # Invalid Content-Length header
     req.headers["Content-Length"] = "invalid"
-    with pytest.raises(ValueError, match="Invalid Content-Length header: invalid"):
+    with pytest.raises(ValueError, match="Invalid Content-Length header"):
+        req._get_content_length()
+
+
+async def test_get_content_length_invalid_formats(
+    make_request: _RequestMaker,
+) -> None:
+    req = make_request("GET", URL("http://python.org/"))
+
+    req.headers["Content-Length"] = "100"
+    assert req._get_content_length() == 100
+
+    req.headers["Content-Length"] = "-100"
+    with pytest.raises(ValueError, match="Invalid Content-Length header"):
+        req._get_content_length()
+
+    req.headers["Content-Length"] = "५"  # Devengali number 5
+    with pytest.raises(ValueError, match="Invalid Content-Length header"):
         req._get_content_length()
 
 

--- a/tests/test_cookie_helpers.py
+++ b/tests/test_cookie_helpers.py
@@ -1095,13 +1095,13 @@ def test_parse_set_cookie_headers_date_formats_with_attributes() -> None:
 @pytest.mark.parametrize(
     ("header", "expected_name", "expected_value", "expected_coded"),
     [
-        # Test cookie values with octal escape sequences
-        (r'name="\012newline\012"', "name", "\nnewline\n", r'"\012newline\012"'),
+        # Test cookie values with octal escape sequences (printable chars only)
+        (r'name="\050parens\051"', "name", "(parens)", r'"\050parens\051"'),
         (
-            r'tab="\011separated\011values"',
-            "tab",
-            "\tseparated\tvalues",
-            r'"\011separated\011values"',
+            r'punct="\053plus\053values"',
+            "punct",
+            "+plus+values",
+            r'"\053plus\053values"',
         ),
         (
             r'mixed="hello\040world\041"',
@@ -1110,10 +1110,10 @@ def test_parse_set_cookie_headers_date_formats_with_attributes() -> None:
             r'"hello\040world\041"',
         ),
         (
-            r'complex="\042quoted\042 text with \012 newline"',
+            r'complex="\042quoted\042 text with \055 hyphen"',
             "complex",
-            '"quoted" text with \n newline',
-            r'"\042quoted\042 text with \012 newline"',
+            '"quoted" text with - hyphen',
+            r'"\042quoted\042 text with \055 hyphen"',
         ),
     ],
 )

--- a/tests/test_cookiejar.py
+++ b/tests/test_cookiejar.py
@@ -3,8 +3,10 @@ import datetime
 import heapq
 import itertools
 import logging
+import os
 import pathlib
 import pickle
+import stat
 import sys
 import unittest
 from http.cookies import BaseCookie, Morsel, SimpleCookie
@@ -1810,6 +1812,40 @@ async def test_save_load_json_secure_cookies(tmp_path: Path) -> None:
     assert cookie["secure"] is True
     assert cookie["httponly"] is True
     assert cookie["domain"] == "example.com"
+
+
+@pytest.mark.skipif(
+    os.name != "posix", reason="POSIX permission bits are required for this test"
+)
+def test_save_creates_private_cookie_file(tmp_path: Path, loop) -> None:
+    file_path = tmp_path / "private-cookies.json"
+    jar = CookieJar(loop=loop)
+    jar.update_cookies_from_headers(
+        ["token=abc123; Path=/"], URL("https://example.com/")
+    )
+
+    jar.save(file_path=file_path)
+
+    assert file_path.exists()
+    assert stat.S_IMODE(file_path.stat().st_mode) == 0o600
+
+
+@pytest.mark.skipif(
+    os.name != "posix", reason="POSIX permission bits are required for this test"
+)
+def test_save_preserves_existing_cookie_file_permissions(tmp_path: Path, loop) -> None:
+    file_path = tmp_path / "existing-cookies.json"
+    file_path.write_text("{}", encoding="utf-8")
+    file_path.chmod(0o644)
+
+    jar = CookieJar(loop=loop)
+    jar.update_cookies_from_headers(
+        ["token=abc123; Path=/"], URL("https://example.com/")
+    )
+
+    jar.save(file_path=file_path)
+
+    assert stat.S_IMODE(file_path.stat().st_mode) == 0o644
 
 
 async def test_cookie_jar_unsafe_property() -> None:

--- a/tests/test_flowcontrol_streams.py
+++ b/tests/test_flowcontrol_streams.py
@@ -82,7 +82,7 @@ class TestFlowControlStreamReader:
         stream.feed_data(b"data", 4)
         res = await stream.readexactly(3)
         assert res == b"dat"
-        assert not stream._protocol.resume_reading.called
+        assert stream._protocol.resume_reading.called
 
     async def test_feed_data(self, stream) -> None:
         stream._protocol._reading_paused = False

--- a/tests/test_flowcontrol_streams.py
+++ b/tests/test_flowcontrol_streams.py
@@ -5,6 +5,7 @@ import pytest
 
 from aiohttp import streams
 from aiohttp.base_protocol import BaseProtocol
+from aiohttp.http_parser import HttpParser
 
 
 @pytest.fixture
@@ -43,7 +44,6 @@ class TestFlowControlStreamReader:
         stream.feed_data(b"d\n", 5)
         res = await stream.readline()
         assert res == b"d\n"
-        assert not stream._protocol.resume_reading.called
 
     async def test_readline_resume_paused(self, stream) -> None:
         stream._protocol._reading_paused = True
@@ -56,7 +56,6 @@ class TestFlowControlStreamReader:
         stream.feed_data(b"data", 4)
         res = await stream.readany()
         assert res == b"data"
-        assert not stream._protocol.resume_reading.called
 
     async def test_readany_resume_paused(self, stream) -> None:
         stream._protocol._reading_paused = True
@@ -70,7 +69,6 @@ class TestFlowControlStreamReader:
         res, end_of_http_chunk = await stream.readchunk()
         assert res == b"data"
         assert not end_of_http_chunk
-        assert not stream._protocol.resume_reading.called
 
     async def test_readchunk_resume_paused(self, stream) -> None:
         stream._protocol._reading_paused = True
@@ -194,7 +192,8 @@ async def test_flow_control_data_queue_read_eof(
 
 async def test_stream_reader_eof_when_full() -> None:
     loop = asyncio.get_event_loop()
-    protocol = BaseProtocol(loop=loop)
+    parser = mock.create_autospec(HttpParser, spec_set=True, instance=True)
+    protocol = BaseProtocol(loop=loop, parser=parser)
     protocol.transport = asyncio.Transport()
     stream = streams.StreamReader(protocol, 1024, loop=loop)
 

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -1,9 +1,11 @@
 # Tests for aiohttp/protocol.py
 
 import asyncio
+import platform
 import re
 import sys
 import zlib
+from collections.abc import Iterator
 from contextlib import nullcontext
 from typing import Any
 from unittest import mock
@@ -16,6 +18,7 @@ from yarl import URL
 import aiohttp
 from aiohttp import http_exceptions, streams
 from aiohttp.base_protocol import BaseProtocol
+from aiohttp.client_proto import ResponseHandler
 from aiohttp.http_parser import (
     NO_EXTENSIONS,
     DeflateBuffer,
@@ -25,8 +28,11 @@ from aiohttp.http_parser import (
     HttpRequestParserPy,
     HttpResponseParser,
     HttpResponseParserPy,
-    HttpVersion,
+    PayloadState,
 )
+from aiohttp.http_writer import HttpVersion
+from aiohttp.web_protocol import RequestHandler
+from aiohttp.web_server import Server
 
 try:
     try:
@@ -57,8 +63,22 @@ except ImportError:  # pragma: no cover
 
 
 @pytest.fixture
-def protocol():
-    return mock.Mock()
+def server() -> Any:
+    return mock.create_autospec(
+        Server,
+        request_factory=mock.Mock(),
+        request_handler=mock.AsyncMock(),
+        instance=True,
+    )
+
+
+@pytest.fixture
+def protocol() -> Any:
+    return mock.create_autospec(
+        BaseProtocol,
+        spec_set=True,
+        instance=True,
+    )
 
 
 def _gen_ids(parsers: list[Any]) -> list[str]:
@@ -69,16 +89,26 @@ def _gen_ids(parsers: list[Any]) -> list[str]:
 
 
 @pytest.fixture(params=REQUEST_PARSERS, ids=_gen_ids(REQUEST_PARSERS))
-def parser(loop: Any, protocol: Any, request: Any):
+def parser(
+    loop: asyncio.AbstractEventLoop,
+    server: Server,
+    request: pytest.FixtureRequest,
+) -> Iterator[HttpRequestParser]:
+    protocol = RequestHandler(server, loop=loop)
+
     # Parser implementations
-    return request.param(
+    parser = request.param(
         protocol,
         loop,
-        2**16,
+        2**18,
         max_line_size=8190,
         max_headers=128,
         max_field_size=8190,
     )
+    protocol._force_close = False
+    protocol._parser = parser
+    with mock.patch.object(protocol, "transport", True):
+        yield parser
 
 
 @pytest.fixture(params=REQUEST_PARSERS, ids=_gen_ids(REQUEST_PARSERS))
@@ -88,17 +118,24 @@ def request_cls(request: Any):
 
 
 @pytest.fixture(params=RESPONSE_PARSERS, ids=_gen_ids(RESPONSE_PARSERS))
-def response(loop: Any, protocol: Any, request: Any):
+def response(
+    loop: asyncio.AbstractEventLoop,
+    request: pytest.FixtureRequest,
+) -> HttpResponseParser:
+    protocol = ResponseHandler(loop)
+
     # Parser implementations
-    return request.param(
+    parser = request.param(
         protocol,
         loop,
-        2**16,
+        2**18,
         max_line_size=8190,
         max_headers=128,
         max_field_size=8190,
         read_until_eof=True,
     )
+    protocol._parser = parser
+    return parser  # type: ignore[no-any-return]
 
 
 @pytest.fixture(params=RESPONSE_PARSERS, ids=_gen_ids(RESPONSE_PARSERS))
@@ -149,7 +186,13 @@ test2: data\r
 
 
 @pytest.mark.skipif(NO_EXTENSIONS, reason="Only tests C parser.")
-def test_invalid_character(loop: Any, protocol: Any, request: Any) -> None:
+def test_invalid_character(
+    loop: asyncio.AbstractEventLoop,
+    server: Server,
+    request: pytest.FixtureRequest,
+) -> None:
+    protocol = RequestHandler(server, loop=loop)
+
     parser = HttpRequestParserC(
         protocol,
         loop,
@@ -157,6 +200,7 @@ def test_invalid_character(loop: Any, protocol: Any, request: Any) -> None:
         max_line_size=8190,
         max_field_size=8190,
     )
+    protocol._parser = parser
     text = b"POST / HTTP/1.1\r\nHost: localhost:8080\r\nSet-Cookie: abc\x01def\r\n\r\n"
     error_detail = re.escape(
         r""":
@@ -169,7 +213,13 @@ def test_invalid_character(loop: Any, protocol: Any, request: Any) -> None:
 
 
 @pytest.mark.skipif(NO_EXTENSIONS, reason="Only tests C parser.")
-def test_invalid_linebreak(loop: Any, protocol: Any, request: Any) -> None:
+def test_invalid_linebreak(
+    loop: asyncio.AbstractEventLoop,
+    server: Server,
+    request: pytest.FixtureRequest,
+) -> None:
+    protocol = RequestHandler(server, loop=loop)
+
     parser = HttpRequestParserC(
         protocol,
         loop,
@@ -177,6 +227,7 @@ def test_invalid_linebreak(loop: Any, protocol: Any, request: Any) -> None:
         max_line_size=8190,
         max_field_size=8190,
     )
+    protocol._parser = parser
     text = b"GET /world HTTP/1.1\r\nHost: 127.0.0.1\n\r\n"
     error_detail = re.escape(
         r""":
@@ -239,7 +290,11 @@ def test_ctl_host_header_bad_characters(parser: HttpRequestParser) -> None:
         parser.feed_data(text)
 
 
-def test_unpaired_surrogate_in_header_py(loop: Any, protocol: Any) -> None:
+def test_unpaired_surrogate_in_header_py(
+    loop: asyncio.AbstractEventLoop, server: Server
+) -> None:
+    protocol = RequestHandler(server, loop=loop)
+
     parser = HttpRequestParserPy(
         protocol,
         loop,
@@ -247,6 +302,7 @@ def test_unpaired_surrogate_in_header_py(loop: Any, protocol: Any) -> None:
         max_line_size=8190,
         max_field_size=8190,
     )
+    protocol._parser = parser
     text = b"POST / HTTP/1.1\r\n\xff\r\n\r\n"
     message = None
     try:
@@ -987,6 +1043,203 @@ def test_max_header_value_size_under_limit(parser: HttpRequestParser) -> None:
     assert msg.url == URL("/test")
 
 
+async def test_chunk_splits_after_pause(parser: HttpRequestParser) -> None:
+    text = (
+        b"GET /test HTTP/1.1\r\nTransfer-Encoding: chunked\r\n\r\n"
+        + b"1\r\nb\r\n" * 50000
+        + b"0\r\n\r\n"
+    )
+
+    messages, upgrade, tail = parser.feed_data(text)
+    payload = messages[0][-1]
+    # Payload should have paused reading and stopped receiving new chunks after 16k.
+    assert payload._http_chunk_splits is not None
+    assert len(payload._http_chunk_splits) == 16385
+    # We should still get the full result after read(), as it will continue processing.
+    result = await payload.read()
+    assert len(result) == 50000  # Compare len first, as it's easier to debug in diff.
+    assert result == b"b" * 50000
+
+
+async def test_compressed_with_tail(response: HttpResponseParser) -> None:
+    """Test compressed content-length body followed by a second response.
+
+    With 2 responses arriving in one call and the first compressed, this should
+    trigger decompression pausing with the second response being saved as the tail.
+    Verify that the second response is resumed from the tail.
+    """
+    # Must be large enough to exceed high water mark.
+    original = b"x" * 1024 * 1024
+    compressed = zlib.compress(original)
+    resp1 = (
+        b"HTTP/1.1 200 OK\r\n"
+        b"Content-Length: " + str(len(compressed)).encode() + b"\r\n"
+        b"Content-Encoding: deflate\r\n"
+        b"\r\n"
+    ) + compressed
+    resp2 = b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok"
+
+    msgs, upgrade, tail = response.feed_data(resp1 + resp2)
+    payload = msgs[0][-1]
+    result = await payload.read()
+    assert len(result) == len(original)
+    assert result == original
+
+    payload = response.protocol._buffer[0][0][-1]
+    result = await payload.read()
+    assert result == b"ok"
+
+
+async def test_two_content_length_responses_in_one_call(
+    response: HttpResponseParser,
+) -> None:
+    """Two complete responses in a single feed_data call.
+
+    The first payload completes with tail data for the second, hitting the
+    PAYLOAD_COMPLETE branch that resets the parser for the next message.
+    """
+    resp1 = b"HTTP/1.1 200 OK\r\nContent-Length: 5\r\n\r\nhello"
+    resp2 = b"HTTP/1.1 200 OK\r\nContent-Length: 5\r\n\r\nworld"
+
+    msgs, upgrade, tail = response.feed_data(resp1 + resp2)
+    assert len(msgs) == 2
+    assert await msgs[0][-1].read() == b"hello"
+    assert await msgs[1][-1].read() == b"world"
+
+
+@pytest.mark.usefixtures("parametrize_zlib_backend")
+async def test_compressed_zlib_64kb(response_cls: type[HttpResponseParser]) -> None:
+    loop = asyncio.get_running_loop()
+    protocol = ResponseHandler(loop)
+    response = response_cls(
+        protocol,
+        loop,
+        # 64KiB limit triggered a bug with isal implementation not returning all data.
+        2**16,
+        max_line_size=8190,
+        max_headers=128,
+        max_field_size=8190,
+    )
+    protocol._parser = response
+
+    original = b"".join(
+        bytes((*range(0, i), *range(i, 0, -1))) for _ in range(255) for i in range(255)
+    )
+    compressed = zlib.compress(original)
+    headers = (
+        b"HTTP/1.1 200 OK\r\n"
+        b"Content-Length: " + str(len(compressed)).encode() + b"\r\n"
+        b"Content-Encoding: deflate\r\n"
+        b"\r\n"
+    )
+
+    msgs, upgrade, tail = response.feed_data(headers + compressed)
+    payload = msgs[0][-1]
+    result = await payload.read()
+    assert len(result) == len(original)
+    assert result == original
+
+
+async def test_compressed_chunked_with_pending(response: HttpResponseParser) -> None:
+    """Test chunked + compressed where the decompressor needs to resume from pause.
+
+    We need to verify that chunked messages continue parsing correctly after
+    a pause and resume in the decompression.
+    """
+    # Must be large enough to exceed high water mark.
+    original = b"A" * 1024 * 1024
+    compressed = zlib.compress(original)
+    chunk_data = hex(len(compressed))[2:].encode() + b"\r\n" + compressed + b"\r\n"
+    headers = (
+        b"HTTP/1.1 200 OK\r\n"
+        b"Transfer-Encoding: chunked\r\n"
+        b"Content-Encoding: deflate\r\n"
+        b"\r\n"
+    )
+    data = headers + chunk_data + b"0\r\n\r\n"
+
+    msgs, upgrade, tail = response.feed_data(data)
+    payload = msgs[0][-1]
+    result = await payload.read()
+    assert len(result) == len(original)
+    assert result == original
+
+
+async def test_compressed_until_eof_with_pending(response: HttpResponseParser) -> None:
+    """Test read-until-eof + compressed with pause."""
+    # Must be large enough to exceed high water mark.
+    original = b"B" * 5 * 1024 * 1024
+    compressed = zlib.compress(original)
+    # No Content-Length or Transfer-Encoding means the parser must parse until EOF.
+    headers = b"HTTP/1.1 200 OK\r\nContent-Encoding: deflate\r\n\r\n"
+
+    msgs, upgrade, tail = response.feed_data(headers + compressed)
+    response.feed_eof()
+    payload = msgs[0][-1]
+
+    # Check that .feed_eof() hasn't decompressed entire payload into memory.
+    assert sum(len(b) for b in payload._buffer) <= (1024 * 1024)
+
+    result = await payload.read()
+    assert len(result) == len(original)
+    assert result == original
+
+
+async def test_compressed_until_eof_high_water(
+    response_cls: type[HttpResponseParser],
+) -> None:
+    """Test read-until-eof + compressed with higher limit."""
+    loop = asyncio.get_running_loop()
+    protocol = ResponseHandler(loop)
+    response = response_cls(
+        protocol,
+        loop,
+        2**19,  # 512 KiB limit
+        max_line_size=8190,
+        max_headers=128,
+        max_field_size=8190,
+        read_until_eof=True,
+    )
+    protocol._parser = response
+
+    # Must be large enough to exceed high water mark.
+    original = b"B" * 5 * 1024 * 1024
+    compressed = zlib.compress(original)
+    # No Content-Length or Transfer-Encoding means the parser must parse until EOF.
+    headers = b"HTTP/1.1 200 OK\r\nContent-Encoding: deflate\r\n\r\n"
+
+    msgs, upgrade, tail = response.feed_data(headers + compressed)
+    response.feed_eof()
+    payload = msgs[0][-1]
+
+    # Check that .feed_eof() hasn't decompressed entire payload into memory.
+    assert sum(len(b) for b in payload._buffer) <= (2 * 1024 * 1024)
+    # Individual chunks should have been decompressed at limit amount.
+    assert all(len(b) == 512 * 1024 for b in payload._buffer)
+
+    result = await payload.read()
+    assert len(result) == len(original)
+    assert result == original
+
+
+async def test_compressed_256kb(response: HttpResponseParser) -> None:
+    original = b"x" * 256 * 1024
+    compressed = zlib.compress(original)
+    headers = (
+        b"HTTP/1.1 200 OK\r\n"
+        b"Content-Length: " + str(len(compressed)).encode() + b"\r\n"
+        b"Content-Encoding: deflate\r\n"
+        b"\r\n"
+    )
+
+    messages, upgrade, tail = response.feed_data(headers + compressed)
+    assert len(messages) == 1
+    payload = messages[0][-1]
+    result = await payload.read()
+    assert len(result) == len(original)
+    assert result == original
+
+
 @pytest.mark.parametrize("size", [40965, 8191])
 def test_max_header_value_size_continuation(response, size) -> None:
     name = b"T" * (size - 5)
@@ -1412,14 +1665,19 @@ async def test_http_response_parser_bad_chunked_lax(response) -> None:
 
 
 @pytest.mark.dev_mode
-async def test_http_response_parser_bad_chunked_strict_py(loop, protocol) -> None:
+async def test_http_response_parser_bad_chunked_strict_py(
+    loop: asyncio.AbstractEventLoop,
+) -> None:
+    protocol = ResponseHandler(loop)
+
     response = HttpResponseParserPy(
         protocol,
         loop,
-        2**16,
+        2**18,
         max_line_size=8190,
         max_field_size=8190,
     )
+    protocol._parser = response
     text = (
         b"HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n5 \r\nabcde\r\n0\r\n\r\n"
     )
@@ -1432,7 +1690,11 @@ async def test_http_response_parser_bad_chunked_strict_py(loop, protocol) -> Non
     "HttpRequestParserC" not in dir(aiohttp.http_parser),
     reason="C based HTTP parser not available",
 )
-async def test_http_response_parser_bad_chunked_strict_c(loop, protocol) -> None:
+async def test_http_response_parser_bad_chunked_strict_c(
+    loop: asyncio.AbstractEventLoop,
+) -> None:
+    protocol = ResponseHandler(loop)
+
     response = HttpResponseParserC(
         protocol,
         loop,
@@ -1440,6 +1702,7 @@ async def test_http_response_parser_bad_chunked_strict_c(loop, protocol) -> None
         max_line_size=8190,
         max_field_size=8190,
     )
+    protocol._parser = response
     text = (
         b"HTTP/1.1 200 OK\r\nTransfer-Encoding: chunked\r\n\r\n5 \r\nabcde\r\n0\r\n\r\n"
     )
@@ -1582,18 +1845,25 @@ async def test_request_chunked_reject_bad_trailer(parser: HttpRequestParser) -> 
 
 def test_parse_no_length_or_te_on_post(
     loop: asyncio.AbstractEventLoop,
-    protocol: BaseProtocol,
+    server: Server,
     request_cls: type[HttpRequestParser],
 ) -> None:
-    parser = request_cls(protocol, loop, limit=2**16)
+    protocol = RequestHandler(server, loop=loop)
+    parser = request_cls(protocol, loop, limit=2**18)
+    protocol._parser = parser
     text = b"POST /test HTTP/1.1\r\n\r\n"
     msg, payload = parser.feed_data(text)[0][0]
 
     assert payload.is_eof()
 
 
-def test_parse_payload_response_without_body(loop, protocol, response_cls) -> None:
+def test_parse_payload_response_without_body(
+    loop: asyncio.AbstractEventLoop,
+    response_cls: type[HttpResponseParser],
+) -> None:
+    protocol = ResponseHandler(loop)
     parser = response_cls(protocol, loop, 2**16, response_with_body=False)
+    protocol._parser = parser
     text = b"HTTP/1.1 200 Ok\r\ncontent-length: 10\r\n\r\n"
     msg, payload = parser.feed_data(text)[0][0]
 
@@ -1849,16 +2119,21 @@ def test_parse_uri_utf8_percent_encoded(parser) -> None:
     "HttpRequestParserC" not in dir(aiohttp.http_parser),
     reason="C based HTTP parser not available",
 )
-def test_parse_bad_method_for_c_parser_raises(loop, protocol):
+def test_parse_bad_method_for_c_parser_raises(
+    loop: asyncio.AbstractEventLoop, server: Server
+) -> None:
+    protocol = RequestHandler(server, loop=loop)
+
     payload = b"GET1 /test HTTP/1.1\r\n\r\n"
     parser = HttpRequestParserC(
         protocol,
         loop,
-        2**16,
+        2**18,
         max_line_size=8190,
         max_headers=128,
         max_field_size=8190,
     )
+    protocol._parser = parser
 
     with pytest.raises(aiohttp.http_exceptions.BadStatusLine):
         messages, upgrade, tail = parser.feed_data(payload)
@@ -1875,7 +2150,7 @@ class TestParsePayload:
         assert [(bytearray(b"data"))] == list(out._buffer)
 
     async def test_parse_length_payload_eof(self, protocol: BaseProtocol) -> None:
-        out = aiohttp.StreamReader(protocol, 2**16, loop=asyncio.get_running_loop())
+        out = aiohttp.StreamReader(protocol, 2**18, loop=asyncio.get_running_loop())
 
         p = HttpPayloadParser(out, length=4, headers_parser=HeadersParser())
         p.feed_data(b"da")
@@ -1899,7 +2174,7 @@ class TestParsePayload:
 
         Regression test for #10596.
         """
-        out = aiohttp.StreamReader(protocol, 2**16, loop=asyncio.get_running_loop())
+        out = aiohttp.StreamReader(protocol, 2**18, loop=asyncio.get_running_loop())
         p = HttpPayloadParser(out, chunked=True, headers_parser=HeadersParser())
         # Declared chunk-size is 4 but actual data is "Hello" (5 bytes).
         # After consuming 4 bytes, remaining starts with "o" not "\r\n".
@@ -1914,7 +2189,7 @@ class TestParsePayload:
 
         Regression test for #10596.
         """
-        out = aiohttp.StreamReader(protocol, 2**16, loop=asyncio.get_running_loop())
+        out = aiohttp.StreamReader(protocol, 2**18, loop=asyncio.get_running_loop())
         p = HttpPayloadParser(out, chunked=True, headers_parser=HeadersParser())
         # Declared chunk-size is 6 but actual data before CRLF is "Hello" (5 bytes).
         # Parser reads 6 bytes: "Hello\r", then expects \r\n but sees "\n0\r\n..."
@@ -1936,7 +2211,7 @@ class TestParsePayload:
     async def test_parse_chunked_payload_split_end2(
         self, protocol: BaseProtocol
     ) -> None:
-        out = aiohttp.StreamReader(protocol, 2**16, loop=asyncio.get_running_loop())
+        out = aiohttp.StreamReader(protocol, 2**18, loop=asyncio.get_running_loop())
         p = HttpPayloadParser(out, chunked=True, headers_parser=HeadersParser())
         p.feed_data(b"4\r\nasdf\r\n0\r\n\r")
         p.feed_data(b"\n")
@@ -1947,7 +2222,7 @@ class TestParsePayload:
     async def test_parse_chunked_payload_split_end_trailers(
         self, protocol: BaseProtocol
     ) -> None:
-        out = aiohttp.StreamReader(protocol, 2**16, loop=asyncio.get_running_loop())
+        out = aiohttp.StreamReader(protocol, 2**18, loop=asyncio.get_running_loop())
         p = HttpPayloadParser(out, chunked=True, headers_parser=HeadersParser())
         p.feed_data(b"4\r\nasdf\r\n0\r\n")
         p.feed_data(b"Content-MD5: 912ec803b2ce49e4a541068d495ab570\r\n")
@@ -1959,7 +2234,7 @@ class TestParsePayload:
     async def test_parse_chunked_payload_split_end_trailers2(
         self, protocol: BaseProtocol
     ) -> None:
-        out = aiohttp.StreamReader(protocol, 2**16, loop=asyncio.get_running_loop())
+        out = aiohttp.StreamReader(protocol, 2**18, loop=asyncio.get_running_loop())
         p = HttpPayloadParser(out, chunked=True, headers_parser=HeadersParser())
         p.feed_data(b"4\r\nasdf\r\n0\r\n")
         p.feed_data(b"Content-MD5: 912ec803b2ce49e4a541068d495ab570\r\n\r")
@@ -1991,10 +2266,10 @@ class TestParsePayload:
         assert b"asdf" == b"".join(out._buffer)
 
     async def test_http_payload_parser_length(self, protocol: BaseProtocol) -> None:
-        out = aiohttp.StreamReader(protocol, 2**16, loop=asyncio.get_running_loop())
+        out = aiohttp.StreamReader(protocol, 2**18, loop=asyncio.get_running_loop())
         p = HttpPayloadParser(out, length=2, headers_parser=HeadersParser())
-        eof, tail = p.feed_data(b"1245")
-        assert eof
+        state, tail = p.feed_data(b"1245")
+        assert state is PayloadState.PAYLOAD_COMPLETE
 
         assert b"12" == out._buffer[0]
         assert b"45" == tail
@@ -2004,7 +2279,7 @@ class TestParsePayload:
         COMPRESSED = b"x\x9cKI,I\x04\x00\x04\x00\x01\x9b"
 
         length = len(COMPRESSED)
-        out = aiohttp.StreamReader(protocol, 2**16, loop=asyncio.get_running_loop())
+        out = aiohttp.StreamReader(protocol, 2**18, loop=asyncio.get_running_loop())
         p = HttpPayloadParser(
             out, length=length, compression="deflate", headers_parser=HeadersParser()
         )
@@ -2075,7 +2350,7 @@ class TestParsePayload:
     async def test_http_payload_parser_length_zero(
         self, protocol: BaseProtocol
     ) -> None:
-        out = aiohttp.StreamReader(protocol, 2**16, loop=asyncio.get_running_loop())
+        out = aiohttp.StreamReader(protocol, 2**18, loop=asyncio.get_running_loop())
         p = HttpPayloadParser(out, length=0, headers_parser=HeadersParser())
         assert p.done
         assert out.is_eof()
@@ -2083,7 +2358,7 @@ class TestParsePayload:
     @pytest.mark.skipif(brotli is None, reason="brotli is not installed")
     async def test_http_payload_brotli(self, protocol: BaseProtocol) -> None:
         compressed = brotli.compress(b"brotli data")
-        out = aiohttp.StreamReader(protocol, 2**16, loop=asyncio.get_running_loop())
+        out = aiohttp.StreamReader(protocol, 2**18, loop=asyncio.get_running_loop())
         p = HttpPayloadParser(
             out,
             length=len(compressed),
@@ -2097,7 +2372,7 @@ class TestParsePayload:
     @pytest.mark.skipif(zstandard is None, reason="zstandard is not installed")
     async def test_http_payload_zstandard(self, protocol: BaseProtocol) -> None:
         compressed = zstandard.compress(b"zstd data")
-        out = aiohttp.StreamReader(protocol, 2**16, loop=asyncio.get_running_loop())
+        out = aiohttp.StreamReader(protocol, 2**18, loop=asyncio.get_running_loop())
         p = HttpPayloadParser(
             out,
             length=len(compressed),
@@ -2115,7 +2390,7 @@ class TestParsePayload:
         frame1 = zstandard.compress(b"first")
         frame2 = zstandard.compress(b"second")
         payload = frame1 + frame2
-        out = aiohttp.StreamReader(protocol, 2**16, loop=asyncio.get_running_loop())
+        out = aiohttp.StreamReader(protocol, 2**18, loop=asyncio.get_running_loop())
         p = HttpPayloadParser(
             out,
             length=len(payload),
@@ -2132,7 +2407,7 @@ class TestParsePayload:
     ) -> None:
         frame1 = zstandard.compress(b"chunk1")
         frame2 = zstandard.compress(b"chunk2")
-        out = aiohttp.StreamReader(protocol, 2**16, loop=asyncio.get_running_loop())
+        out = aiohttp.StreamReader(protocol, 2**18, loop=asyncio.get_running_loop())
         p = HttpPayloadParser(
             out,
             length=len(frame1) + len(frame2),
@@ -2152,7 +2427,7 @@ class TestParsePayload:
         frame2 = zstandard.compress(b"BBBB")
         combined = frame1 + frame2
         split_point = len(frame1) + 3  # 3 bytes into frame2
-        out = aiohttp.StreamReader(protocol, 2**16, loop=asyncio.get_running_loop())
+        out = aiohttp.StreamReader(protocol, 2**18, loop=asyncio.get_running_loop())
         p = HttpPayloadParser(
             out,
             length=len(combined),
@@ -2170,7 +2445,7 @@ class TestParsePayload:
     ) -> None:
         parts = [f"part{i}".encode() for i in range(10)]
         payload = b"".join(zstandard.compress(p) for p in parts)
-        out = aiohttp.StreamReader(protocol, 2**16, loop=asyncio.get_running_loop())
+        out = aiohttp.StreamReader(protocol, 2**18, loop=asyncio.get_running_loop())
         p = HttpPayloadParser(
             out,
             length=len(payload),
@@ -2184,7 +2459,7 @@ class TestParsePayload:
 
 class TestDeflateBuffer:
     async def test_feed_data(self, protocol: BaseProtocol) -> None:
-        buf = aiohttp.StreamReader(protocol, 2**16, loop=asyncio.get_event_loop())
+        buf = aiohttp.StreamReader(protocol, 2**18, loop=asyncio.get_running_loop())
         dbuf = DeflateBuffer(buf, "deflate")
 
         dbuf.decompressor = mock.Mock()
@@ -2212,10 +2487,10 @@ class TestDeflateBuffer:
         dbuf = DeflateBuffer(buf, "deflate")
 
         dbuf.decompressor = mock.Mock()
-        dbuf.decompressor.flush.return_value = b"line"
+        dbuf.decompressor.data_available = False
+        dbuf.decompressor.flush.return_value = b""
 
         dbuf.feed_eof()
-        assert [b"line"] == list(buf._buffer)
         assert buf._eof
 
     async def test_feed_eof_err_deflate(self, protocol: BaseProtocol) -> None:
@@ -2223,8 +2498,10 @@ class TestDeflateBuffer:
         dbuf = DeflateBuffer(buf, "deflate")
 
         dbuf.decompressor = mock.Mock()
-        dbuf.decompressor.flush.return_value = b"line"
+        dbuf.decompressor.data_available = False
+        dbuf.decompressor.flush.return_value = b""
         dbuf.decompressor.eof = False
+        dbuf.size = 1  # Simulate that data was previously fed
 
         with pytest.raises(http_exceptions.ContentEncodingError):
             dbuf.feed_eof()
@@ -2234,22 +2511,24 @@ class TestDeflateBuffer:
         dbuf = DeflateBuffer(buf, "gzip")
 
         dbuf.decompressor = mock.Mock()
-        dbuf.decompressor.flush.return_value = b"line"
+        dbuf.decompressor.data_available = False
+        dbuf.decompressor.flush.return_value = b""
         dbuf.decompressor.eof = False
 
         dbuf.feed_eof()
-        assert [b"line"] == list(buf._buffer)
+        assert buf._eof
 
     async def test_feed_eof_no_err_brotli(self, protocol: BaseProtocol) -> None:
         buf = aiohttp.StreamReader(protocol, 2**16, loop=asyncio.get_running_loop())
         dbuf = DeflateBuffer(buf, "br")
 
         dbuf.decompressor = mock.Mock()
-        dbuf.decompressor.flush.return_value = b"line"
+        dbuf.decompressor.data_available = False
+        dbuf.decompressor.flush.return_value = b""
         dbuf.decompressor.eof = False
 
         dbuf.feed_eof()
-        assert [b"line"] == list(buf._buffer)
+        assert buf._eof
 
     @pytest.mark.skipif(zstandard is None, reason="zstandard is not installed")
     async def test_feed_eof_no_err_zstandard(self, protocol: BaseProtocol) -> None:
@@ -2257,19 +2536,21 @@ class TestDeflateBuffer:
         dbuf = DeflateBuffer(buf, "zstd")
 
         dbuf.decompressor = mock.Mock()
-        dbuf.decompressor.flush.return_value = b"line"
+        dbuf.decompressor.data_available = False
+        dbuf.decompressor.flush.return_value = b""
         dbuf.decompressor.eof = False
 
         dbuf.feed_eof()
-        assert [b"line"] == list(buf._buffer)
+        assert buf._eof
 
     async def test_empty_body(self, protocol: BaseProtocol) -> None:
-        buf = aiohttp.StreamReader(protocol, 2**16, loop=asyncio.get_running_loop())
+        buf = aiohttp.StreamReader(protocol, 2**18, loop=asyncio.get_running_loop())
         dbuf = DeflateBuffer(buf, "deflate")
         dbuf.feed_eof()
 
         assert buf.at_eof()
 
+    @pytest.mark.skipif(platform.python_implementation() == "PyPy", reason="Broken")
     @pytest.mark.parametrize(
         "chunk_size",
         [1024, 2**14, 2**16],  # 1KB, 16KB, 64KB
@@ -2288,13 +2569,14 @@ class TestDeflateBuffer:
         original = b"A" * (3 * 2**20)
         compressed = zlib.compress(original)
 
-        buf = aiohttp.StreamReader(protocol, 2**16, loop=asyncio.get_running_loop())
+        buf = aiohttp.StreamReader(protocol, 2**18, loop=asyncio.get_running_loop())
         dbuf = DeflateBuffer(buf, "deflate")
 
         # Feed compressed data in chunks (simulating network streaming)
         for i in range(0, len(compressed), chunk_size):  # pragma: no branch
             chunk = compressed[i : i + chunk_size]
-            dbuf.feed_data(chunk, len(chunk))
+            while dbuf.feed_data(chunk, len(chunk)):
+                chunk = b""
 
         dbuf.feed_eof()
 

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -160,6 +160,7 @@ def test_c_parser_loaded():
 
 def test_parse_headers(parser: Any) -> None:
     text = b"""GET /test HTTP/1.1\r
+Host: a\r
 test: a line\r
 test2: data\r
 \r
@@ -168,8 +169,16 @@ test2: data\r
     assert len(messages) == 1
     msg = messages[0][0]
 
-    assert list(msg.headers.items()) == [("test", "a line"), ("test2", "data")]
-    assert msg.raw_headers == ((b"test", b"a line"), (b"test2", b"data"))
+    assert list(msg.headers.items()) == [
+        ("Host", "a"),
+        ("test", "a line"),
+        ("test2", "data"),
+    ]
+    assert msg.raw_headers == (
+        (b"Host", b"a"),
+        (b"test", b"a line"),
+        (b"test2", b"data"),
+    )
     assert not msg.should_close
     assert msg.compression is None
     assert not msg.upgrade
@@ -177,6 +186,7 @@ test2: data\r
 
 def test_reject_obsolete_line_folding(parser: Any) -> None:
     text = b"""GET /test HTTP/1.1\r
+Host: a\r
 test: line\r
  Content-Length: 48\r
 test2: data\r
@@ -251,7 +261,7 @@ def test_cve_2023_37276(parser: Any) -> None:
     r'"(),/:;<=>?@[\]{}',
 )
 def test_bad_header_name(parser: Any, rfc9110_5_6_2_token_delim: str) -> None:
-    text = f"POST / HTTP/1.1\r\nhead{rfc9110_5_6_2_token_delim}er: val\r\n\r\n".encode()
+    text = f"POST / HTTP/1.1\r\nHost: a\r\nhead{rfc9110_5_6_2_token_delim}er: val\r\n\r\n".encode()
     expectation = pytest.raises(http_exceptions.BadHttpMessage)
     if rfc9110_5_6_2_token_delim == ":":
         # Inserting colon into header just splits name/value earlier.
@@ -279,7 +289,7 @@ def test_bad_header_name(parser: Any, rfc9110_5_6_2_token_delim: str) -> None:
     ),
 )
 def test_bad_headers(parser: Any, hdr: str) -> None:
-    text = f"POST / HTTP/1.1\r\n{hdr}\r\n\r\n".encode()
+    text = f"POST / HTTP/1.1\r\nHost: a\r\n{hdr}\r\n\r\n".encode()
     with pytest.raises(http_exceptions.BadHttpMessage):
         parser.feed_data(text)
 
@@ -304,7 +314,7 @@ def test_unpaired_surrogate_in_header_py(
         max_field_size=8190,
     )
     protocol._parser = parser
-    text = b"POST / HTTP/1.1\r\n\xff\r\n\r\n"
+    text = b"POST / HTTP/1.1\r\nHost: a\r\n\xff\r\n\r\n"
     message = None
     try:
         parser.feed_data(text)
@@ -407,6 +417,12 @@ def test_duplicate_host_header_rejected(parser: HttpRequestParser) -> None:
         parser.feed_data(text)
 
 
+def test_missing_host_header_rejected(parser: HttpRequestParser) -> None:
+    text = b"GET /admin HTTP/1.1\r\n\r\n"
+    with pytest.raises(http_exceptions.BadHttpMessage, match="Missing 'Host' header"):
+        parser.feed_data(text)
+
+
 @pytest.mark.parametrize(
     ("hdr1", "hdr2"),
     (
@@ -457,7 +473,7 @@ def test_bad_chunked(parser: HttpRequestParser) -> None:
 
 
 def test_whitespace_before_header(parser: Any) -> None:
-    text = b"GET / HTTP/1.1\r\n\tContent-Length: 1\r\n\r\nX"
+    text = b"GET / HTTP/1.1\r\nHost: a\r\n\tContent-Length: 1\r\n\r\nX"
     with pytest.raises(http_exceptions.BadHttpMessage):
         parser.feed_data(text)
 
@@ -488,7 +504,7 @@ def test_parse_unusual_request_line(parser) -> None:
 
 
 def test_parse(parser) -> None:
-    text = b"GET /test HTTP/1.1\r\n\r\n"
+    text = b"GET /test HTTP/1.1\r\nHost: a\r\n\r\n"
     messages, upgrade, tail = parser.feed_data(text)
     assert len(messages) == 1
     msg, _ = messages[0]
@@ -497,10 +513,11 @@ def test_parse(parser) -> None:
     assert msg.method == "GET"
     assert msg.path == "/test"
     assert msg.version == (1, 1)
+    assert msg.headers["Host"] == "a"
 
 
 async def test_parse_body(parser) -> None:
-    text = b"GET /test HTTP/1.1\r\nContent-Length: 4\r\n\r\nbody"
+    text = b"GET /test HTTP/1.1\r\nHost: a\r\nContent-Length: 4\r\n\r\nbody"
     messages, upgrade, tail = parser.feed_data(text)
     assert len(messages) == 1
     _, payload = messages[0]
@@ -509,7 +526,7 @@ async def test_parse_body(parser) -> None:
 
 
 async def test_parse_body_with_CRLF(parser) -> None:
-    text = b"\r\nGET /test HTTP/1.1\r\nContent-Length: 4\r\n\r\nbody"
+    text = b"\r\nGET /test HTTP/1.1\r\nHost: a\r\nContent-Length: 4\r\n\r\nbody"
     messages, upgrade, tail = parser.feed_data(text)
     assert len(messages) == 1
     _, payload = messages[0]
@@ -518,7 +535,7 @@ async def test_parse_body_with_CRLF(parser) -> None:
 
 
 def test_parse_delayed(parser) -> None:
-    text = b"GET /test HTTP/1.1\r\n"
+    text = b"GET /test HTTP/1.1\r\nHost: a\r\n"
     messages, upgrade, tail = parser.feed_data(text)
     assert len(messages) == 0
     assert not upgrade
@@ -531,8 +548,9 @@ def test_parse_delayed(parser) -> None:
 
 def test_headers_multi_feed(parser) -> None:
     text1 = b"GET /test HTTP/1.1\r\n"
-    text2 = b"test: line"
-    text3 = b" continue\r\n\r\n"
+    text2 = b"Host: a\r\n"
+    text3 = b"test: line"
+    text4 = b" continue\r\n\r\n"
 
     messages, upgrade, tail = parser.feed_data(text1)
     assert len(messages) == 0
@@ -541,18 +559,21 @@ def test_headers_multi_feed(parser) -> None:
     assert len(messages) == 0
 
     messages, upgrade, tail = parser.feed_data(text3)
+    assert len(messages) == 0
+
+    messages, upgrade, tail = parser.feed_data(text4)
     assert len(messages) == 1
 
     msg = messages[0][0]
-    assert list(msg.headers.items()) == [("test", "line continue")]
-    assert msg.raw_headers == ((b"test", b"line continue"),)
+    assert list(msg.headers.items()) == [("Host", "a"), ("test", "line continue")]
+    assert msg.raw_headers == ((b"Host", b"a"), (b"test", b"line continue"))
     assert not msg.should_close
     assert msg.compression is None
     assert not msg.upgrade
 
 
 def test_headers_split_field(parser) -> None:
-    text1 = b"GET /test HTTP/1.1\r\n"
+    text1 = b"GET /test HTTP/1.1\r\nHost: a\r\n"
     text2 = b"t"
     text3 = b"es"
     text4 = b"t: value\r\n\r\n"
@@ -565,8 +586,8 @@ def test_headers_split_field(parser) -> None:
     assert len(messages) == 1
 
     msg = messages[0][0]
-    assert list(msg.headers.items()) == [("test", "value")]
-    assert msg.raw_headers == ((b"test", b"value"),)
+    assert list(msg.headers.items()) == [("Host", "a"), ("test", "value")]
+    assert msg.raw_headers == ((b"Host", b"a"), (b"test", b"value"))
     assert not msg.should_close
     assert msg.compression is None
     assert not msg.upgrade
@@ -574,7 +595,7 @@ def test_headers_split_field(parser) -> None:
 
 def test_parse_headers_multi(parser) -> None:
     text = (
-        b"GET /test HTTP/1.1\r\n"
+        b"GET /test HTTP/1.1\r\nHost: a\r\n"
         b"Set-Cookie: c1=cookie1\r\n"
         b"Set-Cookie: c2=cookie2\r\n\r\n"
     )
@@ -584,10 +605,12 @@ def test_parse_headers_multi(parser) -> None:
     msg = messages[0][0]
 
     assert list(msg.headers.items()) == [
+        ("Host", "a"),
         ("Set-Cookie", "c1=cookie1"),
         ("Set-Cookie", "c2=cookie2"),
     ]
     assert msg.raw_headers == (
+        (b"Host", b"a"),
         (b"Set-Cookie", b"c1=cookie1"),
         (b"Set-Cookie", b"c2=cookie2"),
     )
@@ -603,14 +626,14 @@ def test_conn_default_1_0(parser) -> None:
 
 
 def test_conn_default_1_1(parser) -> None:
-    text = b"GET /test HTTP/1.1\r\n\r\n"
+    text = b"GET /test HTTP/1.1\r\nHost: a\r\n\r\n"
     messages, upgrade, tail = parser.feed_data(text)
     msg = messages[0][0]
     assert not msg.should_close
 
 
 def test_conn_close(parser) -> None:
-    text = b"GET /test HTTP/1.1\r\nconnection: close\r\n\r\n"
+    text = b"GET /test HTTP/1.1\r\nHost: a\r\nconnection: close\r\n\r\n"
     messages, upgrade, tail = parser.feed_data(text)
     msg = messages[0][0]
     assert msg.should_close
@@ -631,14 +654,14 @@ def test_conn_keep_alive_1_0(parser) -> None:
 
 
 def test_conn_keep_alive_1_1(parser) -> None:
-    text = b"GET /test HTTP/1.1\r\nconnection: keep-alive\r\n\r\n"
+    text = b"GET /test HTTP/1.1\r\nHost: a\r\nconnection: keep-alive\r\n\r\n"
     messages, upgrade, tail = parser.feed_data(text)
     msg = messages[0][0]
     assert not msg.should_close
 
 
 def test_conn_close_comma_list(parser) -> None:
-    text = b"GET /test HTTP/1.1\r\nconnection: close, keep-alive\r\n\r\n"
+    text = b"GET /test HTTP/1.1\r\nHost: a\r\nconnection: close, keep-alive\r\n\r\n"
     messages, upgrade, tail = parser.feed_data(text)
     msg = messages[0][0]
     assert msg.should_close
@@ -647,6 +670,7 @@ def test_conn_close_comma_list(parser) -> None:
 def test_conn_close_multiple_headers(parser) -> None:
     text = (
         b"GET /test HTTP/1.1\r\n"
+        b"Host: a\r\n"
         b"connection: keep-alive\r\n"
         b"connection: close\r\n\r\n"
     )
@@ -663,14 +687,14 @@ def test_conn_other_1_0(parser) -> None:
 
 
 def test_conn_other_1_1(parser) -> None:
-    text = b"GET /test HTTP/1.1\r\nconnection: test\r\n\r\n"
+    text = b"GET /test HTTP/1.1\r\nHost: a\r\nconnection: test\r\n\r\n"
     messages, upgrade, tail = parser.feed_data(text)
     msg = messages[0][0]
     assert not msg.should_close
 
 
 def test_request_chunked(parser) -> None:
-    text = b"GET /test HTTP/1.1\r\ntransfer-encoding: chunked\r\n\r\n"
+    text = b"GET /test HTTP/1.1\r\nHost: a\r\ntransfer-encoding: chunked\r\n\r\n"
     messages, upgrade, tail = parser.feed_data(text)
     msg, payload = messages[0]
     assert msg.chunked
@@ -680,14 +704,14 @@ def test_request_chunked(parser) -> None:
 
 def test_te_header_non_ascii(parser: HttpRequestParser) -> None:
     # K = Kelvin sign, not valid ascii.
-    text = "GET /test HTTP/1.1\r\nTransfer-Encoding: chunKed\r\n\r\n"
+    text = "GET /test HTTP/1.1\r\nHost: a\r\nTransfer-Encoding: chunKed\r\n\r\n"
     with pytest.raises(http_exceptions.BadHttpMessage):
         parser.feed_data(text.encode())
 
 
 def test_upgrade_header_non_ascii(parser: HttpRequestParser) -> None:
     # K = Kelvin sign, not valid ascii.
-    text = "GET /test HTTP/1.1\r\nUpgrade: websocKet\r\n\r\n"
+    text = "GET /test HTTP/1.1\r\nHost: a\r\nUpgrade: websocKet\r\n\r\n"
     messages, upgrade, tail = parser.feed_data(text.encode())
     assert not upgrade
 
@@ -695,6 +719,7 @@ def test_upgrade_header_non_ascii(parser: HttpRequestParser) -> None:
 def test_request_te_chunked_with_content_length(parser: HttpRequestParser) -> None:
     text = (
         b"GET /test HTTP/1.1\r\n"
+        b"Host: a\r\n"
         b"content-length: 1234\r\n"
         b"transfer-encoding: chunked\r\n\r\n"
     )
@@ -706,7 +731,7 @@ def test_request_te_chunked_with_content_length(parser: HttpRequestParser) -> No
 
 
 def test_request_te_chunked123(parser: Any) -> None:
-    text = b"GET /test HTTP/1.1\r\ntransfer-encoding: chunked123\r\n\r\n"
+    text = b"GET /test HTTP/1.1\r\nHost: a\r\ntransfer-encoding: chunked123\r\n\r\n"
     with pytest.raises(
         http_exceptions.BadHttpMessage,
         match="Request has invalid `Transfer-Encoding`",
@@ -715,14 +740,14 @@ def test_request_te_chunked123(parser: Any) -> None:
 
 
 async def test_request_te_last_chunked(parser: Any) -> None:
-    text = b"GET /test HTTP/1.1\r\nTransfer-Encoding: not, chunked\r\n\r\n1\r\nT\r\n3\r\nest\r\n0\r\n\r\n"
+    text = b"GET /test HTTP/1.1\r\nHost: a\r\nTransfer-Encoding: not, chunked\r\n\r\n1\r\nT\r\n3\r\nest\r\n0\r\n\r\n"
     messages, upgrade, tail = parser.feed_data(text)
     # https://www.rfc-editor.org/rfc/rfc9112#section-6.3-2.4.3
     assert await messages[0][1].read() == b"Test"
 
 
 def test_request_te_first_chunked(parser: Any) -> None:
-    text = b"GET /test HTTP/1.1\r\nTransfer-Encoding: chunked, not\r\n\r\n1\r\nT\r\n3\r\nest\r\n0\r\n\r\n"
+    text = b"GET /test HTTP/1.1\r\nHost: a\r\nTransfer-Encoding: chunked, not\r\n\r\n1\r\nT\r\n3\r\nest\r\n0\r\n\r\n"
     # https://www.rfc-editor.org/rfc/rfc9112#section-6.3-2.4.3
     with pytest.raises(
         http_exceptions.BadHttpMessage,
@@ -734,6 +759,7 @@ def test_request_te_first_chunked(parser: Any) -> None:
 def test_conn_upgrade(parser: Any) -> None:
     text = (
         b"GET /test HTTP/1.1\r\n"
+        b"Host: a\r\n"
         b"connection: upgrade\r\n"
         b"upgrade: websocket\r\n\r\n"
     )
@@ -747,6 +773,7 @@ def test_conn_upgrade(parser: Any) -> None:
 def test_conn_upgrade_comma_list(parser) -> None:
     text = (
         b"GET /test HTTP/1.1\r\n"
+        b"host: a\r\n"
         b"connection: keep-alive, upgrade\r\n"
         b"upgrade: websocket\r\n\r\n"
     )
@@ -760,6 +787,7 @@ def test_conn_upgrade_comma_list(parser) -> None:
 def test_conn_upgrade_multiple_headers(parser) -> None:
     text = (
         b"GET /test HTTP/1.1\r\n"
+        b"host: a\r\n"
         b"connection: keep-alive\r\n"
         b"connection: upgrade\r\n"
         b"upgrade: websocket\r\n\r\n"
@@ -773,7 +801,7 @@ def test_conn_upgrade_multiple_headers(parser) -> None:
 
 def test_bad_upgrade(parser) -> None:
     """Test not upgraded if missing Upgrade header."""
-    text = b"GET /test HTTP/1.1\r\nconnection: upgrade\r\n\r\n"
+    text = b"GET /test HTTP/1.1\r\nHost: a\r\nconnection: upgrade\r\n\r\n"
     messages, upgrade, tail = parser.feed_data(text)
     msg = messages[0][0]
     assert not msg.upgrade
@@ -781,21 +809,21 @@ def test_bad_upgrade(parser) -> None:
 
 
 def test_compression_empty(parser) -> None:
-    text = b"GET /test HTTP/1.1\r\ncontent-encoding: \r\n\r\n"
+    text = b"GET /test HTTP/1.1\r\nHost: a\r\ncontent-encoding: \r\n\r\n"
     messages, upgrade, tail = parser.feed_data(text)
     msg = messages[0][0]
     assert msg.compression is None
 
 
 def test_compression_deflate(parser) -> None:
-    text = b"GET /test HTTP/1.1\r\ncontent-encoding: deflate\r\n\r\n"
+    text = b"GET /test HTTP/1.1\r\nHost: a\r\ncontent-encoding: deflate\r\n\r\n"
     messages, upgrade, tail = parser.feed_data(text)
     msg = messages[0][0]
     assert msg.compression == "deflate"
 
 
 def test_compression_gzip(parser) -> None:
-    text = b"GET /test HTTP/1.1\r\ncontent-encoding: gzip\r\n\r\n"
+    text = b"GET /test HTTP/1.1\r\nHost: a\r\ncontent-encoding: gzip\r\n\r\n"
     messages, upgrade, tail = parser.feed_data(text)
     msg = messages[0][0]
     assert msg.compression == "gzip"
@@ -803,7 +831,7 @@ def test_compression_gzip(parser) -> None:
 
 @pytest.mark.skipif(brotli is None, reason="brotli is not installed")
 def test_compression_brotli(parser) -> None:
-    text = b"GET /test HTTP/1.1\r\ncontent-encoding: br\r\n\r\n"
+    text = b"GET /test HTTP/1.1\r\nHost: a\r\ncontent-encoding: br\r\n\r\n"
     messages, upgrade, tail = parser.feed_data(text)
     msg = messages[0][0]
     assert msg.compression == "br"
@@ -811,7 +839,7 @@ def test_compression_brotli(parser) -> None:
 
 @pytest.mark.skipif(zstandard is None, reason="zstandard is not installed")
 def test_compression_zstd(parser: HttpRequestParser) -> None:
-    text = b"GET /test HTTP/1.1\r\ncontent-encoding: zstd\r\n\r\n"
+    text = b"GET /test HTTP/1.1\r\nHost: a\r\ncontent-encoding: zstd\r\n\r\n"
     messages, upgrade, tail = parser.feed_data(text)
     msg = messages[0][0]
     assert msg.compression == "zstd"
@@ -825,7 +853,7 @@ def test_compression_zstd(parser: HttpRequestParser) -> None:
     ),
 )
 def test_compression_non_ascii(parser: HttpRequestParser, enc: bytes) -> None:
-    text = b"GET /test HTTP/1.1\r\ncontent-encoding: " + enc + b"\r\n\r\n"
+    text = b"GET /test HTTP/1.1\r\nHost: a\r\ncontent-encoding: " + enc + b"\r\n\r\n"
     messages, upgrade, tail = parser.feed_data(text)
     msg = messages[0][0]
     # Non-ascii input should not evaluate to a valid encoding scheme.
@@ -833,14 +861,14 @@ def test_compression_non_ascii(parser: HttpRequestParser, enc: bytes) -> None:
 
 
 def test_compression_unknown(parser: HttpRequestParser) -> None:
-    text = b"GET /test HTTP/1.1\r\ncontent-encoding: compress\r\n\r\n"
+    text = b"GET /test HTTP/1.1\r\nHost: a\r\ncontent-encoding: compress\r\n\r\n"
     messages, upgrade, tail = parser.feed_data(text)
     msg = messages[0][0]
     assert msg.compression is None
 
 
 def test_url_connect(parser: Any) -> None:
-    text = b"CONNECT www.google.com HTTP/1.1\r\ncontent-length: 0\r\n\r\n"
+    text = b"CONNECT www.google.com HTTP/1.1\r\nHost: a\r\ncontent-length: 0\r\n\r\n"
     messages, upgrade, tail = parser.feed_data(text)
     msg, payload = messages[0]
     assert upgrade
@@ -848,7 +876,7 @@ def test_url_connect(parser: Any) -> None:
 
 
 def test_headers_connect(parser: Any) -> None:
-    text = b"CONNECT www.google.com HTTP/1.1\r\ncontent-length: 0\r\n\r\n"
+    text = b"CONNECT www.google.com HTTP/1.1\r\nHost: a\r\ncontent-length: 0\r\n\r\n"
     messages, upgrade, tail = parser.feed_data(text)
     msg, payload = messages[0]
     assert upgrade
@@ -858,6 +886,7 @@ def test_headers_connect(parser: Any) -> None:
 def test_url_absolute(parser: Any) -> None:
     text = (
         b"GET https://www.google.com/path/to.html HTTP/1.1\r\n"
+        b"Host: a\r\n"
         b"content-length: 0\r\n\r\n"
     )
     messages, upgrade, tail = parser.feed_data(text)
@@ -868,21 +897,21 @@ def test_url_absolute(parser: Any) -> None:
 
 
 def test_headers_old_websocket_key1(parser: Any) -> None:
-    text = b"GET /test HTTP/1.1\r\nSEC-WEBSOCKET-KEY1: line\r\n\r\n"
+    text = b"GET /test HTTP/1.1\r\nHost: a\r\nSEC-WEBSOCKET-KEY1: line\r\n\r\n"
 
     with pytest.raises(http_exceptions.BadHttpMessage):
         parser.feed_data(text)
 
 
 def test_headers_content_length_err_1(parser) -> None:
-    text = b"GET /test HTTP/1.1\r\ncontent-length: line\r\n\r\n"
+    text = b"GET /test HTTP/1.1\r\nHost: a\r\ncontent-length: line\r\n\r\n"
 
     with pytest.raises(http_exceptions.BadHttpMessage):
         parser.feed_data(text)
 
 
 def test_headers_content_length_err_2(parser) -> None:
-    text = b"GET /test HTTP/1.1\r\ncontent-length: -1\r\n\r\n"
+    text = b"GET /test HTTP/1.1\r\nHost: a\r\ncontent-length: -1\r\n\r\n"
 
     with pytest.raises(http_exceptions.BadHttpMessage):
         parser.feed_data(text)
@@ -905,7 +934,7 @@ _pad: dict[bytes, str] = {
 @pytest.mark.parametrize("pad2", _pad.keys(), ids=["post-" + n for n in _pad.values()])
 @pytest.mark.parametrize("pad1", _pad.keys(), ids=["pre-" + n for n in _pad.values()])
 def test_invalid_header_spacing(parser, pad1: bytes, pad2: bytes, hdr: bytes) -> None:
-    text = b"GET /test HTTP/1.1\r\n%s%s%s: value\r\n\r\n" % (pad1, hdr, pad2)
+    text = b"GET /test HTTP/1.1\r\nHost: a\r\n%s%s%s: value\r\n\r\n" % (pad1, hdr, pad2)
     expectation = pytest.raises(http_exceptions.BadHttpMessage)
     if pad1 == pad2 == b"" and hdr != b"":
         # one entry in param matrix is correct: non-empty name, not padded
@@ -915,19 +944,19 @@ def test_invalid_header_spacing(parser, pad1: bytes, pad2: bytes, hdr: bytes) ->
 
 
 def test_empty_header_name(parser) -> None:
-    text = b"GET /test HTTP/1.1\r\n:test\r\n\r\n"
+    text = b"GET /test HTTP/1.1\r\nHost: a\r\n:test\r\n\r\n"
     with pytest.raises(http_exceptions.BadHttpMessage):
         parser.feed_data(text)
 
 
 def test_invalid_header(parser) -> None:
-    text = b"GET /test HTTP/1.1\r\ntest line\r\n\r\n"
+    text = b"GET /test HTTP/1.1\r\nHost: a\r\ntest line\r\n\r\n"
     with pytest.raises(http_exceptions.BadHttpMessage):
         parser.feed_data(text)
 
 
 def test_invalid_name(parser) -> None:
-    text = b"GET /test HTTP/1.1\r\ntest[]: line\r\n\r\n"
+    text = b"GET /test HTTP/1.1\r\nHost: a\r\ntest[]: line\r\n\r\n"
 
     with pytest.raises(http_exceptions.BadHttpMessage):
         parser.feed_data(text)
@@ -946,15 +975,15 @@ def test_max_header_field_size(parser, size) -> None:
 
 def test_max_header_size_under_limit(parser: HttpRequestParser) -> None:
     name = b"t" * 8185
-    text = b"GET /test HTTP/1.1\r\n" + name + b":data\r\n\r\n"
+    text = b"GET /test HTTP/1.1\r\nHost: a\r\n" + name + b":data\r\n\r\n"
 
     messages, upgrade, tail = parser.feed_data(text)
     msg = messages[0][0]
     assert msg.method == "GET"
     assert msg.path == "/test"
     assert msg.version == (1, 1)
-    assert msg.headers == CIMultiDict({name.decode(): "data"})
-    assert msg.raw_headers == ((name, b"data"),)
+    assert msg.headers == CIMultiDict([("Host", "a"), (name.decode(), "data")])
+    assert msg.raw_headers == ((b"Host", b"a"), (name, b"data"))
     assert not msg.should_close
     assert msg.compression is None
     assert not msg.upgrade
@@ -986,7 +1015,7 @@ def test_max_header_combined_size(parser: HttpRequestParser) -> None:
 async def test_max_trailer_size(parser: HttpRequestParser, size: int) -> None:
     value = b"t" * size
     text = (
-        b"GET /test HTTP/1.1\r\nTransfer-Encoding: chunked\r\n\r\n"
+        b"GET /test HTTP/1.1\r\nHost: a\r\nTransfer-Encoding: chunked\r\n\r\n"
         + hex(4000)[2:].encode()
         + b"\r\n"
         + b"b" * 4000
@@ -1012,7 +1041,7 @@ async def test_max_headers(
     parser: HttpRequestParser, headers: int, trailers: int
 ) -> None:
     text = (
-        b"GET /test HTTP/1.1\r\nTransfer-Encoding: chunked"
+        b"GET /test HTTP/1.1\r\nHost: a\r\nTransfer-Encoding: chunked"
         + b"".join(b"\r\nHeader-%d: Value" % i for i in range(headers))
         + b"\r\n\r\n4\r\ntest\r\n0"
         + b"".join(b"\r\nTrailer-%d: Value" % i for i in range(trailers))
@@ -1028,15 +1057,15 @@ async def test_max_headers(
 
 def test_max_header_value_size_under_limit(parser: HttpRequestParser) -> None:
     value = b"A" * 8185
-    text = b"GET /test HTTP/1.1\r\ndata:" + value + b"\r\n\r\n"
+    text = b"GET /test HTTP/1.1\r\nHost: a\r\ndata:" + value + b"\r\n\r\n"
 
     messages, upgrade, tail = parser.feed_data(text)
     msg = messages[0][0]
     assert msg.method == "GET"
     assert msg.path == "/test"
     assert msg.version == (1, 1)
-    assert msg.headers == CIMultiDict({"data": value.decode()})
-    assert msg.raw_headers == ((b"data", value),)
+    assert msg.headers == CIMultiDict([("Host", "a"), ("data", value.decode())])
+    assert msg.raw_headers == ((b"Host", b"a"), (b"data", value))
     assert not msg.should_close
     assert msg.compression is None
     assert not msg.upgrade
@@ -1046,7 +1075,7 @@ def test_max_header_value_size_under_limit(parser: HttpRequestParser) -> None:
 
 async def test_chunk_splits_after_pause(parser: HttpRequestParser) -> None:
     text = (
-        b"GET /test HTTP/1.1\r\nTransfer-Encoding: chunked\r\n\r\n"
+        b"GET /test HTTP/1.1\r\nHost: a\r\nTransfer-Encoding: chunked\r\n\r\n"
         + b"1\r\nb\r\n" * 50000
         + b"0\r\n\r\n"
     )
@@ -1272,15 +1301,15 @@ def test_max_header_value_size_continuation_under_limit(
 
 
 def test_http_request_parser(parser) -> None:
-    text = b"GET /path HTTP/1.1\r\n\r\n"
+    text = b"GET /path HTTP/1.1\r\nHost: a\r\n\r\n"
     messages, upgrade, tail = parser.feed_data(text)
     msg = messages[0][0]
 
     assert msg.method == "GET"
     assert msg.path == "/path"
     assert msg.version == (1, 1)
-    assert msg.headers == CIMultiDict()
-    assert msg.raw_headers == ()
+    assert msg.headers == CIMultiDict({"Host": "a"})
+    assert msg.raw_headers == ((b"Host", b"a"),)
     assert not msg.should_close
     assert msg.compression is None
     assert not msg.upgrade
@@ -1311,7 +1340,7 @@ _num: dict[bytes, str] = {
 def test_http_request_bad_status_line_number(
     parser: Any, nonascii_digit: bytes
 ) -> None:
-    text = b"GET /digit HTTP/1." + nonascii_digit + b"\r\n\r\n"
+    text = b"GET /digit HTTP/1." + nonascii_digit + b"\r\nHost: a\r\n\r\n"
     with pytest.raises(http_exceptions.BadStatusLine):
         parser.feed_data(text)
 
@@ -1319,19 +1348,19 @@ def test_http_request_bad_status_line_number(
 def test_http_request_bad_status_line_separator(parser: Any) -> None:
     # single code point, old, multibyte NFKC, multibyte NFKD
     utf8sep = "\N{arabic ligature sallallahou alayhe wasallam}".encode()
-    text = b"GET /ligature HTTP/1" + utf8sep + b"1\r\n\r\n"
+    text = b"GET /ligature HTTP/1" + utf8sep + b"1\r\nHost: a\r\n\r\n"
     with pytest.raises(http_exceptions.BadStatusLine):
         parser.feed_data(text)
 
 
 def test_http_request_bad_status_line_whitespace(parser: Any) -> None:
-    text = b"GET\n/path\fHTTP/1.1\r\n\r\n"
+    text = b"GET\n/path\fHTTP/1.1\r\nHost: a\r\n\r\n"
     with pytest.raises(http_exceptions.BadStatusLine):
         parser.feed_data(text)
 
 
 def test_http_request_message_after_close(parser: HttpRequestParser) -> None:
-    text = b"GET / HTTP/1.1\r\nConnection: close\r\n\r\nInvalid\r\n\r\n"
+    text = b"GET / HTTP/1.1\r\nHost: a\r\nConnection: close\r\n\r\nInvalid\r\n\r\n"
     with pytest.raises(
         http_exceptions.BadHttpMessage, match="Data after `Connection: close`"
     ):
@@ -1339,7 +1368,7 @@ def test_http_request_message_after_close(parser: HttpRequestParser) -> None:
 
 
 def test_http_request_message_after_close_comma_list(parser: HttpRequestParser) -> None:
-    text = b"GET / HTTP/1.1\r\nConnection: close, keep-alive\r\n\r\nInvalid\r\n\r\n"
+    text = b"GET / HTTP/1.1\r\nHost: a\r\nConnection: close, keep-alive\r\n\r\nInvalid\r\n\r\n"
     with pytest.raises(
         http_exceptions.BadHttpMessage, match="Data after `Connection: close`"
     ):
@@ -1349,6 +1378,7 @@ def test_http_request_message_after_close_comma_list(parser: HttpRequestParser) 
 def test_http_request_upgrade(parser: HttpRequestParser) -> None:
     text = (
         b"GET /test HTTP/1.1\r\n"
+        b"Host: a\r\n"
         b"connection: upgrade\r\n"
         b"upgrade: websocket\r\n\r\n"
         b"some raw data"
@@ -1364,6 +1394,7 @@ def test_http_request_upgrade(parser: HttpRequestParser) -> None:
 async def test_http_request_upgrade_unknown(parser: Any) -> None:
     text = (
         b"POST / HTTP/1.1\r\n"
+        b"Host: a\r\n"
         b"Connection: Upgrade\r\n"
         b"Content-Length: 2\r\n"
         b"Upgrade: unknown\r\n"
@@ -1397,7 +1428,7 @@ def xfail_c_parser_url(request) -> None:
 def test_http_request_parser_utf8_request_line(parser) -> None:
     messages, upgrade, tail = parser.feed_data(
         # note the truncated unicode sequence
-        b"GET /P\xc3\xbcnktchen\xa0\xef\xb7 HTTP/1.1\r\n" +
+        b"GET /P\xc3\xbcnktchen\xa0\xef\xb7 HTTP/1.1\r\nHost: a\r\n" +
         # for easier grep: ASCII 0xA0 more commonly known as non-breaking space
         # note the leading and trailing spaces
         "sTeP:  \N{latin small letter sharp s}nek\t\N{no-break space}  "
@@ -1408,8 +1439,8 @@ def test_http_request_parser_utf8_request_line(parser) -> None:
     assert msg.method == "GET"
     assert msg.path == "/Pünktchen\udca0\udcef\udcb7"
     assert msg.version == (1, 1)
-    assert msg.headers == CIMultiDict([("STEP", "ßnek\t\xa0")])
-    assert msg.raw_headers == ((b"sTeP", "ßnek\t\xa0".encode()),)
+    assert msg.headers == CIMultiDict([("Host", "a"), ("STEP", "ßnek\t\xa0")])
+    assert msg.raw_headers == ((b"Host", b"a"), (b"sTeP", "ßnek\t\xa0".encode()))
     assert not msg.should_close
     assert msg.compression is None
     assert not msg.upgrade
@@ -1420,15 +1451,15 @@ def test_http_request_parser_utf8_request_line(parser) -> None:
 
 
 def test_http_request_parser_utf8(parser) -> None:
-    text = "GET /path HTTP/1.1\r\nx-test:тест\r\n\r\n".encode()
+    text = "GET /path HTTP/1.1\r\nHost: a\r\nx-test:тест\r\n\r\n".encode()
     messages, upgrade, tail = parser.feed_data(text)
     msg = messages[0][0]
 
     assert msg.method == "GET"
     assert msg.path == "/path"
     assert msg.version == (1, 1)
-    assert msg.headers == CIMultiDict([("X-TEST", "тест")])
-    assert msg.raw_headers == ((b"x-test", "тест".encode()),)
+    assert msg.headers == CIMultiDict([("Host", "a"), ("X-TEST", "тест")])
+    assert msg.raw_headers == ((b"Host", b"a"), (b"x-test", "тест".encode()))
     assert not msg.should_close
     assert msg.compression is None
     assert not msg.upgrade
@@ -1437,16 +1468,19 @@ def test_http_request_parser_utf8(parser) -> None:
 
 
 def test_http_request_parser_non_utf8(parser) -> None:
-    text = "GET /path HTTP/1.1\r\nx-test:тест\r\n\r\n".encode("cp1251")
+    text = "GET /path HTTP/1.1\r\nHost: a\r\nx-test:тест\r\n\r\n".encode("cp1251")
     msg = parser.feed_data(text)[0][0][0]
 
     assert msg.method == "GET"
     assert msg.path == "/path"
     assert msg.version == (1, 1)
     assert msg.headers == CIMultiDict(
-        [("X-TEST", "тест".encode("cp1251").decode("utf8", "surrogateescape"))]
+        [
+            ("Host", "a"),
+            ("X-TEST", "тест".encode("cp1251").decode("utf8", "surrogateescape")),
+        ]
     )
-    assert msg.raw_headers == ((b"x-test", "тест".encode("cp1251")),)
+    assert msg.raw_headers == ((b"Host", b"a"), (b"x-test", "тест".encode("cp1251")))
     assert not msg.should_close
     assert msg.compression is None
     assert not msg.upgrade
@@ -1455,7 +1489,7 @@ def test_http_request_parser_non_utf8(parser) -> None:
 
 
 def test_http_request_parser_two_slashes(parser) -> None:
-    text = b"GET //path HTTP/1.1\r\n\r\n"
+    text = b"GET //path HTTP/1.1\r\nHost: a\r\n\r\n"
     msg = parser.feed_data(text)[0][0][0]
 
     assert msg.method == "GET"
@@ -1476,17 +1510,19 @@ def test_http_request_parser_bad_method(
     parser, rfc9110_5_6_2_token_delim: bytes
 ) -> None:
     with pytest.raises(http_exceptions.BadHttpMethod):
-        parser.feed_data(rfc9110_5_6_2_token_delim + b'ET" /get HTTP/1.1\r\n\r\n')
+        parser.feed_data(
+            rfc9110_5_6_2_token_delim + b'ET" /get HTTP/1.1\r\nHost: a\r\n\r\n'
+        )
 
 
 def test_http_request_parser_bad_version(parser) -> None:
     with pytest.raises(http_exceptions.BadHttpMessage):
-        parser.feed_data(b"GET //get HT/11\r\n\r\n")
+        parser.feed_data(b"GET //get HT/11\r\nHost: a\r\n\r\n")
 
 
 def test_http_request_parser_bad_version_number(parser: Any) -> None:
     with pytest.raises(http_exceptions.BadHttpMessage):
-        parser.feed_data(b"GET /test HTTP/1.32\r\n\r\n")
+        parser.feed_data(b"GET /test HTTP/1.32\r\nHost: a\r\n\r\n")
 
 
 def test_http_request_parser_bad_ascii_uri(parser: Any) -> None:
@@ -1510,15 +1546,15 @@ def test_http_request_max_status_line(parser, size) -> None:
 def test_http_request_max_status_line_under_limit(parser: HttpRequestParser) -> None:
     path = b"t" * 8172
     messages, upgraded, tail = parser.feed_data(
-        b"GET /path" + path + b" HTTP/1.1\r\n\r\n"
+        b"GET /path" + path + b" HTTP/1.1\r\nHost: a\r\n\r\n"
     )
     msg = messages[0][0]
 
     assert msg.method == "GET"
     assert msg.path == "/path" + path.decode()
     assert msg.version == (1, 1)
-    assert msg.headers == CIMultiDict()
-    assert msg.raw_headers == ()
+    assert msg.headers == CIMultiDict({"Host": "a"})
+    assert msg.raw_headers == ((b"Host", b"a"),)
     assert not msg.should_close
     assert msg.compression is None
     assert not msg.upgrade
@@ -1755,7 +1791,7 @@ def test_http_response_parser_code_not_ascii(response, nonascii_digit: bytes) ->
 
 
 def test_http_request_chunked_payload(parser) -> None:
-    text = b"GET /test HTTP/1.1\r\ntransfer-encoding: chunked\r\n\r\n"
+    text = b"GET /test HTTP/1.1\r\nHost: a\r\ntransfer-encoding: chunked\r\n\r\n"
     msg, payload = parser.feed_data(text)[0][0]
 
     assert msg.chunked
@@ -1771,12 +1807,13 @@ def test_http_request_chunked_payload(parser) -> None:
 
 
 def test_http_request_chunked_payload_and_next_message(parser) -> None:
-    text = b"GET /test HTTP/1.1\r\ntransfer-encoding: chunked\r\n\r\n"
+    text = b"GET /test HTTP/1.1\r\nHost: a\r\ntransfer-encoding: chunked\r\n\r\n"
     msg, payload = parser.feed_data(text)[0][0]
 
     messages, upgraded, tail = parser.feed_data(
         b"4\r\ndata\r\n4\r\nline\r\n0\r\n\r\n"
         b"POST /test2 HTTP/1.1\r\n"
+        b"Host: a\r\n"
         b"transfer-encoding: chunked\r\n\r\n"
     )
 
@@ -1794,7 +1831,7 @@ def test_http_request_chunked_payload_and_next_message(parser) -> None:
 
 
 def test_http_request_chunked_payload_chunks(parser) -> None:
-    text = b"GET /test HTTP/1.1\r\ntransfer-encoding: chunked\r\n\r\n"
+    text = b"GET /test HTTP/1.1\r\nHost: a\r\ntransfer-encoding: chunked\r\n\r\n"
     msg, payload = parser.feed_data(text)[0][0]
 
     parser.feed_data(b"4\r\ndata\r")
@@ -1817,7 +1854,7 @@ def test_http_request_chunked_payload_chunks(parser) -> None:
 
 
 def test_parse_chunked_payload_chunk_extension(parser) -> None:
-    text = b"GET /test HTTP/1.1\r\ntransfer-encoding: chunked\r\n\r\n"
+    text = b"GET /test HTTP/1.1\r\nHost: a\r\ntransfer-encoding: chunked\r\n\r\n"
     msg, payload = parser.feed_data(text)[0][0]
 
     parser.feed_data(b"4;test\r\ndata\r\n4\r\nline\r\n0\r\ntest: test\r\n\r\n")
@@ -1829,7 +1866,7 @@ def test_parse_chunked_payload_chunk_extension(parser) -> None:
 
 
 async def test_request_chunked_with_trailer(parser: HttpRequestParser) -> None:
-    text = b"GET /test HTTP/1.1\r\nTransfer-Encoding: chunked\r\n\r\n4\r\ntest\r\n0\r\ntest: trailer\r\nsecond: test trailer\r\n\r\n"
+    text = b"GET /test HTTP/1.1\r\nHost: a\r\nTransfer-Encoding: chunked\r\n\r\n4\r\ntest\r\n0\r\ntest: trailer\r\nsecond: test trailer\r\n\r\n"
     messages, upgraded, tail = parser.feed_data(text)
     assert not tail
     msg, payload = messages[0]
@@ -1839,7 +1876,7 @@ async def test_request_chunked_with_trailer(parser: HttpRequestParser) -> None:
 
 
 async def test_request_chunked_reject_bad_trailer(parser: HttpRequestParser) -> None:
-    text = b"GET /test HTTP/1.1\r\nTransfer-Encoding: chunked\r\n\r\n0\r\nbad\ntrailer\r\n\r\n"
+    text = b"GET /test HTTP/1.1\r\nHost: a\r\nTransfer-Encoding: chunked\r\n\r\n0\r\nbad\ntrailer\r\n\r\n"
     with pytest.raises(http_exceptions.BadHttpMessage, match=r"b'bad\\ntrailer'"):
         parser.feed_data(text)
 
@@ -1852,7 +1889,7 @@ def test_parse_no_length_or_te_on_post(
     protocol = RequestHandler(server, loop=loop)
     parser = request_cls(protocol, loop, limit=DEFAULT_CHUNK_SIZE)
     protocol._parser = parser
-    text = b"POST /test HTTP/1.1\r\n\r\n"
+    text = b"POST /test HTTP/1.1\r\nHost: a\r\n\r\n"
     msg, payload = parser.feed_data(text)[0][0]
 
     assert payload.is_eof()
@@ -1885,7 +1922,7 @@ def test_parse_length_payload(response) -> None:
 
 
 def test_parse_no_length_payload(parser) -> None:
-    text = b"PUT / HTTP/1.1\r\n\r\n"
+    text = b"PUT / HTTP/1.1\r\nHost: a\r\n\r\n"
     msg, payload = parser.feed_data(text)[0][0]
     assert payload.is_eof()
 
@@ -2055,7 +2092,7 @@ async def test_parse_chunked_payload_with_lf_in_extensions(
 def test_partial_url(parser: HttpRequestParser) -> None:
     messages, upgrade, tail = parser.feed_data(b"GET /te")
     assert len(messages) == 0
-    messages, upgrade, tail = parser.feed_data(b"st HTTP/1.1\r\n\r\n")
+    messages, upgrade, tail = parser.feed_data(b"st HTTP/1.1\r\nHost: a\r\n\r\n")
     assert len(messages) == 1
 
     msg, payload = messages[0]
@@ -2078,7 +2115,7 @@ def test_partial_url(parser: HttpRequestParser) -> None:
     ],
 )
 def test_parse_uri_percent_encoded(parser, uri, path, query, fragment) -> None:
-    text = (f"GET {uri} HTTP/1.1\r\n\r\n").encode()
+    text = (f"GET {uri} HTTP/1.1\r\nHost: a\r\n\r\n").encode()
     messages, upgrade, tail = parser.feed_data(text)
     msg = messages[0][0]
 
@@ -2092,7 +2129,7 @@ def test_parse_uri_percent_encoded(parser, uri, path, query, fragment) -> None:
 def test_parse_uri_utf8(parser) -> None:
     if not isinstance(parser, HttpRequestParserPy):
         pytest.xfail("Not valid HTTP. Maybe update py-parser to reject later.")
-    text = ("GET /путь?ключ=знач#фраг HTTP/1.1\r\n\r\n").encode()
+    text = ("GET /путь?ключ=знач#фраг HTTP/1.1\r\nHost: a\r\n\r\n").encode()
     messages, upgrade, tail = parser.feed_data(text)
     msg = messages[0][0]
 
@@ -2104,7 +2141,8 @@ def test_parse_uri_utf8(parser) -> None:
 
 def test_parse_uri_utf8_percent_encoded(parser) -> None:
     text = (
-        "GET %s HTTP/1.1\r\n\r\n" % quote("/путь?ключ=знач#фраг", safe="/?=#")
+        "GET %s HTTP/1.1\r\nHost: a\r\n\r\n"
+        % quote("/путь?ключ=знач#фраг", safe="/?=#")
     ).encode()
     messages, upgrade, tail = parser.feed_data(text)
     msg = messages[0][0]

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -19,6 +19,7 @@ import aiohttp
 from aiohttp import http_exceptions, streams
 from aiohttp.base_protocol import BaseProtocol
 from aiohttp.client_proto import ResponseHandler
+from aiohttp.helpers import DEFAULT_CHUNK_SIZE
 from aiohttp.http_parser import (
     NO_EXTENSIONS,
     DeflateBuffer,
@@ -100,7 +101,7 @@ def parser(
     parser = request.param(
         protocol,
         loop,
-        2**18,
+        DEFAULT_CHUNK_SIZE,
         max_line_size=8190,
         max_headers=128,
         max_field_size=8190,
@@ -128,7 +129,7 @@ def response(
     parser = request.param(
         protocol,
         loop,
-        2**18,
+        DEFAULT_CHUNK_SIZE,
         max_line_size=8190,
         max_headers=128,
         max_field_size=8190,
@@ -1673,7 +1674,7 @@ async def test_http_response_parser_bad_chunked_strict_py(
     response = HttpResponseParserPy(
         protocol,
         loop,
-        2**18,
+        DEFAULT_CHUNK_SIZE,
         max_line_size=8190,
         max_field_size=8190,
     )
@@ -1849,7 +1850,7 @@ def test_parse_no_length_or_te_on_post(
     request_cls: type[HttpRequestParser],
 ) -> None:
     protocol = RequestHandler(server, loop=loop)
-    parser = request_cls(protocol, loop, limit=2**18)
+    parser = request_cls(protocol, loop, limit=DEFAULT_CHUNK_SIZE)
     protocol._parser = parser
     text = b"POST /test HTTP/1.1\r\n\r\n"
     msg, payload = parser.feed_data(text)[0][0]
@@ -2128,7 +2129,7 @@ def test_parse_bad_method_for_c_parser_raises(
     parser = HttpRequestParserC(
         protocol,
         loop,
-        2**18,
+        DEFAULT_CHUNK_SIZE,
         max_line_size=8190,
         max_headers=128,
         max_field_size=8190,
@@ -2150,7 +2151,9 @@ class TestParsePayload:
         assert [(bytearray(b"data"))] == list(out._buffer)
 
     async def test_parse_length_payload_eof(self, protocol: BaseProtocol) -> None:
-        out = aiohttp.StreamReader(protocol, 2**18, loop=asyncio.get_running_loop())
+        out = aiohttp.StreamReader(
+            protocol, DEFAULT_CHUNK_SIZE, loop=asyncio.get_running_loop()
+        )
 
         p = HttpPayloadParser(out, length=4, headers_parser=HeadersParser())
         p.feed_data(b"da")
@@ -2174,7 +2177,9 @@ class TestParsePayload:
 
         Regression test for #10596.
         """
-        out = aiohttp.StreamReader(protocol, 2**18, loop=asyncio.get_running_loop())
+        out = aiohttp.StreamReader(
+            protocol, DEFAULT_CHUNK_SIZE, loop=asyncio.get_running_loop()
+        )
         p = HttpPayloadParser(out, chunked=True, headers_parser=HeadersParser())
         # Declared chunk-size is 4 but actual data is "Hello" (5 bytes).
         # After consuming 4 bytes, remaining starts with "o" not "\r\n".
@@ -2189,7 +2194,9 @@ class TestParsePayload:
 
         Regression test for #10596.
         """
-        out = aiohttp.StreamReader(protocol, 2**18, loop=asyncio.get_running_loop())
+        out = aiohttp.StreamReader(
+            protocol, DEFAULT_CHUNK_SIZE, loop=asyncio.get_running_loop()
+        )
         p = HttpPayloadParser(out, chunked=True, headers_parser=HeadersParser())
         # Declared chunk-size is 6 but actual data before CRLF is "Hello" (5 bytes).
         # Parser reads 6 bytes: "Hello\r", then expects \r\n but sees "\n0\r\n..."
@@ -2211,7 +2218,9 @@ class TestParsePayload:
     async def test_parse_chunked_payload_split_end2(
         self, protocol: BaseProtocol
     ) -> None:
-        out = aiohttp.StreamReader(protocol, 2**18, loop=asyncio.get_running_loop())
+        out = aiohttp.StreamReader(
+            protocol, DEFAULT_CHUNK_SIZE, loop=asyncio.get_running_loop()
+        )
         p = HttpPayloadParser(out, chunked=True, headers_parser=HeadersParser())
         p.feed_data(b"4\r\nasdf\r\n0\r\n\r")
         p.feed_data(b"\n")
@@ -2222,7 +2231,9 @@ class TestParsePayload:
     async def test_parse_chunked_payload_split_end_trailers(
         self, protocol: BaseProtocol
     ) -> None:
-        out = aiohttp.StreamReader(protocol, 2**18, loop=asyncio.get_running_loop())
+        out = aiohttp.StreamReader(
+            protocol, DEFAULT_CHUNK_SIZE, loop=asyncio.get_running_loop()
+        )
         p = HttpPayloadParser(out, chunked=True, headers_parser=HeadersParser())
         p.feed_data(b"4\r\nasdf\r\n0\r\n")
         p.feed_data(b"Content-MD5: 912ec803b2ce49e4a541068d495ab570\r\n")
@@ -2234,7 +2245,9 @@ class TestParsePayload:
     async def test_parse_chunked_payload_split_end_trailers2(
         self, protocol: BaseProtocol
     ) -> None:
-        out = aiohttp.StreamReader(protocol, 2**18, loop=asyncio.get_running_loop())
+        out = aiohttp.StreamReader(
+            protocol, DEFAULT_CHUNK_SIZE, loop=asyncio.get_running_loop()
+        )
         p = HttpPayloadParser(out, chunked=True, headers_parser=HeadersParser())
         p.feed_data(b"4\r\nasdf\r\n0\r\n")
         p.feed_data(b"Content-MD5: 912ec803b2ce49e4a541068d495ab570\r\n\r")
@@ -2266,7 +2279,9 @@ class TestParsePayload:
         assert b"asdf" == b"".join(out._buffer)
 
     async def test_http_payload_parser_length(self, protocol: BaseProtocol) -> None:
-        out = aiohttp.StreamReader(protocol, 2**18, loop=asyncio.get_running_loop())
+        out = aiohttp.StreamReader(
+            protocol, DEFAULT_CHUNK_SIZE, loop=asyncio.get_running_loop()
+        )
         p = HttpPayloadParser(out, length=2, headers_parser=HeadersParser())
         state, tail = p.feed_data(b"1245")
         assert state is PayloadState.PAYLOAD_COMPLETE
@@ -2279,7 +2294,9 @@ class TestParsePayload:
         COMPRESSED = b"x\x9cKI,I\x04\x00\x04\x00\x01\x9b"
 
         length = len(COMPRESSED)
-        out = aiohttp.StreamReader(protocol, 2**18, loop=asyncio.get_running_loop())
+        out = aiohttp.StreamReader(
+            protocol, DEFAULT_CHUNK_SIZE, loop=asyncio.get_running_loop()
+        )
         p = HttpPayloadParser(
             out, length=length, compression="deflate", headers_parser=HeadersParser()
         )
@@ -2350,7 +2367,9 @@ class TestParsePayload:
     async def test_http_payload_parser_length_zero(
         self, protocol: BaseProtocol
     ) -> None:
-        out = aiohttp.StreamReader(protocol, 2**18, loop=asyncio.get_running_loop())
+        out = aiohttp.StreamReader(
+            protocol, DEFAULT_CHUNK_SIZE, loop=asyncio.get_running_loop()
+        )
         p = HttpPayloadParser(out, length=0, headers_parser=HeadersParser())
         assert p.done
         assert out.is_eof()
@@ -2358,7 +2377,9 @@ class TestParsePayload:
     @pytest.mark.skipif(brotli is None, reason="brotli is not installed")
     async def test_http_payload_brotli(self, protocol: BaseProtocol) -> None:
         compressed = brotli.compress(b"brotli data")
-        out = aiohttp.StreamReader(protocol, 2**18, loop=asyncio.get_running_loop())
+        out = aiohttp.StreamReader(
+            protocol, DEFAULT_CHUNK_SIZE, loop=asyncio.get_running_loop()
+        )
         p = HttpPayloadParser(
             out,
             length=len(compressed),
@@ -2372,7 +2393,9 @@ class TestParsePayload:
     @pytest.mark.skipif(zstandard is None, reason="zstandard is not installed")
     async def test_http_payload_zstandard(self, protocol: BaseProtocol) -> None:
         compressed = zstandard.compress(b"zstd data")
-        out = aiohttp.StreamReader(protocol, 2**18, loop=asyncio.get_running_loop())
+        out = aiohttp.StreamReader(
+            protocol, DEFAULT_CHUNK_SIZE, loop=asyncio.get_running_loop()
+        )
         p = HttpPayloadParser(
             out,
             length=len(compressed),
@@ -2390,7 +2413,9 @@ class TestParsePayload:
         frame1 = zstandard.compress(b"first")
         frame2 = zstandard.compress(b"second")
         payload = frame1 + frame2
-        out = aiohttp.StreamReader(protocol, 2**18, loop=asyncio.get_running_loop())
+        out = aiohttp.StreamReader(
+            protocol, DEFAULT_CHUNK_SIZE, loop=asyncio.get_running_loop()
+        )
         p = HttpPayloadParser(
             out,
             length=len(payload),
@@ -2407,7 +2432,9 @@ class TestParsePayload:
     ) -> None:
         frame1 = zstandard.compress(b"chunk1")
         frame2 = zstandard.compress(b"chunk2")
-        out = aiohttp.StreamReader(protocol, 2**18, loop=asyncio.get_running_loop())
+        out = aiohttp.StreamReader(
+            protocol, DEFAULT_CHUNK_SIZE, loop=asyncio.get_running_loop()
+        )
         p = HttpPayloadParser(
             out,
             length=len(frame1) + len(frame2),
@@ -2427,7 +2454,9 @@ class TestParsePayload:
         frame2 = zstandard.compress(b"BBBB")
         combined = frame1 + frame2
         split_point = len(frame1) + 3  # 3 bytes into frame2
-        out = aiohttp.StreamReader(protocol, 2**18, loop=asyncio.get_running_loop())
+        out = aiohttp.StreamReader(
+            protocol, DEFAULT_CHUNK_SIZE, loop=asyncio.get_running_loop()
+        )
         p = HttpPayloadParser(
             out,
             length=len(combined),
@@ -2445,7 +2474,9 @@ class TestParsePayload:
     ) -> None:
         parts = [f"part{i}".encode() for i in range(10)]
         payload = b"".join(zstandard.compress(p) for p in parts)
-        out = aiohttp.StreamReader(protocol, 2**18, loop=asyncio.get_running_loop())
+        out = aiohttp.StreamReader(
+            protocol, DEFAULT_CHUNK_SIZE, loop=asyncio.get_running_loop()
+        )
         p = HttpPayloadParser(
             out,
             length=len(payload),
@@ -2459,7 +2490,9 @@ class TestParsePayload:
 
 class TestDeflateBuffer:
     async def test_feed_data(self, protocol: BaseProtocol) -> None:
-        buf = aiohttp.StreamReader(protocol, 2**18, loop=asyncio.get_running_loop())
+        buf = aiohttp.StreamReader(
+            protocol, DEFAULT_CHUNK_SIZE, loop=asyncio.get_running_loop()
+        )
         dbuf = DeflateBuffer(buf, "deflate")
 
         dbuf.decompressor = mock.Mock()
@@ -2544,7 +2577,9 @@ class TestDeflateBuffer:
         assert buf._eof
 
     async def test_empty_body(self, protocol: BaseProtocol) -> None:
-        buf = aiohttp.StreamReader(protocol, 2**18, loop=asyncio.get_running_loop())
+        buf = aiohttp.StreamReader(
+            protocol, DEFAULT_CHUNK_SIZE, loop=asyncio.get_running_loop()
+        )
         dbuf = DeflateBuffer(buf, "deflate")
         dbuf.feed_eof()
 
@@ -2569,7 +2604,9 @@ class TestDeflateBuffer:
         original = b"A" * (3 * 2**20)
         compressed = zlib.compress(original)
 
-        buf = aiohttp.StreamReader(protocol, 2**18, loop=asyncio.get_running_loop())
+        buf = aiohttp.StreamReader(
+            protocol, DEFAULT_CHUNK_SIZE, loop=asyncio.get_running_loop()
+        )
         dbuf = DeflateBuffer(buf, "deflate")
 
         # Feed compressed data in chunks (simulating network streaming)

--- a/tests/test_http_writer.py
+++ b/tests/test_http_writer.py
@@ -11,6 +11,7 @@ from multidict import CIMultiDict
 from aiohttp import ClientConnectionResetError, hdrs, http
 from aiohttp.base_protocol import BaseProtocol
 from aiohttp.compression_utils import ZLibBackend
+from aiohttp.helpers import DEFAULT_CHUNK_SIZE
 from aiohttp.http_writer import _serialize_headers
 
 
@@ -1423,7 +1424,7 @@ async def test_write_drain_condition_with_large_buffer(
     protocol._drain_helper.reset_mock()  # type: ignore[attr-defined]
 
     # Write large amount of data with drain=True
-    large_data = b"x" * (2**18 + 1)  # Just over LIMIT
+    large_data = b"x" * (DEFAULT_CHUNK_SIZE + 1)  # Just over LIMIT
     await msg.write(large_data, drain=True)
 
     # Drain should be called because drain=True AND buffer_size > LIMIT
@@ -1452,12 +1453,12 @@ async def test_write_no_drain_with_large_buffer(
     protocol._drain_helper.reset_mock()  # type: ignore[attr-defined]
 
     # Write large amount of data with drain=False
-    large_data = b"x" * (2**18 + 1)  # Just over LIMIT
+    large_data = b"x" * (DEFAULT_CHUNK_SIZE + 1)  # Just over LIMIT
     await msg.write(large_data, drain=False)
 
     # Drain should NOT be called because drain=False
     assert not protocol._drain_helper.called  # type: ignore[attr-defined]
-    assert msg.buffer_size == (2**18 + 1)  # Buffer not reset
+    assert msg.buffer_size == (DEFAULT_CHUNK_SIZE + 1)  # Buffer not reset
     assert large_data in buf
 
 

--- a/tests/test_http_writer.py
+++ b/tests/test_http_writer.py
@@ -1394,7 +1394,7 @@ async def test_write_drain_condition_with_small_buffer(
     protocol._drain_helper.reset_mock()  # type: ignore[attr-defined]
 
     # Write small amount of data with drain=True but buffer under limit
-    small_data = b"x" * 100  # Much less than LIMIT (2**16)
+    small_data = b"x" * 100  # Much less than LIMIT (2**18)
     await msg.write(small_data, drain=True)
 
     # Drain should NOT be called because buffer_size <= LIMIT
@@ -1423,7 +1423,7 @@ async def test_write_drain_condition_with_large_buffer(
     protocol._drain_helper.reset_mock()  # type: ignore[attr-defined]
 
     # Write large amount of data with drain=True
-    large_data = b"x" * (2**16 + 1)  # Just over LIMIT
+    large_data = b"x" * (2**18 + 1)  # Just over LIMIT
     await msg.write(large_data, drain=True)
 
     # Drain should be called because drain=True AND buffer_size > LIMIT
@@ -1452,12 +1452,12 @@ async def test_write_no_drain_with_large_buffer(
     protocol._drain_helper.reset_mock()  # type: ignore[attr-defined]
 
     # Write large amount of data with drain=False
-    large_data = b"x" * (2**16 + 1)  # Just over LIMIT
+    large_data = b"x" * (2**18 + 1)  # Just over LIMIT
     await msg.write(large_data, drain=False)
 
     # Drain should NOT be called because drain=False
     assert not protocol._drain_helper.called  # type: ignore[attr-defined]
-    assert msg.buffer_size == (2**16 + 1)  # Buffer not reset
+    assert msg.buffer_size == (2**18 + 1)  # Buffer not reset
     assert large_data in buf
 
 

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -19,7 +19,7 @@ from aiohttp.hdrs import (
     CONTENT_TRANSFER_ENCODING,
     CONTENT_TYPE,
 )
-from aiohttp.helpers import parse_mimetype
+from aiohttp.helpers import DEFAULT_CHUNK_SIZE, parse_mimetype
 from aiohttp.multipart import (
     BodyPartReader,
     BodyPartReaderPayload,
@@ -739,9 +739,11 @@ class TestPartReader:
         assert "foo.html" == part.filename
 
     async def test_reading_long_part(self) -> None:
-        size = 2 * 2**18
+        size = 2 * DEFAULT_CHUNK_SIZE
         protocol = mock.Mock(_reading_paused=False)
-        stream = StreamReader(protocol, 2**18, loop=asyncio.get_event_loop())
+        stream = StreamReader(
+            protocol, DEFAULT_CHUNK_SIZE, loop=asyncio.get_event_loop()
+        )
         stream.feed_data(b"0" * size + b"\r\n--:--")
         stream.feed_eof()
         obj = aiohttp.BodyPartReader(BOUNDARY, {}, stream)

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -1,7 +1,9 @@
 import asyncio
+import gzip
 import io
 import json
 import pathlib
+import sys
 from unittest import mock
 
 import pytest
@@ -24,6 +26,7 @@ from aiohttp.multipart import (
     MultipartResponseWrapper,
 )
 from aiohttp.streams import StreamReader
+from aiohttp.web_exceptions import HTTPRequestEntityTooLarge
 
 BOUNDARY = b"--:"
 
@@ -345,17 +348,17 @@ class TestPartReader:
             result = await obj.read(decode=True)
         assert b"Time to Relax!" == result
 
+    @pytest.mark.skipif(sys.version_info < (3, 11), reason="wbits not available")
     async def test_read_with_content_encoding_deflate(self) -> None:
-        data = b"\x0b\xc9\xccMU(\xc9W\x08J\xcdI\xacP\x04\x00"
-        tail = b"%s--:--" % newline
-        with Stream(data + tail) as stream:
-            obj = aiohttp.BodyPartReader(
-                BOUNDARY,
-                {CONTENT_ENCODING: "deflate"},
-                stream,
-            )
+        content = b"A" * 1_000_000  # Large enough to exceed max_length.
+        compressed = ZLibBackend.compress(content, wbits=-ZLibBackend.MAX_WBITS)
+
+        h = CIMultiDictProxy(CIMultiDict({CONTENT_ENCODING: "deflate"}))
+        with Stream(compressed + b"\r\n--:--") as stream:
+            obj = aiohttp.BodyPartReader(BOUNDARY, h, stream)
             result = await obj.read(decode=True)
-        assert b"Time to Relax!" == result
+        assert len(result) == len(content)  # Simplifies diff on failure
+        assert result == content
 
     async def test_read_with_content_encoding_identity(self) -> None:
         thing = (
@@ -379,6 +382,22 @@ class TestPartReader:
                 stream,
             )
             with pytest.raises(RuntimeError):
+                await obj.read(decode=True)
+
+    async def test_read_decode_compressed_exceeds_max_size(self) -> None:
+        # Compressed data is small, but decompresses beyond client_max_size.
+        original = b"A" * 1024
+        compressed = gzip.compress(original)
+        h = CIMultiDictProxy(CIMultiDict({CONTENT_ENCODING: "gzip"}))
+        with Stream(compressed + b"\r\n--:--") as stream:
+            obj = aiohttp.BodyPartReader(
+                BOUNDARY,
+                h,
+                stream,
+                client_max_size=256,
+                max_size_error_cls=HTTPRequestEntityTooLarge,
+            )
+            with pytest.raises(HTTPRequestEntityTooLarge):
                 await obj.read(decode=True)
 
     async def test_read_with_content_transfer_encoding_base64(self) -> None:
@@ -720,9 +739,9 @@ class TestPartReader:
         assert "foo.html" == part.filename
 
     async def test_reading_long_part(self) -> None:
-        size = 2 * 2**16
+        size = 2 * 2**18
         protocol = mock.Mock(_reading_paused=False)
-        stream = StreamReader(protocol, 2**16, loop=asyncio.get_event_loop())
+        stream = StreamReader(protocol, 2**18, loop=asyncio.get_event_loop())
         stream.feed_data(b"0" * size + b"\r\n--:--")
         stream.feed_eof()
         obj = aiohttp.BodyPartReader(BOUNDARY, {}, stream)
@@ -1803,6 +1822,35 @@ async def test_body_part_reader_payload_as_bytes() -> None:
     # Test that decode also raises TypeError
     with pytest.raises(TypeError, match="Unable to decode"):
         payload.decode()
+
+
+@pytest.mark.skipif(sys.version_info < (3, 11), reason="No wbits parameter")
+async def test_body_part_reader_payload_write() -> None:
+    content = b"A" * 1_000_000  # Large enough to exceed max_length.
+    compressed = ZLibBackend.compress(content, wbits=-ZLibBackend.MAX_WBITS)
+    output = b""
+
+    async def write(inp: bytes) -> None:
+        nonlocal output
+        output += inp
+
+    h = CIMultiDictProxy(CIMultiDict({CONTENT_ENCODING: "deflate"}))
+    if sys.version_info >= (3, 12):
+        writer = mock.create_autospec(
+            AbstractStreamWriter, write=write, spec_set=True, instance=True
+        )
+    else:
+        writer = mock.create_autospec(
+            AbstractStreamWriter, spec_set=True, instance=True
+        )
+        writer.write.side_effect = write
+    with Stream(compressed + b"\r\n--:--") as stream:
+        body_part = aiohttp.BodyPartReader(BOUNDARY, h, stream)
+        payload = BodyPartReaderPayload(body_part)
+        await payload.write(writer)
+
+    assert len(output) == len(content)  # Simplifies diff on failure
+    assert output == content
 
 
 async def test_multipart_writer_close_with_exceptions() -> None:

--- a/tests/test_payload.py
+++ b/tests/test_payload.py
@@ -331,7 +331,7 @@ async def test_bytesio_payload_write_with_length_remaining_zero() -> None:
 
 async def test_bytesio_payload_large_data_multiple_chunks() -> None:
     """Test BytesIOPayload with large data requiring multiple read chunks."""
-    chunk_size = 2**16  # 64KB (READ_SIZE)
+    chunk_size = 2**18  # 256KiB (READ_SIZE)
     data = b"x" * (chunk_size + 1000)  # Slightly larger than READ_SIZE
     payload_bytesio = payload.BytesIOPayload(io.BytesIO(data))
     writer = MockStreamWriter()
@@ -355,7 +355,7 @@ async def test_bytesio_payload_remaining_bytes_exhausted() -> None:
 
 async def test_iobase_payload_exact_chunk_size_limit() -> None:
     """Test IOBasePayload with content length matching exactly one read chunk."""
-    chunk_size = 2**16  # 65536 bytes (READ_SIZE)
+    chunk_size = 2**18  # 256KiB (READ_SIZE)
     data = b"x" * chunk_size + b"extra"  # Slightly larger than one read chunk
     p = payload.IOBasePayload(io.BytesIO(data))
     writer = MockStreamWriter()

--- a/tests/test_payload.py
+++ b/tests/test_payload.py
@@ -13,7 +13,7 @@ from multidict import CIMultiDict
 
 from aiohttp import payload
 from aiohttp.abc import AbstractStreamWriter
-from aiohttp.payload import READ_SIZE
+from aiohttp.helpers import DEFAULT_CHUNK_SIZE
 
 
 class BufferWriter(AbstractStreamWriter):
@@ -331,14 +331,13 @@ async def test_bytesio_payload_write_with_length_remaining_zero() -> None:
 
 async def test_bytesio_payload_large_data_multiple_chunks() -> None:
     """Test BytesIOPayload with large data requiring multiple read chunks."""
-    chunk_size = 2**18  # 256KiB (READ_SIZE)
-    data = b"x" * (chunk_size + 1000)  # Slightly larger than READ_SIZE
+    data = b"x" * (DEFAULT_CHUNK_SIZE + 1000)
     payload_bytesio = payload.BytesIOPayload(io.BytesIO(data))
     writer = MockStreamWriter()
 
     await payload_bytesio.write_with_length(writer, None)
     assert writer.get_written_bytes() == data
-    assert len(writer.get_written_bytes()) == chunk_size + 1000
+    assert len(writer.get_written_bytes()) == DEFAULT_CHUNK_SIZE + 1000
 
 
 async def test_bytesio_payload_remaining_bytes_exhausted() -> None:
@@ -355,21 +354,20 @@ async def test_bytesio_payload_remaining_bytes_exhausted() -> None:
 
 async def test_iobase_payload_exact_chunk_size_limit() -> None:
     """Test IOBasePayload with content length matching exactly one read chunk."""
-    chunk_size = 2**18  # 256KiB (READ_SIZE)
-    data = b"x" * chunk_size + b"extra"  # Slightly larger than one read chunk
+    data = b"x" * DEFAULT_CHUNK_SIZE + b"extra"  # Slightly larger than one read chunk
     p = payload.IOBasePayload(io.BytesIO(data))
     writer = MockStreamWriter()
 
-    await p.write_with_length(writer, chunk_size)
+    await p.write_with_length(writer, DEFAULT_CHUNK_SIZE)
     written = writer.get_written_bytes()
-    assert len(written) == chunk_size
-    assert written == data[:chunk_size]
+    assert len(written) == DEFAULT_CHUNK_SIZE
+    assert written == data[:DEFAULT_CHUNK_SIZE]
 
 
 async def test_iobase_payload_reads_in_chunks() -> None:
-    """Test IOBasePayload reads data in chunks of READ_SIZE, not all at once."""
-    # Create a large file that's multiple times larger than READ_SIZE
-    large_data = b"x" * (READ_SIZE * 3 + 1000)  # ~192KB + 1000 bytes
+    """Test IOBasePayload reads data in chunks of default size, not all at once."""
+    # Create a large file that's multiple times larger than DEFAULT_CHUNK_SIZE
+    large_data = b"x" * (DEFAULT_CHUNK_SIZE * 3 + 1000)  # ~192KB + 1000 bytes
 
     # Mock the file-like object to track read calls
     mock_file = unittest.mock.Mock(spec=io.BytesIO)
@@ -386,11 +384,11 @@ async def test_iobase_payload_reads_in_chunks() -> None:
         if call_count == 1:
             return large_data[:size]
         elif call_count == 2:
-            return large_data[READ_SIZE : READ_SIZE + size]
+            return large_data[DEFAULT_CHUNK_SIZE : DEFAULT_CHUNK_SIZE + size]
         elif call_count == 3:
-            return large_data[READ_SIZE * 2 : READ_SIZE * 2 + size]
+            return large_data[DEFAULT_CHUNK_SIZE * 2 : DEFAULT_CHUNK_SIZE * 2 + size]
         else:
-            return large_data[READ_SIZE * 3 :]
+            return large_data[DEFAULT_CHUNK_SIZE * 3 :]
 
     mock_file.read.side_effect = mock_read
 
@@ -400,17 +398,17 @@ async def test_iobase_payload_reads_in_chunks() -> None:
     # Write with a large content_length
     await payload_obj.write_with_length(writer, len(large_data))
 
-    # Verify that reads were limited to READ_SIZE
+    # Verify that reads were limited to DEFAULT_CHUNK_SIZE
     assert len(read_sizes) > 1  # Should have multiple reads
     for read_size in read_sizes:
         assert (
-            read_size <= READ_SIZE
-        ), f"Read size {read_size} exceeds READ_SIZE {READ_SIZE}"
+            read_size <= DEFAULT_CHUNK_SIZE
+        ), f"Read size {read_size} exceeds DEFAULT_CHUNK_SIZE {DEFAULT_CHUNK_SIZE}"
 
 
 async def test_iobase_payload_large_content_length() -> None:
     """Test IOBasePayload with very large content_length doesn't read all at once."""
-    data = b"x" * (READ_SIZE + 1000)
+    data = b"x" * (DEFAULT_CHUNK_SIZE + 1000)
 
     # Create a custom file-like object that tracks read sizes
     class TrackingBytesIO(io.BytesIO):
@@ -430,20 +428,20 @@ async def test_iobase_payload_large_content_length() -> None:
     large_content_length = 10 * 1024 * 1024  # 10MB
     await payload_obj.write_with_length(writer, large_content_length)
 
-    # Verify no single read exceeded READ_SIZE
+    # Verify no single read exceeded DEFAULT_CHUNK_SIZE
     for read_size in tracking_file.read_sizes:
         assert (
-            read_size <= READ_SIZE
-        ), f"Read size {read_size} exceeds READ_SIZE {READ_SIZE}"
+            read_size <= DEFAULT_CHUNK_SIZE
+        ), f"Read size {read_size} exceeds DEFAULT_CHUNK_SIZE {DEFAULT_CHUNK_SIZE}"
 
     # Verify the correct amount of data was written
     assert writer.get_written_bytes() == data
 
 
 async def test_textio_payload_reads_in_chunks() -> None:
-    """Test TextIOPayload reads data in chunks of READ_SIZE, not all at once."""
-    # Create a large text file that's multiple times larger than READ_SIZE
-    large_text = "x" * (READ_SIZE * 3 + 1000)  # ~192KB + 1000 chars
+    """Test TextIOPayload reads data in chunks of default size, not all at once."""
+    # Create a large text file that's multiple times larger than DEFAULT_CHUNK_SIZE
+    large_text = "x" * (DEFAULT_CHUNK_SIZE * 3 + 1000)  # ~192KB + 1000 chars
 
     # Mock the file-like object to track read calls
     mock_file = unittest.mock.Mock(spec=io.StringIO)
@@ -461,11 +459,11 @@ async def test_textio_payload_reads_in_chunks() -> None:
         if call_count == 1:
             return large_text[:size]
         elif call_count == 2:
-            return large_text[READ_SIZE : READ_SIZE + size]
+            return large_text[DEFAULT_CHUNK_SIZE : DEFAULT_CHUNK_SIZE + size]
         elif call_count == 3:
-            return large_text[READ_SIZE * 2 : READ_SIZE * 2 + size]
+            return large_text[DEFAULT_CHUNK_SIZE * 2 : DEFAULT_CHUNK_SIZE * 2 + size]
         else:
-            return large_text[READ_SIZE * 3 :]
+            return large_text[DEFAULT_CHUNK_SIZE * 3 :]
 
     mock_file.read.side_effect = mock_read
 
@@ -475,17 +473,17 @@ async def test_textio_payload_reads_in_chunks() -> None:
     # Write with a large content_length
     await payload_obj.write_with_length(writer, len(large_text.encode("utf-8")))
 
-    # Verify that reads were limited to READ_SIZE
+    # Verify that reads were limited to DEFAULT_CHUNK_SIZE
     assert len(read_sizes) > 1  # Should have multiple reads
     for read_size in read_sizes:
         assert (
-            read_size <= READ_SIZE
-        ), f"Read size {read_size} exceeds READ_SIZE {READ_SIZE}"
+            read_size <= DEFAULT_CHUNK_SIZE
+        ), f"Read size {read_size} exceeds DEFAULT_CHUNK_SIZE {DEFAULT_CHUNK_SIZE}"
 
 
 async def test_textio_payload_large_content_length() -> None:
     """Test TextIOPayload with very large content_length doesn't read all at once."""
-    text_data = "x" * (READ_SIZE + 1000)
+    text_data = "x" * (DEFAULT_CHUNK_SIZE + 1000)
 
     # Create a custom file-like object that tracks read sizes
     class TrackingStringIO(io.StringIO):
@@ -505,11 +503,11 @@ async def test_textio_payload_large_content_length() -> None:
     large_content_length = 10 * 1024 * 1024  # 10MB
     await payload_obj.write_with_length(writer, large_content_length)
 
-    # Verify no single read exceeded READ_SIZE
+    # Verify no single read exceeded DEFAULT_CHUNK_SIZE
     for read_size in tracking_file.read_sizes:
         assert (
-            read_size <= READ_SIZE
-        ), f"Read size {read_size} exceeds READ_SIZE {READ_SIZE}"
+            read_size <= DEFAULT_CHUNK_SIZE
+        ), f"Read size {read_size} exceeds DEFAULT_CHUNK_SIZE {DEFAULT_CHUNK_SIZE}"
 
     # Verify the correct amount of data was written
     assert writer.get_written_bytes() == text_data.encode("utf-8")

--- a/tests/test_streams.py
+++ b/tests/test_streams.py
@@ -25,7 +25,7 @@ def chunkify(seq, n):
 async def create_stream():
     loop = asyncio.get_event_loop()
     protocol = mock.Mock(_reading_paused=False)
-    stream = streams.StreamReader(protocol, 2**16, loop=loop)
+    stream = streams.StreamReader(protocol, 2**18, loop=loop)
     stream.feed_data(DATA)
     stream.feed_eof()
     return stream
@@ -73,7 +73,7 @@ class TestStreamReader:
     DATA = b"line1\nline2\nline3\n"
 
     def _make_one(self, *args, **kwargs):
-        kwargs.setdefault("limit", 2**16)
+        kwargs.setdefault("limit", 2**18)
         return streams.StreamReader(mock.Mock(_reading_paused=False), *args, **kwargs)
 
     async def test_create_waiter(self) -> None:
@@ -1131,7 +1131,7 @@ async def test_empty_stream_reader() -> None:
     assert s.set_exception(ValueError()) is None
     assert s.exception() is None
     assert s.feed_eof() is None
-    assert s.feed_data(b"data") is None
+    assert s.feed_data(b"data") is False
     assert s.at_eof()
     assert (await s.wait_eof()) is None
     assert await s.read() == b""
@@ -1293,7 +1293,7 @@ class TestDataQueue:
 
 async def test_feed_data_waiters(protocol) -> None:
     loop = asyncio.get_event_loop()
-    reader = streams.StreamReader(protocol, 2**16, loop=loop)
+    reader = streams.StreamReader(protocol, 2**18, loop=loop)
     waiter = reader._waiter = loop.create_future()
     eof_waiter = reader._eof_waiter = loop.create_future()
 
@@ -1321,7 +1321,7 @@ async def test_feed_data_completed_waiters(protocol) -> None:
 
 async def test_feed_eof_waiters(protocol) -> None:
     loop = asyncio.get_event_loop()
-    reader = streams.StreamReader(protocol, 2**16, loop=loop)
+    reader = streams.StreamReader(protocol, 2**18, loop=loop)
     waiter = reader._waiter = loop.create_future()
     eof_waiter = reader._eof_waiter = loop.create_future()
 
@@ -1353,7 +1353,7 @@ async def test_feed_eof_cancelled(protocol) -> None:
 
 async def test_on_eof(protocol) -> None:
     loop = asyncio.get_event_loop()
-    reader = streams.StreamReader(protocol, 2**16, loop=loop)
+    reader = streams.StreamReader(protocol, 2**18, loop=loop)
 
     on_eof = mock.Mock()
     reader.on_eof(on_eof)
@@ -1374,7 +1374,7 @@ async def test_on_eof_empty_reader() -> None:
 
 async def test_on_eof_exc_in_callback(protocol) -> None:
     loop = asyncio.get_event_loop()
-    reader = streams.StreamReader(protocol, 2**16, loop=loop)
+    reader = streams.StreamReader(protocol, 2**18, loop=loop)
 
     on_eof = mock.Mock()
     on_eof.side_effect = ValueError
@@ -1409,7 +1409,7 @@ async def test_on_eof_eof_is_set(protocol) -> None:
 
 async def test_on_eof_eof_is_set_exception(protocol) -> None:
     loop = asyncio.get_event_loop()
-    reader = streams.StreamReader(protocol, 2**16, loop=loop)
+    reader = streams.StreamReader(protocol, 2**18, loop=loop)
     reader.feed_eof()
 
     on_eof = mock.Mock()
@@ -1455,7 +1455,7 @@ async def test_set_exception_cancelled(protocol) -> None:
 
 async def test_set_exception_eof_callbacks(protocol) -> None:
     loop = asyncio.get_event_loop()
-    reader = streams.StreamReader(protocol, 2**16, loop=loop)
+    reader = streams.StreamReader(protocol, 2**18, loop=loop)
 
     on_eof = mock.Mock()
     reader.on_eof(on_eof)
@@ -1560,8 +1560,8 @@ async def test_stream_reader_pause_on_high_water_chunks(
 ) -> None:
     """Test that reading is paused when chunk count exceeds high water mark."""
     loop = asyncio.get_event_loop()
-    # Use small limit so high_water_chunks is small: limit // 4 = 10
-    stream = streams.StreamReader(protocol, limit=40, loop=loop)
+    # Use small limit so high_water_chunks is small: limit // 16 = 10
+    stream = streams.StreamReader(protocol, limit=160, loop=loop)
 
     assert stream._high_water_chunks == 10
     assert stream._low_water_chunks == 5
@@ -1581,8 +1581,8 @@ async def test_stream_reader_resume_on_low_water_chunks(
 ) -> None:
     """Test that reading resumes when chunk count drops below low water mark."""
     loop = asyncio.get_event_loop()
-    # Use small limit so high_water_chunks is small: limit // 4 = 10
-    stream = streams.StreamReader(protocol, limit=40, loop=loop)
+    # Use small limit so high_water_chunks is small: limit // 16 = 10
+    stream = streams.StreamReader(protocol, limit=160, loop=loop)
 
     assert stream._high_water_chunks == 10
     assert stream._low_water_chunks == 5
@@ -1676,14 +1676,14 @@ async def test_stream_reader_resume_non_chunked_when_paused(
     protocol.resume_reading.assert_called()
 
 
-@pytest.mark.parametrize("limit", [1, 2, 4])
+@pytest.mark.parametrize("limit", (1, 4, 7, 16))
 async def test_stream_reader_small_limit_resumes_reading(
     protocol: mock.Mock,
     limit: int,
 ) -> None:
     """Test that small limits still allow resume_reading to be called.
 
-    Even with very small limits, high_water_chunks should be at least 3
+    Even with very small limits, high_water_chunks should be at least 4
     and low_water_chunks should be at least 2, with high > low to ensure
     proper flow control.
     """
@@ -1691,8 +1691,8 @@ async def test_stream_reader_small_limit_resumes_reading(
     stream = streams.StreamReader(protocol, limit=limit, loop=loop)
 
     # Verify minimum thresholds are enforced and high > low
-    assert stream._high_water_chunks >= 3
-    assert stream._low_water_chunks >= 2
+    assert stream._high_water_chunks == 4
+    assert stream._low_water_chunks == 2
     assert stream._high_water_chunks > stream._low_water_chunks
 
     # Set up pause/resume side effects
@@ -1706,8 +1706,8 @@ async def test_stream_reader_small_limit_resumes_reading(
 
     protocol.resume_reading.side_effect = resume_reading
 
-    # Feed 4 chunks (triggers pause at > high_water_chunks which is >= 3)
-    for char in b"abcd":
+    # Feed 5 chunks (triggers pause at > high_water_chunks which is 4)
+    for char in b"abcde":
         stream.begin_http_chunk_receiving()
         stream.feed_data(bytes([char]))
         stream.end_http_chunk_receiving()
@@ -1718,7 +1718,7 @@ async def test_stream_reader_small_limit_resumes_reading(
 
     # Read all data - should resume (chunk count drops below low_water_chunks)
     data = stream.read_nowait()
-    assert data == b"abcd"
+    assert data == b"abcde"
     assert stream._size == 0
 
     protocol.resume_reading.assert_called()

--- a/tests/test_streams.py
+++ b/tests/test_streams.py
@@ -12,6 +12,7 @@ import pytest
 from re_assert import Matches
 
 from aiohttp import streams
+from aiohttp.helpers import DEFAULT_CHUNK_SIZE
 from aiohttp.http_exceptions import LineTooLong
 
 DATA = b"line1\nline2\nline3\n"
@@ -25,7 +26,7 @@ def chunkify(seq, n):
 async def create_stream():
     loop = asyncio.get_event_loop()
     protocol = mock.Mock(_reading_paused=False)
-    stream = streams.StreamReader(protocol, 2**18, loop=loop)
+    stream = streams.StreamReader(protocol, DEFAULT_CHUNK_SIZE, loop=loop)
     stream.feed_data(DATA)
     stream.feed_eof()
     return stream
@@ -1293,7 +1294,7 @@ class TestDataQueue:
 
 async def test_feed_data_waiters(protocol) -> None:
     loop = asyncio.get_event_loop()
-    reader = streams.StreamReader(protocol, 2**18, loop=loop)
+    reader = streams.StreamReader(protocol, DEFAULT_CHUNK_SIZE, loop=loop)
     waiter = reader._waiter = loop.create_future()
     eof_waiter = reader._eof_waiter = loop.create_future()
 
@@ -1321,7 +1322,7 @@ async def test_feed_data_completed_waiters(protocol) -> None:
 
 async def test_feed_eof_waiters(protocol) -> None:
     loop = asyncio.get_event_loop()
-    reader = streams.StreamReader(protocol, 2**18, loop=loop)
+    reader = streams.StreamReader(protocol, DEFAULT_CHUNK_SIZE, loop=loop)
     waiter = reader._waiter = loop.create_future()
     eof_waiter = reader._eof_waiter = loop.create_future()
 
@@ -1353,7 +1354,7 @@ async def test_feed_eof_cancelled(protocol) -> None:
 
 async def test_on_eof(protocol) -> None:
     loop = asyncio.get_event_loop()
-    reader = streams.StreamReader(protocol, 2**18, loop=loop)
+    reader = streams.StreamReader(protocol, DEFAULT_CHUNK_SIZE, loop=loop)
 
     on_eof = mock.Mock()
     reader.on_eof(on_eof)
@@ -1374,7 +1375,7 @@ async def test_on_eof_empty_reader() -> None:
 
 async def test_on_eof_exc_in_callback(protocol) -> None:
     loop = asyncio.get_event_loop()
-    reader = streams.StreamReader(protocol, 2**18, loop=loop)
+    reader = streams.StreamReader(protocol, DEFAULT_CHUNK_SIZE, loop=loop)
 
     on_eof = mock.Mock()
     on_eof.side_effect = ValueError
@@ -1409,7 +1410,7 @@ async def test_on_eof_eof_is_set(protocol) -> None:
 
 async def test_on_eof_eof_is_set_exception(protocol) -> None:
     loop = asyncio.get_event_loop()
-    reader = streams.StreamReader(protocol, 2**18, loop=loop)
+    reader = streams.StreamReader(protocol, DEFAULT_CHUNK_SIZE, loop=loop)
     reader.feed_eof()
 
     on_eof = mock.Mock()
@@ -1455,7 +1456,7 @@ async def test_set_exception_cancelled(protocol) -> None:
 
 async def test_set_exception_eof_callbacks(protocol) -> None:
     loop = asyncio.get_event_loop()
-    reader = streams.StreamReader(protocol, 2**18, loop=loop)
+    reader = streams.StreamReader(protocol, DEFAULT_CHUNK_SIZE, loop=loop)
 
     on_eof = mock.Mock()
     reader.on_eof(on_eof)

--- a/tests/test_web_functional.py
+++ b/tests/test_web_functional.py
@@ -322,7 +322,28 @@ async def test_multipart(aiohttp_client) -> None:
     await resp.release()
 
 
-async def test_multipart_empty(aiohttp_client) -> None:
+async def test_multipart_client_max_size(aiohttp_client: AiohttpClient) -> None:
+    with multipart.MultipartWriter() as writer:
+        writer.append("A" * 1020)
+
+    async def handler(request: web.Request) -> web.Response:
+        reader = await request.multipart()
+        assert isinstance(reader, multipart.MultipartReader)
+
+        part = await reader.next()
+        assert isinstance(part, multipart.BodyPartReader)
+        await part.text()  # Should raise HttpRequestEntityTooLarge
+        assert False
+
+    app = web.Application(client_max_size=1000)
+    app.router.add_post("/", handler)
+    client = await aiohttp_client(app)
+
+    async with client.post("/", data=writer) as resp:
+        assert resp.status == 413
+
+
+async def test_multipart_empty(aiohttp_client: AiohttpClient) -> None:
     with multipart.MultipartWriter() as writer:
         pass
 
@@ -1698,12 +1719,9 @@ async def test_app_max_client_size(aiohttp_client) -> None:
         resp = await client.post("/", data=data)
     assert 413 == resp.status
     resp_text = await resp.text()
-    assert "Maximum request body size 1048576 exceeded, actual body size" in resp_text
-    # Maximum request body size X exceeded, actual body size X
-    body_size = int(resp_text.split()[-1])
-    assert body_size >= max_size
+    assert "Maximum request body size 1048576 exceeded" in resp_text
 
-    await resp.release()
+    resp.release()
 
 
 async def test_app_max_client_size_adjusted(aiohttp_client: AiohttpClient) -> None:
@@ -1730,10 +1748,7 @@ async def test_app_max_client_size_adjusted(aiohttp_client: AiohttpClient) -> No
         resp = await client.post("/", data=too_large_data)
     assert 413 == resp.status
     resp_text = await resp.text()
-    assert "Maximum request body size 2097152 exceeded, actual body size" in resp_text
-    # Maximum request body size X exceeded, actual body size X
-    body_size = int(resp_text.split()[-1])
-    assert body_size >= custom_max_size
+    assert "Maximum request body size 2097152 exceeded" in resp_text
 
     await resp.release()
 
@@ -1781,11 +1796,10 @@ async def test_post_max_client_size(aiohttp_client) -> None:
 
         assert 413 == resp.status
         resp_text = await resp.text()
-        assert (
-            "Maximum request body size 10 exceeded, "
-            "actual body size 1024" in resp_text
-        )
-        data["file"].close()
+        assert "Maximum request body size 10 exceeded" in resp_text
+        data_file = data["file"]
+        assert isinstance(data_file, io.BytesIO)
+        data_file.close()
 
         await resp.release()
 

--- a/tests/test_web_protocol.py
+++ b/tests/test_web_protocol.py
@@ -1,48 +1,50 @@
 import asyncio
-from typing import Any, cast
 from unittest import mock
 
+import pytest
+
+from aiohttp.http import WebSocketReader
 from aiohttp.web_protocol import RequestHandler
+from aiohttp.web_server import Server
 
 
-class _DummyManager:
-    def __init__(self) -> None:
-        self.request_handler = mock.Mock()
-        self.request_factory = mock.Mock()
+@pytest.fixture
+def dummy_manager() -> Server:
+    return mock.create_autospec(Server, request_handler=mock.Mock(), request_factory=mock.Mock(), instance=True)  # type: ignore[no-any-return]
 
 
-class _DummyParser:
-    def __init__(self) -> None:
-        self.received: list[bytes] = []
-
-    def feed_data(self, data: bytes) -> tuple[bool, bytes]:
-        self.received.append(data)
-        return False, b""
+@pytest.fixture
+def dummy_reader() -> tuple[WebSocketReader, mock.Mock]:
+    m = mock.create_autospec(WebSocketReader, spec_set=True, instance=True)
+    m.feed_data.return_value = False, b""
+    return m, m
 
 
 def test_set_parser_does_not_call_data_received_cb_for_tail(
     loop: asyncio.AbstractEventLoop,
+    dummy_manager: Server,
+    dummy_reader: tuple[WebSocketReader, mock.Mock],
 ) -> None:
-    handler: RequestHandler[Any] = RequestHandler(cast(Any, _DummyManager()), loop=loop)
+    handler = RequestHandler(dummy_manager, loop=loop)
     handler._message_tail = b"tail"
     cb = mock.Mock()
-    parser = _DummyParser()
 
-    handler.set_parser(parser, data_received_cb=cb)
+    handler.set_parser(dummy_reader[0], data_received_cb=cb)
 
     cb.assert_not_called()
-    assert parser.received == [b"tail"]
+    dummy_reader[1].feed_data.assert_called_once_with(b"tail")
 
 
 def test_data_received_calls_data_received_cb(
     loop: asyncio.AbstractEventLoop,
+    dummy_manager: Server,
+    dummy_reader: tuple[WebSocketReader, mock.Mock],
 ) -> None:
-    handler: RequestHandler[Any] = RequestHandler(cast(Any, _DummyManager()), loop=loop)
+    handler = RequestHandler(dummy_manager, loop=loop)
     cb = mock.Mock()
-    parser = _DummyParser()
 
-    handler.set_parser(parser, data_received_cb=cb)
+    handler.set_parser(dummy_reader[0], data_received_cb=cb)
     handler.data_received(b"x")
 
-    assert cb.call_count == 1
-    assert parser.received == [b"x"]
+    cb.assert_called_once()
+    dummy_reader[1].feed_data.assert_called_once_with(b"x")

--- a/tests/test_web_request.py
+++ b/tests/test_web_request.py
@@ -876,8 +876,8 @@ def test_clone_headers_dict() -> None:
     assert req2.raw_headers == ((b"B", b"C"),)
 
 
-async def test_cannot_clone_after_read(protocol) -> None:
-    payload = StreamReader(protocol, 2**16, loop=asyncio.get_event_loop())
+async def test_cannot_clone_after_read(protocol: BaseProtocol) -> None:
+    payload = StreamReader(protocol, 2**18, loop=asyncio.get_event_loop())
     payload.feed_data(b"data")
     payload.feed_eof()
     req = make_mocked_request("GET", "/path", payload=payload)
@@ -899,7 +899,18 @@ async def test_make_too_big_request(protocol) -> None:
     assert err.value.status_code == 413
 
 
-async def test_make_too_big_request_adjust_limit(protocol) -> None:
+async def test_make_too_big_request_same_size_to_max(protocol: BaseProtocol) -> None:
+    payload = StreamReader(protocol, 2**16, loop=asyncio.get_event_loop())
+    large_file = 1024**2 * b"x"
+    payload.feed_data(large_file)
+    payload.feed_eof()
+    req = make_mocked_request("POST", "/", payload=payload)
+    resp_text = await req.read()
+
+    assert resp_text == large_file
+
+
+async def test_make_too_big_request_adjust_limit(protocol: BaseProtocol) -> None:
     payload = StreamReader(protocol, 2**16, loop=asyncio.get_event_loop())
     large_file = 1024**2 * b"x"
     too_large_file = large_file + b"x"
@@ -937,7 +948,7 @@ async def test_multipart_formdata(protocol) -> None:
 
 async def test_multipart_formdata_field_missing_name(protocol: BaseProtocol) -> None:
     # Ensure ValueError is raised when Content-Disposition has no name
-    payload = StreamReader(protocol, 2**16, loop=asyncio.get_event_loop())
+    payload = StreamReader(protocol, 2**18, loop=asyncio.get_event_loop())
     payload.feed_data(
         b"-----------------------------326931944431359\r\n"
         b"Content-Disposition: form-data\r\n"  # Missing name!
@@ -989,7 +1000,7 @@ async def test_multipart_formdata_headers_too_many(protocol: BaseProtocol) -> No
         b"--b--\r\n"
     )
     content_type = "multipart/form-data; boundary=b"
-    payload = StreamReader(protocol, 2**16, loop=asyncio.get_running_loop())
+    payload = StreamReader(protocol, 2**18, loop=asyncio.get_running_loop())
     payload.feed_data(body)
     payload.feed_eof()
     req = make_mocked_request(
@@ -1016,7 +1027,7 @@ async def test_multipart_formdata_header_too_long(protocol: BaseProtocol) -> Non
         b"--b--\r\n"
     )
     content_type = "multipart/form-data; boundary=b"
-    payload = StreamReader(protocol, 2**16, loop=asyncio.get_running_loop())
+    payload = StreamReader(protocol, 2**18, loop=asyncio.get_running_loop())
     payload.feed_data(body)
     payload.feed_eof()
     req = make_mocked_request(

--- a/tests/test_web_request.py
+++ b/tests/test_web_request.py
@@ -14,6 +14,7 @@ from yarl import URL
 
 from aiohttp import HttpVersion
 from aiohttp.base_protocol import BaseProtocol
+from aiohttp.helpers import DEFAULT_CHUNK_SIZE
 from aiohttp.http_exceptions import BadHttpMessage, LineTooLong
 from aiohttp.http_parser import RawRequestMessage
 from aiohttp.streams import StreamReader
@@ -877,7 +878,7 @@ def test_clone_headers_dict() -> None:
 
 
 async def test_cannot_clone_after_read(protocol: BaseProtocol) -> None:
-    payload = StreamReader(protocol, 2**18, loop=asyncio.get_event_loop())
+    payload = StreamReader(protocol, DEFAULT_CHUNK_SIZE, loop=asyncio.get_event_loop())
     payload.feed_data(b"data")
     payload.feed_eof()
     req = make_mocked_request("GET", "/path", payload=payload)
@@ -948,7 +949,7 @@ async def test_multipart_formdata(protocol) -> None:
 
 async def test_multipart_formdata_field_missing_name(protocol: BaseProtocol) -> None:
     # Ensure ValueError is raised when Content-Disposition has no name
-    payload = StreamReader(protocol, 2**18, loop=asyncio.get_event_loop())
+    payload = StreamReader(protocol, DEFAULT_CHUNK_SIZE, loop=asyncio.get_event_loop())
     payload.feed_data(
         b"-----------------------------326931944431359\r\n"
         b"Content-Disposition: form-data\r\n"  # Missing name!
@@ -1000,7 +1001,9 @@ async def test_multipart_formdata_headers_too_many(protocol: BaseProtocol) -> No
         b"--b--\r\n"
     )
     content_type = "multipart/form-data; boundary=b"
-    payload = StreamReader(protocol, 2**18, loop=asyncio.get_running_loop())
+    payload = StreamReader(
+        protocol, DEFAULT_CHUNK_SIZE, loop=asyncio.get_running_loop()
+    )
     payload.feed_data(body)
     payload.feed_eof()
     req = make_mocked_request(
@@ -1027,7 +1030,9 @@ async def test_multipart_formdata_header_too_long(protocol: BaseProtocol) -> Non
         b"--b--\r\n"
     )
     content_type = "multipart/form-data; boundary=b"
-    payload = StreamReader(protocol, 2**18, loop=asyncio.get_running_loop())
+    payload = StreamReader(
+        protocol, DEFAULT_CHUNK_SIZE, loop=asyncio.get_running_loop()
+    )
     payload.feed_data(body)
     payload.feed_eof()
     req = make_mocked_request(

--- a/tests/test_web_response.py
+++ b/tests/test_web_response.py
@@ -585,26 +585,6 @@ async def test_force_compression_deflate() -> None:
 
 
 @pytest.mark.usefixtures("parametrize_zlib_backend")
-async def test_force_compression_deflate_large_payload() -> None:
-    """Make sure a warning is thrown for large payloads compressed in the event loop."""
-    req = make_request(
-        "GET", "/", headers=CIMultiDict({hdrs.ACCEPT_ENCODING: "gzip, deflate"})
-    )
-    resp = Response(body=b"large")
-
-    resp.enable_compression(ContentCoding.deflate)
-    assert resp.compression
-
-    with (
-        pytest.warns(Warning, match="Synchronous compression of large response bodies"),
-        mock.patch("aiohttp.web_response.LARGE_BODY_SIZE", 2),
-    ):
-        msg = await resp.prepare(req)
-        assert msg is not None
-    assert "deflate" == resp.headers.get(hdrs.CONTENT_ENCODING)
-
-
-@pytest.mark.usefixtures("parametrize_zlib_backend")
 async def test_force_compression_no_accept_deflate() -> None:
     req = make_request("GET", "/")
     resp = StreamResponse()

--- a/tests/test_web_server.py
+++ b/tests/test_web_server.py
@@ -1,14 +1,15 @@
 import asyncio
+import gc
 import socket
 from contextlib import suppress
-from typing import NoReturn
+from typing import Any, NoReturn
 from unittest import mock
 
 import pytest
 
 from aiohttp import client, web
 from aiohttp.http_exceptions import BadHttpMethod, BadStatusLine
-from aiohttp.pytest_plugin import AiohttpClient, AiohttpRawServer
+from aiohttp.pytest_plugin import AiohttpClient, AiohttpRawServer, AiohttpServer
 
 
 async def test_simple_server(aiohttp_raw_server, aiohttp_client) -> None:
@@ -417,3 +418,51 @@ async def test_no_handler_cancellation(unused_port_socket: socket.socket) -> Non
         assert done_event.is_set()
     finally:
         await asyncio.gather(runner.shutdown(), site.stop())
+
+
+async def test_no_future_warning_on_disconnect_during_backpressure(
+    aiohttp_server: AiohttpServer,
+) -> None:
+    loop = asyncio.get_running_loop()
+    exc_handler_calls: list[dict[str, Any]] = []
+    original_handler = loop.get_exception_handler()
+    loop.set_exception_handler(lambda _loop, ctx: exc_handler_calls.append(ctx))
+    protocol = None
+
+    async def handler(request: web.Request) -> NoReturn:
+        nonlocal protocol
+        protocol = request.protocol
+        resp = web.StreamResponse()
+        await resp.prepare(request)
+        while True:
+            await resp.write(b"x" * 65536)
+
+    app = web.Application()
+    app.router.add_route("GET", "/", handler)
+    # aiohttp_server enables handler_cancellation by default so the handler
+    # task is cancelled when connection_lost() fires.
+    server = await aiohttp_server(app)
+
+    # Open a raw asyncio connection so we control exactly when the client
+    # side closes.
+    reader, writer = await asyncio.open_connection(server.host, server.port)
+    writer.write(b"GET / HTTP/1.1\r\nHost: localhost\r\n\r\n")
+    await writer.drain()
+
+    try:
+        # Poll until the server protocol reports that writing is paused.
+        async def wait_for_backpressure() -> None:
+            while protocol is None or not protocol.writing_paused:
+                await asyncio.sleep(0.01)
+
+        await asyncio.wait_for(wait_for_backpressure(), timeout=5.0)
+
+        writer.close()
+        await asyncio.sleep(0.1)
+
+        gc.collect()
+        await asyncio.sleep(0)
+    finally:
+        loop.set_exception_handler(original_handler)
+
+    assert not exc_handler_calls

--- a/tests/test_web_urldispatcher.py
+++ b/tests/test_web_urldispatcher.py
@@ -249,7 +249,7 @@ async def test_follow_symlink_directory_traversal(
     # We need to use a raw socket to test this, as the client will normalize
     # the path before sending it to the server.
     reader, writer = await asyncio.open_connection(client.host, client.port)
-    writer.write(b"GET /../private_file HTTP/1.1\r\n\r\n")
+    writer.write(b"GET /../private_file HTTP/1.1\r\nHost: a\r\n\r\n")
     response = await reader.readuntil(b"\r\n\r\n")
     assert b"404 Not Found" in response
     writer.close()
@@ -301,14 +301,14 @@ async def test_follow_symlink_directory_traversal_after_normalization(
     # We need to use a raw socket to test this, as the client will normalize
     # the path before sending it to the server.
     reader, writer = await asyncio.open_connection(client.host, client.port)
-    writer.write(b"GET /my_symlink/../private_file HTTP/1.1\r\n\r\n")
+    writer.write(b"GET /my_symlink/../private_file HTTP/1.1\r\nHost: a\r\n\r\n")
     response = await reader.readuntil(b"\r\n\r\n")
     assert b"404 Not Found" in response
     writer.close()
     await writer.wait_closed()
 
     reader, writer = await asyncio.open_connection(client.host, client.port)
-    writer.write(b"GET /my_symlink/symlink_target_file HTTP/1.1\r\n\r\n")
+    writer.write(b"GET /my_symlink/symlink_target_file HTTP/1.1\r\nHost: a\r\n\r\n")
     response = await reader.readuntil(b"\r\n\r\n")
     assert b"200 OK" in response
     response = await reader.readuntil(b"readable")

--- a/tests/test_websocket_parser.py
+++ b/tests/test_websocket_parser.py
@@ -19,7 +19,7 @@ from aiohttp._websocket.models import WS_DEFLATE_TRAILING
 from aiohttp._websocket.reader import WebSocketDataQueue
 from aiohttp.base_protocol import BaseProtocol
 from aiohttp.compression_utils import ZLibBackend
-from aiohttp.http import WebSocketError, WSCloseCode, WSMessage, WSMsgType
+from aiohttp.http import HttpParser, WebSocketError, WSCloseCode, WSMessage, WSMsgType
 from aiohttp.http_websocket import WebSocketReader
 
 
@@ -106,8 +106,9 @@ def build_close_frame(code=1000, message=b"", noheader=False):
 
 @pytest.fixture()
 def protocol(loop: asyncio.AbstractEventLoop) -> BaseProtocol:
+    parser = mock.create_autospec(HttpParser, spec_set=True, instance=True)
     transport = mock.Mock(spec_set=asyncio.Transport)
-    protocol = BaseProtocol(loop)
+    protocol = BaseProtocol(loop, parser=parser)
     protocol.connection_made(transport)
     return protocol
 

--- a/tests/test_websocket_writer.py
+++ b/tests/test_websocket_writer.py
@@ -12,6 +12,7 @@ from aiohttp import WSMsgType
 from aiohttp._websocket.reader import WebSocketDataQueue
 from aiohttp.base_protocol import BaseProtocol
 from aiohttp.compression_utils import ZLibBackend
+from aiohttp.helpers import DEFAULT_CHUNK_SIZE
 from aiohttp.http import WebSocketReader, WebSocketWriter
 
 
@@ -152,7 +153,9 @@ async def test_send_compress_cancelled(
     monkeypatch.setattr("aiohttp._websocket.writer.WEBSOCKET_MAX_SYNC_CHUNK_SIZE", 1024)
     writer = WebSocketWriter(protocol, transport, compress=15)
     loop = asyncio.get_running_loop()
-    queue = WebSocketDataQueue(mock.Mock(_reading_paused=False), 2**18, loop=loop)
+    queue = WebSocketDataQueue(
+        mock.Mock(_reading_paused=False), DEFAULT_CHUNK_SIZE, loop=loop
+    )
     reader = WebSocketReader(queue, 50000)
 
     # Replace executor with slow one to make race condition reproducible
@@ -299,7 +302,9 @@ async def test_concurrent_messages(
     ):
         writer = WebSocketWriter(protocol, transport, compress=15)
         loop = asyncio.get_running_loop()
-        queue = WebSocketDataQueue(mock.Mock(_reading_paused=False), 2**18, loop=loop)
+        queue = WebSocketDataQueue(
+            mock.Mock(_reading_paused=False), DEFAULT_CHUNK_SIZE, loop=loop
+        )
         reader = WebSocketReader(queue, 50000)
         writers = []
         payloads = []

--- a/tests/test_websocket_writer.py
+++ b/tests/test_websocket_writer.py
@@ -152,7 +152,7 @@ async def test_send_compress_cancelled(
     monkeypatch.setattr("aiohttp._websocket.writer.WEBSOCKET_MAX_SYNC_CHUNK_SIZE", 1024)
     writer = WebSocketWriter(protocol, transport, compress=15)
     loop = asyncio.get_running_loop()
-    queue = WebSocketDataQueue(mock.Mock(_reading_paused=False), 2**16, loop=loop)
+    queue = WebSocketDataQueue(mock.Mock(_reading_paused=False), 2**18, loop=loop)
     reader = WebSocketReader(queue, 50000)
 
     # Replace executor with slow one to make race condition reproducible
@@ -299,7 +299,7 @@ async def test_concurrent_messages(
     ):
         writer = WebSocketWriter(protocol, transport, compress=15)
         loop = asyncio.get_running_loop()
-        queue = WebSocketDataQueue(mock.Mock(_reading_paused=False), 2**16, loop=loop)
+        queue = WebSocketDataQueue(mock.Mock(_reading_paused=False), 2**18, loop=loop)
         reader = WebSocketReader(queue, 50000)
         writers = []
         payloads = []


### PR DESCRIPTION
Backport of #12385 to 3.14.

Applies the same Content-Length validation logic.

Conflicts were resolved by adapting the patch to the 3.14 codebase without changing behavior.