### PR TITLE
[PR #12600/f402c3d8 backport][3.14] Silence uvloop 0.22+ asyncio.AbstractEventLoopPolicy deprecation

### DIFF
--- a/CHANGES/12600.contrib.rst
+++ b/CHANGES/12600.contrib.rst
@@ -1,0 +1,4 @@
+Silenced the ``DeprecationWarning`` raised by ``uvloop`` 0.22+ when it
+accesses the ``asyncio.AbstractEventLoopPolicy`` alias that Python 3.14
+marks for removal in 3.16, so the test suite passes against the newer
+``uvloop`` release -- by :user:`bdraco`.

--- a/setup.cfg
+++ b/setup.cfg
@@ -82,6 +82,10 @@ filterwarnings =
     ignore:coroutine method 'aclose' of 'BodyPartReader._decode_content_async' was never awaited:RuntimeWarning
     # Our own warning
     ignore:aiohttp.pytest_plugin will be removed in v4:DeprecationWarning
+    # uvloop 0.22+ accesses the deprecated asyncio.AbstractEventLoopPolicy
+    # alias, which Python 3.14 marks for removal in 3.16. Drop this when
+    # uvloop stops touching the deprecated alias.
+    ignore:'asyncio.AbstractEventLoopPolicy' is deprecated:DeprecationWarning:uvloop
 junit_suite_name = aiohttp_test_suite
 norecursedirs = dist docs build .tox .eggs
 minversion = 3.8.2


### PR DESCRIPTION
**This is a backport of PR #12600 as merged into master (f402c3d86601b36617edf5d58820d671bafb4c36).**

<!-- Thank you for your contribution! -->

## What do these changes do?

Add a targeted ``filterwarnings`` entry that ignores the
``DeprecationWarning`` ``uvloop`` 0.22+ raises when it accesses the
``asyncio.AbstractEventLoopPolicy`` alias that Python 3.14 marks for
removal in 3.16.

``uvloop`` 0.22 made ``EventLoopPolicy`` a lazy attribute; the lazy
``__getattr__`` calls ``getattr(asyncio, 'AbstractEventLoopPolicy')``,
and under Python 3.14 that triggers a ``DeprecationWarning``. With
``filterwarnings = error`` in ``setup.cfg``, the warning becomes a
test failure on ``test_init_process[UvloopWorker-pyloop]`` and
``test_init_process_no_loop[UvloopWorker-pyloop]``. This is currently
blocking the uvloop 0.22.1 Dependabot bumps in #11682 (master) and
#11683 (3.14).

## Are there changes in behavior for the user?

No. The change is limited to the test configuration in ``setup.cfg``.

## Is it a substantial burden for the maintainers to support this?

No. The filter is narrowly scoped to the ``uvloop`` module and the
specific ``asyncio.AbstractEventLoopPolicy`` message, and can be
removed once ``uvloop`` stops accessing the deprecated alias.

## Related issue number

Refs #11682 and #11683.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [N/A] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to ``CONTRIBUTORS.txt``
- [x] Add a new news fragment into the ``CHANGES/`` folder