### PR TITLE
Fix pipelined request after websocket rejection failing

### DIFF
--- a/aiohttp/web_protocol.py
+++ b/aiohttp/web_protocol.py
@@ -452,7 +452,7 @@ class RequestHandler(BaseProtocol, Generic[_Request]):
                 upgraded = False
                 tail = b""
 
-            for msg, payload in messages or ():
+            for msg, payload in messages:
                 self._request_count += 1
                 self._messages.append((msg, payload))
 
@@ -731,8 +731,14 @@ class RequestHandler(BaseProtocol, Generic[_Request]):
             self._parser.set_upgraded(False)
             self._upgraded = False
             if self._message_tail:
-                self._parser.feed_data(self._message_tail)
-                self._message_tail = b""
+                messages, _upgraded, tail = self._parser.feed_data(self._message_tail)
+                self._message_tail = tail
+                for msg, payload in messages:
+                    self._request_count += 1
+                    self._messages.append((msg, payload))
+                # This shouldn't be possible. If a future refactor results in this
+                # failing, then the code may need to be updated to set the waiter.
+                assert self._waiter is None
         try:
             prepare_meth = resp.prepare
         except AttributeError:

--- a/tests/test_web_websocket_functional.py
+++ b/tests/test_web_websocket_functional.py
@@ -137,7 +137,7 @@ async def test_partial_pipelined_request_after_failed_websocket_upgrade(
         first = await asyncio.wait_for(read_until_first_headers(), timeout=5)
         assert b"426" in first
 
-        writer.write(b"ond HTTP/1.1\r\n" b"Host: localhost\r\n" b"\r\n")
+        writer.write(b"ond HTTP/1.1\r\nHost: localhost\r\n" b"\r\n")
         await writer.drain()
 
         async def read_until_second() -> bytes:

--- a/tests/test_web_websocket_functional.py
+++ b/tests/test_web_websocket_functional.py
@@ -70,23 +70,13 @@ async def test_pipelined_request_after_failed_websocket_upgrade(
         )
         await writer.drain()
 
-        async def read_until_second() -> bytes:
-            data = b""
-            while b"second-ok" not in data:
-                chunk = await reader.read(4096)
-                if not chunk:
-                    break
-                data += chunk
-            return data
-
         # Without the fix the second request is dropped and this read hangs
-        data = await asyncio.wait_for(read_until_second(), timeout=5)
+        data = await asyncio.wait_for(reader.readuntil(b"second-ok"), timeout=5)
     finally:
         writer.close()
         await writer.wait_closed()
 
     assert b"426" in data
-    assert b"second-ok" in data
 
 
 async def test_partial_pipelined_request_after_failed_websocket_upgrade(
@@ -125,32 +115,13 @@ async def test_partial_pipelined_request_after_failed_websocket_upgrade(
         )
         await writer.drain()
 
-        async def read_until_first_headers() -> bytes:
-            data = b""
-            while b"\r\n\r\n" not in data:
-                chunk = await reader.read(4096)
-                if not chunk:
-                    break
-                data += chunk
-            return data
-
-        first = await asyncio.wait_for(read_until_first_headers(), timeout=5)
+        first = await asyncio.wait_for(reader.readuntil(b"\r\n\r\n"), timeout=5)
         assert b"426" in first
 
-        writer.write(b"ond HTTP/1.1\r\nHost: localhost\r\n" b"\r\n")
+        writer.write(b"ond HTTP/1.1\r\nHost: localhost\r\n\r\n")
         await writer.drain()
 
-        async def read_until_second() -> bytes:
-            data = b""
-            while b"second-ok" not in data:
-                chunk = await reader.read(4096)
-                if not chunk:
-                    break
-                data += chunk
-            return data
-
-        rest = await asyncio.wait_for(read_until_second(), timeout=5)
-        assert b"second-ok" in rest
+        await asyncio.wait_for(reader.readuntil(b"second-ok"), timeout=5)
     finally:
         writer.close()
         await writer.wait_closed()

--- a/tests/test_web_websocket_functional.py
+++ b/tests/test_web_websocket_functional.py
@@ -111,14 +111,14 @@ async def test_partial_pipelined_request_after_failed_websocket_upgrade(
             b"Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n"
             b"Sec-WebSocket-Version: 13\r\n"
             b"\r\n"
-            b"GET /sec"  # truncated mid-request
+            b"GET /second HTT"  # truncated mid-request
         )
         await writer.drain()
 
         first = await asyncio.wait_for(reader.readuntil(b"\r\n\r\n"), timeout=5)
         assert b"426" in first
 
-        writer.write(b"ond HTTP/1.1\r\nHost: localhost\r\n\r\n")
+        writer.write(b"P/1.1\r\nHost: localhost\r\n\r\n")
         await writer.drain()
 
         await asyncio.wait_for(reader.readuntil(b"second-ok"), timeout=5)

--- a/tests/test_web_websocket_functional.py
+++ b/tests/test_web_websocket_functional.py
@@ -30,6 +30,132 @@ async def test_websocket_can_prepare(aiohttp_client: AiohttpClient) -> None:
     assert resp.status == 426
 
 
+async def test_pipelined_request_after_failed_websocket_upgrade(
+    aiohttp_server: AiohttpServer,
+) -> None:
+    """Pipelined HTTP request runs after a declined websocket upgrade.
+
+    The parser flips into upgraded mode when it sees the ``Upgrade``
+    header and buffers any trailing bytes in ``_message_tail``. If the
+    handler declines the upgrade, ``finish_response()`` must replay the
+    tail through the parser so the pipelined request is dispatched
+    instead of stalling until the keep-alive timeout fires.
+    """
+
+    async def upgrade_handler(request: web.Request) -> NoReturn:
+        raise web.HTTPUpgradeRequired()
+
+    async def second_handler(request: web.Request) -> web.Response:
+        return web.Response(text="second-ok")
+
+    app = web.Application()
+    app.router.add_route("GET", "/", upgrade_handler)
+    app.router.add_route("GET", "/second", second_handler)
+    server = await aiohttp_server(app)
+
+    # Need to use a raw writer in order to send the pipelined request.
+    reader, writer = await asyncio.open_connection(server.host, server.port)
+    try:
+        writer.write(
+            b"GET / HTTP/1.1\r\n"
+            b"Host: localhost\r\n"
+            b"Upgrade: websocket\r\n"
+            b"Connection: Upgrade\r\n"
+            b"Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n"
+            b"Sec-WebSocket-Version: 13\r\n"
+            b"\r\n"
+            b"GET /second HTTP/1.1\r\n"
+            b"Host: localhost\r\n"
+            b"\r\n"
+        )
+        await writer.drain()
+
+        async def read_until_second() -> bytes:
+            data = b""
+            while b"second-ok" not in data:
+                chunk = await reader.read(4096)
+                if not chunk:
+                    break
+                data += chunk
+            return data
+
+        # Without the fix the second request is dropped and this read hangs
+        data = await asyncio.wait_for(read_until_second(), timeout=5)
+    finally:
+        writer.close()
+        await writer.wait_closed()
+
+    assert b"426" in data
+    assert b"second-ok" in data
+
+
+async def test_partial_pipelined_request_after_failed_websocket_upgrade(
+    aiohttp_server: AiohttpServer,
+) -> None:
+    """Partial pipelined bytes are preserved across finish_response.
+
+    Only part of the second request rides along with the upgrade, so
+    feed_data() in finish_response() returns no messages and the parser
+    keeps the partial bytes in its internal buffer. When the remainder
+    arrives via data_received() the request is completed and dispatched.
+    """
+
+    async def upgrade_handler(request: web.Request) -> NoReturn:
+        raise web.HTTPUpgradeRequired()
+
+    async def second_handler(request: web.Request) -> web.Response:
+        return web.Response(text="second-ok")
+
+    app = web.Application()
+    app.router.add_route("GET", "/", upgrade_handler)
+    app.router.add_route("GET", "/second", second_handler)
+    server = await aiohttp_server(app)
+
+    reader, writer = await asyncio.open_connection(server.host, server.port)
+    try:
+        writer.write(
+            b"GET / HTTP/1.1\r\n"
+            b"Host: localhost\r\n"
+            b"Upgrade: websocket\r\n"
+            b"Connection: Upgrade\r\n"
+            b"Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n"
+            b"Sec-WebSocket-Version: 13\r\n"
+            b"\r\n"
+            b"GET /sec"  # truncated mid-request
+        )
+        await writer.drain()
+
+        async def read_until_first_headers() -> bytes:
+            data = b""
+            while b"\r\n\r\n" not in data:
+                chunk = await reader.read(4096)
+                if not chunk:
+                    break
+                data += chunk
+            return data
+
+        first = await asyncio.wait_for(read_until_first_headers(), timeout=5)
+        assert b"426" in first
+
+        writer.write(b"ond HTTP/1.1\r\n" b"Host: localhost\r\n" b"\r\n")
+        await writer.drain()
+
+        async def read_until_second() -> bytes:
+            data = b""
+            while b"second-ok" not in data:
+                chunk = await reader.read(4096)
+                if not chunk:
+                    break
+                data += chunk
+            return data
+
+        rest = await asyncio.wait_for(read_until_second(), timeout=5)
+        assert b"second-ok" in rest
+    finally:
+        writer.close()
+        await writer.wait_closed()
+
+
 async def test_handshake_connection_header_substring_not_a_token(
     aiohttp_client: AiohttpClient,
 ) -> None:


### PR DESCRIPTION
This is a weird edge case that should never actually be reached, but just in case.

Fixes #12734 