### PR TITLE
[3.14] Improve HTTPS-on-HTTP parser error

### DIFF
--- a/CHANGES/10142.bugfix.rst
+++ b/CHANGES/10142.bugfix.rst
@@ -1,0 +1,1 @@
+Improved the parser error message shown when TLS handshake bytes are received on an HTTP port -- by :user:`puneetdixit200`.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -308,6 +308,7 @@ Phebe Polk
 Philipp A.
 Pierre-Louis Peeters
 Pieter van Beek
+Puneet Dixit
 Qiao Han
 Rafael Viotti
 Rahul Nahata

--- a/aiohttp/_http_parser.pyx
+++ b/aiohttp/_http_parser.pyx
@@ -931,6 +931,8 @@ cdef parser_error_from_errno(cparser.llhttp_t* parser, data, pointer):
                  cparser.HPE_INVALID_TRANSFER_ENCODING}:
         return BadHttpMessage(err_msg)
     elif errno == cparser.HPE_INVALID_METHOD:
+        if data.startswith(b"\x16\x03"):
+            return BadHttpMethod(error="Received HTTPS traffic on an HTTP port")
         return BadHttpMethod(error=err_msg)
     elif errno in {cparser.HPE_INVALID_STATUS,
                    cparser.HPE_INVALID_VERSION,

--- a/aiohttp/http_exceptions.py
+++ b/aiohttp/http_exceptions.py
@@ -109,6 +109,8 @@ class BadHttpMethod(BadStatusLine):
     """Invalid HTTP method in status line."""
 
     def __init__(self, line: str = "", error: str | None = None) -> None:
+        if error is None and line.startswith("\x16\x03"):
+            error = "Received HTTPS traffic on an HTTP port"
         super().__init__(line, error or f"Bad HTTP method in status line {line!r}")
 
 

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -1517,7 +1517,16 @@ def test_http_request_parser_bad_method(
         )
 
 
-def test_http_request_parser_bad_version(parser) -> None:
+def test_http_request_parser_tls_handshake_on_http_port(
+    parser: HttpRequestParser,
+) -> None:
+    with pytest.raises(http_exceptions.BadHttpMethod) as ctx:
+        parser.feed_data(b"\x16\x03\x03\x01F\x01\r\n\r\n")
+
+    assert "Received HTTPS traffic on an HTTP port" in str(ctx.value)
+
+
+def test_http_request_parser_bad_version(parser: HttpRequestParser) -> None:
     with pytest.raises(http_exceptions.BadHttpMessage):
         parser.feed_data(b"GET //get HT/11\r\nHost: a\r\n\r\n")
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Backport #12672 to the 3.14 branch. The automated cherry-pick conflicted in `tests/test_http_parser.py`; this resolves that conflict while preserving the original parser behavior and regression test.

## Are there changes in behavior for the user?

Yes. HTTP parsers on 3.14 report a clearer error when TLS handshake bytes are sent to an HTTP port, matching the merged master-branch behavior.

## Is it a substantial burden for the maintainers to support this?

No. This is a direct bug-fix backport with the existing test coverage from the merged PR.

## Related issue number

Backport of #12672.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes (N/A; no docs-facing API change)
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
- [x] Add a new news fragment into the `CHANGES/` folder

<details>
<summary>Local verification</summary>

```console
$ PYTHONPATH='.' .venv/bin/python -m pytest tests/test_http_parser.py::test_http_request_parser_tls_handshake_on_http_port tests/test_http_parser.py::test_http_request_parser_bad_method
36 passed in 0.77s

$ git diff --check
```

</details>

Drafted with OpenAI GPT-5; human review pending.
