### PR TITLE
Document agent pitfalls in AGENTS.md: test coverage and docs spell check

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -257,7 +257,32 @@ is non-obvious, a short reproducer or a paragraph on root cause is
 welcome. Long, multi-section essays with bolded sub-headings are
 not the style here.
 
-### 6. Commit hygiene
+### 6. Run the docs spell check before pushing
+
+The `lint` CI job builds the docs with `sphinxcontrib.spelling`
+under `make doc-spelling`, which is invoked with `-W
+--keep-going` so any unknown word is a hard failure. The spell
+checker reads every `CHANGES/*.rst` fragment as part of the
+build, so a technical word in your news fragment (`codecov`,
+`monkeypatch`, `parametrize`, `repr`, and so on) that is
+not in
+[`docs/spelling_wordlist.txt`](docs/spelling_wordlist.txt)
+will fail `make doc-spelling` and burn a CI run before a human
+even sees the PR.
+
+Before pushing:
+
+```bash
+make doc-spelling
+```
+
+If it flags a word you actually meant to use, add it to
+`docs/spelling_wordlist.txt` (one word per line, roughly
+alphabetical) in the same commit as the fragment. If it flags
+a typo, fix the typo. Do not paper over real misspellings by
+adding them to the wordlist.
+
+### 7. Commit hygiene
 
 - One logical change per PR. If a refactor and a bugfix are bundled
   together, split them.
@@ -485,6 +510,10 @@ spell-check leg that CI also runs.
 - Do not invent a `## What / ## Why / ## How / ## Testing` PR
   body; use the shipped template at
   `.github/PULL_REQUEST_TEMPLATE.md`.
+- Do not push without running `make doc-spelling` first if you
+  edited any `.rst` file (including a `CHANGES/` fragment). The
+  docs build fails on unknown words and burns a CI run; see
+  _Run the docs spell check before pushing_ above.
 - Do not skip the `CHANGES/` fragment "because the change is
   small". Even a one-line bugfix needs one.
 - Do not add `Co-Authored-By` trailers for LLM tools, in either

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -352,6 +352,48 @@ CodSpeed benchmark leg, and wheel builds for manylinux, musllinux,
 macOS, and Windows. Do not regress the benchmarks without flagging
 the trade-off in the PR body.
 
+### Every line in a test must be covered
+
+Coverage in this repo tracks both `aiohttp/` and `tests/`; the
+CI test jobs run pytest with `--cov=aiohttp/ --cov=tests/` and
+the cython-coverage job does the same, so uncovered lines in
+`tests/` show up in the codecov patch report on every PR.
+Reviewers do look at that report. This catches a class of
+mistake agents make all the time: a defensive
+`raise RuntimeError("must not be called")` inside a
+monkeypatched stub the happy path never invokes, a cleanup
+branch behind `if had_own_attr:` that the test never enters, an
+`else` arm guarding a condition that is always true under the
+fixture. From the perspective of the unit suite all of those
+lines are dead code, and the codecov report flags them the same
+as dead code in `aiohttp/`.
+
+Design tests so every line runs:
+
+- Drive the fixture deterministically so both arms of any
+  conditional are hit, or drop the conditional entirely and
+  assert the single shape you actually set up.
+- Do not add `raise TypeError("must not be invoked")` guards
+  inside stubs the test installs; if the stub is never meant to
+  fire, either omit it or assert at the call site that it did
+  not. An unreachable `raise` is the most common form of this
+  failure.
+- Cleanup branches that only run when setup took a particular
+  shape (`if had_own_attr: ...` style restores) need a second
+  test, or a parametrize, that exercises the other shape. If
+  you cannot justify the second case, unconditionally restore
+  instead.
+- Prefer `monkeypatch` (which auto-reverts) over hand-rolled
+  save/restore blocks; the auto-revert path has no untaken
+  branch for coverage to flag.
+
+See [aio-libs/yarl#1687](https://github.com/aio-libs/yarl/pull/1687)
+for the canonical example: a test added an unreachable `raise`
+inside a patched `__getstate__` and a conditional restore of the
+original attribute, both of which the codecov report rejected as
+uncovered. The same pattern recurs in aiohttp test PRs and the
+same review feedback applies.
+
 ## Cython and generated files
 
 `aiohttp/_http_parser.pyx`, `aiohttp/_http_writer.pyx`, and
@@ -462,6 +504,11 @@ spell-check leg that CI also runs.
   source changes.
 - Do not change one backend without checking the other; see
   "Dual-backend discipline" above.
+- Do not leave unreachable lines in tests (defensive `raise`
+  inside a stub the suite never invokes, cleanup branches that
+  only run for a setup shape the test does not exercise). Tests
+  are part of the coverage report; see _Every line in a test
+  must be covered_ above.
 - Do not open PRs against the release branches (`3.12`, `3.13`,
   etc.); target `master` and let `patchback` handle the
   backport after merge.

--- a/CHANGES/12580.contrib.rst
+++ b/CHANGES/12580.contrib.rst
@@ -1,0 +1,5 @@
+Documented in :file:`AGENTS.md` that the coverage report also
+covers ``tests/``, so unreachable defensive ``raise`` guards in
+patched stubs and one-sided cleanup branches in tests will be
+flagged on the codecov patch report
+-- by :user:`bdraco`.

--- a/CHANGES/12580.contrib.rst
+++ b/CHANGES/12580.contrib.rst
@@ -1,5 +1,8 @@
-Documented in :file:`AGENTS.md` that the coverage report also
-covers ``tests/``, so unreachable defensive ``raise`` guards in
-patched stubs and one-sided cleanup branches in tests will be
-flagged on the codecov patch report
+Documented in :file:`AGENTS.md` that the coverage report covers
+``tests/`` as well as ``aiohttp/`` (so unreachable defensive
+``raise`` guards in patched stubs and one-sided cleanup branches
+in tests will surface as uncovered on the codecov patch report),
+and that the docs spell check (``make doc-spelling``) is a hard
+CI gate that reads every ``CHANGES/*.rst`` fragment and should be
+run locally before pushing
 -- by :user:`bdraco`.

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -72,6 +72,7 @@ CIMultiDict
 ClientSession
 cls
 cmd
+codecov
 codebase
 codec
 Codings


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Two AGENTS.md additions for failure modes agents keep hitting in
this repo:

- **Test coverage gate.** New _Every line in a test must be
  covered_ section under Tests, explaining that the CI test
  runs use `--cov=aiohttp/ --cov=tests/` so uncovered lines in
  `tests/` show up in the codecov patch report alongside
  uncovered lines in `aiohttp/`. Lists the shapes agents
  commonly leave uncovered (defensive `raise` inside a
  monkeypatched stub, one-sided cleanup branches behind
  `if had_own_attr:`) and the patterns that keep tests fully
  covered. References
  [aio-libs/yarl#1687](https://github.com/aio-libs/yarl/pull/1687)
  and the corresponding
  [aio-libs/yarl#1689](https://github.com/aio-libs/yarl/pull/1689).
- **Docs spell check.** New PR rule #6 _Run the docs spell
  check before pushing_, documenting that the `lint` CI job
  runs `make doc-spelling` with `-W --keep-going` and reads
  every `CHANGES/*.rst` fragment, so an unknown technical word
  in a news fragment fails CI before a human sees the PR.
  Adds `codecov` to `docs/spelling_wordlist.txt` for the new
  fragment. Mirrors the equivalent
  [aio-libs/multidict#1345](https://github.com/aio-libs/multidict/pull/1345)
  addition.

Renumbers the surrounding PR rule (Commit hygiene becomes #7)
and extends Things-not-to-do with matching bullets.

## Are there changes in behavior for the user?

No. Docs-only change to the agent-facing contributor notes,
plus one wordlist entry.

## Is it a substantial burden for the maintainers to support this?

No. Both rules are already enforced (by the codecov patch
report and by the docs spelling step in CI); this just writes
them down where agents will read them.

## Related issue number

N/A.

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist (N/A, docs only)
- [x] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt` (N/A, already listed)
- [x] Add a new news fragment into the `CHANGES/` folder

Drafted with Claude Opus 4.7; reviewed by @bdraco.

<details>
<summary>Agent run details (optional, for reviewers)</summary>

Docs-only change, no test suite to run. Verification:

- `pre-commit run --files AGENTS.md CHANGES/12580.contrib.rst docs/spelling_wordlist.txt` passed.
- `make doc-spelling` flagged `codecov` before the wordlist entry was added; after adding it, the only remaining warnings are two pre-existing words (`accessor` from `CHANGES/10665.feature.rst`, `flakey` from `CHANGES/12571.contrib.rst`), unrelated to this PR.
</details>