### PR TITLE
Fix flakey test_tcp_connector_fingerprint_ok by aborting SSL shutdown

### DIFF
--- a/CHANGES/12592.contrib.rst
+++ b/CHANGES/12592.contrib.rst
@@ -1,0 +1,6 @@
+Fixed a flakey ``test_tcp_connector_fingerprint_ok`` by aborting
+the SSL shutdown on the test's TCP connector before returning.
+The graceful TLS close was occasionally outliving the test event
+loop on one of the CI jobs, and the teardown ``gc.collect()``
+then surfaced the still-open transport as a
+``PytestUnraisableExceptionWarning`` -- by :user:`bdraco`.

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -840,6 +840,12 @@ async def test_tcp_connector_fingerprint_ok(
     async with client.get("/") as resp:
         assert resp.status == 200
 
+    # Abort the SSL shutdown explicitly so the pooled TLS transport is
+    # released before the test loop tears down. Otherwise a slow graceful
+    # close can outlive the loop, and the teardown gc.collect() finalises
+    # the still-open socket as an unraisable ResourceWarning.
+    await connector.close(abort_ssl=True)
+
 
 async def test_tcp_connector_fingerprint_fail(
     aiohttp_server: AiohttpServer,


### PR DESCRIPTION
## What do these changes do?

Adds an explicit ``await connector.close(abort_ssl=True)`` at the
end of ``test_tcp_connector_fingerprint_ok``. The pooled TLS
transport is now torn down inside the test loop instead of being
left to the graceful shutdown that ``aiohttp_client``'s fixture
teardown kicks off, which on a CPython 3.13 macOS runner
occasionally outlives the loop and surfaces during
``teardown_test_loop``'s ``gc.collect()`` as a
``PytestUnraisableExceptionWarning`` for the unclosed
``_SelectorSocketTransport`` and its socket.

## Are there changes in behavior for the user?

No. Test-only change. The fingerprint validation path under test
is unchanged.

## Is it a substantial burden for the maintainers to support this?

No.

## Related issue number

Observed on the patchback backport CI for #12589 (#12591), most
recently in https://github.com/aio-libs/aiohttp/actions/runs/25999760213/job/76420871614.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist (the test itself is the unit; the change is to its cleanup path)
- [x] Documentation reflects the changes (N/A; test-only)
- [x] If you provide code modification, please add yourself to ``CONTRIBUTORS.txt`` (already present as J. Nick Koston)
- [x] Add a new news fragment into the ``CHANGES/`` folder

Drafted with Claude Code (claude-opus-4-7); reviewed by @bdraco.