### PR TITLE
fix(client_reqrep): clear _traces in close/release to break session reference cycle

### DIFF
--- a/CHANGES/11043.bugfix
+++ b/CHANGES/11043.bugfix
@@ -1,0 +1,1 @@
+Fixed a slow memory leak where ``ClientResponse`` retained a circular reference to ``ClientSession`` via ``_traces`` after the response was closed.

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -593,6 +593,7 @@ class ClientResponse(HeadersMixin):
             self._output_size = self._stream_writer.output_size
             self._stream_writer = None
         self._session = None
+        self._traces = []
 
     def _notify_content(self) -> None:
         content = self.content

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -525,6 +525,7 @@ class ClientResponse(HeadersMixin):
             return
 
         self._cleanup_writer()
+        self._traces = []
         if self._connection is not None:
             self._connection.close()
             self._connection = None
@@ -536,6 +537,7 @@ class ClientResponse(HeadersMixin):
         self._closed = True
 
         self._cleanup_writer()
+        self._traces = []
         self._release_connection()
 
     @property
@@ -593,7 +595,6 @@ class ClientResponse(HeadersMixin):
             self._output_size = self._stream_writer.output_size
             self._stream_writer = None
         self._session = None
-        self._traces = []
 
     def _notify_content(self) -> None:
         content = self.content

--- a/tests/test_client_response.py
+++ b/tests/test_client_response.py
@@ -1891,9 +1891,12 @@ def test_release_clears_traces_and_session(
     assert response._session is None
 
 
-def test_response_eof_clears_traces_and_session(
+def test_response_eof_clears_session_but_not_traces(
     event_loop: asyncio.AbstractEventLoop, session: ClientSession
 ) -> None:
+    # _response_eof() must NOT clear _traces: it fires during payload EOF which
+    # happens inside read(), before read() iterates _traces to send callbacks.
+    # Clearing _traces here would silently drop on_response_chunk_received hooks.
     url = URL("http://def-cl-resp.org")
     trace = mock.Mock()
     response = ClientResponse(
@@ -1916,7 +1919,7 @@ def test_response_eof_clears_traces_and_session(
     conn.protocol.upgraded = False
 
     response._response_eof()
-    assert response._traces == []
+    assert response._traces == [trace]  # preserved so read() callbacks can still fire
     assert response._session is None
 
 

--- a/tests/test_client_response.py
+++ b/tests/test_client_response.py
@@ -3,6 +3,7 @@
 import asyncio
 import gc
 import sys
+import weakref
 from http.cookies import SimpleCookie
 from json import JSONDecodeError
 from unittest import mock
@@ -1834,3 +1835,121 @@ def test_response_cookies_setter_updates_raw_headers(
     response.cookies = empty_cookies
     # Should not set _raw_cookie_headers for empty cookies
     assert response._raw_cookie_headers is None
+
+
+def test_close_clears_traces_and_session(
+    event_loop: asyncio.AbstractEventLoop, session: ClientSession
+) -> None:
+    url = URL("http://def-cl-resp.org")
+    trace = mock.Mock()
+    response = ClientResponse(
+        "get",
+        url,
+        writer=WriterMock(),
+        continue100=None,
+        timer=TimerNoop(),
+        traces=[trace],
+        loop=event_loop,
+        session=session,
+        request_headers=CIMultiDict[str](),
+        original_url=url,
+        stream_writer=mock.create_autospec(
+            AbstractStreamWriter, spec_set=True, instance=True
+        ),
+    )
+    response._closed = False
+    response._connection = mock.Mock()
+    response.close()
+    assert response._traces == []
+    assert response._session is None
+
+
+def test_release_clears_traces_and_session(
+    event_loop: asyncio.AbstractEventLoop, session: ClientSession
+) -> None:
+    url = URL("http://def-cl-resp.org")
+    trace = mock.Mock()
+    response = ClientResponse(
+        "get",
+        url,
+        writer=WriterMock(),
+        continue100=None,
+        timer=TimerNoop(),
+        traces=[trace],
+        loop=event_loop,
+        session=session,
+        request_headers=CIMultiDict[str](),
+        original_url=url,
+        stream_writer=mock.create_autospec(
+            AbstractStreamWriter, spec_set=True, instance=True
+        ),
+    )
+    response._closed = False
+    response._connection = mock.Mock()
+    response.release()
+    assert response._traces == []
+    assert response._session is None
+
+
+def test_response_eof_clears_traces_and_session(
+    event_loop: asyncio.AbstractEventLoop, session: ClientSession
+) -> None:
+    url = URL("http://def-cl-resp.org")
+    trace = mock.Mock()
+    response = ClientResponse(
+        "get",
+        url,
+        writer=None,
+        continue100=None,
+        timer=TimerNoop(),
+        traces=[trace],
+        loop=event_loop,
+        session=session,
+        request_headers=CIMultiDict[str](),
+        original_url=url,
+        stream_writer=mock.create_autospec(
+            AbstractStreamWriter, spec_set=True, instance=True
+        ),
+    )
+    response._closed = False
+    conn = response._connection = mock.Mock()
+    conn.protocol.upgraded = False
+
+    response._response_eof()
+    assert response._traces == []
+    assert response._session is None
+
+
+@pytest.mark.skipif(
+    sys.implementation.name != "cpython",
+    reason="Other implementations have different GC strategies",
+)
+def test_no_circular_ref_after_close(
+    event_loop: asyncio.AbstractEventLoop, session: ClientSession
+) -> None:
+    url = URL("http://def-cl-resp.org")
+    trace = mock.Mock()
+    response = ClientResponse(
+        "get",
+        url,
+        writer=WriterMock(),
+        continue100=None,
+        timer=TimerNoop(),
+        traces=[trace],
+        loop=event_loop,
+        session=session,
+        request_headers=CIMultiDict[str](),
+        original_url=url,
+        stream_writer=mock.create_autospec(
+            AbstractStreamWriter, spec_set=True, instance=True
+        ),
+    )
+    response._closed = False
+    response._connection = mock.Mock()
+
+    ref = weakref.ref(response)
+    response.close()
+    del response
+    gc.collect()
+
+    assert ref() is None


### PR DESCRIPTION
## What

Clears `self._traces = []` in `ClientResponse.close()` and `ClientResponse.release()` to deterministically break a circular reference that causes slow memory growth (issue #11043).

A `CHANGES/11043.bugfix` towncrier fragment is also included.

Closes #11043

## Why

Issue #11043 reports slow, steady RSS growth when making repeated HTTP requests with tracing enabled. The root cause is a reference cycle that prevents CPython's reference-counting from reclaiming `ClientResponse` objects promptly:

```
ClientResponse._traces  ->  [Trace, ...]
Trace._session          ->  ClientSession
ClientSession           ->  (keeps other things alive)
```

`_cleanup_writer()` already clears `self._session = None`, but `self._traces` was never cleared, keeping every `Trace` (and therefore the session) alive until the cycle GC ran — which is delayed and non-deterministic under load.

## How

`self._traces = []` is added to `close()` and `release()` — **not** to `_cleanup_writer()`.

The reason `_cleanup_writer()` is excluded: it is also called from `_response_eof()`, which fires synchronously as a payload EOF callback *during* `await self.content.read()`. At that point `read()` has not yet iterated `_traces` to fire `on_response_chunk_received` hooks. Clearing `_traces` there silently dropped all response chunk trace callbacks (confirmed by `test_request_tracing` and `test_request_tracing_url_params` regressions).

`close()` and `release()` are always called after the user finishes consuming the response (via context manager `__aexit__`), so the cycle is still broken deterministically — just at the right time.

Key files:
- `aiohttp/client_reqrep.py` — `self._traces = []` added to `close()` and `release()`
- `CHANGES/11043.bugfix` — towncrier changelog fragment
- `tests/test_client_response.py` — four regression tests (including one that asserts `_response_eof()` intentionally does NOT clear `_traces`)

## Testing

```bash
pytest tests/test_client_response.py tests/test_client_session.py -q
```

New tests:
- `test_close_clears_traces_and_session` — `_traces == []` and `_session is None` after `close()`
- `test_release_clears_traces_and_session` — same after `release()`
- `test_response_eof_clears_session_but_not_traces` — `_session is None` but `_traces` preserved after `_response_eof()`, so trace callbacks can still fire
- `test_no_circular_ref_after_close` — CPython-only weakref test confirming the object is collected after `close()`

## Checklist
- [x] Tests pass (`pytest tests/test_client_response.py tests/test_client_session.py -q`)
- [x] Changelog entry added (`CHANGES/11043.bugfix`)
- [x] No new abstractions or unnecessary changes