### PR TITLE
[PR #12581/77e2e2d7 backport][3.14] Shrink slow client and URL dispatcher benchmarks

### DIFF
--- a/CHANGES/12569.misc.rst
+++ b/CHANGES/12569.misc.rst
@@ -1,0 +1,3 @@
+Reduced payload sizes and request counts in the slowest client and URL
+dispatcher benchmarks so they no longer dominate CI runtime
+-- by :user:`bdraco`.

--- a/tests/test_benchmarks_client.py
+++ b/tests/test_benchmarks_client.py
@@ -177,14 +177,14 @@ def test_one_hundred_get_requests_with_30000_chunked_payload(
         loop.run_until_complete(run_client_benchmark())
 
 
-def test_one_hundred_get_requests_with_10mb_chunked_payload(
+def test_one_hundred_get_requests_with_1mb_chunked_payload(
     loop: asyncio.AbstractEventLoop,
     aiohttp_client: AiohttpClient,
     benchmark: BenchmarkFixture,
 ) -> None:
-    """Benchmark 100 GET requests with a payload of 10 MiB using read."""
+    """Benchmark 100 GET requests with a 1 MiB chunked payload using read."""
     message_count = 100
-    payload = b"a" * (10 * 2**20)
+    payload = b"a" * 2**20
 
     async def handler(request: web.Request) -> web.Response:
         resp = web.Response(body=payload)
@@ -206,14 +206,14 @@ def test_one_hundred_get_requests_with_10mb_chunked_payload(
         loop.run_until_complete(run_client_benchmark())
 
 
-def test_one_hundred_get_requests_iter_chunks_on_10mb_chunked_payload(
+def test_one_hundred_get_requests_iter_chunks_on_1mb_chunked_payload(
     loop: asyncio.AbstractEventLoop,
     aiohttp_client: AiohttpClient,
     benchmark: BenchmarkFixture,
 ) -> None:
-    """Benchmark 100 GET requests with a payload of 10 MiB using iter_chunks."""
+    """Benchmark 100 GET requests with a 1 MiB chunked payload using iter_chunks."""
     message_count = 100
-    payload = b"a" * (10 * 2**20)
+    payload = b"a" * 2**20
 
     async def handler(request: web.Request) -> web.Response:
         resp = web.Response(body=payload)
@@ -327,14 +327,14 @@ def test_one_hundred_get_requests_with_30000_content_length_payload(
         loop.run_until_complete(run_client_benchmark())
 
 
-def test_one_hundred_get_requests_with_10mb_content_length_payload(
+def test_one_hundred_get_requests_with_1mb_content_length_payload(
     loop: asyncio.AbstractEventLoop,
     aiohttp_client: AiohttpClient,
     benchmark: BenchmarkFixture,
 ) -> None:
-    """Benchmark 100 GET requests with a payload of 10 MiB."""
+    """Benchmark 100 GET requests with a content-length payload of 1 MiB."""
     message_count = 100
-    payload = b"a" * (10 * 2**20)
+    payload = b"a" * 2**20
     headers = {hdrs.CONTENT_LENGTH: str(len(payload))}
 
     async def handler(request: web.Request) -> web.Response:
@@ -479,7 +479,7 @@ def test_ten_streamed_responses_iter_chunked_1mb(
     """Benchmark 10 streamed responses using iter_chunked 1 MiB."""
     message_count = 10
     MB = 2**20
-    data = b"x" * 10 * MB
+    data = b"x" * 6 * MB
 
     async def handler(request: web.Request) -> web.StreamResponse:
         resp = web.StreamResponse()

--- a/tests/test_benchmarks_web_urldispatcher.py
+++ b/tests/test_benchmarks_web_urldispatcher.py
@@ -359,7 +359,7 @@ def test_resolve_dynamic_resource_url_with_many_dynamic_routes_with_common_prefi
 
     requests = [
         _mock_request(method="GET", path=f"/api/{customer}/update")
-        for customer in range(250)
+        for customer in range(150)
     ]
 
     async def run_url_dispatcher_benchmark() -> web.UrlMappingMatchInfo | None:
@@ -401,7 +401,7 @@ def test_resolve_gitapi(
     alnums = string.ascii_letters + string.digits
 
     requests = []
-    for i in range(250):
+    for i in range(150):
         owner = "".join(random.sample(alnums, 10))
         repo = "".join(random.sample(alnums, 10))
         pull_number = random.randint(0, 250)
@@ -472,7 +472,7 @@ def test_resolve_gitapi_subapps(
     alnums = string.ascii_letters + string.digits
 
     requests = []
-    for i in range(250):
+    for i in range(150):
         owner = "".join(random.sample(alnums, 10))
         repo = "".join(random.sample(alnums, 10))
         pull_number = random.randint(0, 250)


### PR DESCRIPTION
**This is a backport of PR #12581 as merged into master (77e2e2d701139ec9861d200503b403a43adad932).**

## What do these changes do?

Shrink the constant amount of work done in the slowest benchmark
tests so they stop dominating CI runtime. Per the `--durations`
report on the benchmark job, the slowest entries were taking 60
to 105 seconds each under codspeed instrumentation:

* `test_one_hundred_get_requests_with_10mb_content_length_payload`
* `test_one_hundred_get_requests_with_10mb_chunked_payload`
* `test_one_hundred_get_requests_iter_chunks_on_10mb_chunked_payload`
* `test_ten_streamed_responses_iter_chunked_1mb`
* `test_resolve_gitapi` and `test_resolve_gitapi_subapps`
* `test_resolve_dynamic_resource_url_with_many_dynamic_routes_with_common_prefix`

The three `_10mb_*` client benchmarks now use a 1 MiB payload and
have been renamed to `_1mb_*` to match. The streamed
`iter_chunked_1mb` benchmark drops its source data from 10 MiB to
6 MiB, which keeps 6 chunks per response so the chunked-read loop
body is still exercised. The three URL dispatcher resolve loops
drop from 250 to 150 requests.

This is a follow-up that supersedes the closed #12570.

## Are there changes in behavior for the user?

No. Test-suite only.

## Is it a substantial burden for the maintainers to support this?

No, the change is a handful of integer constants and three docstring
tweaks.

## Related issue number

Fixes #12569

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist (the benchmarks themselves)
- [x] Documentation reflects the changes (no user-facing docs affected)
- [x] Add a new news fragment into the `CHANGES/` folder (`12569.misc.rst`)

Drafted with Claude Code (claude-opus-4-7); reviewed by @bdraco.