### PR TITLE
[3.14] Validate Content-Length format in ClientRequest (backport of #12385)

### DIFF
--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -905,9 +905,7 @@ class ClientRequest:
 
         content_length_hdr = self.headers[hdrs.CONTENT_LENGTH]
         if not _DIGITS_RE.fullmatch(content_length_hdr):
-            raise ValueError(
-                f"Invalid Content-Length header: {content_length_hdr!r}"
-            )
+            raise ValueError(f"Invalid Content-Length header: {content_length_hdr!r}")
         return int(content_length_hdr)
 
     @property

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -87,6 +87,7 @@ if TYPE_CHECKING:
 _CONNECTION_CLOSED_EXCEPTION = ClientConnectionError("Connection closed")
 _CONTAINS_CONTROL_CHAR_RE = re.compile(r"[^-!#$%&'*+.^_`|~0-9a-zA-Z]")
 json_re = re.compile(r"^application/(?:[\w.+-]+?\+)?json")
+_DIGITS_RE = re.compile(r"\d+", re.ASCII)
 
 
 def _gen_default_accept_encoding() -> str:
@@ -903,12 +904,11 @@ class ClientRequest:
             return None
 
         content_length_hdr = self.headers[hdrs.CONTENT_LENGTH]
-        try:
-            return int(content_length_hdr)
-        except ValueError:
+        if not _DIGITS_RE.fullmatch(content_length_hdr):
             raise ValueError(
-                f"Invalid Content-Length header: {content_length_hdr}"
-            ) from None
+                f"Invalid Content-Length header: {content_length_hdr!r}"
+            )
+        return int(content_length_hdr)
 
     @property
     def skip_auto_headers(self) -> CIMultiDict[None]:

--- a/tests/test_client_request.py
+++ b/tests/test_client_request.py
@@ -1667,7 +1667,24 @@ def test_get_content_length(make_request: _RequestMaker) -> None:
 
     # Invalid Content-Length header
     req.headers["Content-Length"] = "invalid"
-    with pytest.raises(ValueError, match="Invalid Content-Length header: invalid"):
+    with pytest.raises(ValueError, match="Invalid Content-Length header"):
+        req._get_content_length()
+
+
+async def test_get_content_length_invalid_formats(
+    make_request: _RequestMaker,
+) -> None:
+    req = make_request("GET", URL("http://python.org/"))
+
+    req.headers["Content-Length"] = "100"
+    assert req._get_content_length() == 100
+
+    req.headers["Content-Length"] = "-100"
+    with pytest.raises(ValueError, match="Invalid Content-Length header"):
+        req._get_content_length()
+
+    req.headers["Content-Length"] = "५"  # Devengali number 5
+    with pytest.raises(ValueError, match="Invalid Content-Length header"):
         req._get_content_length()
 
 


### PR DESCRIPTION
Backport of #12385 to 3.14.

Applies the same Content-Length validation logic.

Conflicts were resolved by adapting the patch to the 3.14 codebase without changing behavior.