### PR TITLE
Combine build-tool update and dependency install into one CI step per job

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -80,12 +80,9 @@ jobs:
         path: ~/.cache/pip
         restore-keys: |
             pip-lint-
-    - name: Update pip, wheel, setuptools, build, twine
-      run: |
-        python -m pip install -U pip wheel setuptools build twine
     - name: Install dependencies
       run: |
-        python -m pip install -r requirements/lint.in -c requirements/lint.txt
+        python -m pip install -U pip wheel setuptools build twine -r requirements/lint.in -c requirements/lint.txt
     - name: Install self
       run: |
         python -m pip install . -c requirements/runtime-deps.txt
@@ -198,14 +195,11 @@ jobs:
         python-version: ${{ matrix.pyver }}
         activate-environment: true
         enable-cache: true
-    - name: Update pip, wheel, setuptools, build, twine
-      run: |
-        uv pip install -U pip wheel setuptools build twine
     - name: Install dependencies
       env:
         DEPENDENCY_GROUP: test${{ endsWith(matrix.pyver, 't') && '-ft' || '' }}
       run: |
-        uv pip install -r requirements/${{ env.DEPENDENCY_GROUP }}.in -c requirements/${{ env.DEPENDENCY_GROUP }}.txt
+        uv pip install -U pip wheel setuptools build twine -r requirements/${{ env.DEPENDENCY_GROUP }}.in -c requirements/${{ env.DEPENDENCY_GROUP }}.txt
     - name: Set PYTHON_GIL=0 for free-threading builds
       if: ${{ endsWith(matrix.pyver, 't') }}
       run: echo "PYTHON_GIL=0" >> $GITHUB_ENV
@@ -303,14 +297,11 @@ jobs:
         python-version: ${{ matrix.pyver }}
         activate-environment: true
         enable-cache: true
-    - name: Update pip, wheel, setuptools, build, twine
-      run: |
-        uv pip install -U pip wheel setuptools build twine
     - name: Install dependencies
       env:
         DEPENDENCY_GROUP: test${{ endsWith(matrix.pyver, 't') && '-ft' || '' }}
       run: |
-        uv pip install -r requirements/${{ env.DEPENDENCY_GROUP }}.in -c requirements/${{ env.DEPENDENCY_GROUP }}.txt
+        uv pip install -U pip wheel setuptools build twine -r requirements/${{ env.DEPENDENCY_GROUP }}.in -c requirements/${{ env.DEPENDENCY_GROUP }}.txt
     - name: Restore llhttp generated files
       if: ${{ matrix.no-extensions == '' }}
       uses: actions/download-artifact@v8
@@ -375,12 +366,9 @@ jobs:
         python-version: 3.13.2
         cache: pip
         cache-dependency-path: requirements/*.txt
-    - name: Update pip, wheel, setuptools, build, twine
-      run: |
-        python -m pip install -U pip wheel setuptools build twine
     - name: Install dependencies
       run: |
-        python -m pip install -r requirements/test.in -c requirements/test.txt
+        python -m pip install -U pip wheel setuptools build twine -r requirements/test.in -c requirements/test.txt
     - name: Restore llhttp generated files
       uses: actions/download-artifact@v8
       with:
@@ -419,12 +407,9 @@ jobs:
       uses: actions/setup-python@v6
       with:
         python-version: '3.12'
-    - name: Update pip, wheel, setuptools, build, twine
-      run: |
-        python -m pip install -U pip wheel setuptools build twine
     - name: Install dependencies
       run: |
-        python -Im pip install -r requirements/test.in -c requirements/test.txt
+        python -Im pip install -U pip wheel setuptools build twine -r requirements/test.in -c requirements/test.txt
     - name: Uninstall blocbuster
       run: python -m pip uninstall blockbuster -y
     - name: Restore llhttp generated files
@@ -508,13 +493,10 @@ jobs:
         submodules: true
     - name: Setup Python
       uses: actions/setup-python@v6
-    - name: Update pip, wheel, setuptools, build, twine
-      run: |
-        python -m pip install -U pip wheel setuptools build twine
-    - name: Install cython
+    - name: Install build tooling and cython
       run: >-
         python -m
-        pip install -r requirements/cython.in -c requirements/cython.txt
+        pip install -U pip wheel setuptools build twine -r requirements/cython.in -c requirements/cython.txt
     - name: Restore llhttp generated files
       uses: actions/download-artifact@v8
       with:
@@ -601,13 +583,10 @@ jobs:
       uses: actions/setup-python@v6
       with:
         python-version: 3.x
-    - name: Update pip, wheel, setuptools, build, twine
-      run: |
-        python -m pip install -U pip wheel setuptools build twine
-    - name: Install cython
+    - name: Install build tooling and cython
       run: >-
         python -m
-        pip install -r requirements/cython.in -c requirements/cython.txt
+        pip install -U pip wheel setuptools build twine -r requirements/cython.in -c requirements/cython.txt
     - name: Restore llhttp generated files
       uses: actions/download-artifact@v8
       with:

--- a/CHANGES/12643.contrib.rst
+++ b/CHANGES/12643.contrib.rst
@@ -1,0 +1,5 @@
+Merged the "Update pip, wheel, setuptools, build, twine" step into
+the following ``Install dependencies`` (or ``Install cython``) step
+in every job in ``.github/workflows/ci-cd.yml``, so each job now
+runs a single ``pip``/``uv pip install`` invocation instead of two
+-- by :user:`bdraco`.

--- a/CHANGES/12643.contrib.rst
+++ b/CHANGES/12643.contrib.rst
@@ -1,5 +1,5 @@
 Merged the "Update pip, wheel, setuptools, build, twine" step into
 the following ``Install dependencies`` (or ``Install cython``) step
-in every job in ``.github/workflows/ci-cd.yml``, so each job now
+in every job in :file:`.github/workflows/ci-cd.yml`, so each job now
 runs a single ``pip``/``uv pip install`` invocation instead of two
 -- by :user:`bdraco`.


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Merges the "Update pip, wheel, setuptools, build, twine" step into the following "Install dependencies" (or "Install cython") step in every job in `ci-cd.yml`; one resolver invocation per job instead of two, with the same set of packages getting installed.

## Are there changes in behavior for the user?

No; same packages are still installed, just in a single `pip`/`uv pip install` call. The "Install self" steps are intentionally left alone since they run after `make cythonize` and rely on built extensions.

## Is it a substantial burden for the maintainers to support this?

No; it is a mechanical collapse across seven jobs, easy to revert per-job if anything regresses.

## Related issue number

Follow-up to #12641, continuing the work to make the CI install path cheaper for downstream consumers using uv.

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
  * N/A, workflow-only change.
- [ ] Documentation reflects the changes
  * N/A.
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * Already listed.
- [x] Add a new news fragment into the `CHANGES/` folder
  * `CHANGES/12643.contrib.rst`.

Drafted with Claude Code (claude-opus-4-7); reviewed by @bdraco.