### PR TITLE
Fix flakey middleware recursion tests by using server URL

### DIFF
--- a/CHANGES/12571.contrib.rst
+++ b/CHANGES/12571.contrib.rst
@@ -1,4 +1,4 @@
 Fixed two flakey ``test_middleware_uses_session_avoids_recursion_with_*`` tests
-that hardcoded ``localhost`` in the inner middleware request; they now target
+that hard coded ``localhost`` in the inner middleware request; they now target
 the bound server URL so happy eyeballs cannot pick an unbound address on
 Windows runners -- by :user:`bdraco`.

--- a/CHANGES/12571.contrib.rst
+++ b/CHANGES/12571.contrib.rst
@@ -1,0 +1,4 @@
+Fixed two flakey ``test_middleware_uses_session_avoids_recursion_with_*`` tests
+that hardcoded ``localhost`` in the inner middleware request; they now target
+the bound server URL so happy eyeballs cannot pick an unbound address on
+Windows runners -- by :user:`bdraco`.

--- a/tests/test_client_middleware.py
+++ b/tests/test_client_middleware.py
@@ -955,7 +955,7 @@ async def test_middleware_uses_session_avoids_recursion_with_path_check(
         if request.url.path != "/log":
             # Use the session from the request to make the logging call
             async with request.session.post(
-                f"http://localhost:{log_server.port}/log",
+                log_server.make_url("/log"),
                 json={"method": str(request.method), "url": str(request.url)},
             ) as resp:
                 assert resp.status == 200
@@ -1023,7 +1023,7 @@ async def test_middleware_uses_session_avoids_recursion_with_disabled_middleware
         # Use the session from the request to make the logging call
         # Disable middleware to avoid infinite recursion
         async with request.session.post(
-            f"http://localhost:{log_server.port}/log",
+            log_server.make_url("/log"),
             json={"method": str(request.method), "url": str(request.url)},
             middlewares=(),  # This prevents infinite recursion
         ) as resp:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

The two `test_middleware_uses_session_avoids_recursion_with_*` tests in `tests/test_client_middleware.py` post to the log server via a hard coded `f"http://localhost:{log_server.port}/log"` string. The `aiohttp_server` fixture binds to `127.0.0.1`, but on Windows runners `localhost` resolves to both `::1` and `127.0.0.1`, so happy eyeballs occasionally returns `ConnectionRefusedError` on both candidates and the test goes red while the pytest `--lf` rerun then passes the same test in 0.33 s; see https://github.com/aio-libs/aiohttp/actions/runs/25972484360/job/76347464995 for an instance.

Switch both call sites to `log_server.make_url("/log")` so the request targets the address the server actually bound to.

## Are there changes in behavior for the user?

No; test only change.

## Is it a substantial burden for the maintainers to support this?

No.

## Related issue number

Surfaced repeatedly on Windows CI; no tracking issue.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES/` folder
  * name it `<issue_or_pr_num>.<type>.rst` (e.g. `588.bugfix.rst`)
  * if you don't have an issue number, change it to the pull request
    number after creating the PR
    * `.bugfix`: A bug fix for something the maintainers deemed an
      improper undesired behavior that got corrected to match
      pre-agreed expectations.
    * `.feature`: A new behavior, public APIs. That sort of stuff.
    * `.deprecation`: A declaration of future API removals and breaking
      changes in behavior.
    * `.breaking`: When something public is removed in a breaking way.
      Could be deprecated in an earlier release.
    * `.doc`: Notable updates to the documentation structure or build
      process.
    * `.packaging`: Notes for downstreams about unobvious side effects
      and tooling. Changes in the test invocation considerations and
      runtime assumptions.
    * `.contrib`: Stuff that affects the contributor experience. e.g.
      Running tests, building the docs, setting up the development
      environment.
    * `.misc`: Changes that are hard to assign to any of the above
      categories.
  * Make sure to use full sentences with correct case and punctuation,
    for example:
    ```rst
    Fixed issue with non-ascii contents in doctest text files
    -- by :user:`contributor-gh-handle`.
    ```

    Use the past tense or the present tense a non-imperative mood,
    referring to what's changed compared to the last released version
    of this project.