### PR TITLE
fix: BodyPartReader.read() now returns bytes instead of bytearray

### DIFF
--- a/CHANGES/12404.bugfix.rst
+++ b/CHANGES/12404.bugfix.rst
@@ -1,0 +1,3 @@
+Fixed ``BodyPartReader.read()`` returning ``bytearray`` instead of ``bytes``,
+which caused ``TypeError: Object of type bytearray is not JSON serializable``
+when the result was passed to ``json.dumps()`` -- by :user:`algojogacor`.

--- a/aiohttp/multipart.py
+++ b/aiohttp/multipart.py
@@ -329,8 +329,8 @@ class BodyPartReader:
                 decoded_data.extend(d)
                 if len(decoded_data) > self._client_max_size:
                     raise self._max_size_error_cls(self._client_max_size)
-            return decoded_data
-        return data
+            return bytes(decoded_data)
+        return bytes(data)
 
     async def read_chunk(self, size: int = chunk_size) -> bytes:
         """Reads body part content chunk of the specified size.


### PR DESCRIPTION
## What do these changes do?

Fix `BodyPartReader.read()` returning `bytearray` instead of `bytes`, which violates the method's return type annotation (`-> bytes`) and causes `TypeError: Object of type bytearray is not JSON serializable` when the result is passed to `json.dumps()`.

## Are there changes in behavior for the user?

Yes - `BodyPartReader.read()` now correctly returns `bytes` instead of `bytearray`. This is a bug fix that aligns the return type with the documented API contract.

## Related issue number

Fixes #12404

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] Add a new news fragment into the `CHANGES/` folder