### PR TITLE
[PR #12597/28d1214f backport][3.13] Stop calling socket.getfqdn() in BaseRequest.host fallback

### DIFF
--- a/CHANGES/12597.breaking.rst
+++ b/CHANGES/12597.breaking.rst
@@ -1,0 +1,1 @@
+9308.breaking.rst

--- a/CHANGES/9308.breaking.rst
+++ b/CHANGES/9308.breaking.rst
@@ -1,0 +1,12 @@
+Stopped calling :func:`socket.getfqdn` as the fallback for
+:attr:`aiohttp.web.BaseRequest.host`. :func:`socket.getfqdn`
+performs blocking reverse DNS resolution on the event loop
+thread and can stall a worker for many seconds when the system
+resolver is slow, and could be triggered remotely by an HTTP/1.0
+request that omits the ``Host`` header. The fallback when no
+``Host`` header is present is now the local socket address the
+request arrived on (transport ``sockname``), or an empty string
+if no transport information is available. Code that relied on
+the FQDN being returned must now read it from
+:func:`socket.getfqdn` directly, off the event loop
+-- by :user:`bdraco`.

--- a/aiohttp/test_utils.py
+++ b/aiohttp/test_utils.py
@@ -651,11 +651,10 @@ def _create_app_mock() -> mock.MagicMock:
 def _create_transport(sslcontext: Optional[SSLContext] = None) -> mock.Mock:
     transport = mock.Mock()
 
-    def get_extra_info(key: str) -> Optional[SSLContext]:
+    def get_extra_info(key: str) -> SSLContext | tuple[str, int] | None:
         if key == "sslcontext":
             return sslcontext
-        else:
-            return None
+        return ("127.0.0.1", 80) if key == "sockname" else None
 
     transport.get_extra_info.side_effect = get_extra_info
     return transport
@@ -735,6 +734,9 @@ def make_mocked_request(
         protocol.transport = transport
         type(protocol).peername = mock.PropertyMock(
             return_value=transport.get_extra_info("peername")
+        )
+        type(protocol).sockname = mock.PropertyMock(
+            return_value=transport.get_extra_info("sockname")
         )
         type(protocol).ssl_context = mock.PropertyMock(return_value=sslcontext)
 

--- a/aiohttp/test_utils.py
+++ b/aiohttp/test_utils.py
@@ -19,8 +19,10 @@ from typing import (
     Iterator,
     List,
     Optional,
+    Tuple,
     Type,
     TypeVar,
+    Union,
     cast,
     overload,
 )
@@ -651,7 +653,7 @@ def _create_app_mock() -> mock.MagicMock:
 def _create_transport(sslcontext: Optional[SSLContext] = None) -> mock.Mock:
     transport = mock.Mock()
 
-    def get_extra_info(key: str) -> SSLContext | tuple[str, int] | None:
+    def get_extra_info(key: str) -> Optional[Union[SSLContext, Tuple[str, int]]]:
         if key == "sslcontext":
             return sslcontext
         return ("127.0.0.1", 80) if key == "sockname" else None

--- a/aiohttp/web_protocol.py
+++ b/aiohttp/web_protocol.py
@@ -288,6 +288,17 @@ class RequestHandler(BaseProtocol):
             else self.transport.get_extra_info("peername")
         )
 
+    @under_cached_property
+    def sockname(
+        self,
+    ) -> Optional[Union[str, Tuple[str, int, int, int], Tuple[str, int]]]:
+        """Return sockname if available."""
+        return (
+            None
+            if self.transport is None
+            else self.transport.get_extra_info("sockname")
+        )
+
     @property
     def keepalive_timeout(self) -> float:
         return self._keepalive_timeout

--- a/aiohttp/web_request.py
+++ b/aiohttp/web_request.py
@@ -2,7 +2,6 @@ import asyncio
 import datetime
 import io
 import re
-import socket
 import string
 import tempfile
 import types
@@ -200,6 +199,7 @@ class BaseRequest(MutableMapping[str, Any], HeadersMixin):
 
         self._transport_sslcontext = protocol.ssl_context
         self._transport_peername = protocol.peername
+        self._transport_sockname = protocol.sockname
 
         if remote is not None:
             self._cache["remote"] = remote
@@ -426,7 +426,9 @@ class BaseRequest(MutableMapping[str, Any], HeadersMixin):
 
         - overridden value by .clone(host=new_host) call.
         - HOST HTTP header
-        - socket.getfqdn() value
+        - local socket address the request arrived on
+          (transport ``sockname``)
+        - empty string if no transport information is available
 
         For example, 'example.com' or 'localhost:8080'.
 
@@ -435,7 +437,17 @@ class BaseRequest(MutableMapping[str, Any], HeadersMixin):
         host = self._message.headers.get(hdrs.HOST)
         if host is not None:
             return host
-        return socket.getfqdn()
+        sockname = self._transport_sockname
+        if sockname is None:
+            return ""
+        if isinstance(sockname, tuple):
+            # AF_INET6 returns a 4-tuple (host, port, flowinfo, scopeid);
+            # bracket the bare address so it matches the Host-header shape
+            # and is a valid URL authority component.
+            if len(sockname) == 4:
+                return f"[{sockname[0]}]"
+            return str(sockname[0])
+        return str(sockname)
 
     @reify
     def remote(self) -> Optional[str]:

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -118,7 +118,9 @@ and :ref:`aiohttp-web-signals` handlers.
 
       - Overridden value by :meth:`~BaseRequest.clone` call.
       - *Host* HTTP header
-      - :func:`socket.getfqdn`
+      - local socket address the request arrived on
+        (transport ``sockname``)
+      - empty string if no transport information is available
 
       Read-only :class:`str` property.
 
@@ -128,6 +130,13 @@ and :ref:`aiohttp-web-signals` handlers.
 
          Call ``.clone(host=new_host)`` for setting up the value
          explicitly.
+
+      .. versionchanged:: 3.13
+
+         The fallback when no ``Host`` header is present no longer
+         calls :func:`socket.getfqdn`, which performed blocking
+         reverse-DNS resolution on the event loop. The local socket
+         address (transport ``sockname``) is used instead.
 
       .. seealso:: :ref:`aiohttp-web-forwarded-support`
 

--- a/tests/test_web_request.py
+++ b/tests/test_web_request.py
@@ -1,7 +1,6 @@
 import asyncio
 import datetime
 import logging
-import socket
 import time
 from collections.abc import MutableMapping
 from typing import Any
@@ -40,16 +39,19 @@ def test_base_ctor() -> None:
         URL("/path/to?a=1&b=2"),
     )
 
+    protocol = mock.Mock()
+    protocol.ssl_context = None
+    protocol.peername = None
+    protocol.sockname = ("127.0.0.1", 80)
     req = BaseRequest(
-        message, mock.Mock(), mock.Mock(), mock.Mock(), mock.Mock(), mock.Mock()
+        message, mock.Mock(), protocol, mock.Mock(), mock.Mock(), mock.Mock()
     )
 
     assert "GET" == req.method
     assert HttpVersion(1, 1) == req.version
-    # MacOS may return CamelCased host name, need .lower()
-    # FQDN can be wider than host, e.g.
-    # 'fv-az397-495' in 'fv-az397-495.internal.cloudapp.net'
-    assert req.host.lower() in socket.getfqdn().lower()
+    # No Host header in this request, so host falls back to the
+    # local socket address the request arrived on.
+    assert req.host == "127.0.0.1"
     assert "/path/to?a=1&b=2" == req.path_qs
     assert "/path/to" == req.path
     assert "a=1&b=2" == req.query_string
@@ -71,10 +73,10 @@ def test_ctor() -> None:
 
     assert "GET" == req.method
     assert HttpVersion(1, 1) == req.version
-    # MacOS may return CamelCased host name, need .lower()
-    # FQDN can be wider than host, e.g.
-    # 'fv-az397-495' in 'fv-az397-495.internal.cloudapp.net'
-    assert req.host.lower() in socket.getfqdn().lower()
+    # No Host header in this request, so host falls back to the
+    # local socket address the request arrived on (the default
+    # sockname configured by make_mocked_request).
+    assert req.host == "127.0.0.1"
     assert "/path/to?a=1&b=2" == req.path_qs
     assert "/path/to" == req.path
     assert "a=1&b=2" == req.query_string
@@ -114,6 +116,53 @@ def test_deprecated_message() -> None:
     req = make_mocked_request("GET", "/path/to?a=1&b=2")
     with pytest.deprecated_call(match=r"^Request\.message is deprecated$"):
         assert req.message == req._message
+
+
+def test_host_falls_back_to_sockname_not_dns() -> None:
+    """Regression: request.host must not call socket.getfqdn().
+
+    socket.getfqdn() does blocking reverse DNS resolution on the
+    event loop thread and can stall a worker for many seconds when
+    the system resolver is slow. The fallback for a request with no
+    Host header is the local socket address the request arrived on,
+    not the system FQDN.
+    """
+    req = make_mocked_request("GET", "/")
+    assert req.host == "127.0.0.1"
+    assert str(req.url).startswith("http://127.0.0.1")
+
+
+def test_host_with_ipv6_sockname() -> None:
+    """AF_INET6 sockname is bracketed to form a valid URL authority.
+
+    A bare IPv6 string would cause ``URL.build(authority=...)`` to
+    raise ``ValueError``.
+    """
+    transport = mock.Mock()
+    transport.get_extra_info.side_effect = lambda key: (
+        ("::1", 80, 0, 0) if key == "sockname" else None
+    )
+    req = make_mocked_request("GET", "/", transport=transport)
+    assert req.host == "[::1]"
+    assert str(req.url) == "http://[::1]/"
+
+
+def test_host_with_unix_socket_sockname() -> None:
+    """Unix-socket transports expose sockname as a str path."""
+    transport = mock.Mock()
+    transport.get_extra_info.side_effect = lambda key: (
+        "/tmp/aiohttp.sock" if key == "sockname" else None
+    )
+    req = make_mocked_request("GET", "/", transport=transport)
+    assert req.host == "/tmp/aiohttp.sock"
+
+
+def test_host_with_no_transport_sockname() -> None:
+    """An empty string is returned when no sockname is available."""
+    transport = mock.Mock()
+    transport.get_extra_info.return_value = None
+    req = make_mocked_request("GET", "/", transport=transport)
+    assert req.host == ""
 
 
 def test_doubleslashes() -> None:


### PR DESCRIPTION
**This is a backport of PR #12597 as merged into master (28d1214f76e59e84d5905c0b7dedfac73f785b18).**

<!-- Thank you for your contribution! -->

## What do these changes do?

Replace the ``socket.getfqdn()`` fallback in
``BaseRequest.host`` with the local socket address the request
arrived on, exposed via a new ``sockname`` cached property on
``RequestHandler`` that mirrors ``peername``.

``socket.getfqdn()`` does blocking reverse DNS resolution on
the event loop and can stall a worker for many seconds when
the system resolver is slow. The call is reachable remotely:
an HTTP/1.0 request with no ``Host`` header (the 1.1 parser
rejects those; 1.0 has no such requirement), combined with any
handler or middleware that reads ``request.host`` or
``request.url``, is enough to freeze the loop for one full
resolver timeout per request.

The new fallback is non-blocking and is arguably more correct
for what ``request.host`` is answering. Code that needs the
FQDN should call ``socket.getfqdn()`` directly, off the loop.

## Are there changes in behavior for the user?

Yes. ``BaseRequest.host`` and ``BaseRequest.url`` no longer
return the system FQDN when a request arrives without a
``Host`` header; they return the local socket address instead,
or empty string if no transport information is available.
Well-behaved HTTP/1.1 clients always send ``Host`` and are
unaffected.

This ships as a ``breaking`` news fragment, but I am not
bumping the major version. It is a security fix being
backported to ``3.13`` and ``3.14`` to close the event-loop
block there as well. Holding it behind a major-version cycle
would leave the hole open in supported branches for the strict
semver value of a behavior change that only fires on code
paths well-behaved clients never hit.

## Is it a substantial burden for the maintainers to support this?

No. Small, self-contained diff.

## Related issue number

Closes #9308.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to ``CONTRIBUTORS.txt``: N/A (already listed)
- [x] Add a new news fragment into the ``CHANGES/`` folder (``CHANGES/9308.breaking.rst``)

Drafted with Claude Code (Opus 4.7); reviewed by @bdraco.
