### PR TITLE
Switch test-results upload to codecov-action

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -275,8 +275,10 @@ jobs:
         token: ${{ secrets.CODECOV_TOKEN }}
     - name: Upload test results to Codecov
       if: ${{ !cancelled() }}
-      uses: codecov/test-results-action@v1
+      uses: codecov/codecov-action@v6
       with:
+        files: ./junit.xml
+        report_type: test_results
         token: ${{ secrets.CODECOV_TOKEN }}
 
   autobahn:
@@ -360,8 +362,10 @@ jobs:
         token: ${{ secrets.CODECOV_TOKEN }}
     - name: Upload test results to Codecov
       if: ${{ !cancelled() }}
-      uses: codecov/test-results-action@v1
+      uses: codecov/codecov-action@v6
       with:
+        files: ./junit.xml
+        report_type: test_results
         token: ${{ secrets.CODECOV_TOKEN }}
 
   benchmark:

--- a/CHANGES/12596.contrib.rst
+++ b/CHANGES/12596.contrib.rst
@@ -1,0 +1,4 @@
+Switched the test-results upload step to ``codecov/codecov-action@v6``
+with ``report_type: test_results``, since
+``codecov/test-results-action`` is being deprecated in favor of
+``codecov-action`` -- by :user:`bdraco`.


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Replace the two ``codecov/test-results-action@v1`` steps in
``ci-cd.yml`` with ``codecov/codecov-action@v6`` invoked with
``report_type: test_results`` and the ``junit.xml`` path the
pytest steps already produce.

## Are there changes in behavior for the user?

No. CI-only change.

## Is it a substantial burden for the maintainers to support this?

No; ``codecov-action`` is the action upstream is steering everyone
toward and the rest of the workflow already uses it for coverage
uploads.

## Related issue number

Codecov is now printing a deprecation notice on every CI run, e.g.
https://github.com/aio-libs/aiohttp/actions/runs/26001473823/job/76426685944?pr=12595

> Upload test results to Codecov
> This action is being deprecated in favor of 'codecov-action'.
> Please update CI accordingly to use 'codecov-action@v5' with
> 'report_type: test_results'.

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist  N/A (CI-only change)
- [ ] Documentation reflects the changes  N/A
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
- [x] Add a new news fragment into the `CHANGES/` folder

Drafted with Claude Code (claude-opus-4-7); reviewed by @bdraco.