### PR TITLE
Add GitHub Action to validate issue/PR template compliance

### DIFF
--- a/.github/workflows/check-template.yml
+++ b/.github/workflows/check-template.yml
@@ -1,0 +1,250 @@
+name: Check Template
+
+on:
+  issues:
+    types: [opened, edited]
+  pull_request_target:
+    types: [opened, edited]
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  check-template:
+    name: Check Template
+    runs-on: ubuntu-latest
+    # Skip bots (dependabot, pre-commit-ci, etc.)
+    if: >-
+      (github.event.issue.user.type || 'User') != 'Bot'
+      && (github.event.pull_request.user.type || 'User') != 'Bot'
+    steps:
+      - name: Validate submission against template
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const isIssue = !!context.payload.issue && !context.payload.pull_request;
+            const isPR = !!context.payload.pull_request;
+            const item = isPR ? context.payload.pull_request : context.payload.issue;
+            const body = (item.body || '').trim();
+            const itemNumber = isPR
+              ? context.payload.pull_request.number
+              : context.payload.issue.number;
+
+            // --- Maintainer bypass ---
+            // If a maintainer has already triaged the item by applying
+            // a label, skip validation so human decisions are not overridden.
+            const bypassLabels = new Set([
+              'bot:chronographer:skip',
+              'backport:skip',
+            ]);
+            const currentLabels = (item.labels || []).map(l => l.name);
+            if (currentLabels.some(l => bypassLabels.has(l))) {
+              core.info('Maintainer bypass label found — skipping validation.');
+              return;
+            }
+
+            let problems = [];
+
+            if (isIssue) {
+              // --- Bug report (Issue Forms YAML) validation ---
+              // GitHub Issue Forms render `textarea` fields with
+              // `render: console` as fenced code blocks.  An unfilled
+              // field looks like:
+              //
+              //   ### Python Version
+              //
+              //   ```console
+              //   $ python --version
+              //   ```
+              //
+              // A properly filled field has extra lines between the
+              // command and the closing fence.
+
+              const versionChecks = [
+                {
+                  name: 'Python Version',
+                  regex: /### Python Version\s*```console\s*\$ python --version\s*```/,
+                },
+                {
+                  name: 'aiohttp Version',
+                  regex: /### aiohttp Version\s*```console\s*\$ python -m pip show aiohttp\s*```/,
+                },
+                {
+                  name: 'multidict Version',
+                  regex: /### multidict Version\s*```console\s*\$ python -m pip show multidict\s*```/,
+                },
+                {
+                  name: 'propcache Version',
+                  regex: /### propcache Version\s*```console\s*\$ python -m pip show propcache\s*```/,
+                },
+                {
+                  name: 'yarl Version',
+                  regex: /### yarl Version\s*```console\s*\$ python -m pip show yarl\s*```/,
+                },
+              ];
+
+              for (const { name, regex } of versionChecks) {
+                if (regex.test(body)) {
+                  problems.push(
+                    `The **${name}** field still contains only the default ` +
+                    `placeholder command. Please paste the actual output.`
+                  );
+                }
+              }
+
+              // Detect required textarea sections that are completely empty
+              // (heading followed immediately by the next heading).
+              const requiredSections = [
+                'Describe the bug',
+                'To Reproduce',
+                'Expected behavior',
+              ];
+              for (const section of requiredSections) {
+                const emptyPattern = new RegExp(
+                  `### ${section}\\s*(?:###|$)`
+                );
+                if (emptyPattern.test(body)) {
+                  problems.push(
+                    `The **${section}** section appears to be empty. ` +
+                    `Please provide the requested information.`
+                  );
+                }
+              }
+
+              // --- Legacy markdown template (ISSUE_TEMPLATE.md) ---
+              const oldTemplateBlank =
+                /## Long story short\s*(?:<!--[\s\S]*?-->\s*)*## Expected behaviour/;
+              if (oldTemplateBlank.test(body)) {
+                problems.push(
+                  'The **Long story short** section is empty. ' +
+                  'Please describe your problem.'
+                );
+              }
+            } else if (isPR) {
+              // --- Pull Request template validation ---
+
+              if (!body) {
+                problems.push(
+                  'The PR description is completely empty. ' +
+                  'Please use the provided PR template.'
+                );
+              } else {
+                if (!body.includes('## What do these changes do?')) {
+                  problems.push(
+                    'The PR description is missing the ' +
+                    '"What do these changes do?" section from the template.'
+                  );
+                }
+                if (!body.includes('## Checklist')) {
+                  problems.push(
+                    'The PR description is missing the ' +
+                    '"Checklist" section from the template.'
+                  );
+                }
+
+                // Detect a blank "What do these changes do?" section
+                // (only HTML comments between the heading and the next one).
+                const emptyBrief =
+                  /## What do these changes do\?\s*(?:<!--[\s\S]*?-->\s*)*## Are there changes in behavior for the user\?/;
+                if (emptyBrief.test(body)) {
+                  problems.push(
+                    'The **What do these changes do?** section is blank. ' +
+                    'Please describe your changes.'
+                  );
+                }
+              }
+
+              // --- Reject PRs opened from the fork's default branch ---
+              const head = context.payload.pull_request.head;
+              const base = context.payload.pull_request.base;
+              if (
+                head.repo.full_name !== base.repo.full_name
+                && head.ref === context.payload.repository.default_branch
+              ) {
+                problems.push(
+                  `This PR was opened from your fork's \`${head.ref}\` ` +
+                  `branch. Please create a dedicated feature branch instead ` +
+                  `(e.g. \`git checkout -b my-feature\`).`
+                );
+              }
+            }
+
+            if (problems.length === 0) {
+              core.info('Template validation passed.');
+              return;
+            }
+
+            // Build the comment
+            const itemType = isIssue ? 'issue' : 'pull request';
+            const lines = [
+              `👋 Thanks for your submission!`,
+              ``,
+              `However, it looks like the ${itemType} description does not ` +
+              `fully follow the expected template:`,
+              ``,
+              ...problems.map(p => `- ${p}`),
+              ``,
+              `Please update the description to address the above and ` +
+              `reopen the ${itemType}.`,
+            ];
+            const message = lines.join('\n');
+
+            // Apply a label for easier triage
+            const labelName = 'invalid';
+            try {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: itemNumber,
+                labels: [labelName],
+              });
+            } catch (e) {
+              core.warning(`Could not add label "${labelName}": ${e.message}`);
+            }
+
+            // Avoid duplicate bot comments on re-edits
+            const comments = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: itemNumber,
+            });
+            const botLogin = 'github-actions[bot]';
+            const existing = comments.data.find(
+              c => c.user.login === botLogin
+                && c.body.includes('does not fully follow the expected template')
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body: message,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: itemNumber,
+                body: message,
+              });
+            }
+
+            // Close the issue/PR
+            if (isIssue && item.state === 'open') {
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: itemNumber,
+                state: 'closed',
+                state_reason: 'not_planned',
+              });
+            } else if (isPR && item.state === 'open') {
+              await github.rest.pulls.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: itemNumber,
+                state: 'closed',
+              });
+            }

--- a/CHANGES/12541.contrib.rst
+++ b/CHANGES/12541.contrib.rst
@@ -1,0 +1,1 @@
+Added a GitHub Actions workflow to validate that issues and PRs follow the expected templates, closing non-compliant submissions with an explanatory comment -- by :user:`rodrigobnogueira`.


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
Adds a `Check Template` GitHub Actions workflow (`.github/workflows/check-template.yml`) that automatically validates issue and PR descriptions against the repository templates.

**For issues (bug reports):**
- Detects version fields left at the default placeholder (e.g. `$ python --version` with no actual output)
- Detects empty required sections (Describe the bug, To Reproduce, Expected behavior)
- Handles the legacy markdown issue template (`ISSUE_TEMPLATE.md`)

**For PRs:**
- Checks that the template sections are present ("What do these changes do?", "Checklist")
- Detects a blank "What do these changes do?" section
- Rejects PRs opened from the fork's default branch (inspired by [bdraco's suggestion](https://github.com/aio-libs/aiohttp/issues/12163#issuecomment-4318524174))

**When violations are found**, the workflow:
1. Applies the `invalid` label for triage
2. Posts an explanatory comment listing all problems
3. Closes the issue/PR

**Safeguards:**
- Skips bot-authored submissions (dependabot, pre-commit-ci, etc.)
- Avoids duplicate comments on re-edits (updates the existing comment instead)
- Maintainers can bypass validation by applying `bot:chronographer:skip` or `backport:skip` labels

**Prior validation on fork:**
- [Invalid issue — closed by bot](https://github.com/rodrigobnogueira/aiohttp/issues/1)
- [Valid issue — left open](https://github.com/rodrigobnogueira/aiohttp/issues/2)
- [Invalid PR — closed by bot](https://github.com/rodrigobnogueira/aiohttp/pull/3)
- [Valid PR — left open](https://github.com/rodrigobnogueira/aiohttp/pull/4)

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->
No changes to the library itself. This only affects the GitHub repository workflow for contributors: issues and PRs that do not follow the templates will now be automatically flagged and closed with a comment explaining what needs to be fixed.

## Is it a substantial burden for the maintainers to support this?

No — this is a standalone GitHub Actions workflow with no dependencies on the codebase. It can be disabled by simply deleting the file or adding a `workflow_dispatch` condition. The label-based bypass mechanism means maintainers can override it at any time.

## Related issue number

<!-- Will this resolve any open issues? -->
Fixes #12163

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
- [x] Add a new news fragment into the `CHANGES/` folder
