### PR TITLE
ci: fall back to plain build frontend for odd-arch wheels

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -577,6 +577,9 @@ jobs:
           # Build emulated architectures only if QEMU is set,
           # use default "auto" otherwise
           echo "CIBW_ARCHS_LINUX=${{ matrix.qemu }}" >> $GITHUB_ENV
+          # Override pyproject.toml's `build[uv]`: the pypa odd-arch
+          # manylinux/musllinux containers do not ship `uv` preinstalled.
+          echo "CIBW_BUILD_FRONTEND=build" >> $GITHUB_ENV
         fi
       shell: bash
     - name: Setup Python
@@ -600,8 +603,11 @@ jobs:
       with:
         # `build-frontend = "build[uv]"` (pyproject.toml) requires uv to be
         # available on the runner for Windows and macOS. Installing
-        # cibuildwheel with the `uv` extra bundles uv with it; Linux
-        # already has uv inside the manylinux/musllinux container.
+        # cibuildwheel with the `uv` extra bundles uv with it; the
+        # tested-arch manylinux/musllinux containers also ship uv
+        # preinstalled. The odd-arch containers do not, so the
+        # `Prepare emulation` step above sets `CIBW_BUILD_FRONTEND=build`
+        # for those QEMU matrix cells.
         extras: uv
       env:
         CIBW_SKIP: pp* ${{ matrix.musl == 'musllinux' && '*manylinux*' || '*musllinux*' }}

--- a/CHANGES/12647.contrib.rst
+++ b/CHANGES/12647.contrib.rst
@@ -1,0 +1,4 @@
+Override ``CIBW_BUILD_FRONTEND=build`` on the QEMU-emulated odd-arch wheel
+jobs so cibuildwheel falls back to plain pip, because the pypa
+``manylinux``/``musllinux`` containers for those arches do not ship ``uv``
+preinstalled -- by :user:`bdraco`.

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -68,6 +68,7 @@ charset
 charsetdetect
 chunked
 chunking
+cibuildwheel
 CIMultiDict
 ClientSession
 cls
@@ -264,6 +265,7 @@ py
 pydantic
 pyenv
 pyflakes
+pypa
 pyright
 pytest
 Pytest


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Set `CIBW_BUILD_FRONTEND=build` in the `Prepare emulation` step of the
`build-wheels` matrix, so cibuildwheel uses plain pip to drive the
QEMU-emulated odd-arch builds (`ppc64le`, `riscv64`, `s390x`, `armv7l`
x manylinux/musllinux).

`pyproject.toml` sets `build-frontend = "build[uv]"`, which requires a
`uv` binary on `PATH` inside the build container. The pypa tested-arch
manylinux/musllinux images ship `uv` preinstalled, but the odd-arch
images do not. Mirrors the fix landed in yarl as
https://github.com/aio-libs/yarl/pull/1720.

The override sits in the existing shell step that already gates on
`matrix.qemu`, so native (x86_64 / ubuntu-24.04-arm) jobs are
untouched.

## Are there changes in behavior for the user?

No user-visible API change. Restores production of odd-arch wheels in
future releases.

## Is it a substantial burden for the maintainers to support this?

No; one extra `echo` inside an existing `if` plus a comment update.
The override can be reverted once the pypa odd-arch images ship `uv`.

## Related issue number

Ports https://github.com/aio-libs/yarl/pull/1720 to aiohttp.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist -- N/A, CI workflow change
- [x] Documentation reflects the changes -- N/A
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt` -- already listed
- [x] Add a new news fragment into the `CHANGES/` folder

<details>
<summary>Agent run details (optional, for reviewers)</summary>

- This is a port of aio-libs/yarl#1720; aiohttp's wheel matrix is a
  single `build-wheels` job rather than yarl's split tested-arch /
  odd-arch matrices, so the override lives inside the existing
  `Prepare emulation` step that already keys off `matrix.qemu`. Native
  ARM (`ubuntu-24.04-arm`) keeps the `build[uv]` frontend.
- The odd-arch matrix is gated on `pre-deploy` (tag pushes only), so
  this change cannot be smoke-tested on a PR. Verification path is the
  next tagged release.
- Pre-commit ran clean on the changed files.

Drafted with Claude Code (Opus 4.7); reviewed by @bdraco before flipping out of draft.

</details>