### PR TITLE
Skip IPv6-only tests when IPv6 is unavailable

### DIFF
--- a/CHANGES/9891.contrib.rst
+++ b/CHANGES/9891.contrib.rst
@@ -1,0 +1,2 @@
+Skipped IPv6-only connector and test utility tests when the runtime does not support
+IPv6 -- by :user:`nightcityblade`.

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -53,6 +53,14 @@ if sys.version_info >= (3, 11):
 else:
     _RequestMaker = Any
 
+HAS_IPV6: bool = socket.has_ipv6
+if HAS_IPV6:  # pragma: no branch
+    try:
+        with socket.socket(socket.AF_INET6, socket.SOCK_STREAM):
+            pass
+    except OSError:  # pragma: no cover
+        HAS_IPV6 = False
+
 
 @pytest.fixture
 def key() -> ConnectionKey:
@@ -887,6 +895,7 @@ async def test_tcp_connector_multiple_hosts_errors(
     await conn.close()
 
 
+@pytest.mark.skipif(not HAS_IPV6, reason="IPv6 is not available")
 @pytest.mark.parametrize(
     ("happy_eyeballs_delay"),
     [0.1, 0.25, None],
@@ -979,6 +988,7 @@ async def test_tcp_connector_happy_eyeballs(  # type: ignore[misc]
     await conn.close()
 
 
+@pytest.mark.skipif(not HAS_IPV6, reason="IPv6 is not available")
 async def test_tcp_connector_interleave(make_client_request: _RequestMaker) -> None:
     loop = asyncio.get_running_loop()
     conn = aiohttp.TCPConnector(interleave=2)

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -989,7 +989,7 @@ async def test_tcp_connector_happy_eyeballs(  # type: ignore[misc]
 
 
 @pytest.mark.skipif(not HAS_IPV6, reason="IPv6 is not available")
-async def test_tcp_connector_interleave(make_client_request: _RequestMaker) -> None:
+async def test_tcp_connector_interleave(make_client_request: _RequestMaker) -> None:  # type: ignore[misc]
     loop = asyncio.get_running_loop()
     conn = aiohttp.TCPConnector(interleave=2)
 

--- a/tests/test_test_utils.py
+++ b/tests/test_test_utils.py
@@ -26,6 +26,14 @@ from aiohttp.test_utils import (
 if sys.version_info >= (3, 11):
     from typing import assert_type
 
+HAS_IPV6: bool = socket.has_ipv6
+if HAS_IPV6:  # pragma: no branch
+    try:
+        with socket.socket(socket.AF_INET6, socket.SOCK_STREAM):
+            pass
+    except OSError:  # pragma: no cover
+        HAS_IPV6 = False
+
 _TestClient = TestClient[web.Request, web.Application]
 
 _hello_world_str = "Hello, world"
@@ -368,7 +376,15 @@ async def test_custom_port(
 
 @pytest.mark.parametrize(
     ("hostname", "expected_host"),
-    [("127.0.0.1", "127.0.0.1"), ("localhost", "127.0.0.1"), ("::1", "::1")],
+    [
+        ("127.0.0.1", "127.0.0.1"),
+        ("localhost", "127.0.0.1"),
+        pytest.param(
+            "::1",
+            "::1",
+            marks=pytest.mark.skipif(not HAS_IPV6, reason="IPv6 is not available"),
+        ),
+    ],
 )
 async def test_test_server_hostnames(hostname: str, expected_host: str) -> None:
     app = _create_example_app()


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Skips IPv6-specific connector and test utility cases when the runtime does not actually support IPv6, matching the existing `test_run_app.py` behavior.

## Are there changes in behavior for the user?

No user-facing behavior changes. This only affects the test suite on environments without IPv6 support.

## Is it a substantial burden for the maintainers to support this?

No. The change is limited to test skip markers and reuses the same IPv6 availability check already used elsewhere in the test suite.

## Related issue number

Fixes #9891

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * Already listed as `Shensheng Shen`.
- [x] Add a new news fragment into the `CHANGES/` folder
