### PR TITLE
fix: Improve error message for HTTPS on HTTP port

### DIFF
--- a/CHANGES/10142.bugfix.rst
+++ b/CHANGES/10142.bugfix.rst
@@ -1,0 +1,1 @@
+Improved error message for HTTPS requests sent to an HTTP port by detecting the TLS handshake bytes. -- by :user:`NIK-TIGER-BILL`.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -282,8 +282,8 @@ Morgan Delahaye-Prat
 Moss Collum
 Mun Gwan-gyeong
 Navid Sheikhol
-NIK-TIGER-BILL
 Nicolas Braem
+NIK-TIGER-BILL
 Nikolay Kim
 Nikolay Novik
 Nikolay Tiunov

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -282,6 +282,7 @@ Morgan Delahaye-Prat
 Moss Collum
 Mun Gwan-gyeong
 Navid Sheikhol
+NIK-TIGER-BILL
 Nicolas Braem
 Nikolay Kim
 Nikolay Novik

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -577,6 +577,18 @@ class HttpRequestParser(HttpParser[RawRequestMessage]):
     def parse_message(self, lines: list[bytes]) -> RawRequestMessage:
         # request line
         line = lines[0].decode("utf-8", "surrogateescape")
+        if lines[0].startswith(b"\x16\x03"):
+            raise BadHttpMethod(
+                line,
+                error="Client appears to be trying to connect via HTTPS to an HTTP port",
+            )
+
+        if lines[0].startswith(b"\x16\x03"):
+            raise BadHttpMethod(
+                line,
+                error="Client appears to be trying to connect via HTTPS to an HTTP port",
+            )
+
         try:
             method, path, version = line.split(" ", maxsplit=2)
         except ValueError:

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -1170,6 +1170,22 @@ def test_http_request_parser_bad_method(
         parser.feed_data(rfc9110_5_6_2_token_delim + b'ET" /get HTTP/1.1\r\n\r\n')
 
 
+def test_http_request_parser_bad_method_https_on_http_port(
+    parser: HttpRequestParser,
+) -> None:
+    with pytest.raises(http_exceptions.BadHttpMethod) as exc_info:
+        parser.feed_data(b"\x16\x03\x01\x00\xa5\x01\x00\x00\xa1\x03\x03")
+    assert "HTTPS" in str(exc_info.value)
+
+
+def test_http_request_parser_bad_method_https_on_http_port(
+    parser: HttpRequestParser,
+) -> None:
+    with pytest.raises(http_exceptions.BadHttpMethod) as exc_info:
+        parser.feed_data(b"\x16\x03\x01\x00\xa5\x01\x00\x00\xa1\x03\x03")
+    assert "HTTPS" in str(exc_info.value)
+
+
 def test_http_request_parser_bad_version(parser: HttpRequestParser) -> None:
     with pytest.raises(http_exceptions.BadHttpMessage):
         parser.feed_data(b"GET //get HT/11\r\n\r\n")


### PR DESCRIPTION
## What do these changes do?

Improved the error message in `HttpRequestParser` when a client sends TLS handshake bytes (`\x16\x03`) to an HTTP port. Previously, this produced a generic `Bad HTTP method` error which was confusing for users. Now it raises a clear `BadHttpMethod` explaining that the client appears to be trying to connect via HTTPS to an HTTP port.

## Are there changes in behavior for the user?

Yes — the error message for this very common misconfiguration is now self-explanatory. No API changes.

## Is it a substantial burden for the maintainers to support this?

No. The change is a single early-exit check in the parser with an accompanying unit test.

## Related issue number

Fixes #10142

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes (news fragment added)
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
- [x] Add a new news fragment into the `CHANGES/` folder