### PR TITLE
Revert "Move pip-tools into pyproject.toml"

### DIFF
--- a/.pip-tools.toml
+++ b/.pip-tools.toml
@@ -1,0 +1,5 @@
+[pip-tools]
+allow-unsafe = false
+resolver = "backtracking"
+strip-extras = true
+unsafe-package = "aiohttp"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -174,13 +174,6 @@ skip = "pp*"
 # iOS currently does not support build[uv]
 build-frontend = "build"
 
-[tool.pip-tools]
-# Dependabot won't pick up .pip-tools.toml, so must be defined here.
-allow-unsafe = false
-resolver = "backtracking"
-strip-extras = true
-unsafe-package = ["aiohttp"]
-
 [tool.codespell]
 skip = '.git,*.pdf,*.svg,Makefile,CONTRIBUTORS.txt,venvs,_build'
 ignore-words-list = 'te,assertIn'


### PR DESCRIPTION
Reverts aio-libs/aiohttp#12739

https://github.com/dependabot/dependabot-core/pull/15202 claims to have fixed support for loading the config (at least, partially).