### PR TITLE
[PR #12619/b391f7be backport][3.13] Add timeouts to test runners to prevent CI hangs

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -167,6 +167,7 @@ jobs:
       fail-fast: true
     runs-on: ${{ matrix.os }}-latest
     continue-on-error: ${{ matrix.experimental }}
+    timeout-minutes: 15
     steps:
     - name: Checkout
       uses: actions/checkout@v5


### PR DESCRIPTION
**This is a backport of PR #12619 as merged into master (b391f7beec755dac3977f930f0f7705337240a35).**

<!-- Thank you for your contribution! -->

## What do these changes do?

Add timeouts to test runners to prevent CI hangs

https://github.com/aio-libs/aiohttp/pull/12611 hung on 3.9 and I can't figure out why just yet. We need to avoid multi hour hangs because they use up runners.


## Are there changes in behavior for the user?

no

## Is it a substantial burden for the maintainers to support this?

no

## Related issue number

https://github.com/aio-libs/aiohttp/pull/12611 

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES/` folder
  * name it `<issue_or_pr_num>.<type>.rst` (e.g. `588.bugfix.rst`)
  * if you don't have an issue number, change it to the pull request
    number after creating the PR
    * `.bugfix`: A bug fix for something the maintainers deemed an
      improper undesired behavior that got corrected to match
      pre-agreed expectations.
    * `.feature`: A new behavior, public APIs. That sort of stuff.
    * `.deprecation`: A declaration of future API removals and breaking
      changes in behavior.
    * `.breaking`: When something public is removed in a breaking way.
      Could be deprecated in an earlier release.
    * `.doc`: Notable updates to the documentation structure or build
      process.
    * `.packaging`: Notes for downstreams about unobvious side effects
      and tooling. Changes in the test invocation considerations and
      runtime assumptions.
    * `.contrib`: Stuff that affects the contributor experience. e.g.
      Running tests, building the docs, setting up the development
      environment.
    * `.misc`: Changes that are hard to assign to any of the above
      categories.
  * Make sure to use full sentences with correct case and punctuation,
    for example:
    ```rst
    Fixed issue with non-ascii contents in doctest text files
    -- by :user:`contributor-gh-handle`.
    ```

    Use the past tense or the present tense a non-imperative mood,
    referring to what's changed compared to the last released version
    of this project.