### PR TITLE
Fix BodyPartReader.read() returning bytearray instead of bytes

### DIFF
--- a/aiohttp/multipart.py
+++ b/aiohttp/multipart.py
@@ -322,8 +322,8 @@ class BodyPartReader:
                 decoded_data.extend(d)
                 if len(decoded_data) > self._client_max_size:
                     raise self._max_size_error_cls(self._client_max_size)
-            return decoded_data
-        return data
+            return bytes(decoded_data)
+        return bytes(data)
 
     async def read_chunk(self, size: int = chunk_size) -> bytes:
         """Reads body part content chunk of the specified size.


### PR DESCRIPTION
BodyPartReader.read() was returning the internal bytearray buffer directly instead of bytes, violating the annotated return type of `bytes`.

This caused `TypeError: Object of type bytearray is not JSON serializable` when downstream code (like `json.dump`) tried to serialize the value.

The fix wraps the return values with `bytes()` to match the annotated return type.

Fixes #12404