### PR TITLE
feat: add on_response_headers_received signal to TraceConfig

### DIFF
--- a/CHANGES/7386.feature.rst
+++ b/CHANGES/7386.feature.rst
@@ -1,0 +1,1 @@
+Added on_response_headers_received signal to TraceConfig, allowing users to trace response headers as soon as they are received from the server.

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -11,7 +11,7 @@ from collections.abc import Callable, Iterable, Sequence
 from hashlib import md5, sha1, sha256
 from http.cookies import BaseCookie, SimpleCookie
 from types import MappingProxyType, TracebackType
-from typing import TYPE_CHECKING, Any, Literal, NamedTuple, TypedDict
+from typing import TYPE_CHECKING, Any, Literal, NamedTuple, TypedDict, cast
 
 from multidict import CIMultiDict, CIMultiDictProxy, MultiDict, MultiDictProxy
 from yarl import URL, Query
@@ -464,7 +464,7 @@ class ClientResponse(HeadersMixin):
         if self._traces:
             for trace in self._traces:
                 await trace.send_response_headers_received(
-                    self.method, self.url, CIMultiDictProxy(self._headers)
+                    self.method, self.url, cast(CIMultiDictProxy[str], self._headers)
                 )
 
         # payload

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -464,7 +464,7 @@ class ClientResponse(HeadersMixin):
         if self._traces:
             for trace in self._traces:
                 await trace.send_response_headers_received(
-                    self.method, self.url, self._headers
+                    self.method, self.url, CIMultiDictProxy(self._headers)
                 )
 
         # payload

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -460,6 +460,13 @@ class ClientResponse(HeadersMixin):
         self._headers = message.headers
         self._raw_headers = message.raw_headers
 
+        # fire headers_received trace signal
+        if self._traces:
+            for trace in self._traces:
+                await trace.send_response_headers_received(
+                    self.method, self.url, self._headers
+                )
+
         # payload
         self.content = payload
 

--- a/aiohttp/tracing.py
+++ b/aiohttp/tracing.py
@@ -488,7 +488,7 @@ class Trace:
         )
 
     async def send_response_headers_received(
-        self, method: str, url: URL, headers: "CIMultiDict[str]"
+        self, method: str, url: URL, headers: "CIMultiDictProxy[str]"
     ) -> None:
         return await self._trace_config.on_response_headers_received.send(
             self._session,

--- a/aiohttp/tracing.py
+++ b/aiohttp/tracing.py
@@ -2,7 +2,7 @@ from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any, Generic, Protocol, TypeVar, overload
 
 from aiosignal import Signal
-from multidict import CIMultiDict
+from multidict import CIMultiDict, CIMultiDictProxy
 from yarl import URL
 
 from .client_reqrep import ClientResponse
@@ -30,6 +30,7 @@ __all__ = (
     "TraceRequestChunkSentParams",
     "TraceResponseChunkReceivedParams",
     "TraceRequestHeadersSentParams",
+    "TraceResponseHeadersReceivedParams",
 )
 
 _T = TypeVar("_T", covariant=True)
@@ -97,6 +98,9 @@ class TraceConfig(Generic[_T]):
         self._on_request_headers_sent: _TracingSignal[
             _T, TraceRequestHeadersSentParams
         ] = Signal(self)
+        self._on_response_headers_received: _TracingSignal[
+            _T, TraceResponseHeadersReceivedParams
+        ] = Signal(self)
 
         self._trace_config_ctx_factory: _Factory[_T] = trace_config_ctx_factory
 
@@ -121,6 +125,7 @@ class TraceConfig(Generic[_T]):
         self._on_dns_cache_hit.freeze()
         self._on_dns_cache_miss.freeze()
         self._on_request_headers_sent.freeze()
+        self._on_response_headers_received.freeze()
 
     @property
     def on_request_start(self) -> "_TracingSignal[_T, TraceRequestStartParams]":
@@ -209,6 +214,12 @@ class TraceConfig(Generic[_T]):
         self,
     ) -> "_TracingSignal[_T, TraceRequestHeadersSentParams]":
         return self._on_request_headers_sent
+
+    @property
+    def on_response_headers_received(
+        self,
+    ) -> "_TracingSignal[_T, TraceResponseHeadersReceivedParams]":
+        return self._on_response_headers_received
 
 
 @frozen_dataclass_decorator
@@ -328,6 +339,15 @@ class TraceRequestHeadersSentParams:
     method: str
     url: URL
     headers: "CIMultiDict[str]"
+
+
+@frozen_dataclass_decorator
+class TraceResponseHeadersReceivedParams:
+    """Parameters sent by the `on_response_headers_received` signal"""
+
+    method: str
+    url: URL
+    headers: "CIMultiDictProxy[str]"
 
 
 class Trace:
@@ -465,4 +485,13 @@ class Trace:
             self._session,
             self._trace_config_ctx,
             TraceRequestHeadersSentParams(method, url, headers),
+        )
+
+    async def send_response_headers_received(
+        self, method: str, url: URL, headers: "CIMultiDict[str]"
+    ) -> None:
+        return await self._trace_config.on_response_headers_received.send(
+            self._session,
+            self._trace_config_ctx,
+            TraceResponseHeadersReceivedParams(method, url, headers),
         )

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -26,6 +26,7 @@ from aiohttp.tracing import (
     TraceRequestRedirectParams,
     TraceRequestStartParams,
     TraceResponseChunkReceivedParams,
+    TraceResponseHeadersReceivedParams,
 )
 
 if sys.version_info >= (3, 11):
@@ -92,6 +93,7 @@ class TestTraceConfig:
         assert trace_config.on_dns_cache_hit.frozen
         assert trace_config.on_dns_cache_miss.frozen
         assert trace_config.on_request_headers_sent.frozen
+        assert trace_config.on_response_headers_received.frozen
 
 
 class TestTrace:
@@ -129,6 +131,11 @@ class TestTrace:
             ("dns_resolvehost_end", (Mock(),), TraceDnsResolveHostEndParams),
             ("dns_cache_hit", (Mock(),), TraceDnsCacheHitParams),
             ("dns_cache_miss", (Mock(),), TraceDnsCacheMissParams),
+            (
+                "response_headers_received",
+                (Mock(), Mock(), Mock()),
+                TraceResponseHeadersReceivedParams,
+            ),
         ],
     )
     async def test_send(  # type: ignore[misc]


### PR DESCRIPTION
Closes #7386

## Summary

Adds the missing `on_response_headers_received` signal to `TraceConfig`, allowing users to observe response headers as soon as they are parsed from the server — before the response body is consumed.

## Changes

- **`aiohttp/tracing.py`** — Added `TraceResponseHeadersReceivedParams` dataclass (`method`, `url`, `headers: CIMultiDictProxy[str]`), `on_response_headers_received` signal to `TraceConfig`, and `Trace.send_response_headers_received()` method
- **`aiohttp/client_reqrep.py`** — Fire the signal in `ClientResponse.start()` after headers are parsed, before payload is set
- **`tests/test_tracing.py`** — Added `TraceResponseHeadersReceivedParams` to freeze test + parametrized `test_send` coverage
- **`CHANGES/7386.feature.rst`** — Towncrier changelog fragment

## Signal firing point

Fires in `ClientResponse.start()` immediately after `self._headers = message.headers` is set, before `self.content = payload`. Subscribers receive the full parsed response headers (and status line) but no body bytes yet — symmetric to how `on_request_headers_sent` fires after request headers are written but before the body.