### PR TITLE
Fix connection pool poisoning by widening exception handler

### DIFF
--- a/aiohttp/client_proto.py
+++ b/aiohttp/client_proto.py
@@ -147,7 +147,7 @@ class ResponseHandler(BaseProtocol, DataQueue[tuple[RawResponseMessage, StreamRe
         if self._parser is not None:
             try:
                 uncompleted = self._parser.feed_eof()
-            except Exception as underlying_exc:
+            except BaseException as underlying_exc:
                 if self._payload is not None:
                     client_payload_exc_msg = (
                         f"Response payload is not completed: {underlying_exc !r}"
@@ -323,7 +323,7 @@ class ResponseHandler(BaseProtocol, DataQueue[tuple[RawResponseMessage, StreamRe
         # parse http messages
         try:
             messages, upgraded, tail = self._parser.feed_data(data)
-        except Exception as underlying_exc:
+        except BaseException as underlying_exc:
             if self.transport is not None:
                 # connection.release() could be called BEFORE
                 # data_received(), the transport is already


### PR DESCRIPTION
## Problem

When `self._parser.feed_data(data)` raises a `KeyboardInterrupt` or `SystemExit` (which inherit from `BaseException` but not `Exception`), the handler `except Exception` fails to catch it. This leaves the connection in an inconsistent state, causing read timeouts (~2ms) on subsequent pooled connection reuse.

## Fix

Widen `except Exception` back to `except BaseException`, restoring the pre-3.14.0 behavior.

Closes #12795