### PR TITLE
Reduce client timeout test runtime

### DIFF
--- a/CHANGES/9705.contrib.rst
+++ b/CHANGES/9705.contrib.rst
@@ -1,0 +1,2 @@
+Reduced the runtime of a client timeout regression test by shortening its artificial response delay.
+-- by :user:`nightcityblade`.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -282,8 +282,8 @@ Morgan Delahaye-Prat
 Moss Collum
 Mun Gwan-gyeong
 Navid Sheikhol
-Night Cityblade
 Nicolas Braem
+Night Cityblade
 Nikolay Kim
 Nikolay Novik
 Nikolay Tiunov

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -282,6 +282,7 @@ Morgan Delahaye-Prat
 Moss Collum
 Mun Gwan-gyeong
 Navid Sheikhol
+Night Cityblade
 Nicolas Braem
 Nikolay Kim
 Nikolay Novik

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -1161,9 +1161,9 @@ async def test_read_timeout_between_chunks(
     async def handler(request: web.Request) -> web.StreamResponse:
         resp = aiohttp.web.StreamResponse()
         await resp.prepare(request)
-        # write data 4 times, with pauses. Total time 0.2 seconds.
+        # write data 4 times, with pauses. Total time 0.4 seconds.
         for _ in range(4):
-            await asyncio.sleep(0.05)
+            await asyncio.sleep(0.1)
             await resp.write(b"data\n")
         return resp
 

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -1161,17 +1161,17 @@ async def test_read_timeout_between_chunks(
     async def handler(request: web.Request) -> web.StreamResponse:
         resp = aiohttp.web.StreamResponse()
         await resp.prepare(request)
-        # write data 4 times, with pauses. Total time 2 seconds.
+        # write data 4 times, with pauses. Total time 0.2 seconds.
         for _ in range(4):
-            await asyncio.sleep(0.5)
+            await asyncio.sleep(0.05)
             await resp.write(b"data\n")
         return resp
 
     app = web.Application()
     app.add_routes([web.get("/", handler)])
 
-    # A timeout of 0.2 seconds should apply per read.
-    timeout = aiohttp.ClientTimeout(sock_read=1)
+    # The read timeout should apply per read, not to the whole response.
+    timeout = aiohttp.ClientTimeout(sock_read=0.2)
     client = await aiohttp_client(app, timeout=timeout)
 
     res = b""


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Reduce the runtime of `test_read_timeout_between_chunks` by shortening the artificial per-chunk delay while keeping it below the configured per-read timeout.

## Are there changes in behavior for the user?

No. This only changes test timing.

## Is it a substantial burden for the maintainers to support this?

No. The test still covers the same per-read timeout behavior with shorter waits, so it should reduce CI time without adding maintenance overhead.

## Related issue number

Refs #9705.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is <Name> <Surname>.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES/` folder
  * name it `<issue_or_pr_num>.<type>.rst` (e.g. `588.bugfix.rst`)
  * if you don't have an issue number, change it to the pull request
    number after creating the PR
    * `.bugfix`: A bug fix for something the maintainers deemed an
      improper undesired behavior that got corrected to match
      pre-agreed expectations.
    * `.feature`: A new behavior, public APIs. That sort of stuff.
    * `.deprecation`: A declaration of future API removals and breaking
      changes in behavior.
    * `.breaking`: When something public is removed in a breaking way.
      Could be deprecated in an earlier release.
    * `.doc`: Notable updates to the documentation structure or build
      process.
    * `.packaging`: Notes for downstreams about unobvious side effects
      and tooling. Changes in the test invocation considerations and
      runtime assumptions.
    * `.contrib`: Stuff that affects the contributor experience. e.g.
      Running tests, building the docs, setting up the development
      environment.
    * `.misc`: Changes that are hard to assign to any of the above
      categories.
  * Make sure to use full sentences with correct case and punctuation,
    for example:
    ```rst
    Fixed issue with non-ascii contents in doctest text files
    -- by :user:`contributor-gh-handle`.
    ```

    Use the past tense or the present tense a non-imperative mood,
    referring to what's changed compared to the last released version
    of this project.
