### PR TITLE
[PR #12624/3bca18a8 backport][3.14] Add per-test pytest-timeout to surface hung tests

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -335,7 +335,7 @@ jobs:
         PIP_USER: 1
       run: >-
         PATH="${HOME}/Library/Python/3.11/bin:${HOME}/.local/bin:${PATH}"
-        pytest --junitxml=junit.xml --cov=aiohttp/ --cov=tests/ -m autobahn
+        pytest --junitxml=junit.xml --cov=aiohttp/ --cov=tests/ --timeout=0 -m autobahn
       shell: bash
     - name: Turn coverage into xml
       env:
@@ -405,7 +405,7 @@ jobs:
       uses: CodSpeedHQ/action@v4
       with:
         mode: instrumentation
-        run: python -Im pytest --no-cov -vvvvv --codspeed --durations=30
+        run: python -Im pytest --no-cov -vvvvv --codspeed --durations=30 --timeout=0
 
 
   cython-coverage:

--- a/CHANGES/12624.contrib.rst
+++ b/CHANGES/12624.contrib.rst
@@ -1,0 +1,4 @@
+Added a default 120-second per-test timeout via ``pytest-timeout`` so a
+hung test surfaces by name in CI output instead of getting hidden behind
+the job-level timeout added in :pr:`12619`. The ``autobahn`` and
+benchmark jobs opt out with ``--timeout=0`` -- by :user:`bdraco`.

--- a/requirements/test-common.in
+++ b/requirements/test-common.in
@@ -8,6 +8,7 @@ proxy.py >= 2.4.4rc5
 pytest
 pytest-cov
 pytest-mock
+pytest-timeout
 pytest-xdist
 pytest_codspeed
 python-on-whales

--- a/requirements/test-common.txt
+++ b/requirements/test-common.txt
@@ -79,6 +79,8 @@ pytest-cov==7.1.0
     # via -r requirements/test-common.in
 pytest-mock==3.15.1
     # via -r requirements/test-common.in
+pytest-timeout==2.4.0
+    # via -r requirements/test-common.in
 pytest-xdist==3.8.0
     # via -r requirements/test-common.in
 python-dateutil==2.9.0.post0

--- a/requirements/test-ft.txt
+++ b/requirements/test-ft.txt
@@ -115,6 +115,8 @@ pytest-cov==7.1.0
     # via -r requirements/test-common.in
 pytest-mock==3.15.1
     # via -r requirements/test-common.in
+pytest-timeout==2.4.0
+    # via -r requirements/test-common.in
 pytest-xdist==3.8.0
     # via -r requirements/test-common.in
 python-dateutil==2.9.0.post0

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -115,6 +115,8 @@ pytest-cov==7.1.0
     # via -r requirements/test-common.in
 pytest-mock==3.15.1
     # via -r requirements/test-common.in
+pytest-timeout==2.4.0
+    # via -r requirements/test-common.in
 pytest-xdist==3.8.0
     # via -r requirements/test-common.in
 python-dateutil==2.9.0.post0

--- a/setup.cfg
+++ b/setup.cfg
@@ -54,6 +54,9 @@ addopts =
     --showlocals
 
     -m "not dev_mode and not autobahn and not internal"
+# 2-minute per-test timeout so a hung test surfaces by name instead of taking
+# down the whole job. Autobahn and benchmark jobs override with `--timeout=0`.
+timeout = 120
 filterwarnings =
     error
     ignore:module 'ssl' has no attribute 'OP_NO_COMPRESSION'. The Python interpreter is compiled against OpenSSL < 1.0.0. Ref. https.//docs.python.org/3/library/ssl.html#ssl.OP_NO_COMPRESSION:UserWarning


### PR DESCRIPTION
**This is a backport of PR #12624 as merged into master (3bca18a8398e5045bc2332a521d535b84ef1fa12).**

## What do these changes do?

Follow-up to #12619, which added a 15-minute job-level timeout to the
test, autobahn, and cython-coverage workflows. That timeout stops the
job from hanging forever but tells us nothing about *which* test is
stuck — the whole job just gets killed.

This PR adds `pytest-timeout` (2.4.0) and a default `timeout = 120` to
`[tool:pytest]` in `setup.cfg`, so an individual hung test is killed by
name and shows up in the junit/log output. The autobahn and benchmark
jobs opt out with `--timeout=0` because those workloads are
intentionally long-running.

## Are there changes in behavior for the user?

None. CI-only.

## Is it a substantial burden for the maintainers to support this?

No — `pytest-timeout` is a well-maintained plugin and the configuration
is two lines. Tests that legitimately need more than 2 minutes can opt
out per-test with `@pytest.mark.timeout(0)` or a larger value.

## Related issue number

Follow-up to #12619.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist — N/A (CI/test-infra change)
- [x] Documentation reflects the changes — N/A
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt` — already listed
- [x] Add a new news fragment into the `CHANGES/` folder — `CHANGES/12620.contrib.rst` (rename to the PR number once assigned)

---

Drafted with Claude Code (Opus 4.7); reviewed by @bdraco.