### PR TITLE
Fix pipelined request being silently dropped on failed WebSocket upgrade

### DIFF
--- a/CHANGES/12734.bugfix.rst
+++ b/CHANGES/12734.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed pipelined requests being silently dropped and connections hanging when a WebSocket upgrade fails in the handler -- by :user:`sapirbaruch`.

--- a/aiohttp/web_protocol.py
+++ b/aiohttp/web_protocol.py
@@ -735,10 +735,10 @@ class RequestHandler(BaseProtocol, Generic[_Request]):
                     messages, upgraded, tail = self._parser.feed_data(
                         self._message_tail
                     )
-                except HttpProcessingError as exc:
+                except HttpProcessingError as parse_exc:
                     messages = [
                         (
-                            _ErrInfo(status=400, exc=exc, message=exc.message),
+                            _ErrInfo(status=400, exc=parse_exc, message=parse_exc.message),
                             EMPTY_PAYLOAD,
                         )
                     ]

--- a/aiohttp/web_protocol.py
+++ b/aiohttp/web_protocol.py
@@ -731,8 +731,28 @@ class RequestHandler(BaseProtocol, Generic[_Request]):
             self._parser.set_upgraded(False)
             self._upgraded = False
             if self._message_tail:
-                self._parser.feed_data(self._message_tail)
+                try:
+                    messages, upgraded, tail = self._parser.feed_data(
+                        self._message_tail
+                    )
+                except HttpProcessingError as exc:
+                    messages = [
+                        (
+                            _ErrInfo(status=400, exc=exc, message=exc.message),
+                            EMPTY_PAYLOAD,
+                        )
+                    ]
+                    upgraded = False
+                    tail = b""
                 self._message_tail = b""
+                for msg, payload in messages or ():
+                    self._request_count += 1
+                    self._messages.append((msg, payload))
+                if upgraded and tail:
+                    self._message_tail = tail
+                waiter = self._waiter
+                if self._messages and waiter is not None and not waiter.done():
+                    waiter.set_result(None)
         try:
             prepare_meth = resp.prepare
         except AttributeError:

--- a/aiohttp/web_protocol.py
+++ b/aiohttp/web_protocol.py
@@ -738,7 +738,9 @@ class RequestHandler(BaseProtocol, Generic[_Request]):
                 except HttpProcessingError as parse_exc:
                     messages = [
                         (
-                            _ErrInfo(status=400, exc=parse_exc, message=parse_exc.message),
+                            _ErrInfo(
+                                status=400, exc=parse_exc, message=parse_exc.message
+                            ),
                             EMPTY_PAYLOAD,
                         )
                     ]

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -251,6 +251,7 @@ peername
 performant
 pickleable
 ping
+pipelined
 pipelining
 pluggable
 plugin

--- a/tests/test_web_protocol.py
+++ b/tests/test_web_protocol.py
@@ -84,8 +84,11 @@ async def test_finish_response_replays_message_tail_into_messages(
     event_loop: asyncio.AbstractEventLoop,
     dummy_manager: Server[BaseRequest],
 ) -> None:
-    """finish_response must replay _message_tail so the next pipelined
-    request is queued in _messages and the waiter is signalled."""
+    """Replay _message_tail into _messages and signal the waiter.
+
+    finish_response must replay _message_tail so the next pipelined
+    request is queued in _messages and the waiter is signalled.
+    """
     handler = _make_handler(event_loop)
 
     raw_msg = mock.create_autospec(RawRequestMessage, instance=True)
@@ -121,9 +124,12 @@ async def test_finish_response_handles_parse_error_in_message_tail(
     event_loop: asyncio.AbstractEventLoop,
     dummy_manager: Server[BaseRequest],
 ) -> None:
-    """If feed_data raises HttpProcessingError while replaying the tail,
+    """Queue _ErrInfo(400) on HttpProcessingError during tail replay.
+
+    If feed_data raises HttpProcessingError while replaying the tail,
     finish_response must queue a 400 _ErrInfo instead of propagating the
-    exception, and still signal the waiter."""
+    exception, and still signal the waiter.
+    """
     handler = _make_handler(event_loop)
 
     parse_error = HttpProcessingError(code=400, message="Bad request")
@@ -152,3 +158,34 @@ async def test_finish_response_handles_parse_error_in_message_tail(
     assert handler._message_tail == b""
     # Waiter must be resolved.
     assert waiter.done()
+
+
+async def test_finish_response_stores_upgraded_tail(
+    event_loop: asyncio.AbstractEventLoop,
+    dummy_manager: Server[BaseRequest],
+) -> None:
+    """Re-upgraded tail bytes are preserved in _message_tail.
+
+    When feed_data signals another upgrade (upgraded=True) together with
+    leftover bytes, finish_response must keep those bytes in _message_tail
+    for the next protocol handler to consume.
+    """
+    handler = _make_handler(event_loop)
+
+    raw_msg = mock.create_autospec(RawRequestMessage, instance=True)
+    payload = mock.create_autospec(StreamReader, instance=True)
+    leftover = b"leftover"
+
+    parser = mock.Mock()
+    parser.set_upgraded = mock.Mock()
+    parser.feed_data = mock.Mock(
+        return_value=([(raw_msg, payload)], True, leftover)
+    )
+    handler._parser = parser
+    handler._upgraded = True
+    handler._message_tail = b"GET /ws HTTP/1.1\r\n\r\n"
+
+    await handler.finish_response(_make_mock_request(), _make_mock_resp(), 0.0)
+
+    # Leftover bytes from a re-upgrade must be stored for the next handler.
+    assert handler._message_tail == leftover

--- a/tests/test_web_protocol.py
+++ b/tests/test_web_protocol.py
@@ -3,8 +3,9 @@ from unittest import mock
 
 import pytest
 
-from aiohttp.http import WebSocketReader
-from aiohttp.web_protocol import RequestHandler
+from aiohttp.http import HttpProcessingError, RawRequestMessage, WebSocketReader
+from aiohttp.streams import EMPTY_PAYLOAD, StreamReader
+from aiohttp.web_protocol import RequestHandler, _ErrInfo
 from aiohttp.web_request import BaseRequest
 from aiohttp.web_server import Server
 
@@ -49,3 +50,105 @@ def test_data_received_calls_data_received_cb(
 
     cb.assert_called_once()
     dummy_reader[1].feed_data.assert_called_once_with(b"x")
+
+
+# ---------------------------------------------------------------------------
+# Tests for finish_response message-tail replay (regression for #12734)
+# ---------------------------------------------------------------------------
+
+
+def _make_handler(event_loop: asyncio.AbstractEventLoop) -> RequestHandler:  # type: ignore[type-arg]
+    manager = mock.create_autospec(
+        Server[BaseRequest],
+        request_handler=mock.Mock(),
+        request_factory=mock.Mock(),
+        instance=True,
+    )
+    return RequestHandler(manager, loop=event_loop)
+
+
+def _make_mock_request() -> mock.Mock:
+    req = mock.Mock()
+    req._finish = mock.Mock()
+    return req
+
+
+def _make_mock_resp() -> mock.Mock:
+    resp = mock.AsyncMock()
+    resp.prepare = mock.AsyncMock()
+    resp.write_eof = mock.AsyncMock()
+    return resp
+
+
+async def test_finish_response_replays_message_tail_into_messages(
+    event_loop: asyncio.AbstractEventLoop,
+    dummy_manager: Server[BaseRequest],
+) -> None:
+    """finish_response must replay _message_tail so the next pipelined
+    request is queued in _messages and the waiter is signalled."""
+    handler = _make_handler(event_loop)
+
+    raw_msg = mock.create_autospec(RawRequestMessage, instance=True)
+    payload = mock.create_autospec(StreamReader, instance=True)
+
+    parser = mock.Mock()
+    parser.set_upgraded = mock.Mock()
+    parser.feed_data = mock.Mock(return_value=([(raw_msg, payload)], False, b""))
+    handler._parser = parser
+    handler._upgraded = True
+    handler._message_tail = b"GET /next HTTP/1.1\r\n\r\n"
+
+    waiter: asyncio.Future[None] = event_loop.create_future()
+    handler._waiter = waiter
+
+    request = _make_mock_request()
+    resp = _make_mock_resp()
+
+    await handler.finish_response(request, resp, None)
+
+    # The parser must have been called with the tail bytes.
+    parser.feed_data.assert_called_once_with(b"GET /next HTTP/1.1\r\n\r\n")
+    # The parsed message must have been queued.
+    assert len(handler._messages) == 1
+    assert handler._messages[0] == (raw_msg, payload)
+    # The tail must be cleared.
+    assert handler._message_tail == b""
+    # The waiter must have been resolved so the start() loop can proceed.
+    assert waiter.done()
+
+
+async def test_finish_response_handles_parse_error_in_message_tail(
+    event_loop: asyncio.AbstractEventLoop,
+    dummy_manager: Server[BaseRequest],
+) -> None:
+    """If feed_data raises HttpProcessingError while replaying the tail,
+    finish_response must queue a 400 _ErrInfo instead of propagating the
+    exception, and still signal the waiter."""
+    handler = _make_handler(event_loop)
+
+    parse_error = HttpProcessingError(code=400, message="Bad request")
+    parser = mock.Mock()
+    parser.set_upgraded = mock.Mock()
+    parser.feed_data = mock.Mock(side_effect=parse_error)
+    handler._parser = parser
+    handler._upgraded = True
+    handler._message_tail = b"BADREQUEST\r\n"
+
+    waiter: asyncio.Future[None] = event_loop.create_future()
+    handler._waiter = waiter
+
+    request = _make_mock_request()
+    resp = _make_mock_resp()
+
+    await handler.finish_response(request, resp, None)
+
+    # A single error message must be queued.
+    assert len(handler._messages) == 1
+    err_msg, err_payload = handler._messages[0]
+    assert isinstance(err_msg, _ErrInfo)
+    assert err_msg.status == 400
+    assert err_payload is EMPTY_PAYLOAD
+    # Tail must be cleared.
+    assert handler._message_tail == b""
+    # Waiter must be resolved.
+    assert waiter.done()

--- a/tests/test_web_protocol.py
+++ b/tests/test_web_protocol.py
@@ -64,7 +64,7 @@ def _make_handler(event_loop: asyncio.AbstractEventLoop) -> RequestHandler:  # t
         request_factory=mock.Mock(),
         instance=True,
     )
-    return RequestHandler(manager, loop=event_loop)
+    return RequestHandler(manager, loop=event_loop, access_log=None)
 
 
 def _make_mock_request() -> mock.Mock:
@@ -104,7 +104,7 @@ async def test_finish_response_replays_message_tail_into_messages(
     request = _make_mock_request()
     resp = _make_mock_resp()
 
-    await handler.finish_response(request, resp, None)
+    await handler.finish_response(request, resp, 0.0)
 
     # The parser must have been called with the tail bytes.
     parser.feed_data.assert_called_once_with(b"GET /next HTTP/1.1\r\n\r\n")
@@ -140,7 +140,7 @@ async def test_finish_response_handles_parse_error_in_message_tail(
     request = _make_mock_request()
     resp = _make_mock_resp()
 
-    await handler.finish_response(request, resp, None)
+    await handler.finish_response(request, resp, 0.0)
 
     # A single error message must be queued.
     assert len(handler._messages) == 1

--- a/tests/test_web_protocol.py
+++ b/tests/test_web_protocol.py
@@ -178,9 +178,7 @@ async def test_finish_response_stores_upgraded_tail(
 
     parser = mock.Mock()
     parser.set_upgraded = mock.Mock()
-    parser.feed_data = mock.Mock(
-        return_value=([(raw_msg, payload)], True, leftover)
-    )
+    parser.feed_data = mock.Mock(return_value=([(raw_msg, payload)], True, leftover))
     handler._parser = parser
     handler._upgraded = True
     handler._message_tail = b"GET /ws HTTP/1.1\r\n\r\n"


### PR DESCRIPTION
Fixes #12734.

## What's wrong

When a WebSocket upgrade request fails in the handler (e.g. `HTTPBadRequest` raised by `WebSocketResponse.prepare()`), `finish_response` calls `self._parser.set_upgraded(False)` and then tries to replay any bytes that were stashed in `self._message_tail` (data that arrived pipelined after the upgrade request):

```python
# web_protocol.py — before fix
if self._message_tail:
    self._parser.feed_data(self._message_tail)   # return value discarded
    self._message_tail = b""
```

`feed_data` returns a `(messages, upgraded, tail)` tuple. By discarding it, the parsed request never reaches `self._messages`. The `start()` loop then blocks on `self._waiter` indefinitely because no new data arrives from the client (it's already sent everything), and the waiter is only signalled from `data_received`. The connection hangs until the keepalive timeout (~1 hour by default).

## Fix

Apply the same pattern that `data_received` already uses: capture the three-tuple, handle `HttpProcessingError`, append any messages to `self._messages`, carry forward a new tail if the parse produced one, and signal the waiter so the start loop can process the request.

```python
if self._message_tail:
    try:
        messages, upgraded, tail = self._parser.feed_data(self._message_tail)
    except HttpProcessingError as exc:
        messages = [
            (_ErrInfo(status=400, exc=exc, message=exc.message), EMPTY_PAYLOAD)
        ]
        upgraded = False
        tail = b""
    self._message_tail = b""
    for msg, payload in messages or ():
        self._request_count += 1
        self._messages.append((msg, payload))
    if upgraded and tail:
        self._message_tail = tail
    waiter = self._waiter
    if self._messages and waiter is not None and not waiter.done():
        waiter.set_result(None)
```

The change is confined to `finish_response`; `data_received` and the rest of the protocol loop are untouched.