### PR TITLE
[PR #12174/ca9d73dd backport][3.14] feat: add cookies and host_only_cookies properties to CookieJar

### DIFF
--- a/CHANGES/3951.feature.rst
+++ b/CHANGES/3951.feature.rst
@@ -1,0 +1,1 @@
+Added :py:attr:`~aiohttp.CookieJar.cookies` and :py:attr:`~aiohttp.CookieJar.host_only_cookies` read-only properties to :py:class:`~aiohttp.CookieJar` exposing the stored cookies with their full attributes -- by :user:`Br1an67`.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -65,6 +65,7 @@ Benedikt Reinartz
 Bob Haddleton
 Boris Feld
 Boyi Chen
+Br1an67
 Brett Cannon
 Brett Higgins
 Brian Bouterse

--- a/aiohttp/abc.py
+++ b/aiohttp/abc.py
@@ -3,7 +3,8 @@ import logging
 import socket
 from abc import ABC, abstractmethod
 from collections.abc import Awaitable, Callable, Generator, Iterable, Sequence, Sized
-from http.cookies import BaseCookie, Morsel
+from http.cookies import BaseCookie, Morsel, SimpleCookie
+from types import MappingProxyType
 from typing import TYPE_CHECKING, Any, TypedDict
 
 from multidict import CIMultiDict
@@ -172,6 +173,16 @@ class AbstractCookieJar(Sized, IterableBase):
     @abstractmethod
     def quote_cookie(self) -> bool:
         """Return True if cookies should be quoted."""
+
+    @property
+    @abstractmethod
+    def cookies(self) -> MappingProxyType[tuple[str, str], SimpleCookie]:
+        """Return the cookies stored in this jar."""
+
+    @property
+    @abstractmethod
+    def host_only_cookies(self) -> frozenset[tuple[str, str]]:
+        """Return the host-only cookies stored in this jar."""
 
     @abstractmethod
     def clear(self, predicate: ClearCookiePredicate | None = None) -> None:

--- a/aiohttp/cookiejar.py
+++ b/aiohttp/cookiejar.py
@@ -14,6 +14,7 @@ import warnings
 from collections import defaultdict
 from collections.abc import Iterable, Iterator, Mapping
 from http.cookies import BaseCookie, Morsel, SimpleCookie
+from types import MappingProxyType
 from typing import Union
 
 from yarl import URL
@@ -155,6 +156,16 @@ class CookieJar(AbstractCookieJar):
     @property
     def quote_cookie(self) -> bool:
         return self._quote_cookie
+
+    @property
+    def cookies(self) -> MappingProxyType[tuple[str, str], SimpleCookie]:
+        """Return the cookies stored in this jar."""
+        return MappingProxyType(self._cookies)
+
+    @property
+    def host_only_cookies(self) -> frozenset[tuple[str, str]]:
+        """Return the host-only cookies stored in this jar."""
+        return frozenset(self._host_only_cookies)
 
     def save(self, file_path: PathLike) -> None:
         """Save cookies to a file using JSON format.
@@ -625,6 +636,16 @@ class DummyCookieJar(AbstractCookieJar):
     @property
     def quote_cookie(self) -> bool:
         return True
+
+    @property
+    def cookies(self) -> MappingProxyType[tuple[str, str], SimpleCookie]:
+        """Return an empty mapping."""
+        return MappingProxyType({})
+
+    @property
+    def host_only_cookies(self) -> frozenset[tuple[str, str]]:
+        """Return an empty frozenset."""
+        return frozenset()
 
     def clear(self, predicate: ClearCookiePredicate | None = None) -> None:
         pass

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -2586,6 +2586,21 @@ Utilities
 
       .. versionadded:: 4.0
 
+   .. attribute:: cookies
+
+      A read-only view of the jar's cookies as a
+      :class:`~types.MappingProxyType` mapping ``(domain, path)`` tuples
+      to :class:`~http.cookies.SimpleCookie` instances.
+
+      .. versionadded:: 3.14
+
+   .. attribute:: host_only_cookies
+
+      A :class:`frozenset` of ``(domain, name)`` tuples indicating which
+      cookies are host-only (not sent to subdomains).
+
+      .. versionadded:: 3.14
+
 
 .. class:: DummyCookieJar(*, loop=None)
 

--- a/tests/test_client_session.py
+++ b/tests/test_client_session.py
@@ -8,6 +8,7 @@ import warnings
 from collections import deque
 from collections.abc import Awaitable, Callable, Iterator
 from http.cookies import BaseCookie, SimpleCookie
+from types import MappingProxyType
 from typing import Any, cast
 from unittest import mock
 from uuid import uuid4
@@ -755,6 +756,14 @@ async def test_cookie_jar_usage(loop: Any, aiohttp_client: Any) -> None:
         def quote_cookie(self) -> bool:
             return True
 
+        @property
+        def cookies(self) -> MappingProxyType[tuple[str, str], SimpleCookie]:
+            return MappingProxyType({})
+
+        @property
+        def host_only_cookies(self) -> frozenset[tuple[str, str]]:
+            return frozenset()
+
         def clear(self, predicate: abc.ClearCookiePredicate | None = None) -> None:
             self._clear_mock(predicate)
 
@@ -777,6 +786,8 @@ async def test_cookie_jar_usage(loop: Any, aiohttp_client: Any) -> None:
 
     assert jar.quote_cookie is True
     assert jar.unsafe is False
+    assert jar.cookies == MappingProxyType({})
+    assert jar.host_only_cookies == frozenset()
     assert len(jar) == 0
     assert list(jar) == []
     jar.clear()

--- a/tests/test_cookiejar.py
+++ b/tests/test_cookiejar.py
@@ -12,6 +12,7 @@ import unittest
 from http.cookies import BaseCookie, Morsel, SimpleCookie
 from operator import not_
 from pathlib import Path
+from types import MappingProxyType
 from unittest import mock
 
 import pytest
@@ -838,6 +839,54 @@ async def test_dummy_cookie_jar() -> None:
         next(iter(dummy_jar))
     assert not dummy_jar.filter_cookies(URL("http://example.com/"))
     dummy_jar.clear()
+
+
+async def test_dummy_cookie_jar_cookies_property() -> None:
+    dummy_jar = DummyCookieJar()
+    assert dict(dummy_jar.cookies) == {}
+    assert dummy_jar.host_only_cookies == frozenset()
+
+
+async def test_cookie_jar_cookies_property() -> None:
+    jar = CookieJar()
+    cookie = SimpleCookie(
+        "shared-cookie=first; domain-cookie=second; Domain=example.com; Path=/; "
+    )
+    jar.update_cookies(cookie, URL("http://example.com/"))
+
+    cookies = jar.cookies
+    # Should be a read-only view
+    assert isinstance(cookies, MappingProxyType)
+    # Should contain the stored cookies with their full attributes
+    found_names = {name for simple_cookie in cookies.values() for name in simple_cookie}
+    assert "shared-cookie" in found_names
+    assert "domain-cookie" in found_names
+    # Verify that domain attribute is preserved
+    for key, simple_cookie in cookies.items():
+        for name, morsel in simple_cookie.items():
+            if name == "domain-cookie":
+                assert morsel["domain"] == "example.com"
+                assert morsel["path"] == "/"
+
+
+async def test_cookie_jar_host_only_cookies_property() -> None:
+    jar = CookieJar()
+    # Cookies without an explicit Domain attribute are host-only
+    cookie = SimpleCookie("hostonly=value;")
+    jar.update_cookies(cookie, URL("http://example.com/"))
+
+    host_only = jar.host_only_cookies
+    assert isinstance(host_only, frozenset)
+    assert ("example.com", "hostonly") in host_only
+
+
+async def test_cookie_jar_cookies_property_immutable() -> None:
+    jar = CookieJar()
+    cookie = SimpleCookie("foo=bar;")
+    jar.update_cookies(cookie, URL("http://example.com/"))
+    cookies = jar.cookies
+    with pytest.raises(TypeError):
+        cookies[("new", "key")] = SimpleCookie()  # type: ignore[index]
 
 
 async def test_loose_cookies_types() -> None:


### PR DESCRIPTION
**This is a backport of PR #12174 as merged into master (ca9d73ddf1e2a182e058641561b7766186b30485).**

## What do these changes do?

Add read-only `cookies` and `host_only_cookies` properties to `CookieJar` (and `AbstractCookieJar` / `DummyCookieJar`) so users can access stored cookies with their full attributes (expires, domain, path, etc.) without relying on private `_cookies` / `_host_only_cookies`.

- `cookies` returns `MappingProxyType[tuple[str, str], SimpleCookie]` — an immutable view of the internal cookie storage
- `host_only_cookies` returns `frozenset[tuple[str, str]]` — a frozen copy of the host-only cookie set

This addresses the long-standing request to expose cookie metadata that `filter_cookies()` intentionally strips (since the HTTP `Cookie` header does not include attributes like `expires`).

## Are there changes in behavior for the user?

Two new public read-only properties are available on `CookieJar` and `DummyCookieJar`:
- `jar.cookies` — read-only mapping of `(domain, path) -> SimpleCookie`
- `jar.host_only_cookies` — frozen set of `(domain, name)` tuples

No existing behavior is changed.

## Is it a substantial burden for the maintainers to support this?

Minimal. The properties are thin wrappers (`MappingProxyType` / `frozenset`) over existing internal state with no new data structures. The `MappingProxyType` prevents direct mutation of the mapping, though the underlying `SimpleCookie` values are still mutable — this matches the trade-off discussed in the issue.

## Related issue number

Fixes #3951

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
- [x] Add a new news fragment into the `CHANGES/` folder