### PR TITLE
Fix Dependabot Security

### DIFF
--- a/requirements/pyproject.toml
+++ b/requirements/pyproject.toml
@@ -1,0 +1,1 @@
+../pyproject.toml


### PR DESCRIPTION
Dependabot Security runs from /requirements instead of the root (as Dependabot Updates does). Therefore we need to symlink the pyproject.toml file here.