### PR TITLE
Fix flaky test_handler_returns_not_response on PyPy via debug-mode fixture

### DIFF
--- a/CHANGES/12603.contrib.rst
+++ b/CHANGES/12603.contrib.rst
@@ -1,0 +1,8 @@
+Fixed flaky ``test_handler_returns_not_response`` and
+``test_handler_returns_none`` by routing ``loop.set_debug(True)``
+through a new ``loop_debug_mode`` fixture that disables debug
+mode before the ``aiohttp_client`` fixture finalizes. Leaving
+debug on through teardown let PyPy 3.11's asyncio slow-callback
+logger walk into ``Task.__repr__`` during connector close,
+surfacing a spurious ``RuntimeWarning: coroutine was never
+awaited`` -- by :user:`bdraco`.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -180,6 +180,24 @@ async def create_mocked_conn() -> AsyncIterator[Callable[[], ResponseHandler]]:
 
 
 @pytest.fixture
+async def loop_debug_mode() -> AsyncIterator[None]:
+    """Enable asyncio debug mode for the duration of the test.
+
+    Disables debug before teardown so PyPy 3.11's recursive
+    ``Task.__repr__``, triggered by the asyncio slow-callback
+    logger during connector close, does not surface a spurious
+    ``RuntimeWarning: coroutine ... was never awaited`` while
+    the ``aiohttp_client`` fixture finalizes.
+    """
+    loop = asyncio.get_running_loop()
+    loop.set_debug(True)
+    try:
+        yield
+    finally:
+        loop.set_debug(False)
+
+
+@pytest.fixture
 def unix_sockname(
     tmp_path: Path, tmp_path_factory: pytest.TempPathFactory
 ) -> Iterator[str]:

--- a/tests/test_web_functional.py
+++ b/tests/test_web_functional.py
@@ -95,9 +95,10 @@ async def test_simple_get_with_text(aiohttp_client: AiohttpClient) -> None:
 
 
 async def test_handler_returns_not_response(
-    aiohttp_server: AiohttpServer, aiohttp_client: AiohttpClient
+    aiohttp_server: AiohttpServer,
+    aiohttp_client: AiohttpClient,
+    loop_debug_mode: None,
 ) -> None:
-    asyncio.get_running_loop().set_debug(True)
     logger = mock.Mock()
 
     async def handler(request: web.Request) -> str:
@@ -113,9 +114,10 @@ async def test_handler_returns_not_response(
 
 
 async def test_handler_returns_none(
-    aiohttp_server: AiohttpServer, aiohttp_client: AiohttpClient
+    aiohttp_server: AiohttpServer,
+    aiohttp_client: AiohttpClient,
+    loop_debug_mode: None,
 ) -> None:
-    asyncio.get_running_loop().set_debug(True)
     logger = mock.Mock()
 
     async def handler(request: web.Request) -> None:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Route ``loop.set_debug(True)`` through a new ``loop_debug_mode``
fixture in ``tests/conftest.py`` so the two failing tests in
``tests/test_web_functional.py`` turn debug off before the
``aiohttp_client`` fixture finalizes. The fixture is requested as
the last test parameter so pytest tears it down before
``aiohttp_client``.

Leaving debug on through teardown let PyPy 3.11's asyncio
slow-callback logger walk into ``Task.__repr__`` during connector
close, surfacing a spurious ``RuntimeWarning: coroutine was never
awaited`` that ``filterwarnings = error`` promotes to a teardown
failure. CPython's ``reprlib.recursive_repr`` keeps the same walk
bounded so the flake only manifested on the PyPy CI leg, as seen
on https://github.com/aio-libs/aiohttp/actions/runs/26003637612/job/76431289229.

## Are there changes in behavior for the user?

No. Tests-only.

## Is it a substantial burden for the maintainers to support this?

No.

## Related issue number

None.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist  (the changes are themselves to tests)
- [ ] Documentation reflects the changes  N/A
- [x] If you provide code modification, please add yourself to ``CONTRIBUTORS.txt``
- [x] Add a new news fragment into the ``CHANGES/`` folder

<details>
<summary>Agent run details (optional, for reviewers)</summary>

Verified the fixture teardown order with an instrumented probe: the
``aiohttp_client`` teardown runs after ``loop_debug_mode`` has set
debug back to ``False`` when ``loop_debug_mode`` is the last test
parameter. Ran the two affected tests against the default C build
and ``AIOHTTP_NO_EXTENSIONS=1`` on CPython 3.14; both pass. The
PyPy 3.11 leg cannot be reproduced locally and will be verified by
CI on this PR.

``make doc-spelling`` passes on the new fragment (pre-existing
``flakey`` / ``accessor`` warnings in older fragments are
unaffected).

Drafted with Claude Code (claude-opus-4-7); reviewed by @bdraco.
</details>