### PR TITLE
[PR #12641/1aef5d70 backport][3.13] Make pip command configurable via PIP variable in Makefile

### DIFF
--- a/CHANGES/12641.contrib.rst
+++ b/CHANGES/12641.contrib.rst
@@ -1,0 +1,5 @@
+Made the ``pip`` command used by the ``Makefile`` configurable via a
+``PIP`` variable; downstream consumers can now run, for example,
+``make .develop PIP="uv pip"`` to install via ``uv`` without us
+maintaining a parallel target
+-- by :user:`bdraco`.

--- a/CHANGES/12641.contrib.rst
+++ b/CHANGES/12641.contrib.rst
@@ -1,4 +1,4 @@
-Made the ``pip`` command used by the ``Makefile`` configurable via a
+Made the ``pip`` command used by the :file:`Makefile` configurable via a
 ``PIP`` variable; downstream consumers can now run, for example,
 ``make .develop PIP="uv pip"`` to install via ``uv`` without us
 maintaining a parallel target

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@
 to-hash-one = $(dir $1).hash/$(addsuffix .hash,$(notdir $1))
 to-hash = $(foreach fname,$1,$(call to-hash-one,$(fname)))
 
+PIP ?= python -m pip
 CYS := $(wildcard aiohttp/*.pyx) $(wildcard aiohttp/*.pyi)  $(wildcard aiohttp/*.pxd) $(wildcard aiohttp/_websocket/*.pyx) $(wildcard aiohttp/_websocket/*.pyi) $(wildcard aiohttp/_websocket/*.pxd)
 PYXS := $(wildcard aiohttp/*.pyx) $(wildcard aiohttp/_websocket/*.pyx)
 CS := $(wildcard aiohttp/*.c) $(wildcard aiohttp/_websocket/*.c)
@@ -47,10 +48,10 @@ endif
 .SECONDARY: $(call to-hash,$(ALLS))
 
 .update-pip:
-	@python -m pip install --upgrade pip
+	@$(PIP) install --upgrade pip
 
 .install-cython: .update-pip $(call to-hash,requirements/cython.txt)
-	@python -m pip install -r requirements/cython.in -c requirements/cython.txt
+	@$(PIP) install -r requirements/cython.in -c requirements/cython.txt
 	@touch .install-cython
 
 aiohttp/_find_header.c: $(call to-hash,aiohttp/hdrs.py ./tools/gen.py)
@@ -85,7 +86,7 @@ cythonize: .install-cython $(PYXS:.pyx=.c) aiohttp/_websocket/reader_c.c
 cythonize-nodeps: $(PYXS:.pyx=.c) aiohttp/_websocket/reader_c.c
 
 .install-deps: .install-cython $(PYXS:.pyx=.c) aiohttp/_websocket/reader_c.c $(call to-hash,$(CYS) $(REQS))
-	@python -m pip install -r requirements/dev.in -c requirements/dev.txt
+	@$(PIP) install -r requirements/dev.in -c requirements/dev.txt
 	@touch .install-deps
 
 .PHONY: lint
@@ -100,7 +101,7 @@ mypy:
 	mypy
 
 .develop: .install-deps generate-llhttp $(call to-hash,$(PYS) $(CYS) $(CS))
-	python -m pip install -e . -c requirements/runtime-deps.txt
+	$(PIP) install -e . -c requirements/runtime-deps.txt
 	@touch .develop
 
 .PHONY: test
@@ -182,7 +183,7 @@ doc-spelling:
 
 .PHONY: install
 install: .update-pip
-	@python -m pip install -r requirements/dev.in -c requirements/dev.txt
+	@$(PIP) install -r requirements/dev.in -c requirements/dev.txt
 
 .PHONY: install-dev
 install-dev: .develop


### PR DESCRIPTION
**This is a backport of PR #12641 as merged into master (1aef5d7021e138fa2297f5cc12e2f370c3614c96).**

<!-- Thank you for your contribution! -->

## What do these changes do?

Adds a `PIP ?= python -m pip` variable to the Makefile and threads `$(PIP)` through every install recipe (`.update-pip`, `.install-cython`, `.install-deps`, `.develop`, `install`); downstream CI such as yarl can now run `make .develop PIP="uv pip"` to install via uv without us maintaining a parallel `.develop-uv` target.

## Are there changes in behavior for the user?

No; the default expands to the existing `python -m pip` invocation, so contributors and existing CI see no difference.

## Is it a substantial burden for the maintainers to support this?

No; it is one variable plus five mechanical substitutions, and the default value preserves current behavior.

## Related issue number

Follow-up to https://github.com/aio-libs/yarl/pull/1716, which switched yarl's downstream aiohttp test runner to uv but still falls back to pip inside `make .develop`.

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
  * N/A, Makefile-only knob with no behavior change at the default.
- [ ] Documentation reflects the changes
  * N/A, internal contributor knob.
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * Already listed.
- [x] Add a new news fragment into the `CHANGES/` folder
  * `CHANGES/12641.contrib.rst`.

Drafted with Claude Code (claude-opus-4-7); reviewed by @bdraco.