### PR TITLE
fix(connector): resolve race condition in TCPConnector.close()

### DIFF
--- a/CHANGES/12497.bugfix.rst
+++ b/CHANGES/12497.bugfix.rst
@@ -1,3 +1,3 @@
 Fixed a race condition in :py:class:`~aiohttp.TCPConnector` where closing the connector while a DNS resolution was in-flight could raise :py:exc:`AttributeError` instead of :py:exc:`~aiohttp.ClientConnectionError`.
 
-The fix ensures that :meth:`~aiohttp.TCPConnector.close` marks the connector as closed before shutting down the resolver, and adds a guard in :meth:`~aiohttp.TCPConnector._resolve_host` to raise :py:exc:`~aiohttp.ClientConnectionError` when the connector has already been closed.
+The fix ensures that ``TCPConnector.close`` marks the connector as closed before shutting down the resolver, and adds a guard in ``TCPConnector._resolve_host`` to raise :py:exc:`~aiohttp.ClientConnectionError` when the connector has already been closed.

--- a/CHANGES/12497.bugfix.rst
+++ b/CHANGES/12497.bugfix.rst
@@ -1,0 +1,3 @@
+Fixed a race condition in :py:class:`~aiohttp.TCPConnector` where closing the connector while a DNS resolution was in-flight could raise :py:exc:`AttributeError` instead of :py:exc:`~aiohttp.ClientConnectionError`.
+
+The fix ensures that :meth:`~aiohttp.TCPConnector.close` marks the connector as closed before shutting down the resolver, and adds a guard in :meth:`~aiohttp.TCPConnector._resolve_host` to raise :py:exc:`~aiohttp.ClientConnectionError` when the connector has already been closed.

--- a/CHANGES/12497.bugfix.rst
+++ b/CHANGES/12497.bugfix.rst
@@ -1,3 +1,1 @@
-Fixed a race condition in :py:class:`~aiohttp.TCPConnector` where closing the connector while a DNS resolution was in-flight could raise :py:exc:`AttributeError` instead of :py:exc:`~aiohttp.ClientConnectionError`.
-
-The fix ensures that ``TCPConnector.close`` marks the connector as closed before shutting down the resolver, and adds a guard in ``TCPConnector._resolve_host`` to raise :py:exc:`~aiohttp.ClientConnectionError` when the connector has already been closed.
+Fixed a race condition in :py:class:`~aiohttp.TCPConnector` where closing the connector while a DNS resolution was in-flight could raise :py:exc:`AttributeError` instead of :py:exc:`~aiohttp.ClientConnectionError` -- by :user:`goingforstudying-ctrl`.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -153,6 +153,7 @@ Gary Wilson Jr.
 Gene Hoffman
 Gennady Andreyev
 Georges Dubus
+goingforstudying-ctrl
 Greg Holt
 Gregory Haynes
 Grigoriy Soldatov
@@ -439,4 +440,3 @@ Zlatan Sičanica
 Łukasz Setla
 Марк Коренберг
 Семён Марьясин
-goingforstudying-ctrl

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -439,3 +439,4 @@ Zlatan Sičanica
 Łukasz Setla
 Марк Коренберг
 Семён Марьясин
+goingforstudying-ctrl

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -1005,10 +1005,10 @@ class TCPConnector(BaseConnector):
                          - If ssl_shutdown_timeout=0: connections are aborted
                          - If ssl_shutdown_timeout>0: graceful shutdown is performed
         """
-        if self._resolver_owner:
-            await self._resolver.close()
         # Use abort_ssl param if explicitly set, otherwise use ssl_shutdown_timeout default
         await super().close(abort_ssl=abort_ssl or self._ssl_shutdown_timeout == 0)
+        if self._resolver_owner:
+            await self._resolver.close()
 
     def _close_immediately(self, *, abort_ssl: bool = False) -> list[Awaitable[object]]:
         for fut in chain.from_iterable(self._throttle_dns_futures.values()):
@@ -1061,6 +1061,9 @@ class TCPConnector(BaseConnector):
             if traces:
                 for trace in traces:
                     await trace.send_dns_resolvehost_start(host)
+
+            if self._closed:
+                raise ClientConnectionError("Connector is closed")
 
             res = await self._resolver.resolve(host, port, family=self._family)
 

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -4726,7 +4726,7 @@ async def test_tcp_connector_close_race_condition() -> None:
             ]
 
         async def close(self) -> None:
-            pass
+            assert False
 
     connector = TCPConnector(use_dns_cache=False, resolver=FakeResolver())
 

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -4701,9 +4701,7 @@ async def test_connect_tunnel_connection_release() -> None:
 
 
 async def test_tcp_connector_close_race_condition() -> None:
-    """Test that closing a TCPConnector while DNS resolution is in-flight
-    completes gracefully, and subsequent resolves raise ClientConnectionError
-    instead of AttributeError (race condition #12497)."""
+    """Test closing TCPConnector while DNS resolution is in-flight."""
     loop = asyncio.get_running_loop()
     resolve_started = loop.create_future()
     close_started = loop.create_future()

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -4731,7 +4731,7 @@ async def test_tcp_connector_close_race_condition() -> None:
 
     async def resolve_host() -> None:
         with pytest.raises(aiohttp.ClientConnectionError, match="Connector is closed"):
-            await connector._resolve_host("127.0.0.1", 80)
+            await connector._resolve_host("localhost", 80)
 
     async def close_connector() -> None:
         await resolve_started

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -4701,8 +4701,9 @@ async def test_connect_tunnel_connection_release() -> None:
 
 
 async def test_tcp_connector_close_race_condition() -> None:
-    """Test that closing a TCPConnector while DNS resolution is in-flight raises
-    ClientConnectionError instead of AttributeError (race condition #12497)."""
+    """Test that closing a TCPConnector while DNS resolution is in-flight
+    completes gracefully, and subsequent resolves raise ClientConnectionError
+    instead of AttributeError (race condition #12497)."""
     loop = asyncio.get_running_loop()
     resolve_started = loop.create_future()
     close_started = loop.create_future()
@@ -4730,8 +4731,10 @@ async def test_tcp_connector_close_race_condition() -> None:
     connector = TCPConnector(use_dns_cache=False, resolver=FakeResolver())
 
     async def resolve_host() -> None:
-        with pytest.raises(aiohttp.ClientConnectionError, match="Connector is closed"):
-            await connector._resolve_host("localhost", 80)
+        # The in-flight resolve should complete normally since close()
+        # happens after the resolver returns
+        result = await connector._resolve_host("localhost", 80)
+        assert len(result) == 1
 
     async def close_connector() -> None:
         await resolve_started
@@ -4739,3 +4742,7 @@ async def test_tcp_connector_close_race_condition() -> None:
         await connector.close()
 
     await asyncio.gather(resolve_host(), close_connector())
+
+    # After close, new resolves should raise ClientConnectionError
+    with pytest.raises(aiohttp.ClientConnectionError, match="Connector is closed"):
+        await connector._resolve_host("localhost", 80)

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -4698,3 +4698,44 @@ async def test_connect_tunnel_connection_release() -> None:
 
     # Clean up to avoid resource warning
     conn.close()
+
+
+async def test_tcp_connector_close_race_condition() -> None:
+    """Test that closing a TCPConnector while DNS resolution is in-flight raises
+    ClientConnectionError instead of AttributeError (race condition #12497)."""
+    loop = asyncio.get_running_loop()
+    resolve_started = loop.create_future()
+    close_started = loop.create_future()
+
+    class FakeResolver(AbstractResolver):
+        async def resolve(
+            self, host: str, port: int = 0, family: int = socket.AF_INET
+        ) -> list[ResolveResult]:
+            resolve_started.set_result(None)
+            await close_started
+            return [
+                {
+                    "hostname": host,
+                    "host": host,
+                    "port": port,
+                    "family": family,
+                    "proto": 0,
+                    "flags": socket.AI_NUMERICHOST,
+                }
+            ]
+
+        async def close(self) -> None:
+            pass
+
+    connector = TCPConnector(use_dns_cache=False, resolver=FakeResolver())
+
+    async def resolve_host() -> None:
+        with pytest.raises(aiohttp.ClientConnectionError, match="Connector is closed"):
+            await connector._resolve_host("127.0.0.1", 80)
+
+    async def close_connector() -> None:
+        await resolve_started
+        close_started.set_result(None)
+        await connector.close()
+
+    await asyncio.gather(resolve_host(), close_connector())


### PR DESCRIPTION
Fixes #12497

Reorders `TCPConnector.close()` to mark the connector as closed before shutting down the resolver, and adds a `_closed` guard in `_resolve_host()` so in-flight DNS resolutions get a clean `ClientConnectionError` instead of `AttributeError`.