### PR TITLE
Fix documentation field-list label rendering

### DIFF
--- a/CHANGES/4127.doc.rst
+++ b/CHANGES/4127.doc.rst
@@ -1,0 +1,2 @@
+Improved the documentation field-list styling so parameter labels keep enough width to avoid cramped vertical rendering.
+-- by :user:`nightcityblade`.

--- a/docs/_static/css/logo-adjustments.css
+++ b/docs/_static/css/logo-adjustments.css
@@ -5,3 +5,7 @@
 .sphinxsidebarwrapper>p.logo>a>img.logo {
   width: 65%;
 }
+
+.field-list>dt {
+  min-width: 6em;
+}


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Adds a small CSS rule for Sphinx field-list labels so labels such as `Parameters:` keep enough width instead of rendering as a cramped vertical column.

## Are there changes in behavior for the user?

No runtime behavior changes. Documentation pages should render parameter labels more readably.

## Is it a substantial burden for the maintainers to support this?

No. This is a small documentation stylesheet adjustment with minimal maintenance impact.

## Related issue number

Fixes aio-libs/aiohttp-theme#117.

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is <Name> <Surname>.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES/` folder
  * name it `<issue_or_pr_num>.<type>.rst` (e.g. `588.bugfix.rst`)
  * if you don't have an issue number, change it to the pull request
    number after creating the PR
    * `.bugfix`: A bug fix for something the maintainers deemed an
      improper undesired behavior that got corrected to match
      pre-agreed expectations.
    * `.feature`: A new behavior, public APIs. That sort of stuff.
    * `.deprecation`: A declaration of future API removals and breaking
      changes in behavior.
    * `.breaking`: When something public is removed in a breaking way.
      Could be deprecated in an earlier release.
    * `.doc`: Notable updates to the documentation structure or build
      process.
    * `.packaging`: Notes for downstreams about unobvious side effects
      and tooling. Changes in the test invocation considerations and
      runtime assumptions.
    * `.contrib`: Stuff that affects the contributor experience. e.g.
      Running tests, building the docs, setting up the development
      environment.
    * `.misc`: Changes that are hard to assign to any of the above
      categories.
  * Make sure to use full sentences with correct case and punctuation,
    for example:
    ```rst
    Fixed issue with non-ascii contents in doctest text files
    -- by :user:`contributor-gh-handle`.
    ```
