### PR TITLE
Silence uvloop 0.22+ asyncio.AbstractEventLoopPolicy deprecation

### DIFF
--- a/CHANGES/12600.contrib.rst
+++ b/CHANGES/12600.contrib.rst
@@ -1,0 +1,4 @@
+Silenced the ``DeprecationWarning`` raised by ``uvloop`` 0.22+ when it
+accesses the ``asyncio.AbstractEventLoopPolicy`` alias that Python 3.14
+marks for removal in 3.16, so the test suite passes against the newer
+``uvloop`` release -- by :user:`bdraco`.

--- a/setup.cfg
+++ b/setup.cfg
@@ -86,6 +86,10 @@ filterwarnings =
     ignore:datetime.*utcnow\(\) is deprecated and scheduled for removal:DeprecationWarning:freezegun.api
     # Weird issue in Python 3.13+ triggered in test_multipart.py
     ignore:coroutine method 'aclose' of 'BodyPartReader._decode_content_async' was never awaited:RuntimeWarning
+    # uvloop 0.22+ accesses the deprecated asyncio.AbstractEventLoopPolicy
+    # alias, which Python 3.14 marks for removal in 3.16. Drop this when
+    # uvloop stops touching the deprecated alias.
+    ignore:'asyncio.AbstractEventLoopPolicy' is deprecated:DeprecationWarning:uvloop
 junit_suite_name = aiohttp_test_suite
 norecursedirs = dist docs build .tox .eggs
 minversion = 3.8.2


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Add a targeted ``filterwarnings`` entry that ignores the
``DeprecationWarning`` ``uvloop`` 0.22+ raises when it accesses the
``asyncio.AbstractEventLoopPolicy`` alias that Python 3.14 marks for
removal in 3.16.

``uvloop`` 0.22 made ``EventLoopPolicy`` a lazy attribute; the lazy
``__getattr__`` calls ``getattr(asyncio, 'AbstractEventLoopPolicy')``,
and under Python 3.14 that triggers a ``DeprecationWarning``. With
``filterwarnings = error`` in ``setup.cfg``, the warning becomes a
test failure on ``test_init_process[UvloopWorker-pyloop]`` and
``test_init_process_no_loop[UvloopWorker-pyloop]``. This is currently
blocking the uvloop 0.22.1 Dependabot bumps in #11682 (master) and
#11683 (3.14).

## Are there changes in behavior for the user?

No. The change is limited to the test configuration in ``setup.cfg``.

## Is it a substantial burden for the maintainers to support this?

No. The filter is narrowly scoped to the ``uvloop`` module and the
specific ``asyncio.AbstractEventLoopPolicy`` message, and can be
removed once ``uvloop`` stops accessing the deprecated alias.

## Related issue number

Refs #11682 and #11683.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [N/A] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to ``CONTRIBUTORS.txt``
- [x] Add a new news fragment into the ``CHANGES/`` folder

<details>
<summary>Agent run details (optional, for reviewers)</summary>

Reproduced the failure locally with a Python 3.14.2 venv and
``uvloop==0.22.1``: calling ``uvloop.EventLoopPolicy()`` raises the
``DeprecationWarning`` from ``uvloop/__init__.py`` and pytest's
``filterwarnings = error`` turns it into a failure.

Verified the filter:

* Without the new filter, a one-line pytest run on
  ``uvloop.EventLoopPolicy()`` fails with
  ``DeprecationWarning: 'asyncio.AbstractEventLoopPolicy' is deprecated
  and slated for removal in Python 3.16``.
* With the new filter
  (``ignore:'asyncio.AbstractEventLoopPolicy' is deprecated:DeprecationWarning:uvloop``),
  the same test passes.

The full aiohttp suite was not re-run on Python 3.14 against the
extension and pure-Python backends in this environment; CI will cover
both legs.

Drafted with Claude Code (Opus 4.7); reviewed by :user:`bdraco`.
</details>