### PR TITLE
Add serve_forever() method to BaseRunner

### DIFF
--- a/aiohttp/web_runner.py
+++ b/aiohttp/web_runner.py
@@ -298,6 +298,18 @@ class BaseRunner(ABC, Generic[_Request]):
 
         self._server = await self._make_server()
 
+    async def serve_forever(self) -> None:
+        """Start the server and run until stopped.
+
+        Calls :meth:`setup` to start the server, then waits
+        indefinitely until the runner is stopped.
+        """
+        await self.setup()
+        try:
+            await asyncio.Event().wait()
+        finally:
+            await self.cleanup()
+
     @abstractmethod
     async def shutdown(self) -> None:
         """Call any shutdown hooks to help server close gracefully."""


### PR DESCRIPTION
Adds a `serve_forever()` async method to `BaseRunner` that calls `setup()` and then waits until the runner is stopped, mirroring `asyncio.Server.serve_forever()`.

Closes #2746