### PR TITLE
Drop per-request cookies on cross-origin redirects

### DIFF
--- a/CHANGES/12614.bugfix.rst
+++ b/CHANGES/12614.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed per-request ``cookies`` parameter leaking to cross-origin redirect targets -- by :user:`rodrigobnogueira`.

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -916,6 +916,7 @@ class ClientSession:
 
                         if url.origin() != redirect_origin:
                             auth = None
+                            cookies = None
                             headers.pop(hdrs.AUTHORIZATION, None)
                             headers.pop(hdrs.COOKIE, None)
                             headers.pop(hdrs.PROXY_AUTHORIZATION, None)

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -3490,6 +3490,87 @@ async def test_drop_auth_on_redirect_to_other_host(
             assert resp.status == 200
 
 
+@pytest.mark.parametrize(
+    ("url_from_s", "url_to_s"),
+    (
+        ("http://host1.com/path1", "http://host2.com/path2"),
+        ("http://host1.com/path1", "https://host1.com/path1"),
+        ("https://host1.com/path1", "http://host1.com/path2"),
+        ("http://host1.com/path1", "https://host1.com:9443/path1"),
+    ),
+    ids=(
+        "entirely different hosts",
+        "http -> https",
+        "https -> http",
+        "http -> https different port",
+    ),
+)
+async def test_drop_cookies_param_on_redirect_to_other_host(
+    create_server_for_url_and_handler: Callable[[URL, Handler], Awaitable[TestServer]],
+    url_from_s: str,
+    url_to_s: str,
+) -> None:
+    """Per-request cookies= must not leak to cross-origin redirect targets."""
+    url_from, url_to = URL(url_from_s), URL(url_to_s)
+
+    async def srv_from(request: web.Request) -> NoReturn:
+        assert request.host.split(":")[0] == url_from.host
+        assert "session" in request.cookies
+        raise web.HTTPFound(url_to)
+
+    async def srv_to(request: web.Request) -> web.Response:
+        assert request.host.split(":")[0] == url_to.host
+        assert "Cookie" not in request.headers, "Per-request cookies leaked to redirect"
+        return web.Response()
+
+    server_from = await create_server_for_url_and_handler(url_from, srv_from)
+    server_to = await create_server_for_url_and_handler(url_to, srv_to)
+
+    assert (
+        url_from.host != url_to.host
+        or server_from.scheme != server_to.scheme
+        or url_from.port != url_to.port
+    ), "Invalid test case, host, scheme, or port must differ"
+
+    etc_hosts = {
+        (url_from.host, url_from.port): server_from,
+        (url_to.host, url_to.port): server_to,
+    }
+
+    class FakeResolver(AbstractResolver):
+        async def resolve(
+            self,
+            host: str,
+            port: int = 0,
+            family: socket.AddressFamily = socket.AF_INET,
+        ) -> list[ResolveResult]:
+            server = etc_hosts[(host, port)]
+            assert server.port is not None
+
+            return [
+                {
+                    "hostname": host,
+                    "host": server.host,
+                    "port": server.port,
+                    "family": socket.AF_INET,
+                    "proto": 0,
+                    "flags": socket.AI_NUMERICHOST,
+                }
+            ]
+
+        async def close(self) -> None:
+            """Dummy"""
+
+    connector = aiohttp.TCPConnector(resolver=FakeResolver(), ssl=False)
+
+    async with aiohttp.ClientSession(connector=connector) as client:
+        async with client.get(
+            url_from,
+            cookies={"session": "SECRET"},
+        ) as resp:
+            assert resp.status == 200
+
+
 async def test_auth_persist_on_redirect_to_other_host_with_global_auth(
     create_server_for_url_and_handler: Callable[[URL, Handler], Awaitable[TestServer]],
 ) -> None:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Clear per-request ``cookies=`` after a redirect crosses origins, matching the existing handling for auth and explicit ``Cookie`` headers.

This prevents the request-level cookie value from being rebuilt into the redirected request.

## Are there changes in behavior for the user?

Yes. Cookies passed through the per-request ``cookies`` parameter are no longer sent to a different origin after a redirect.

## Is it a substantial burden for the maintainers to support this?

No. The change follows the existing redirect-origin boundary for other sensitive request data.

## Related issue number

Related to a private security report.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
- [x] Add a new news fragment into the `CHANGES/` folder

Drafted with Codex GPT-5; pending human review by rodrigobnogueira.

<details>
<summary>Agent run details</summary>

Tests:

- `.venv/bin/python -m pytest tests/test_client_functional.py::test_drop_cookies_param_on_redirect_to_other_host -q`: passed, 4 tests.
- `AIOHTTP_NO_EXTENSIONS=1 .venv/bin/python -m pytest tests/test_client_functional.py::test_drop_cookies_param_on_redirect_to_other_host -q`: passed, 4 tests.
- `.venv/bin/python -m pytest -q`: failed with one unrelated failure in `tests/test_multipart.py::test_body_part_reader_payload_write`; the new redirect test passed during the run.
- `AIOHTTP_NO_EXTENSIONS=1 .venv/bin/python -m pytest -q`: failed with the same unrelated failure in `tests/test_multipart.py::test_body_part_reader_payload_write`; the new redirect test passed during the run.

Checks:

- `.venv/bin/python tools/check_changes.py`: passed.
- `git diff --check -- aiohttp/client.py tests/test_client_functional.py CHANGES/12614.bugfix.rst`: passed.
- `make doc-spelling SPHINXBUILD=../.venv/bin/sphinx-build`: failed due existing spelling entries in generated towncrier fragments, `accessor` and `flakey`, plus offline intersphinx warnings; the new fragment did not add a spelling failure.
- `.venv/bin/python -m pre_commit run --files aiohttp/client.py tests/test_client_functional.py CHANGES/12614.bugfix.rst`: failed because the isolated pre-commit flake8 environment could not import `pkg_resources` for `flake8-requirements`; earlier hooks, formatters, `Check CHANGES`, and codespell passed.
</details>
