### PR TITLE
[PR #12609/b26cfbff backport][3.13] Fix flaky test_shutdown_handler_cancellation_suppressed

### DIFF
--- a/tests/test_run_app.py
+++ b/tests/test_run_app.py
@@ -1268,6 +1268,7 @@ class TestShutdown:
         sock = unused_port_socket
         port = sock.getsockname()[1]
         actions = []
+        suppressed = asyncio.Event()
 
         async def test() -> None:
             async def test_resp(sess):
@@ -1279,7 +1280,8 @@ class TestShutdown:
 
             async with ClientSession() as sess:
                 t = asyncio.create_task(test_resp(sess))
-                await asyncio.sleep(0.5)
+                # Wait until the handler has observed its cancellation.
+                await asyncio.wait_for(suppressed.wait(), timeout=3)
                 # Handler is in-progress while we trigger server shutdown.
                 actions.append("PRESTOP")
                 async with sess.get(f"http://127.0.0.1:{port}/stop"):
@@ -1300,6 +1302,7 @@ class TestShutdown:
                 await asyncio.sleep(5)
             except asyncio.CancelledError:
                 actions.append("SUPPRESSED")
+                suppressed.set()
                 await asyncio.sleep(2)
                 actions.append("DONE")
             return web.Response(text="FOO")


### PR DESCRIPTION
**This is a backport of PR #12609 as merged into master (b26cfbff865fcb7c3f89f37d0c351fb25193fb1d).**

<!-- Thank you for your contribution! -->

## What do these changes do?

Replace a wall-clock ``await asyncio.sleep(0.5)`` in
``test_shutdown_handler_cancellation_suppressed`` with an
``asyncio.Event`` the handler sets immediately after appending
``SUPPRESSED``. The test was relying on a 0.1 second margin
between the client-side ``ClientTimeout(total=0.4)`` and the
client coroutine's wake-up to order ``PRESTOP`` after
``CANCELLED``/``SUPPRESSED``; on slow Windows runners that
margin flips and the test fails with assertions like:

```
AssertionError: assert ['PRESTOP', '... 'SUPPRESSED'] ==
                       ['CANCELLED', ...'PING', 'DONE']
```

The wait is bounded with ``asyncio.wait_for(..., timeout=3)``
so a real regression fails fast instead of hanging on the
event.

## Are there changes in behavior for the user?

No, test only.

## Is it a substantial burden for the maintainers to support this?

No.

## Related issue number

No issue.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
- [ ] Add a new news fragment into the `CHANGES/` folder
  * N/A: small CI flake fix, no user- or contributor-visible behaviour change beyond the test itself.

<details>
<summary>Agent run details (optional, for reviewers)</summary>

Reproducer: failed on aio-libs/aiohttp#12606 CI in
``Test (3.10, windows, false)`` with
``AssertionError: assert ['PRESTOP', '... 'SUPPRESSED'] == ['CANCELLED',...PING', 'DONE']``.
The rerun passed, which matches a timing race.

Local verification (macOS, Python 3.14):

* Default (C extension) build: 5 consecutive runs of
  ``pytest tests/test_run_app.py::TestShutdown::test_shutdown_handler_cancellation_suppressed``
  pass at ~2.42s each.
* ``AIOHTTP_NO_EXTENSIONS=1`` build: 3 consecutive runs pass
  at ~2.42s each.

Pre-commit hooks all pass on the staged file.
</details>

Drafted with Claude Code (Opus 4.7); reviewed by @bdraco.