### PR TITLE
Normalize multiple Transfer-Encoding headers before chunked detection

### DIFF
--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -584,8 +584,11 @@ class HttpParser(abc.ABC, Generic[_MsgT]):
             encoding = enc
 
         # chunking
-        te = headers.get(hdrs.TRANSFER_ENCODING)
-        if te is not None:
+        te_values = headers.getall(hdrs.TRANSFER_ENCODING, ())
+        if te_values:
+            # RFC 9110 §5.3: Multiple header fields are equivalent to a single
+            # comma-separated value. Normalize before determining message framing.
+            te = ",".join(v.strip() for v in te_values)
             if self._is_chunked_te(te):
                 chunked = True
 

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -399,6 +399,25 @@ def test_duplicate_singleton_header_accepted_in_lax_mode(
     assert len(messages) == 1
 
 
+async def test_response_te_split_headers_chunked(
+    response: HttpResponseParser,
+) -> None:
+    text = (
+        b"HTTP/1.1 200 OK\r\n"
+        b"Transfer-Encoding: gzip\r\n"
+        b"Transfer-Encoding: chunked\r\n"
+        b"\r\n"
+        b"4\r\nWiki\r\n0\r\n\r\n"
+        b"HTTP/1.1 204 No Content\r\n\r\n"
+    )
+    messages, upgrade, tail = response.feed_data(text)
+    assert len(messages) == 2
+    msg1, payload1 = messages[0]
+    assert msg1.chunked
+    assert await payload1.read() == b"Wiki"
+    assert messages[1][0].code == 204
+
+
 def test_duplicate_host_header_rejected(parser: HttpRequestParser) -> None:
     text = (
         b"GET /admin HTTP/1.1\r\n"


### PR DESCRIPTION
## Summary

Normalize multiple `Transfer-Encoding` headers into a single comma-separated value before chunked detection.

* * *

## Motivation

RFC 9110 §5.3 defines that multiple header fields are equivalent to a single comma-separated value. This makes the parser behavior explicit and consistent with the RFC.

* * *

## Changes

*   Use `headers.getall(...)` for `Transfer-Encoding`
*   Join values before evaluating chunked encoding
*   No change to existing parsing logic

* * *

## Test

Add test covering split `Transfer-Encoding` headers (`gzip` + `chunked`) and verifying correct parsing of multiple responses.

***

## What do these changes do?

Normalize multiple `Transfer-Encoding` headers into a single comma-separated value before evaluating chunked encoding, in line with RFC 9110 §5.3.

* * *

## Are there changes in behavior for the user?

No.  
This makes header handling explicit and consistent without changing observable behavior.

* * *

## Is it a substantial burden for the maintainers to support this?

No.  
The change is small, self-contained, and limited to parsing normalization. It does not introduce new APIs or complexity.

* * *

## Related issue number

N/A

* * *

## Checklist 

*   [x]  I think the code is well written
*   [x]  Unit tests for the changes exist
*   [ ]  Documentation reflects the changes
*   [ ]  If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
*   [ ]  Add a new news fragment into the `CHANGES/` folder (`.misc`)