### PR TITLE
fix: duplicated "on" in cookiejar.py comment

### DIFF
--- a/aiohttp/cookiejar.py
+++ b/aiohttp/cookiejar.py
@@ -374,7 +374,7 @@ class CookieJar(AbstractCookieJar):
             )
             request_url = URL(request_url)
         # We always use BaseCookie now since all
-        # cookies set on on filtered are fully constructed
+        # cookies set on filtered are fully constructed
         # Morsels, not just names and values.
         filtered: BaseCookie[str] = BaseCookie()
         if not self._cookies:


### PR DESCRIPTION
One-line typo fix in `aiohttp/cookiejar.py`: "# cookies set on on filtered are fully constructed" → "# cookies set on filtered are fully constructed". No code/behavior change.