### PR TITLE
[PR #12595/fbf44b7e backport][3.13] Switch cibuildwheel to the uv build frontend

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -459,7 +459,13 @@ jobs:
       run: |
         make cythonize
     - name: Build wheels
-      uses: pypa/cibuildwheel@v3.2.0
+      uses: pypa/cibuildwheel@v3.4.1
+      with:
+        # `build-frontend = "build[uv]"` (pyproject.toml) requires uv to be
+        # available on the runner for Windows and macOS. Installing
+        # cibuildwheel with the `uv` extra bundles uv with it; Linux
+        # already has uv inside the manylinux/musllinux container.
+        extras: uv
       env:
         CIBW_SKIP: pp* ${{ matrix.musl == 'musllinux' && '*manylinux*' || '*musllinux*' }}
         CIBW_ARCHS_MACOS: x86_64 arm64 universal2

--- a/CHANGES/12595.contrib.rst
+++ b/CHANGES/12595.contrib.rst
@@ -1,0 +1,5 @@
+Switched the ``cibuildwheel`` build frontend to ``build[uv]`` so
+that ``uv`` provisions every build-isolation virtual environment
+in the wheel matrix, replacing the per-ABI ``pip`` resolve with a
+roughly sub-second ``uv`` resolve
+-- by :user:`bdraco`.

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -1,4 +1,5 @@
 abc
+ABI
 addons
 aiodns
 aioes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -160,6 +160,13 @@ include = [
 
 
 [tool.cibuildwheel]
+# `build[uv]` makes cibuildwheel use `uv` for every venv it provisions,
+# both on the build side (passed to `python -m build` as `--installer=uv`)
+# and when materializing the build isolation environment. uv resolves and
+# installs the build requirements in roughly a second; the previous
+# pip-based path took noticeably longer per ABI and ran once per matrix
+# cell.
+build-frontend = "build[uv]"
 test-command = ""
 # don't build PyPy wheels, install from source instead
 skip = "pp*"


### PR DESCRIPTION
**This is a backport of PR #12595 as merged into master (fbf44b7e896581bd481d58a2543649631d117f5b).**

<!-- Thank you for your contribution! -->

## What do these changes do?

Set ``build-frontend = "build[uv]"`` in ``[tool.cibuildwheel]``
so that ``uv`` provisions the build-isolation virtual
environment cibuildwheel creates for each ABI, both on the build
side (passed to ``python -m build`` as ``--installer=uv``) and
when materializing the build environment. The previous (implicit
``pip``) frontend re-resolved the build requirements with pip on
every matrix cell; ``uv`` does the same work in roughly a
second, which compounds across the ABIs and host platforms in
the wheel matrix.

The wheel matrix does not run cibuildwheel's test phase
(``test-command = ""``), so the speedup is limited to the build
isolation environment. ``ABI`` is added to
``docs/spelling_wordlist.txt`` so the news fragment passes the
docs spell check.

## Are there changes in behavior for the user?

No, contributor tooling only.

## Is it a substantial burden for the maintainers to support this?

No. The change is two configuration lines (one in
``pyproject.toml``, one in the workflow ``with:`` block) plus a
news fragment.

## Related issue number

N/A

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist: N/A (CI-only change; the wheel-matrix run on this PR is the verification path)
- [x] Documentation reflects the changes: N/A (no user-visible API change)
- [x] If you provide code modification, please add yourself to ``CONTRIBUTORS.txt``: N/A (already listed)
- [x] Add a new news fragment into the ``CHANGES/`` folder (``CHANGES/12595.contrib.rst``)

Drafted with Claude Code (Opus 4.7); reviewed by @bdraco.

<details>
<summary>Agent run details (optional, for reviewers)</summary>

Local validation:

```
$ python3 -c "import tomllib; tomllib.load(open('pyproject.toml','rb'))"
$ python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci-cd.yml'))"
$ make doc-spelling
2 pre-existing misspellings only (``accessor`` and ``flakey`` in older CHANGES fragments); CHANGES/12595.contrib.rst is clean after adding ``ABI`` to the wordlist.
```

Not verified locally: the actual cibuildwheel + uv interaction
inside the build container; that requires running cibuildwheel
which is impractical without pushing. The live CI run on this
branch is the verification.

Mirrors aio-libs/propcache#234, scoped down for aiohttp:

* aiohttp's ``[tool.cibuildwheel]`` had no ``before-test`` block
  or Windows override to remove (cibuildwheel tests are
  disabled in this repo via ``test-command = ""``), so the diff
  is just the frontend switch plus the ``extras: uv`` on the
  action call.
* propcache's news fragment word ``frontend`` was already in
  aiohttp's spelling wordlist; ``ABI`` was added by this PR.
</details>
