### PR TITLE
Improve HTTPS-on-HTTP parser error

### DIFF
--- a/CHANGES/10142.bugfix.rst
+++ b/CHANGES/10142.bugfix.rst
@@ -1,0 +1,1 @@
+Improved the parser error message shown when TLS handshake bytes are received on an HTTP port -- by :user:`puneetdixit200`.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -316,6 +316,7 @@ Phebe Polk
 Philipp A.
 Pierre-Louis Peeters
 Pieter van Beek
+Puneet Dixit
 Qiao Han
 Rafael Viotti
 Rahul Nahata

--- a/aiohttp/_http_parser.pyx
+++ b/aiohttp/_http_parser.pyx
@@ -25,6 +25,7 @@ from .http_exceptions import (
     BadHttpMethod,
     BadStatusLine,
     ContentLengthError,
+    HTTPS_ON_HTTP_PORT_ERROR,
     InvalidHeader,
     InvalidURLError,
     LineTooLong,
@@ -932,6 +933,8 @@ cdef parser_error_from_errno(cparser.llhttp_t* parser, data, pointer):
                  cparser.HPE_INVALID_TRANSFER_ENCODING}:
         return BadHttpMessage(err_msg)
     elif errno == cparser.HPE_INVALID_METHOD:
+        if data.startswith(b"\x16\x03"):
+            return BadHttpMethod(error=HTTPS_ON_HTTP_PORT_ERROR)
         return BadHttpMethod(error=err_msg)
     elif errno in {cparser.HPE_INVALID_STATUS,
                    cparser.HPE_INVALID_VERSION,

--- a/aiohttp/_http_parser.pyx
+++ b/aiohttp/_http_parser.pyx
@@ -21,11 +21,11 @@ from aiohttp.helpers import DEBUG, set_exception
 
 from .helpers import HeadersDictProxy as _HeadersDictProxy
 from .http_exceptions import (
+    HTTPS_ON_HTTP_PORT_ERROR,
     BadHttpMessage,
     BadHttpMethod,
     BadStatusLine,
     ContentLengthError,
-    HTTPS_ON_HTTP_PORT_ERROR,
     InvalidHeader,
     InvalidURLError,
     LineTooLong,

--- a/aiohttp/_http_parser.pyx
+++ b/aiohttp/_http_parser.pyx
@@ -21,7 +21,6 @@ from aiohttp.helpers import DEBUG, set_exception
 
 from .helpers import HeadersDictProxy as _HeadersDictProxy
 from .http_exceptions import (
-    HTTPS_ON_HTTP_PORT_ERROR,
     BadHttpMessage,
     BadHttpMethod,
     BadStatusLine,
@@ -934,7 +933,7 @@ cdef parser_error_from_errno(cparser.llhttp_t* parser, data, pointer):
         return BadHttpMessage(err_msg)
     elif errno == cparser.HPE_INVALID_METHOD:
         if data.startswith(b"\x16\x03"):
-            return BadHttpMethod(error=HTTPS_ON_HTTP_PORT_ERROR)
+            return BadHttpMethod(error="Received HTTPS traffic on an HTTP port")
         return BadHttpMethod(error=err_msg)
     elif errno in {cparser.HPE_INVALID_STATUS,
                    cparser.HPE_INVALID_VERSION,

--- a/aiohttp/http_exceptions.py
+++ b/aiohttp/http_exceptions.py
@@ -94,15 +94,12 @@ class BadStatusLine(BadHttpMessage):
         self.line = line
 
 
-HTTPS_ON_HTTP_PORT_ERROR = "Received HTTPS traffic on an HTTP port"
-
-
 class BadHttpMethod(BadStatusLine):
     """Invalid HTTP method in status line."""
 
     def __init__(self, line: str = "", error: str | None = None) -> None:
         if error is None and line.startswith("\x16\x03"):
-            error = HTTPS_ON_HTTP_PORT_ERROR
+            error = "Received HTTPS traffic on an HTTP port"
         super().__init__(line, error or f"Bad HTTP method in status line {line!r}")
 
 

--- a/aiohttp/http_exceptions.py
+++ b/aiohttp/http_exceptions.py
@@ -94,10 +94,15 @@ class BadStatusLine(BadHttpMessage):
         self.line = line
 
 
+HTTPS_ON_HTTP_PORT_ERROR = "Received HTTPS traffic on an HTTP port"
+
+
 class BadHttpMethod(BadStatusLine):
     """Invalid HTTP method in status line."""
 
     def __init__(self, line: str = "", error: str | None = None) -> None:
+        if error is None and line.startswith("\x16\x03"):
+            error = HTTPS_ON_HTTP_PORT_ERROR
         super().__init__(line, error or f"Bad HTTP method in status line {line!r}")
 
 

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -1600,6 +1600,15 @@ def test_http_request_parser_bad_method(
         )
 
 
+def test_http_request_parser_tls_handshake_on_http_port(
+    parser: HttpRequestParser,
+) -> None:
+    with pytest.raises(http_exceptions.BadHttpMethod) as ctx:
+        parser.feed_data(b"\x16\x03\x03\x01F\x01\r\n\r\n")
+
+    assert "Received HTTPS traffic on an HTTP port" in str(ctx.value)
+
+
 def test_http_request_parser_bad_version(parser: HttpRequestParser) -> None:
     with pytest.raises(http_exceptions.BadHttpMessage):
         parser.feed_data(b"GET //get HT/11\r\nHost: a\r\n\r\n")


### PR DESCRIPTION
## What do these changes do?

Special-cases request parser errors where the incoming method bytes start with `\x16\x03`, which is the common TLS ClientHello prefix. Both the pure-Python and Cython parser paths now report that HTTPS traffic was received on an HTTP port instead of showing the generic invalid method message.

## Are there changes in behavior for the user?

Yes. Misconfigured clients that send HTTPS traffic to an aiohttp HTTP server port now get a clearer 400 parser error message. There are no public API changes.

## Is it a substantial burden for the maintainers to support this?

No. The change is a small error-message special case for a well-known byte prefix, with regression coverage for both parser implementations.

## Related issue number

Fixes #10142.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes (N/A: parser error message only)
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is <Name> <Surname>.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES/` folder
  * name it `<issue_or_pr_num>.<type>.rst` (e.g. `588.bugfix.rst`)
  * if you don't have an issue number, change it to the pull request
    number after creating the PR
    * `.bugfix`: A bug fix for something the maintainers deemed an
      improper undesired behavior that got corrected to match
      pre-agreed expectations.
    * `.feature`: A new behavior, public APIs. That sort of stuff.
    * `.deprecation`: A declaration of future API removals and breaking
      changes in behavior.
    * `.breaking`: When something public is removed in a breaking way.
      Could be deprecated in an earlier release.
    * `.doc`: Notable updates to the documentation structure or build
      process.
    * `.packaging`: Notes for downstreams about unobvious side effects
      and tooling. Changes in the test invocation considerations and
      runtime assumptions.
    * `.contrib`: Stuff that affects the contributor experience. e.g.
      Running tests, building the docs, setting up the development
      environment.
    * `.misc`: Changes that are hard to assign to any of the above
      categories.

<details>
<summary>Local validation</summary>

- Red regression before the fix: `pytest tests/test_http_parser.py::test_http_request_parser_tls_handshake_on_http_port -q` failed because the message was still the generic bad method error.
- Pure-Python parser: `AIOHTTP_NO_EXTENSIONS=1 PYTHONPATH=. pytest tests/test_http_parser.py -q` -> 377 passed, 13 skipped, 4 deselected.
- Accelerated parser build: generated Cython sources and installed editable package with extensions enabled.
- Cython-enabled parser run: `PYTHONPATH=. pytest tests/test_http_parser.py -q` -> 725 passed, 12 skipped, 6 deselected, 3 xfailed.
- Exception tests: `PYTHONPATH=. pytest tests/test_http_exceptions.py -q` -> 19 passed.
- `black --check aiohttp/http_exceptions.py tests/test_http_parser.py` passed.
- `git diff --check` reported only Windows LF-to-CRLF working-copy warnings.

</details>

Drafted with OpenAI GPT-5; reviewed by puneetdixit200.