### PR TITLE
Fix BodyPartReader.read() returning bytearray instead of bytes

### DIFF
--- a/aiohttp/multipart.py
+++ b/aiohttp/multipart.py
@@ -329,8 +329,8 @@ class BodyPartReader:
                 decoded_data.extend(d)
                 if len(decoded_data) > self._client_max_size:
                     raise self._max_size_error_cls(self._client_max_size)
-            return decoded_data
-        return data
+            return bytes(decoded_data)
+        return bytes(data)
 
     async def read_chunk(self, size: int = chunk_size) -> bytes:
         """Reads body part content chunk of the specified size.

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -184,6 +184,15 @@ class TestPartReader:
             result = await obj.read()
             assert b"Hello, world!" == result
             assert obj.at_eof()
+            assert type(result) is bytes
+
+    async def test_read_returns_bytes_not_bytearray_with_decode(self) -> None:
+        h = HeadersDictProxy(CIMultiDict({CONTENT_ENCODING: "identity"}))
+        with Stream(b"Hello!\r\n--:--") as stream:
+            obj = aiohttp.BodyPartReader(BOUNDARY, h, stream)
+            result = await obj.read(decode=True)
+        assert result == b"Hello!"
+        assert type(result) is bytes
 
     async def test_read_chunk_at_eof(self) -> None:
         with Stream(b"--:") as stream:


### PR DESCRIPTION
Fixes #12404

## Problem

`BodyPartReader.read()` accumulates data in a `bytearray` internally and returns it directly, violating the `-> bytes` return type annotation. With `decode=True` the decoded accumulation buffer also returns as `bytearray`.

This causes downstream failures like `TypeError: Object of type bytearray is not JSON serializable` when the result is passed to `json.dumps`, and silently breaks code that checks `isinstance(result, bytes)`.

## Fix

Convert the internal `bytearray` to `bytes` at the return point in both code paths:

```python
# before
return decoded_data  # bytearray
return data          # bytearray

# after
return bytes(decoded_data)
return bytes(data)
```

The `bytearray` is still used internally for efficient `.extend()` accumulation; only the final return value changes.

## Tests

- Added `assert type(result) is bytes` to the existing `test_read` test
- Added `test_read_returns_bytes_not_bytearray_with_decode` covering the `decode=True` path with `Content-Encoding: identity`