### PR TITLE
Fix packaging checksum file exclusion

### DIFF
--- a/CHANGES/10860.packaging.rst
+++ b/CHANGES/10860.packaging.rst
@@ -1,0 +1,2 @@
+Excluded internal checksum files from source distributions and wheels.
+-- by :user:`nightcityblade`.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -11,6 +11,7 @@ graft tools
 graft requirements
 graft vendor
 global-exclude *.pyc
+global-exclude *.hash
 global-exclude *.pyd
 global-exclude *.so
 global-exclude *.lib

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,7 @@ include = [
 ]
 
 [tool.setuptools.exclude-package-data]
-"*" = ["*.c", "*.h"]
+"*" = ["*.c", "*.h", "*.hash"]
 
 [tool.towncrier]
   package = "aiohttp"


### PR DESCRIPTION
## What do these changes do?

Exclude generated `.hash/*.hash` checksum files from aiohttp source distributions and wheels.

## Are there changes in behavior for the user?

No runtime behavior changes. Built distributions no longer include internal build checksum files.

## Is it a substantial burden for the maintainers to support this?

No. This only extends the existing packaging exclusions alongside other generated/build artifacts.

## Related issue number

Fixes #10860.

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is <Name> <Surname>.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES/` folder
  * name it `<issue_or_pr_num>.<type>.rst` (e.g. `588.bugfix.rst`)
  * if you don't have an issue number, change it to the pull request
    number after creating the PR
    * `.bugfix`: A bug fix for something the maintainers deemed an
      improper undesired behavior that got corrected to match
      pre-agreed expectations.
    * `.feature`: A new behavior, public APIs. That sort of stuff.
    * `.deprecation`: A declaration of future API removals and breaking
      changes in behavior.
    * `.breaking`: When something public is removed in a breaking way.
      Could be deprecated in an earlier release.
    * `.doc`: Notable updates to the documentation structure or build
      process.
    * `.packaging`: Notes for downstreams about unobvious side effects
      and tooling. Changes in the test invocation considerations and
      runtime assumptions.
    * `.contrib`: Stuff that affects the contributor experience. e.g.
      Running tests, building the docs, setting up the development
      environment.
    * `.misc`: Changes that are hard to assign to any of the above
      categories.
  * Make sure to use full sentences with correct case and punctuation,
    for example:
    ```rst
    Fixed issue with non-ascii contents in doctest text files
    -- by :user:`contributor-gh-handle`.
    ```

    Use the past tense or the present tense a non-imperative mood,
    referring to what's changed compared to the last released version
    of this project.

Notes:
- No unit test was added because this is packaging metadata only.
- No `CONTRIBUTORS.txt` entry was added because this is not a code modification.

Validation:
- `AIOHTTP_NO_EXTENSIONS=1 /tmp/aiohttp-build-venv/bin/python -m build --sdist --wheel --outdir /tmp/aiohttp-dist`
- Verified the resulting `.tar.gz` and `.whl` contain no `/.hash/` entries and no files ending in `.hash`.
