### PR TITLE
ci: build armv7l wheels on native ARM runners

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -546,10 +546,15 @@ jobs:
         - os: ubuntu-latest
           qemu: s390x
           musl: musllinux
-        - os: ubuntu-latest
+        # armv7l builds on aarch64 hosts. We still register QEMU so
+        # binfmt picks up the 32-bit ARM userspace handler regardless of
+        # whether the host kernel has CONFIG_COMPAT enabled. Even with
+        # emulation, aarch64-on-aarch64 hosting beats x86_64 by a wide
+        # margin.
+        - os: ubuntu-24.04-arm
           qemu: armv7l
           musl: ""
-        - os: ubuntu-latest
+        - os: ubuntu-24.04-arm
           qemu: armv7l
           musl: musllinux
         - os: ubuntu-latest

--- a/CHANGES/12652.contrib.rst
+++ b/CHANGES/12652.contrib.rst
@@ -1,0 +1,4 @@
+Switched the armv7l wheel builds onto GitHub's hosted ARM runners. The
+32-bit ARM build still runs under QEMU, but the host is now aarch64
+rather than x86_64, so the emulation overhead drops sharply
+-- by :user:`bdraco`.

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -1,3 +1,4 @@
+aarch
 abc
 ABI
 addons


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Move the ``armv7l`` legs of the release wheel matrix off the x86_64
QEMU path and onto GitHub's hosted ``ubuntu-24.04-arm`` runner.
``docker/setup-qemu-action`` still runs so binfmt registers a 32-bit
ARM userspace handler whether or not the host kernel ships
``CONFIG_COMPAT``; even under emulation, ``armv7l``-on-``aarch64``
is far cheaper than the previous ``armv7l``-on-``x86_64`` layout.

The ``aarch64`` wheels were already native on ``ubuntu-24.04-arm`` via
the base ``os`` list, so no change there. ``ppc64le``, ``s390x``, and
``riscv64`` keep the ``ubuntu-latest`` + QEMU setup since there are no
native GH-hosted runners for those.

Ported from aio-libs/yarl#1724, which made the equivalent change there
(and additionally moved ``aarch64`` to native; yarl had ``aarch64`` on
QEMU which aiohttp does not).

## Are there changes in behavior for the user?

No. Wheels are still built for the same architectures and tags; only
the host that builds the ``armv7l`` legs changes.

## Is it a substantial burden for the maintainers to support this?

No. ``ubuntu-24.04-arm`` is already used in the base ``os`` list of the
same matrix; the matrix shape stays the same.

## Related issue number

N/A. Mirrors aio-libs/yarl#1724 for aiohttp's ``armv7l`` legs.

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist -- N/A (CI workflow change, exercised by the next release run)
- [ ] Documentation reflects the changes -- N/A
- [x] If you provide code modification, please add yourself to ``CONTRIBUTORS.txt`` -- already listed
- [x] Add a new news fragment into the ``CHANGES/`` folder

<details>
<summary>Agent run details (optional, for reviewers)</summary>

Drafted with Claude Code (claude-opus-4-7); reviewed by @bdraco.

Local checks:
- ``pre-commit run --files .github/workflows/ci-cd.yml docs/spelling_wordlist.txt CHANGES/12652.contrib.rst`` -- all hooks pass.
- Not validated locally: actual native-ARM cibuildwheel run for ``armv7l``. The matrix wiring (``Set up QEMU`` step is still gated on ``matrix.qemu`` and runs on the ``ubuntu-24.04-arm`` host, ``CIBW_ARCHS_LINUX=armv7l`` set via ``Prepare emulation``) looks correct, but the real proof is the next release run.
- News fragment number ``12652`` is a guess; rename to the actual PR number once it is assigned.

</details>