### PR TITLE
fix(_websocket): avoid Cython redeclaration errors with freethreading_compatible=True (#12709)

### DIFF
--- a/aiohttp/_websocket/reader_py.py
+++ b/aiohttp/_websocket/reader_py.py
@@ -24,7 +24,7 @@ from .models import (
     WSMsgType,
 )
 
-ALLOWED_CLOSE_CODES: Final[set[int]] = {int(i) for i in WSCloseCode}
+ALLOWED_CLOSE_CODES = {int(i) for i in WSCloseCode}
 
 # States for the reader, used to parse the WebSocket frame
 # integer values are used so they can be cythonized
@@ -154,18 +154,18 @@ class WebSocketReader:
         self._partial = bytearray()
         self._state = READ_HEADER
 
-        self._opcode: int = OP_CODE_NOT_SET
+        self._opcode = OP_CODE_NOT_SET
         self._frame_fin = False
-        self._frame_opcode: int = OP_CODE_NOT_SET
-        self._payload_fragments: list[bytes] = []
+        self._frame_opcode = OP_CODE_NOT_SET
+        self._payload_fragments = []
         self._frame_payload_len = 0
 
-        self._tail: bytes = b""
+        self._tail = b""
         self._has_mask = False
-        self._frame_mask: bytes | None = None
+        self._frame_mask = None
         self._payload_bytes_to_read = 0
         self._payload_len_flag = 0
-        self._compressed: int = COMPRESSED_NOT_SET
+        self._compressed = COMPRESSED_NOT_SET
         self._decompressobj: ZLibDecompressor | None = None
         self._compress = compress
 
@@ -347,7 +347,7 @@ class WebSocketReader:
         if self._tail:
             data, self._tail = self._tail + data, b""
 
-        start_pos: int = 0
+        start_pos = 0
         data_len = len(data)
         data_cstr = data
 


### PR DESCRIPTION
## Description

Cython 3.2.5 with `freethreading_compatible=True` (the default in modern Cython 3.x) treats type-annotated variables as `cdef` declarations. When those variables are already declared as `cdef` in the `.pxd` file, this causes a "redeclared" compilation error.

This fix removes the duplicate type annotations from `reader_py.py` for variables that are already declared as `cdef` in `reader_c.pxd`, allowing Cython compilation to succeed with `freethreading_compatible=True`.

## Reproduction

```bash
export AIOHTTP_USE_SYSTEM_DEPS=1
pip install cython>=3.2.0
make cythonize
python -m build --wheel --no-isolation
```

Without this fix, the build fails with:

```
Error compiling Cython file:
...
ALLOWED_CLOSE_CODES: Final[set[int]] = {int(i) for i in WSCloseCode}
^
reader_c.py:27:0: ALLOWED_CLOSE_CODES redeclared

Error compiling Cython file:
...
start_pos: int = 0
^
reader_c.py:350:8: start_pos redeclared
```

## Changes

Removed `: int`, `: bytes`, `: list[bytes]`, `: Final[set[int]]`, and `: bytes | None` type annotations from 8 variable declarations in `reader_py.py` that are already declared in `reader_c.pxd`:

- `ALLOWED_CLOSE_CODES: Final[set[int]]` → `ALLOWED_CLOSE_CODES`
- `self._opcode: int` → `self._opcode`
- `self._frame_opcode: int` → `self._frame_opcode`
- `self._payload_fragments: list[bytes]` → `self._payload_fragments`
- `self._tail: bytes` → `self._tail`
- `self._frame_mask: bytes | None` → `self._frame_mask`
- `self._compressed: int` → `self._compressed`
- `start_pos: int` → `start_pos`

Fixes #12709