### PR TITLE
Drop paths restriction on dep submission

### DIFF
--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -11,10 +11,6 @@ on:
   push:
     branches:
       - master
-    paths:
-      - .gitmodules
-      - vendor/llhttp
-      - .github/workflows/dependency-submission.yml
 
 permissions: {}
 


### PR DESCRIPTION
This literally takes 9 seconds, safer to remove the paths and ensure it's always submitted.