### PR TITLE
fix(web_protocol): replay pipelined requests after failed websocket upgrade

### DIFF
--- a/aiohttp/web_protocol.py
+++ b/aiohttp/web_protocol.py
@@ -453,7 +453,6 @@ class RequestHandler(BaseProtocol, Generic[_Request]):
                 tail = b""
 
             for msg, payload in messages:
-                self._request_count += 1
                 self._messages.append((msg, payload))
 
             waiter = self._waiter

--- a/aiohttp/web_protocol.py
+++ b/aiohttp/web_protocol.py
@@ -732,7 +732,7 @@ class RequestHandler(BaseProtocol, Generic[_Request]):
             self._upgraded = False
             if self._message_tail:
                 messages, upgraded, tail = self._parser.feed_data(self._message_tail)
-                self._message_tail = b""
+                self._message_tail = tail
                 for msg, payload in messages:
                     self._request_count += 1
                     self._messages.append((msg, payload))

--- a/aiohttp/web_protocol.py
+++ b/aiohttp/web_protocol.py
@@ -731,8 +731,15 @@ class RequestHandler(BaseProtocol, Generic[_Request]):
             self._parser.set_upgraded(False)
             self._upgraded = False
             if self._message_tail:
-                self._parser.feed_data(self._message_tail)
+                messages, upgraded, tail = self._parser.feed_data(self._message_tail)
                 self._message_tail = b""
+                for msg, payload in messages or ():
+                    self._request_count += 1
+                    self._messages.append((msg, payload))
+                if messages:
+                    waiter = self._waiter
+                    if waiter is not None and not waiter.done():
+                        waiter.set_result(None)
         try:
             prepare_meth = resp.prepare
         except AttributeError:

--- a/aiohttp/web_protocol.py
+++ b/aiohttp/web_protocol.py
@@ -452,7 +452,7 @@ class RequestHandler(BaseProtocol, Generic[_Request]):
                 upgraded = False
                 tail = b""
 
-            for msg, payload in messages or ():
+            for msg, payload in messages:
                 self._request_count += 1
                 self._messages.append((msg, payload))
 
@@ -733,7 +733,7 @@ class RequestHandler(BaseProtocol, Generic[_Request]):
             if self._message_tail:
                 messages, upgraded, tail = self._parser.feed_data(self._message_tail)
                 self._message_tail = b""
-                for msg, payload in messages or ():
+                for msg, payload in messages:
                     self._request_count += 1
                     self._messages.append((msg, payload))
                 if messages:

--- a/aiohttp/web_protocol.py
+++ b/aiohttp/web_protocol.py
@@ -453,6 +453,7 @@ class RequestHandler(BaseProtocol, Generic[_Request]):
                 tail = b""
 
             for msg, payload in messages:
+                self._request_count += 1
                 self._messages.append((msg, payload))
 
             waiter = self._waiter

--- a/tests/test_web_protocol.py
+++ b/tests/test_web_protocol.py
@@ -97,3 +97,31 @@ async def test_finish_response_replays_message_tail(
     assert handler._message_tail == b""
     assert handler._upgraded is False
     assert mock_parser.set_upgraded.called
+
+
+async def test_finish_response_replays_empty_message_tail(
+    dummy_manager: Server[BaseRequest],
+) -> None:
+    """No messages queued when parser returns empty list from tail."""
+    event_loop = asyncio.get_running_loop()
+    handler = RequestHandler(dummy_manager, loop=event_loop)
+
+    mock_parser = mock.create_autospec(HttpRequestParser, spec_set=True, instance=True)
+    mock_parser.feed_data.return_value = [], False, b""
+    handler._parser = mock_parser
+    handler._messages = deque()
+    handler._message_tail = b"\r\n"
+    handler._waiter = event_loop.create_future()
+
+    request = mock.create_autospec(BaseRequest, spec_set=True, instance=True)
+    response = mock.Mock()
+    response.prepare = mock.AsyncMock()
+    response.write_eof = mock.AsyncMock()
+
+    await handler.finish_response(request, response, None)
+
+    mock_parser.feed_data.assert_called_once_with(b"\r\n")
+    assert len(handler._messages) == 0
+    assert not handler._waiter.done()
+    assert handler._message_tail == b""
+    assert handler._upgraded is False

--- a/tests/test_web_protocol.py
+++ b/tests/test_web_protocol.py
@@ -86,7 +86,9 @@ def test_finish_response_replays_message_tail(
     event_loop.run_until_complete(_run())
 
     # The tail should have been fed to the parser
-    mock_parser.feed_data.assert_called_once_with(b"GET /second HTTP/1.1\r\nHost: localhost\r\n\r\n")
+    mock_parser.feed_data.assert_called_once_with(
+        b"GET /second HTTP/1.1\r\nHost: localhost\r\n\r\n"
+    )
     # The parsed message must be queued
     assert len(handler._messages) == 1
     assert handler._messages[0] == (mock_msg, mock_payload)

--- a/tests/test_web_protocol.py
+++ b/tests/test_web_protocol.py
@@ -1,9 +1,11 @@
 import asyncio
+from collections import deque
 from unittest import mock
 
 import pytest
 
-from aiohttp.http import WebSocketReader
+from aiohttp.http import HttpRequestParser, RawRequestMessage, WebSocketReader
+from aiohttp.streams import StreamReader
 from aiohttp.web_protocol import RequestHandler
 from aiohttp.web_request import BaseRequest
 from aiohttp.web_server import Server
@@ -49,3 +51,47 @@ def test_data_received_calls_data_received_cb(
 
     cb.assert_called_once()
     dummy_reader[1].feed_data.assert_called_once_with(b"x")
+
+
+def test_finish_response_replays_message_tail(
+    event_loop: asyncio.AbstractEventLoop,
+    dummy_manager: Server[BaseRequest],
+) -> None:
+    """When a websocket upgrade fails and _message_tail contains a pipelined
+    HTTP request, finish_response must parse the tail and queue the message
+    so the connection does not hang forever."""
+    handler = RequestHandler(dummy_manager, loop=event_loop)
+
+    # Build a mock parser whose feed_data returns a synthetic message
+    mock_parser = mock.create_autospec(HttpRequestParser, spec_set=True, instance=True)
+    mock_msg = mock.create_autospec(RawRequestMessage, spec_set=True, instance=True)
+    mock_payload = mock.create_autospec(StreamReader, spec_set=True, instance=True)
+    mock_parser.feed_data.return_value = [(mock_msg, mock_payload)], False, b""
+    handler._parser = mock_parser
+    handler._messages = deque()
+    handler._message_tail = b"GET /second HTTP/1.1\r\nHost: localhost\r\n\r\n"
+
+    # _waiter must exist so finish_response can signal it
+    handler._waiter = event_loop.create_future()
+
+    # Build a minimal request/response pair
+    request = mock.create_autospec(BaseRequest, spec_set=True, instance=True)
+    response = mock.Mock()
+    response.prepare = mock.AsyncMock()
+    response.write_eof = mock.AsyncMock()
+
+    async def _run() -> None:
+        await handler.finish_response(request, response, None)
+
+    event_loop.run_until_complete(_run())
+
+    # The tail should have been fed to the parser
+    mock_parser.feed_data.assert_called_once_with(b"GET /second HTTP/1.1\r\nHost: localhost\r\n\r\n")
+    # The parsed message must be queued
+    assert len(handler._messages) == 1
+    assert handler._messages[0] == (mock_msg, mock_payload)
+    # The waiter must be resolved so the main loop can proceed
+    assert handler._waiter.done()
+    assert handler._message_tail == b""
+    assert handler._upgraded is False
+    assert mock_parser.set_upgraded.called

--- a/tests/test_web_protocol.py
+++ b/tests/test_web_protocol.py
@@ -57,9 +57,12 @@ def test_finish_response_replays_message_tail(
     event_loop: asyncio.AbstractEventLoop,
     dummy_manager: Server[BaseRequest],
 ) -> None:
-    """When a websocket upgrade fails and _message_tail contains a pipelined
+    """Replay pipelined requests after a failed websocket upgrade.
+
+    When a websocket upgrade fails and _message_tail contains a pipelined
     HTTP request, finish_response must parse the tail and queue the message
-    so the connection does not hang forever."""
+    so the connection does not hang forever.
+    """
     handler = RequestHandler(dummy_manager, loop=event_loop)
 
     # Build a mock parser whose feed_data returns a synthetic message

--- a/tests/test_web_protocol.py
+++ b/tests/test_web_protocol.py
@@ -106,11 +106,10 @@ async def test_finish_response_replays_empty_message_tail(
     event_loop = asyncio.get_running_loop()
     handler = RequestHandler(dummy_manager, loop=event_loop)
 
-    mock_parser = mock.create_autospec(HttpRequestParser, spec_set=True, instance=True)
-    mock_parser.feed_data.return_value = [], False, b""
-    handler._parser = mock_parser
+    # Use a partial message tail instead of mocking the parser
+    # This tests the same code path with real parser behavior
+    handler._message_tail = b"GET /second HTT"
     handler._messages = deque()
-    handler._message_tail = b"\r\n"
     handler._waiter = event_loop.create_future()
 
     request = mock.create_autospec(BaseRequest, spec_set=True, instance=True)
@@ -120,8 +119,8 @@ async def test_finish_response_replays_empty_message_tail(
 
     await handler.finish_response(request, response, None)
 
-    mock_parser.feed_data.assert_called_once_with(b"\r\n")
+    # The partial message should be stored back in _message_tail
     assert len(handler._messages) == 0
     assert not handler._waiter.done()
-    assert handler._message_tail == b""
+    assert handler._message_tail == b"GET /second HTT"
     assert handler._upgraded is False

--- a/tests/test_web_protocol.py
+++ b/tests/test_web_protocol.py
@@ -106,8 +106,11 @@ async def test_finish_response_replays_empty_message_tail(
     event_loop = asyncio.get_running_loop()
     handler = RequestHandler(dummy_manager, loop=event_loop)
 
-    # Use a partial message tail instead of mocking the parser
-    # This tests the same code path with real parser behavior
+    # Set up a mock parser that returns empty messages but preserves tail
+    mock_parser = mock.create_autospec(HttpRequestParser, spec_set=True, instance=True)
+    mock_parser.feed_data.return_value = ([], False, b"GET /second HTT")
+    handler._parser = mock_parser
+
     handler._message_tail = b"GET /second HTT"
     handler._messages = deque()
     handler._waiter = event_loop.create_future()
@@ -120,6 +123,7 @@ async def test_finish_response_replays_empty_message_tail(
     await handler.finish_response(request, response, None)
 
     # The partial message should be stored back in _message_tail
+    mock_parser.feed_data.assert_called_once_with(b"GET /second HTT")
     assert len(handler._messages) == 0
     assert not handler._waiter.done()
     assert handler._message_tail == b"GET /second HTT"

--- a/tests/test_web_protocol.py
+++ b/tests/test_web_protocol.py
@@ -128,3 +128,37 @@ async def test_finish_response_replays_empty_message_tail(
     assert not handler._waiter.done()
     assert handler._message_tail == b"GET /second HTT"
     assert handler._upgraded is False
+
+
+async def test_finish_response_replays_message_tail_waiter_none(
+    dummy_manager: Server[BaseRequest],
+) -> None:
+    """Messages queued even when waiter is None (no pending request)."""
+    event_loop = asyncio.get_running_loop()
+    handler = RequestHandler(dummy_manager, loop=event_loop)
+
+    mock_parser = mock.create_autospec(HttpRequestParser, spec_set=True, instance=True)
+    mock_msg = mock.create_autospec(RawRequestMessage, spec_set=True, instance=True)
+    mock_payload = mock.create_autospec(StreamReader, spec_set=True, instance=True)
+    mock_parser.feed_data.return_value = [(mock_msg, mock_payload)], False, b""
+    handler._parser = mock_parser
+    handler._messages = deque()
+    handler._message_tail = b"GET /second HTTP/1.1\r\nHost: localhost\r\n\r\n"
+
+    # No waiter set (None) – code must not crash
+    handler._waiter = None
+
+    request = mock.create_autospec(BaseRequest, spec_set=True, instance=True)
+    response = mock.Mock()
+    response.prepare = mock.AsyncMock()
+    response.write_eof = mock.AsyncMock()
+
+    await handler.finish_response(request, response, None)
+
+    mock_parser.feed_data.assert_called_once_with(
+        b"GET /second HTTP/1.1\r\nHost: localhost\r\n\r\n"
+    )
+    assert len(handler._messages) == 1
+    assert handler._messages[0] == (mock_msg, mock_payload)
+    assert handler._message_tail == b""
+    assert handler._upgraded is False

--- a/tests/test_web_protocol.py
+++ b/tests/test_web_protocol.py
@@ -53,8 +53,7 @@ def test_data_received_calls_data_received_cb(
     dummy_reader[1].feed_data.assert_called_once_with(b"x")
 
 
-def test_finish_response_replays_message_tail(
-    event_loop: asyncio.AbstractEventLoop,
+async def test_finish_response_replays_message_tail(
     dummy_manager: Server[BaseRequest],
 ) -> None:
     """Replay pipelined requests after a failed websocket upgrade.
@@ -63,6 +62,7 @@ def test_finish_response_replays_message_tail(
     HTTP request, finish_response must parse the tail and queue the message
     so the connection does not hang forever.
     """
+    event_loop = asyncio.get_running_loop()
     handler = RequestHandler(dummy_manager, loop=event_loop)
 
     # Build a mock parser whose feed_data returns a synthetic message
@@ -83,10 +83,7 @@ def test_finish_response_replays_message_tail(
     response.prepare = mock.AsyncMock()
     response.write_eof = mock.AsyncMock()
 
-    async def _run() -> None:
-        await handler.finish_response(request, response, None)
-
-    event_loop.run_until_complete(_run())
+    await handler.finish_response(request, response, None)
 
     # The tail should have been fed to the parser
     mock_parser.feed_data.assert_called_once_with(


### PR DESCRIPTION
Fixes #12734

When a websocket upgrade fails in the handler and the client has pipelined a second HTTP request, finish_response() previously called self._parser.feed_data(self._message_tail) and discarded the return value. The pipelined request was therefore lost and the connection hung until the keep-alive timeout expired.

Capture the (messages, upgraded, tail) tuple from feed_data(), queue the parsed messages into self._messages, and wake up self._waiter so the main request loop can process the next request immediately.