### PR TITLE
Shrink three slow tests without changing their intent

### DIFF
--- a/CHANGES/12606.contrib.rst
+++ b/CHANGES/12606.contrib.rst
@@ -1,0 +1,6 @@
+Reduced runtime of several of the slowest unit tests
+(decompress size-limit payloads from 64 MiB to 2 MiB,
+``test_chunk_splits_after_pause`` chunk count from 50000
+to 20000, and ``test_set_cookies_max_age`` sleep from 2
+seconds to 1.1 seconds) without changing what they
+exercise -- by :user:`bdraco`.

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -2416,7 +2416,7 @@ async def test_payload_decompress_size_limit(aiohttp_client: AiohttpClient) -> N
     we raise DecompressSizeError.
     """
     # Create a highly compressible payload.
-    payload_size = 64 * 2**20
+    payload_size = 2 * 2**20
     original = b"A" * payload_size
     compressed = zlib.compress(original)
     assert len(original) > DEFAULT_CHUNK_SIZE
@@ -2448,7 +2448,7 @@ async def test_payload_decompress_size_limit_brotli(
     """Test that brotli decompression size limit triggers DecompressSizeError."""
     assert brotli is not None
     # Create a highly compressible payload
-    payload_size = 64 * 2**20
+    payload_size = 2 * 2**20
     original = b"A" * payload_size
     compressed = brotli.compress(original)
     assert len(original) > DEFAULT_CHUNK_SIZE
@@ -2479,7 +2479,7 @@ async def test_payload_decompress_size_limit_zstd(
     """Test that zstd decompression size limit triggers DecompressSizeError."""
     assert ZstdCompressor is not None
     # Create a highly compressible payload.
-    payload_size = 64 * 2**20
+    payload_size = 2 * 2**20
     original = b"A" * payload_size
     compressor = ZstdCompressor()
     compressed = compressor.compress(original) + compressor.flush()
@@ -2904,7 +2904,7 @@ async def test_set_cookies_max_age(aiohttp_client: AiohttpClient) -> None:
         assert 200 == resp.status
         cookie_names = {c.key for c in client.session.cookie_jar}
         assert cookie_names == {"c1", "c2", "c3"}
-        await asyncio.sleep(2)
+        await asyncio.sleep(1.1)
         cookie_names = {c.key for c in client.session.cookie_jar}
         assert cookie_names == {"c1", "c2"}
 

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -1155,9 +1155,10 @@ def test_max_header_value_size_under_limit(parser: HttpRequestParser) -> None:
 
 
 async def test_chunk_splits_after_pause(parser: HttpRequestParser) -> None:
+    num_chunks = 20000  # comfortably above the 16385 pause threshold
     text = (
         b"GET /test HTTP/1.1\r\nHost: a\r\nTransfer-Encoding: chunked\r\n\r\n"
-        + b"1\r\nb\r\n" * 50000
+        + b"1\r\nb\r\n" * num_chunks
         + b"0\r\n\r\n"
     )
 
@@ -1168,8 +1169,9 @@ async def test_chunk_splits_after_pause(parser: HttpRequestParser) -> None:
     assert len(payload._http_chunk_splits) == 16385
     # We should still get the full result after read(), as it will continue processing.
     result = await payload.read()
-    assert len(result) == 50000  # Compare len first, as it's easier to debug in diff.
-    assert result == b"b" * 50000
+    # Compare len first, as it's easier to debug in diff.
+    assert len(result) == num_chunks
+    assert result == b"b" * num_chunks
 
 
 async def test_compressed_with_tail(response: HttpResponseParser) -> None:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Three small test-runtime reductions for the slowest unit tests
flagged by ``--durations`` on the Linux CI legs:

* ``test_payload_decompress_size_limit`` and its ``_brotli`` and
  ``_zstd`` siblings shrink the payload from 64 MiB to 2 MiB. The
  only invariant the tests assert is ``len(original) >
  DEFAULT_CHUNK_SIZE`` (256 KiB), so 2 MiB still exercises the same
  multi-chunk decompression and ``iter_chunked`` path.
* ``test_chunk_splits_after_pause`` drops the chunk count from
  50000 to 20000. The assertion is
  ``len(_http_chunk_splits) == 16385`` (the pause threshold) plus
  that the resumed read returns the full payload, so anything
  comfortably above 16385 verifies the same behaviour.
* ``test_set_cookies_max_age`` waits ``1.1`` seconds instead of
  ``2`` for a cookie with ``Max-Age=1``.

Together this knocks roughly 7 to 8 seconds off each Linux unit
test job. The HTTP parser test runs against both the C and pure
Python backends via the existing parametrization.

## Are there changes in behavior for the user?

No, tests only.

## Is it a substantial burden for the maintainers to support this?

No.

## Related issue number

No issue.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
- [x] Add a new news fragment into the `CHANGES/` folder

<details>
<summary>Agent run details (optional, for reviewers)</summary>

Tests, default (C extension) build, Python 3.14, macOS:
``python -Im pytest --no-cov --durations=10 tests/test_client_functional.py::test_payload_decompress_size_limit tests/test_client_functional.py::test_payload_decompress_size_limit_brotli tests/test_client_functional.py::test_payload_decompress_size_limit_zstd tests/test_client_functional.py::test_set_cookies_max_age tests/test_http_parser.py::test_chunk_splits_after_pause``
→ 5 passed, 1 skipped (zstd not installed locally). Slowest now
1.10s (the ``Max-Age`` sleep) and 0.13s (``test_chunk_splits_after_pause[py-parser]``).

Tests, ``AIOHTTP_NO_EXTENSIONS=1`` build, same Python:
same set passes; only the ``[py-parser]`` variant of
``test_chunk_splits_after_pause`` is collected, as expected.

``make doc-spelling``: my fragment introduces no new misspellings;
the 3 pre-existing baseline warnings (``accessor``, ``flakey``)
come from other in-flight CHANGES fragments and reproduce on a
clean master.

Pre-commit hooks all pass on the staged files.
</details>

Drafted with Claude Code (Opus 4.7); reviewed by @bdraco.