### PR TITLE
[3.14] Fix AppKey repr tests for collections.abc typing module change

### DIFF
--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -292,7 +292,7 @@ def test_appkey_repr_nonconcrete() -> None:
         assert repr(key) in (
             # pytest-xdist:
             "<AppKey(__channelexec__.key, type=collections.abc.Iterator[int])>",
-            "<AppKey(__main__.key, type=collections.Iterator[int])>",
+            "<AppKey(__main__.key, type=collections.abc.Iterator[int])>",
         )
 
 
@@ -308,7 +308,7 @@ def test_appkey_repr_annotated() -> None:
         assert repr(key) in (
             # pytest-xdist:
             "<AppKey(__channelexec__.key, type=collections.abc.Iterator[int])>",
-            "<AppKey(__main__.key, type=collections.Iterator[int])>",
+            "<AppKey(__main__.key, type=collections.abc.Iterator[int])>",
         )
 
 

--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -292,6 +292,7 @@ def test_appkey_repr_nonconcrete() -> None:
         assert repr(key) in (
             # pytest-xdist:
             "<AppKey(__channelexec__.key, type=collections.abc.Iterator[int])>",
+            "<AppKey(__main__.key, type=collections.Iterator[int])>",
             "<AppKey(__main__.key, type=collections.abc.Iterator[int])>",
         )
 
@@ -308,6 +309,7 @@ def test_appkey_repr_annotated() -> None:
         assert repr(key) in (
             # pytest-xdist:
             "<AppKey(__channelexec__.key, type=collections.abc.Iterator[int])>",
+            "<AppKey(__main__.key, type=collections.Iterator[int])>",
             "<AppKey(__main__.key, type=collections.abc.Iterator[int])>",
         )
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

`test_appkey_repr_nonconcrete` and `test_appkey_repr_annotated` still expected the legacy `collections.Iterator[int]` typing repr in the non-xdist case; newer versions use collections.abc, so the tests fail on every yarl PR run. This adds the new form to the accepted tuple while keeping the legacy form so older Python 3.10/3.11/3.12 patch releases that still produce the old repr also pass. `master` already expects the new form via #11600.

## Are there changes in behavior for the user?

No, it is a test only change.

## Is it a substantial burden for the maintainers to support this?

No.

## Related issue number

Fixes #12560

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES/` folder