### PR TITLE
Fix TCPConnector.close race nullifying resolver during in-flight resolve (#12497)

### DIFF
--- a/CHANGES/12497.bugfix.rst
+++ b/CHANGES/12497.bugfix.rst
@@ -2,7 +2,7 @@ Fixed ``AttributeError: 'NoneType' object has no attribute 'getaddrinfo'`` when
 ``TCPConnector.close()`` ran concurrently with an in-flight non-cached resolve
 suspended inside a trace callback (e.g. ``on_dns_resolvehost_start``). The
 owned resolver was torn down before the connector was marked closed, leaving
-the resuming resolve to dereference a nullified backend. The connector is now
-marked closed before the resolver is torn down, and the non-cached resolve
-path raises ``ClientConnectionError("Connector is closed.")`` instead --
+the resuming resolve to call a nullified backend. The connector is now marked
+closed before the resolver is torn down, and the non-cached resolve path
+raises ``ClientConnectionError("Connector is closed.")`` instead --
 by :user:`jbbqqf`.

--- a/CHANGES/12497.bugfix.rst
+++ b/CHANGES/12497.bugfix.rst
@@ -1,0 +1,8 @@
+Fixed ``AttributeError: 'NoneType' object has no attribute 'getaddrinfo'`` when
+``TCPConnector.close()`` ran concurrently with an in-flight non-cached resolve
+suspended inside a trace callback (e.g. ``on_dns_resolvehost_start``). The
+owned resolver was torn down before the connector was marked closed, leaving
+the resuming resolve to dereference a nullified backend. The connector is now
+marked closed before the resolver is torn down, and the non-cached resolve
+path raises ``ClientConnectionError("Connector is closed.")`` instead --
+by :user:`jbbqqf`.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -194,6 +194,7 @@ Jan Gosmann
 Jarno Elonen
 Jashandeep Sohi
 Javier Torres
+Jean-Baptiste Braun
 Jean-Baptiste Estival
 Jens Steinhauser
 Jeonghun Lee

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -1005,10 +1005,15 @@ class TCPConnector(BaseConnector):
                          - If ssl_shutdown_timeout=0: connections are aborted
                          - If ssl_shutdown_timeout>0: graceful shutdown is performed
         """
-        if self._resolver_owner:
-            await self._resolver.close()
+        # Mark the connector as closed (and cancel any tracked resolve tasks in
+        # _close_immediately) BEFORE tearing down the owned resolver. Otherwise
+        # an in-flight non-cached resolve suspended inside a trace callback would
+        # wake up after self._resolver was nullified and crash with
+        # AttributeError instead of seeing the closed connector (see #12497).
         # Use abort_ssl param if explicitly set, otherwise use ssl_shutdown_timeout default
         await super().close(abort_ssl=abort_ssl or self._ssl_shutdown_timeout == 0)
+        if self._resolver_owner:
+            await self._resolver.close()
 
     def _close_immediately(self, *, abort_ssl: bool = False) -> list[Awaitable[object]]:
         for fut in chain.from_iterable(self._throttle_dns_futures.values()):
@@ -1061,6 +1066,14 @@ class TCPConnector(BaseConnector):
             if traces:
                 for trace in traces:
                     await trace.send_dns_resolvehost_start(host)
+
+            # If the connector was closed while a trace callback was suspended,
+            # the owned resolver may already have been torn down. Surface the
+            # closed state as ClientConnectionError instead of letting the
+            # resolver crash with AttributeError on its nullified backend
+            # (see #12497).
+            if self._closed:
+                raise ClientConnectionError("Connector is closed.")
 
             res = await self._resolver.resolve(host, port, family=self._family)
 

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -2844,6 +2844,56 @@ async def test_close_cancels_resolve_host(make_client_request: _RequestMaker) ->
             await t
 
 
+async def test_close_during_non_cached_resolve_raises_client_error(
+    make_client_request: _RequestMaker,
+) -> None:
+    """Regression test for #12497.
+
+    When ``use_dns_cache=False`` the resolve call is not tracked in
+    ``_resolve_host_tasks``, so a request suspended inside a trace callback
+    right before the resolver call could previously resume after the owned
+    resolver had been torn down and crash with ``AttributeError`` on the
+    nullified backend. The teardown must instead surface a
+    ``ClientConnectionError("Connector is closed.")`` to the caller, matching
+    the cached-path behavior.
+    """
+    trace_yielded = asyncio.Event()
+
+    async def yielding_on_dns_start(
+        session: object, ctx: object, params: object
+    ) -> None:
+        # Yield so close() can run while the in-flight resolve is suspended
+        # right between the trace callback and the resolver call.
+        trace_yielded.set()
+        await asyncio.sleep(0)
+
+    trace_config = aiohttp.TraceConfig()
+    trace_config.on_dns_resolvehost_start.append(yielding_on_dns_start)
+    trace_config.freeze()
+    trace_obj = Trace(
+        mock.Mock(),
+        trace_config,
+        trace_config.trace_config_ctx(),
+    )
+
+    conn = aiohttp.TCPConnector(use_dns_cache=False)
+    req = make_client_request(
+        "GET",
+        URL("http://example.com:80"),
+        loop=asyncio.get_running_loop(),
+        response_class=mock.Mock(),
+    )
+    task = asyncio.create_task(conn.connect(req, [trace_obj], ClientTimeout()))
+    # Let the request reach the trace-callback yield.
+    await trace_yielded.wait()
+
+    # Close while the resolve is suspended in the trace callback.
+    await conn.close()
+
+    with pytest.raises(aiohttp.ClientConnectionError, match="Connector is closed"):
+        await task
+
+
 async def test_multiple_dns_resolution_requests_success(
     make_client_request: _RequestMaker,
 ) -> None:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

When `TCPConnector.close()` runs concurrently with an in-flight non-cached
resolve that is suspended inside a trace callback (e.g.
`on_dns_resolvehost_start`), the owned resolver used to be torn down
**before** the connector was marked closed. The suspended resolve then
resumed, called `self._resolver.resolve(...)` against a nullified backend,
and crashed with
`AttributeError: 'NoneType' object has no attribute 'getaddrinfo'`.

This PR:

1. Closes the connector first in `TCPConnector.close()` (so `_closed` flips
   to `True` and any tracked resolve tasks are cancelled via
   `_close_immediately`), **then** awaits `self._resolver.close()`.
2. After the trace callback await in the non-cached `_resolve_host` path,
   short-circuits with `ClientConnectionError("Connector is closed.")`
   whenever `self._closed` is set. The non-cached path doesn't store its
   resolve task in `_resolve_host_tasks`, so this guard is what makes the
   teardown observable to the resuming coroutine.

Net effect: the resuming coroutine now sees the connector as closed and
surfaces `ClientConnectionError` to the caller, matching the cached-path
behavior described in the issue.

## Are there changes in behavior for the user?

Yes, but only in the previously-broken edge case: callers that hit this
race now see `ClientConnectionError("Connector is closed.")` instead of
`AttributeError`. The new error matches the wording of the existing check
at `aiohttp/connector.py:621` raised on the post-resolve fast path, so
it's consistent with how an already-closed connector is reported
elsewhere.

## Is it a substantial burden for the maintainers to support this?

No. The fix is two narrow edits in `aiohttp/connector.py`
(`TCPConnector.close` swap + a `self._closed` guard right after the
trace-callback await) plus a regression test. No public-API change.

## Related issue number

Fixes #12497.

## Reproduce BEFORE/AFTER yourself (copy-paste)

```bash
# Setup (Python 3.11+, aiodns optional but reproduces the AttributeError variant)
git clone https://github.com/aio-libs/aiohttp.git /tmp/aiohttp-repro
cd /tmp/aiohttp-repro
git submodule update --init
python -m venv .venv && source .venv/bin/activate
AIOHTTP_NO_EXTENSIONS=1 pip install -e . aiodns

cat > /tmp/repro_12497.py <<'PY'
import asyncio, sys, aiohttp

async def main():
    async def on_dns_start(session, ctx, params):
        await asyncio.sleep(0)
    trace = aiohttp.TraceConfig()
    trace.on_dns_resolvehost_start.append(on_dns_start)
    session = aiohttp.ClientSession(
        trace_configs=[trace],
        connector=aiohttp.TCPConnector(use_dns_cache=False),
    )
    task = asyncio.create_task(session.ws_connect("wss://example.com"))
    await asyncio.sleep(0)
    await session.close()
    try:
        await task
    except AttributeError as e:
        print(f"REPRODUCED: {type(e).__name__}: {e}")
    except aiohttp.ClientConnectionError as e:
        print(f"FIXED: {type(e).__name__}: {e}")
    except Exception as e:
        print(f"OTHER: {type(e).__name__}: {e}")

print(f"Python {sys.version.split()[0]}, aiohttp {aiohttp.__version__}")
asyncio.run(main())
PY

# BEFORE — on origin/master
git checkout master
AIOHTTP_NO_EXTENSIONS=1 pip install -e . --quiet
AIOHTTP_NO_EXTENSIONS=1 python /tmp/repro_12497.py
# Expected: REPRODUCED: AttributeError: 'NoneType' object has no attribute 'getaddrinfo'

# AFTER — on this PR branch
git fetch https://github.com/jbbqqf/aiohttp.git fix/12497-connector-close-race
git checkout FETCH_HEAD
AIOHTTP_NO_EXTENSIONS=1 pip install -e . --quiet
AIOHTTP_NO_EXTENSIONS=1 python /tmp/repro_12497.py
# Expected: FIXED: ClientConnectionError: Connector is closed.
```

## What I ran locally

```
$ AIOHTTP_NO_EXTENSIONS=1 pytest tests/test_connector.py --timeout=60 -q
================== 180 passed, 7 skipped, 1 xfailed in 1.19s ===================

$ AIOHTTP_NO_EXTENSIONS=1 pytest tests/test_connector.py::test_close_during_non_cached_resolve_raises_client_error \
    tests/test_connector.py::test_tcp_connector_close_resolver \
    tests/test_connector.py::test_close_cancels_resolve_host \
    tests/test_connector.py::test_close_twice \
    tests/test_connector.py::test_dns_error -v --timeout=60
============================== 5 passed in 0.06s ===============================

$ AIOHTTP_NO_EXTENSIONS=1 pytest tests/test_client_session.py tests/test_resolver.py --timeout=60 -q
======================== 113 passed, 1 skipped in 0.64s ========================
```

The new regression test `test_close_during_non_cached_resolve_raises_client_error`
**fails on master** with the exact `AttributeError: 'NoneType' object has
no attribute 'getaddrinfo'` from the issue, and **passes on this branch**.

## Edge cases

| Scenario | Before | After |
|---|---|---|
| `use_dns_cache=False` + trace cb yielding before resolve | `AttributeError: 'NoneType'...` | `ClientConnectionError("Connector is closed.")` |
| `use_dns_cache=True` cached hit + close mid-flight | already OK (cached path doesn't touch resolver after `_cached_hosts.next_addrs`) | unchanged |
| `use_dns_cache=True` cache miss + tracked task | tracked task cancelled by `_close_immediately` | unchanged (cancellation still fires first because `super().close()` now precedes `resolver.close()`) |
| Connector closed twice (`close()` reentry) | OK (`_close_immediately` early-returns on `_closed`) | unchanged |
| Resolver not owned by the connector (`resolver_owner=False`) | resolver kept alive | unchanged: we still skip `resolver.close()` |

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes (N/A — bug fix, no public API change)
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
- [x] Add a new news fragment into the `CHANGES/` folder (`CHANGES/12497.bugfix.rst`)

---

Drafted with Claude Code (claude-opus-4-7, Anthropic); to be reviewed by @jbbqqf.
