### PR TITLE
Fix BodyPartReader.read() returning bytearray instead of bytes

### DIFF
--- a/CHANGES/12404.bugfix.rst
+++ b/CHANGES/12404.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed :meth:`aiohttp.BodyPartReader.read` returning :class:`bytearray` instead of :class:`bytes`, violating the documented API contract and breaking JSON serialization of multipart body parts -- by :user:`terminalchai`.

--- a/aiohttp/multipart.py
+++ b/aiohttp/multipart.py
@@ -322,8 +322,8 @@ class BodyPartReader:
                 decoded_data.extend(d)
                 if len(decoded_data) > self._client_max_size:
                     raise self._max_size_error_cls(self._client_max_size)
-            return decoded_data
-        return data
+            return bytes(decoded_data)
+        return bytes(data)
 
     async def read_chunk(self, size: int = chunk_size) -> bytes:
         """Reads body part content chunk of the specified size.

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -185,6 +185,22 @@ class TestPartReader:
             assert b"Hello, world!" == result
             assert obj.at_eof()
 
+    async def test_read_returns_bytes_not_bytearray(self) -> None:
+        # Regression test for #12404 - read() was returning bytearray
+        with Stream(b"Hello, world!\r\n--:") as stream:
+            d = CIMultiDictProxy[str](CIMultiDict())
+            obj = aiohttp.BodyPartReader(BOUNDARY, d, stream)
+            result = await obj.read()
+            assert isinstance(result, bytes), f"Expected bytes, got {type(result)}"
+
+    async def test_read_decode_returns_bytes_not_bytearray(self) -> None:
+        # Regression test for #12404 - read(decode=True) was returning bytearray
+        with Stream(b"Hello, world!\r\n--:") as stream:
+            d = CIMultiDictProxy[str](CIMultiDict())
+            obj = aiohttp.BodyPartReader(BOUNDARY, d, stream)
+            result = await obj.read(decode=True)
+            assert isinstance(result, bytes), f"Expected bytes, got {type(result)}"
+
     async def test_read_chunk_at_eof(self) -> None:
         with Stream(b"--:") as stream:
             d = CIMultiDictProxy[str](CIMultiDict())


### PR DESCRIPTION
## Problem

`BodyPartReader.read()` accumulates data into a `bytearray` internally but returns it directly without converting to `bytes`, violating the documented return type.

This affects both code paths in `read()`:
- `decode=False`: returns the raw `bytearray` accumulation
- `decode=True`: returns the decoded `bytearray` accumulation

The result is a silent type error downstream. For example, trying to JSON-serialize the result fails:

```python
data = await part.read()
json.dumps({'content': data})
# TypeError: Object of type bytearray is not JSON serializable
```

Fixes #12404.

## Fix

Wrap both return values in `bytes()`:

```python
return bytes(result)
```

One-line change on each code path. Two regression tests added to `tests/test_multipart.py` covering both `decode=False` and `decode=True`.
