### PR TITLE
Remove obsolete add_static response_factory docs

### DIFF
--- a/CHANGES/12718.doc.rst
+++ b/CHANGES/12718.doc.rst
@@ -1,0 +1,2 @@
+Removed the obsolete ``response_factory`` parameter from the
+``UrlDispatcher.add_static()`` documentation.

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -1880,7 +1880,6 @@ Application and Router
 
    .. method:: add_static(prefix, path, *, name=None, expect_handler=None, \
                           chunk_size=256*1024, \
-                          response_factory=StreamResponse, \
                           show_index=False, \
                           break_symlink_sandbox=False, \
                           append_version=False)


### PR DESCRIPTION
## What do these changes do?

Removes the obsolete `response_factory` parameter from the `UrlDispatcher.add_static()` documentation and adds a changelog fragment.

## Are there changes in behavior for the user?

No runtime behavior changes. The reference documentation now matches the current `add_static()` signature.

## Is it a substantial burden for the maintainers to support this?

No. This only removes a stale documented parameter.

## Related issue number

Fixes #12718

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
- [x] Add a new news fragment into the `CHANGES/` folder

Local checks:

- `git diff --check HEAD~1..HEAD`

Docs build not run locally; this environment does not have Sphinx installed.