### PR TITLE
Install Python via astral-sh/setup-uv in test/autobahn jobs

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -190,11 +190,12 @@ jobs:
         submodules: true
     - name: Setup Python ${{ matrix.pyver }}
       id: python-install
+      # important: do not use system python
+      env:
+        UV_PYTHON_PREFERENCE: only-managed
       uses: astral-sh/setup-uv@v8.1.0
       with:
         python-version: ${{ matrix.pyver }}
-        # important: do not use system python
-        python-preference: only-managed
         activate-environment: true
         enable-cache: true
     - name: Update pip, wheel, setuptools, build, twine
@@ -294,11 +295,12 @@ jobs:
         submodules: true
     - name: Setup Python ${{ matrix.pyver }}
       id: python-install
+      # important: do not use system python
+      env:
+        UV_PYTHON_PREFERENCE: only-managed
       uses: astral-sh/setup-uv@v8.1.0
       with:
         python-version: ${{ matrix.pyver }}
-        # important: do not use system python
-        python-preference: only-managed
         activate-environment: true
         enable-cache: true
     - name: Update pip, wheel, setuptools, build, twine

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -190,30 +190,19 @@ jobs:
         submodules: true
     - name: Setup Python ${{ matrix.pyver }}
       id: python-install
-      uses: actions/setup-python@v6
+      uses: astral-sh/setup-uv@v8.1.0
       with:
-        allow-prereleases: true
         python-version: ${{ matrix.pyver }}
-    - name: Get pip cache dir
-      id: pip-cache
-      run: |
-        echo "dir=$(pip cache dir)" >> "${GITHUB_OUTPUT}"
-      shell: bash
-    - name: Cache PyPI
-      uses: actions/cache@v5.0.5
-      with:
-        key: pip-ci-${{ runner.os }}-${{ matrix.pyver }}-${{ matrix.no-extensions }}-${{ hashFiles('requirements/*.txt') }}
-        path: ${{ steps.pip-cache.outputs.dir }}
-        restore-keys: |
-            pip-ci-${{ runner.os }}-${{ matrix.pyver }}-${{ matrix.no-extensions }}-
+        activate-environment: true
+        enable-cache: true
     - name: Update pip, wheel, setuptools, build, twine
       run: |
-        python -m pip install -U pip wheel setuptools build twine
+        uv pip install -U pip wheel setuptools build twine
     - name: Install dependencies
       env:
         DEPENDENCY_GROUP: test${{ endsWith(matrix.pyver, 't') && '-ft' || '' }}
       run: |
-        python -Im pip install -r requirements/${{ env.DEPENDENCY_GROUP }}.in -c requirements/${{ env.DEPENDENCY_GROUP }}.txt
+        uv pip install -r requirements/${{ env.DEPENDENCY_GROUP }}.in -c requirements/${{ env.DEPENDENCY_GROUP }}.txt
     - name: Set PYTHON_GIL=0 for free-threading builds
       if: ${{ endsWith(matrix.pyver, 't') }}
       run: echo "PYTHON_GIL=0" >> $GITHUB_ENV
@@ -230,7 +219,7 @@ jobs:
     - name: Install self
       env:
         AIOHTTP_NO_EXTENSIONS: ${{ matrix.no-extensions }}
-      run: python -m pip install -e .
+      run: uv pip install -e .
     - name: Run unittests
       env:
         COLOR: yes
@@ -303,30 +292,19 @@ jobs:
         submodules: true
     - name: Setup Python ${{ matrix.pyver }}
       id: python-install
-      uses: actions/setup-python@v6
+      uses: astral-sh/setup-uv@v8.1.0
       with:
-        allow-prereleases: true
         python-version: ${{ matrix.pyver }}
-    - name: Get pip cache dir
-      id: pip-cache
-      run: |
-        echo "dir=$(pip cache dir)" >> "${GITHUB_OUTPUT}"
-      shell: bash
-    - name: Cache PyPI
-      uses: actions/cache@v5.0.5
-      with:
-        key: pip-ci-${{ runner.os }}-${{ matrix.pyver }}-${{ matrix.no-extensions }}-${{ hashFiles('requirements/*.txt') }}
-        path: ${{ steps.pip-cache.outputs.dir }}
-        restore-keys: |
-            pip-ci-${{ runner.os }}-${{ matrix.pyver }}-${{ matrix.no-extensions }}-
+        activate-environment: true
+        enable-cache: true
     - name: Update pip, wheel, setuptools, build, twine
       run: |
-        python -m pip install -U pip wheel setuptools build twine
+        uv pip install -U pip wheel setuptools build twine
     - name: Install dependencies
       env:
         DEPENDENCY_GROUP: test${{ endsWith(matrix.pyver, 't') && '-ft' || '' }}
       run: |
-        python -Im pip install -r requirements/${{ env.DEPENDENCY_GROUP }}.in -c requirements/${{ env.DEPENDENCY_GROUP }}.txt
+        uv pip install -r requirements/${{ env.DEPENDENCY_GROUP }}.in -c requirements/${{ env.DEPENDENCY_GROUP }}.txt
     - name: Restore llhttp generated files
       if: ${{ matrix.no-extensions == '' }}
       uses: actions/download-artifact@v8
@@ -340,7 +318,7 @@ jobs:
     - name: Install self
       env:
         AIOHTTP_NO_EXTENSIONS: ${{ matrix.no-extensions }}
-      run: python -m pip install -e .
+      run: uv pip install -e .
     - name: Run unittests
       env:
         COLOR: yes

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -193,6 +193,8 @@ jobs:
       uses: astral-sh/setup-uv@v8.1.0
       with:
         python-version: ${{ matrix.pyver }}
+        # important: do not use system python
+        python-preference: only-managed
         activate-environment: true
         enable-cache: true
     - name: Update pip, wheel, setuptools, build, twine
@@ -295,6 +297,8 @@ jobs:
       uses: astral-sh/setup-uv@v8.1.0
       with:
         python-version: ${{ matrix.pyver }}
+        # important: do not use system python
+        python-preference: only-managed
         activate-environment: true
         enable-cache: true
     - name: Update pip, wheel, setuptools, build, twine

--- a/CHANGES/12629.contrib.rst
+++ b/CHANGES/12629.contrib.rst
@@ -1,6 +1,7 @@
 Switched the CI ``test`` and ``autobahn`` jobs from
 ``actions/setup-python`` to ``astral-sh/setup-uv`` for installing
 interpreters, cutting the ``Setup Python`` step from 40-58s to a
-few seconds on macOS and Windows runners for variants not in the
-hosted tool-cache (notably the free-threaded ``3.14t``)
+few seconds on ``macos-latest`` and ``windows-latest`` runners for
+variants not in the hosted tool-cache (notably the free-threaded
+``3.14t``)
 -- by :user:`bdraco`.

--- a/CHANGES/12629.contrib.rst
+++ b/CHANGES/12629.contrib.rst
@@ -1,0 +1,6 @@
+Switched the CI ``test`` and ``autobahn`` jobs from
+``actions/setup-python`` to ``astral-sh/setup-uv`` for installing
+interpreters, cutting the ``Setup Python`` step from 40-58s to a
+few seconds on macOS and Windows runners for variants not in the
+hosted tool-cache (notably the free-threaded ``3.14t``)
+-- by :user:`bdraco`.


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Swap `actions/setup-python@v6` for `astral-sh/setup-uv@v8.1.0` in
the two CI matrix jobs that install a Python interpreter — `test`
and `autobahn`. `activate-environment: true` keeps `python`/`pip`
on PATH so the subsequent `uv pip install ...` invocations target
the seeded venv. `enable-cache: true` subsumes the previous
`actions/cache` pip-cache step, which is dropped.

## Are there changes in behavior for the user?

No. This only affects CI runner provisioning. End-user-visible
behavior of `aiohttp` is unaffected.

The Codecov flag derived from
`steps.python-install.outputs.python-version` now reports the
matrix spec (`3.14t`) rather than the resolved patch
(`3.14.5t`); coarser, but easier to group across patch releases.

## Is it a substantial burden for the maintainers to support this?

No. `astral-sh/setup-uv` is widely used across aio-libs and the
broader Python ecosystem; `activate-environment: true` reproduces
the behavior the existing pipeline already relies on, so the swap
is local to the action invocation.

This mirrors aio-libs/yarl#1704, which made the same swap.

## Related issue number

N/A.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist — N/A (CI configuration)
- [x] Documentation reflects the changes — N/A (no user-visible change)
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt` — already listed
- [ ] Add a new news fragment into the `CHANGES/` folder — to be added in a follow-up commit once the PR number is assigned

<details>
<summary>Agent run details (optional, for reviewers)</summary>

`actions/setup-python` downloads non-cached interpreter variants
from its release index, which takes ~40s on macos-latest and ~58s
on windows-latest for `3.14t` (the free-threaded build is not in
the hosted-tool-cache). `astral-sh/setup-uv` pulls
python-build-standalone from a CDN, which is a few seconds across
all three OSes. Motivation transferred from the yarl PR's own
measurements.

</details>

Drafted with Claude Code (Opus 4.7); reviewed by @bdraco.