### PR TITLE
Fix pushes not removing labels

### DIFF
--- a/.github/workflows/label-remove.yml
+++ b/.github/workflows/label-remove.yml
@@ -1,6 +1,6 @@
 name: Clear needs-info/pr-unfinished on activity
 on:
-  pull_request:
+  pull_request_target:
     types: [synchronize, review_requested]
   issue_comment:
     types: [created]


### PR DESCRIPTION
Need pull_request_target for this. There's nothing in this workflow that can run code from the repo, so this should be safe.