### PR TITLE
reject non-digit Content-Length in multipart body parts

### DIFF
--- a/CHANGES/12794.bugfix.rst
+++ b/CHANGES/12794.bugfix.rst
@@ -1,0 +1,4 @@
+Rejected multipart body parts whose ``Content-Length`` header is not a
+plain sequence of digits (e.g. ``+5``, ``-1``, ``1_0``), matching the
+strictness of the main request parser per :rfc:`9110#section-8.6`
+-- by :user:`dxbjavid`.

--- a/aiohttp/multipart.py
+++ b/aiohttp/multipart.py
@@ -283,6 +283,11 @@ class BodyPartReader:
         self._is_form_data = subtype == "form-data"
         # https://datatracker.ietf.org/doc/html/rfc7578#section-4.8
         length = None if self._is_form_data else self.headers.get(CONTENT_LENGTH, None)
+        if length is not None and not (length.isascii() and length.isdigit()):
+            # Reject sign prefixes, underscores, whitespace and non-ASCII
+            # digits that int() would otherwise accept.
+            # https://www.rfc-editor.org/rfc/rfc9110#section-8.6
+            raise ValueError(f"invalid Content-Length: {length!r}")
         self._length = int(length) if length is not None else None
         self._read_bytes = 0
         self._unread: deque[bytes] = deque()

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -293,6 +293,13 @@ class TestPartReader:
             assert b"" == result
             assert obj.at_eof()
 
+    @pytest.mark.parametrize("value", ["-1", "+5", "1_0", " 5", "0x5", "５"])
+    async def test_rejects_malformed_content_length(self, value: str) -> None:
+        h = HeadersDictProxy(CIMultiDict({"CONTENT-LENGTH": value}))
+        with Stream(b"Hello, world!\r\n--:--") as stream:
+            with pytest.raises(ValueError, match="Content-Length"):
+                aiohttp.BodyPartReader(BOUNDARY, h, stream)
+
     async def test_read_chunk_properly_counts_read_bytes(self) -> None:
         expected = b"." * 10
         size = len(expected)


### PR DESCRIPTION
A multipart part header like `Content-Length: -1` (also `+5`, `1_0`, leading space) is accepted by bare `int()` in `BodyPartReader`, unlike the main request parser which rejects it via `DIGITS.fullmatch` per :rfc:`9110` section 8.6; a negative value makes the reader consume the whole stream past the boundary, so validate it's ASCII digits at construction.