### PR TITLE
docs: include THREAT_MODEL.md in Sphinx documentation via MyST-parser

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -59,6 +59,7 @@ extensions = [
     "sphinx.ext.intersphinx",
     "sphinx.ext.viewcode",
     # Third-party extensions:
+    "myst_parser",
     "sphinxcontrib.towncrier.ext",  # provides `towncrier-draft-entries` directive
 ]
 
@@ -92,7 +93,10 @@ intersphinx_mapping = {
 templates_path = ["_templates"]
 
 # The suffix of source filenames.
-source_suffix = ".rst"
+source_suffix = {
+    ".rst": "restructuredtext",
+    ".md": "markdown",
+}
 
 # The encoding of source files.
 # source_encoding = 'utf-8-sig'

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -231,3 +231,4 @@ Table Of Contents
    misc
    external
    contributing
+   security

--- a/docs/security.rst
+++ b/docs/security.rst
@@ -9,4 +9,3 @@ analysis of the library's security properties.
 
 .. include:: ../THREAT_MODEL.md
    :parser: myst_parser.sphinx_
-

--- a/docs/security.rst
+++ b/docs/security.rst
@@ -1,0 +1,12 @@
+.. _aiohttp-security:
+
+========
+Security
+========
+
+This section contains the aiohttp threat model, which is a STRIDE-based
+analysis of the library's security properties.
+
+.. include:: ../THREAT_MODEL.md
+   :parser: myst_parser.sphinx_
+

--- a/requirements/doc.in
+++ b/requirements/doc.in
@@ -1,5 +1,5 @@
 aiohttp-theme
+myst-parser
 sphinx
 sphinxcontrib-towncrier
 towncrier
-myst-parser

--- a/requirements/doc.in
+++ b/requirements/doc.in
@@ -2,3 +2,4 @@ aiohttp-theme
 sphinx
 sphinxcontrib-towncrier
 towncrier
+myst-parser


### PR DESCRIPTION
## Summary

This PR includes the `THREAT_MODEL.md` file in the Sphinx documentation via MyST-parser integration, as requested in #12549.

## Changes

1. **`requirements/doc.in`**: Added `myst-parser` dependency
2. **`docs/conf.py`**: 
   - Added `myst_parser` to the extensions list
   - Updated `source_suffix` to support both `.rst` and `.md` files
3. **`docs/index.rst`**: Added `security` page to the documentation toctree
4. **`docs/security.rst`**: New page that includes `THREAT_MODEL.md` using MyST-parser's include directive

## How it works

The `security.rst` page uses Sphinx's `.. include::` directive with the `myst_parser.sphinx_` parser to render the Markdown threat model within the RST-based documentation.

## Verification

After this PR is merged, the threat model will be accessible at:
- `/security.html` in the built documentation
- The "Security" link in the sidebar navigation

Closes #12549
