### PR TITLE
Parallelize Cython extension compilation

### DIFF
--- a/CHANGES/12576.packaging.rst
+++ b/CHANGES/12576.packaging.rst
@@ -1,0 +1,4 @@
+Parallelized the Cython extension compilation by defaulting
+``build_ext.parallel`` to ``os.cpu_count()``, so each module's
+``gcc`` invocation now runs concurrently instead of one at a time
+-- by :user:`bdraco`.

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@ import pathlib
 import sys
 
 from setuptools import Extension, setup
+from setuptools.command.build_ext import build_ext
 
 if sys.version_info < (3, 10):
     raise RuntimeError("aiohttp 4.x requires Python 3.10+")
@@ -87,8 +88,19 @@ extensions = [
 ]
 
 
+class ParallelBuildExt(build_ext):
+    def build_extensions(self) -> None:
+        if self.parallel is None:
+            self.parallel = os.cpu_count() or 1
+        super().build_extensions()
+
+
 build_type = "Pure" if NO_EXTENSIONS else "Accelerated"
-setup_kwargs = {} if NO_EXTENSIONS else {"ext_modules": extensions}
+setup_kwargs = (
+    {}
+    if NO_EXTENSIONS
+    else {"ext_modules": extensions, "cmdclass": {"build_ext": ParallelBuildExt}}
+)
 
 print("*********************", file=sys.stderr)
 print("* {build_type} build *".format_map(locals()), file=sys.stderr)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Default the ``build_ext`` ``parallel`` option to ``os.cpu_count()`` so each module's ``gcc`` compilation of the Cythonized hot paths (``_http_parser``, ``_http_writer``, ``_websocket.mask``, ``_websocket.reader_c``, plus the ``llhttp`` sources) runs concurrently instead of one at a time. The QEMU emulated wheel jobs are the biggest beneficiary, but local ``make .develop`` rebuilds and CI wheel matrix runs also see a measurable speed up.

Mirrors esphome/aioesphomeapi#1662, Bluetooth-Devices/habluetooth#421, and python-zeroconf/python-zeroconf#1689.

## Are there changes in behavior for the user?

No runtime behavior change; only the build is faster. Downstream packagers can still override the level by passing ``--parallel N`` (``-j N``) to ``build_ext``, since the default only kicks in when ``parallel`` is unset.

## Is it a substantial burden for the maintainers to support this?

No; it is a small ``build_ext`` subclass with a single ``if self.parallel is None`` guard, wired in only on the accelerated build path.

## Related issue number

None.

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist (N/A, setup.py build hook)
- [ ] Documentation reflects the changes (N/A, build only)
- [x] If you provide code modification, please add yourself to ``CONTRIBUTORS.txt``
- [x] Add a new news fragment into the ``CHANGES/`` folder

Drafted with Claude Opus 4.7; reviewed by @bdraco.
