### PR TITLE
Add creation tracebacks to unclosed warnings

### DIFF
--- a/CHANGES/11235.feature.rst
+++ b/CHANGES/11235.feature.rst
@@ -1,0 +1,2 @@
+Included object creation tracebacks in unclosed resource warnings when loop debug mode is enabled.
+-- by :user:`nightcityblade`.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -285,6 +285,7 @@ Morgan Delahaye-Prat
 Moss Collum
 Mun Gwan-gyeong
 Navid Sheikhol
+Nightcity Blade
 Nicolas Braem
 Nikolay Kim
 Nikolay Novik

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -285,8 +285,8 @@ Morgan Delahaye-Prat
 Moss Collum
 Mun Gwan-gyeong
 Navid Sheikhol
-Nightcity Blade
 Nicolas Braem
+Nightcity Blade
 Nikolay Kim
 Nikolay Novik
 Nikolay Tiunov

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -98,6 +98,7 @@ from .helpers import (
     _auth_header_from_netrc,
     frozen_dataclass_decorator,
     get_env_proxy_for_url,
+    get_unclosed_warning_message,
     netrc_from_env,
     sentinel,
     strip_auth_from_url,
@@ -431,7 +432,9 @@ class ClientSession:
     def __del__(self, _warnings: Any = warnings) -> None:
         if not self.closed:
             _warnings.warn(
-                f"Unclosed client session {self!r}",
+                get_unclosed_warning_message(
+                    f"Unclosed client session {self!r}", self._source_traceback
+                ),
                 ResourceWarning,
                 source=self,
             )

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -42,6 +42,7 @@ from .helpers import (
     TimerNoop,
     encode_basic_auth,
     frozen_dataclass_decorator,
+    get_unclosed_warning_message,
     is_expected_content_type,
     parse_mimetype,
     reify,
@@ -390,7 +391,11 @@ class ClientResponse(HeadersMixin):
 
             if self._loop.get_debug():
                 _warnings.warn(
-                    f"Unclosed response {self!r}", ResourceWarning, source=self
+                    get_unclosed_warning_message(
+                        f"Unclosed response {self!r}", self._source_traceback
+                    ),
+                    ResourceWarning,
+                    source=self,
                 )
                 context = {"client_response": self, "message": "Unclosed response"}
                 if self._source_traceback:

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -43,6 +43,7 @@ from .client_reqrep import (
 from .helpers import (
     _SENTINEL,
     ceil_timeout,
+    get_unclosed_warning_message,
     is_ip_address,
     sentinel,
     set_exception,
@@ -130,7 +131,11 @@ class Connection:
     def __del__(self, _warnings: Any = warnings) -> None:
         if self._protocol is not None:
             _warnings.warn(
-                f"Unclosed connection {self!r}", ResourceWarning, source=self
+                get_unclosed_warning_message(
+                    f"Unclosed connection {self!r}", self._source_traceback
+                ),
+                ResourceWarning,
+                source=self,
             )
             if self._loop.is_closed():
                 return
@@ -333,7 +338,13 @@ class BaseConnector:
 
         self._close_immediately()
 
-        _warnings.warn(f"Unclosed connector {self!r}", ResourceWarning, source=self)
+        _warnings.warn(
+            get_unclosed_warning_message(
+                f"Unclosed connector {self!r}", self._source_traceback
+            ),
+            ResourceWarning,
+            source=self,
+        )
         context = {
             "connector": self,
             "connections": conns,

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -125,7 +125,7 @@ def get_unclosed_warning_message(
 ) -> str:
     if source_traceback is None:
         return message
-    return f"{message}\nThe object was created at (most recent call last):\n{''.join(traceback.format_list(source_traceback)).rstrip()}"  # noqa: E501
+    return f"{message}\nThe object was created at (most recent call last):\n{''.join(traceback.format_list(source_traceback)).rstrip()}"
 
 
 CHAR = {chr(i) for i in range(0, 128)}

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -14,6 +14,7 @@ import platform
 import re
 import sys
 import time
+import traceback
 import warnings
 import weakref
 from collections.abc import Callable, Iterable, Iterator, Mapping
@@ -117,6 +118,14 @@ EMPTY_BODY_METHODS = hdrs.METH_HEAD_ALL
 DEBUG = sys.flags.dev_mode or (
     not sys.flags.ignore_environment and bool(os.environ.get("PYTHONASYNCIODEBUG"))
 )
+
+
+def get_unclosed_warning_message(
+    message: str, source_traceback: traceback.StackSummary | None
+) -> str:
+    if source_traceback is None:
+        return message
+    return f"{message}\nThe object was created at (most recent call last):\n{''.join(traceback.format_list(source_traceback)).rstrip()}"  # noqa: E501
 
 
 CHAR = {chr(i) for i in range(0, 128)}

--- a/tests/test_client_session.py
+++ b/tests/test_client_session.py
@@ -534,10 +534,12 @@ async def test_del_debug(connector: BaseConnector) -> None:
     logs = []
     loop.set_exception_handler(lambda loop, ctx: logs.append(ctx))
 
-    with pytest.warns(ResourceWarning):
+    with pytest.warns(ResourceWarning) as cm:
         del session
         gc.collect()
 
+    warning_message = str(cm[0].message)
+    assert "The object was created at" in warning_message
     assert len(logs) == 1
     expected = {
         "client_session": mock.ANY,

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -176,10 +176,12 @@ async def test_connection_del_loop_debug() -> None:
     exc_handler = mock.Mock()
     loop.set_exception_handler(exc_handler)
 
-    with pytest.warns(ResourceWarning):
+    with pytest.warns(ResourceWarning) as cm:
         del conn
         gc.collect()
 
+    warning_message = str(cm[0].message)
+    assert "The object was created at" in warning_message
     msg = {
         "message": mock.ANY,
         "client_connection": mock.ANY,


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Include the object creation traceback in unclosed resource warning messages when the event loop is running in debug mode.

## Are there changes in behavior for the user?

Yes. In debug mode, unclosed `ClientSession`, connection, connector, and response warnings now include where the object was created, making leaks easier to trace. Non-debug behavior is unchanged.

## Is it a substantial burden for the maintainers to support this?

No. This reuses the existing `_source_traceback` captured in debug mode and keeps the formatting in a small helper shared by the existing unclosed-resource warnings.

## Related issue number

Fixes #11235.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is <Name> <Surname>.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES/` folder
  * name it `<issue_or_pr_num>.<type>.rst` (e.g. `588.bugfix.rst`)
  * if you don't have an issue number, change it to the pull request
    number after creating the PR
    * `.bugfix`: A bug fix for something the maintainers deemed an
      improper undesired behavior that got corrected to match
      pre-agreed expectations.
    * `.feature`: A new behavior, public APIs. That sort of stuff.
    * `.deprecation`: A declaration of future API removals and breaking
      changes in behavior.
    * `.breaking`: When something public is removed in a breaking way.
      Could be deprecated in an earlier release.
    * `.doc`: Notable updates to the documentation structure or build
      process.
    * `.packaging`: Notes for downstreams about unobvious side effects
      and tooling. Changes in the test invocation considerations and
      runtime assumptions.
    * `.contrib`: Stuff that affects the contributor experience. e.g.
      Running tests, building the docs, setting up the development
      environment.
    * `.misc`: Changes that are hard to assign to any of the above
      categories.

    Use the past tense or the present tense a non-imperative mood,
    referring to what's changed compared to the last released version
    of this project.
