### PR TITLE
Gate isal test dependency to CPython

### DIFF
--- a/CHANGES/12589.contrib.rst
+++ b/CHANGES/12589.contrib.rst
@@ -1,0 +1,7 @@
+Restricted the ``isal`` test dependency to CPython, since
+``isal`` 1.8.0 stopped publishing PyPy wheels and the source
+build requires ``nasm``, which is not available on the CI
+runners. The ``parametrize_zlib_backend`` fixture already
+calls ``pytest.importorskip``, so PyPy continues to exercise
+the ``zlib`` and ``zlib_ng`` backends with no further
+changes -- by :user:`bdraco`.

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -109,7 +109,7 @@ imagesize==2.0.0
     # via sphinx
 iniconfig==2.3.0
     # via pytest
-isal==1.7.2 ; python_version < "3.14"
+isal==1.7.2 ; python_version < "3.14" and implementation_name == "cpython"
     # via
     #   -r requirements/lint.in
     #   -r requirements/test-common.in

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -107,7 +107,7 @@ imagesize==2.0.0
     # via sphinx
 iniconfig==2.3.0
     # via pytest
-isal==1.7.2 ; python_version < "3.14"
+isal==1.7.2 ; python_version < "3.14" and implementation_name == "cpython"
     # via
     #   -r requirements/lint.in
     #   -r requirements/test-common.in

--- a/requirements/test-common.in
+++ b/requirements/test-common.in
@@ -1,7 +1,7 @@
 blockbuster
 coverage
 freezegun
-isal; python_version < "3.14" # no wheel for 3.14
+isal; python_version < "3.14" and implementation_name == "cpython" # no wheel for 3.14, no PyPy wheel for 1.8.0+
 mypy; implementation_name == "cpython"
 pkgconfig
 proxy.py >= 2.4.4rc5

--- a/requirements/test-common.txt
+++ b/requirements/test-common.txt
@@ -50,7 +50,7 @@ idna==3.15
     #   yarl
 iniconfig==2.3.0
     # via pytest
-isal==1.8.0 ; python_version < "3.14"
+isal==1.8.0 ; python_version < "3.14" and implementation_name == "cpython"
     # via -r requirements/test-common.in
 librt==0.11.0
     # via mypy

--- a/requirements/test-ft.txt
+++ b/requirements/test-ft.txt
@@ -67,7 +67,7 @@ idna==3.15
     #   yarl
 iniconfig==2.3.0
     # via pytest
-isal==1.8.0 ; python_version < "3.14"
+isal==1.8.0 ; python_version < "3.14" and implementation_name == "cpython"
     # via -r requirements/test-common.in
 librt==0.11.0
     # via mypy

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -67,7 +67,7 @@ idna==3.15
     #   yarl
 iniconfig==2.3.0
     # via pytest
-isal==1.7.2 ; python_version < "3.14"
+isal==1.7.2 ; python_version < "3.14" and implementation_name == "cpython"
     # via -r requirements/test-common.in
 librt==0.11.0
     # via mypy


### PR DESCRIPTION
## What do these changes do?

Adds ``implementation_name == \"cpython\"`` to the ``isal`` test
requirement marker (and regenerates the pinned ``.txt`` files).
``isal`` 1.8.0 stopped shipping PyPy wheels, so the dependabot
bump in #11589 falls back to a source build that needs ``nasm``;
``nasm`` is not on the CI runners, the wheel build fails, and the
PyPy job dies before it gets to any tests. The
``parametrize_zlib_backend`` fixture already calls
``pytest.importorskip``, so PyPy keeps exercising ``zlib`` and
``zlib_ng`` after this change.

## Are there changes in behavior for the user?

No. Test-only dependency marker.

## Is it a substantial burden for the maintainers to support this?

No.

## Related issue number

Unblocks #11589.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist (N/A; test-only requirements marker, no code path touched)
- [x] Documentation reflects the changes (N/A; CI/test config only)
- [x] If you provide code modification, please add yourself to ``CONTRIBUTORS.txt`` (already present as J. Nick Koston)
- [x] Add a new news fragment into the ``CHANGES/`` folder

Drafted with Claude Code (claude-opus-4-7); reviewed by @bdraco.