### PR TITLE
Add request_timeout to WebSocket handshakes

### DIFF
--- a/CHANGES/7220.feature.rst
+++ b/CHANGES/7220.feature.rst
@@ -1,0 +1,3 @@
+Added a ``request_timeout`` parameter to :meth:`aiohttp.ClientSession.ws_connect`
+for controlling the HTTP request timeout used while establishing WebSocket
+handshakes -- by :user:`marko1olo`.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -260,6 +260,7 @@ Mariano Anaya
 Mariusz Masztalerczuk
 Mark Larah
 Marko Kohtala
+marko1olo
 Martijn Pieters
 Martin Melka
 Martin Richard

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -205,6 +205,7 @@ class _WSConnectOptions(TypedDict, total=False):
     method: str
     protocols: Collection[str]
     timeout: "ClientWSTimeout | _SENTINEL"
+    request_timeout: "ClientTimeout | None"
     receive_timeout: float | None
     autoclose: bool
     autoping: bool
@@ -944,6 +945,7 @@ class ClientSession:
         method: str = hdrs.METH_GET,
         protocols: Collection[str] = (),
         timeout: ClientWSTimeout | _SENTINEL = sentinel,
+        request_timeout: ClientTimeout | None = None,
         receive_timeout: float | None = None,
         autoclose: bool = True,
         autoping: bool = True,
@@ -966,6 +968,7 @@ class ClientSession:
                 method=method,
                 protocols=protocols,
                 timeout=timeout,
+                request_timeout=request_timeout,
                 receive_timeout=receive_timeout,
                 autoclose=autoclose,
                 autoping=autoping,
@@ -1019,6 +1022,7 @@ class ClientSession:
         method: str = hdrs.METH_GET,
         protocols: Collection[str] = (),
         timeout: ClientWSTimeout | _SENTINEL = sentinel,
+        request_timeout: ClientTimeout | None = None,
         receive_timeout: float | None = None,
         autoclose: bool = True,
         autoping: bool = True,
@@ -1097,6 +1101,7 @@ class ClientSession:
             headers=real_headers,
             read_until_eof=False,
             proxy=proxy,
+            timeout=request_timeout,
             ssl=ssl,
             server_hostname=server_hostname,
             proxy_headers=proxy_headers,

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -697,6 +697,7 @@ The client session supports the context manager protocol for self closing.
    .. method:: ws_connect(url, *, method='GET', \
                             protocols=(), \
                             timeout=sentinel,\
+                            request_timeout=None,\
                             autoclose=True,\
                             autoping=True,\
                             heartbeat=None,\
@@ -724,6 +725,13 @@ The client session supports the context manager protocol for self closing.
                       `ClientWSTimeout(ws_receive=None, ws_close=10.0)` is used
                       (``10.0`` seconds for the websocket to close).
                       ``None`` means no timeout will be used.
+
+      :param request_timeout: a :class:`ClientTimeout` timeout for the HTTP
+                              request used to establish the websocket
+                              connection. If ``None``, the session timeout
+                              is used.
+
+         .. versionadded:: 3.13
 
       :param bool autoclose: Automatically close websocket connection on close
                              message from server. If *autoclose* is False

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -731,7 +731,7 @@ The client session supports the context manager protocol for self closing.
                               connection. If ``None``, the session timeout
                               is used.
 
-         .. versionadded:: 3.13
+         .. versionadded:: 3.14
 
       :param bool autoclose: Automatically close websocket connection on close
                              message from server. If *autoclose* is False

--- a/tests/test_client_ws.py
+++ b/tests/test_client_ws.py
@@ -10,6 +10,7 @@ import pytest
 import aiohttp
 from aiohttp import (
     ClientConnectionResetError,
+    ClientTimeout,
     ClientWSTimeout,
     ServerDisconnectedError,
     client,
@@ -74,6 +75,40 @@ async def test_ws_connect_read_timeout_is_reset_to_inf(
     assert res.protocol == "chat"
     assert hdrs.ORIGIN not in m_req.call_args[1]["headers"]
     assert resp.connection.protocol.read_timeout is None
+
+
+async def test_ws_connect_passes_request_timeout_to_request(
+    ws_key: str, key_data: bytes
+) -> None:
+    session_timeout = ClientTimeout(total=10.0)
+    request_timeout = ClientTimeout(total=1.0, connect=0.5)
+    resp = mock.Mock()
+    resp.status = 101
+    resp.headers = {
+        hdrs.UPGRADE: "websocket",
+        hdrs.CONNECTION: "upgrade",
+        hdrs.SEC_WEBSOCKET_ACCEPT: ws_key,
+        hdrs.SEC_WEBSOCKET_PROTOCOL: "chat",
+    }
+    resp.connection.protocol.read_timeout = None
+    with (
+        mock.patch("aiohttp.client.os") as m_os,
+        mock.patch("aiohttp.client.ClientSession.request") as m_req,
+    ):
+        m_os.urandom.return_value = key_data
+        m_req.return_value = asyncio.get_running_loop().create_future()
+        m_req.return_value.set_result(resp)
+
+        async with aiohttp.ClientSession(timeout=session_timeout) as session:
+            res = await session.ws_connect(
+                "http://test.org",
+                protocols=("t1", "t2", "chat"),
+                request_timeout=request_timeout,
+            )
+
+    assert isinstance(res, client.ClientWebSocketResponse)
+    assert res.protocol == "chat"
+    assert m_req.call_args[1]["timeout"] is request_timeout
 
 
 async def test_ws_connect_read_timeout_stays_inf(ws_key: str, key_data: bytes) -> None:

--- a/tests/test_client_ws.py
+++ b/tests/test_client_ws.py
@@ -108,7 +108,7 @@ async def test_ws_connect_passes_request_timeout_to_request(
 
     assert isinstance(res, client.ClientWebSocketResponse)
     assert res.protocol == "chat"
-    assert m_req.call_args[1]["timeout"] is request_timeout
+    assert m_req.call_args[1]["timeout"] == request_timeout
 
 
 async def test_ws_connect_read_timeout_stays_inf(ws_key: str, key_data: bytes) -> None:

--- a/tests/test_client_ws_functional.py
+++ b/tests/test_client_ws_functional.py
@@ -786,7 +786,9 @@ async def test_ws_connect_request_timeout(
     timeout = aiohttp.ClientTimeout(total=0.05)
     ws_timeout = ClientWSTimeout(ws_close=1.0)
     request_timeout = timeout if use_request_timeout else None
-    session_timeout = aiohttp.ClientTimeout(total=30) if use_request_timeout else timeout
+    session_timeout = (
+        aiohttp.ClientTimeout(total=30) if use_request_timeout else timeout
+    )
     async with aiohttp.ClientSession(timeout=session_timeout) as client:
         with pytest.raises(asyncio.TimeoutError):
             await client.ws_connect(

--- a/tests/test_client_ws_functional.py
+++ b/tests/test_client_ws_functional.py
@@ -771,6 +771,31 @@ async def test_receive_timeout_deprecation(aiohttp_client: AiohttpClient) -> Non
     await resp.close()
 
 
+@pytest.mark.parametrize("use_request_timeout", [False, True])
+async def test_ws_connect_request_timeout(
+    aiohttp_server: AiohttpServer, use_request_timeout: bool
+) -> None:
+    async def handler(request: web.Request) -> web.Response:
+        await asyncio.sleep(1)
+        return web.Response()
+
+    app = web.Application()
+    app.router.add_route("GET", "/", handler)
+    server = await aiohttp_server(app)
+
+    timeout = aiohttp.ClientTimeout(total=0.05)
+    ws_timeout = ClientWSTimeout(ws_close=1.0)
+    request_timeout = timeout if use_request_timeout else None
+    session_timeout = aiohttp.ClientTimeout(total=30) if use_request_timeout else timeout
+    async with aiohttp.ClientSession(timeout=session_timeout) as client:
+        with pytest.raises(asyncio.TimeoutError):
+            await client.ws_connect(
+                server.make_url("/"),
+                request_timeout=request_timeout,
+                timeout=ws_timeout,
+            )
+
+
 async def test_custom_receive_timeout(aiohttp_client: AiohttpClient) -> None:
     async def handler(request: web.Request) -> web.WebSocketResponse:
         ws = web.WebSocketResponse()

--- a/tests/test_client_ws_functional.py
+++ b/tests/test_client_ws_functional.py
@@ -775,9 +775,9 @@ async def test_receive_timeout_deprecation(aiohttp_client: AiohttpClient) -> Non
 async def test_ws_connect_request_timeout(
     aiohttp_server: AiohttpServer, use_request_timeout: bool
 ) -> None:
-    async def handler(request: web.Request) -> web.Response:
-        await asyncio.sleep(1)
-        return web.Response()
+    async def handler(request: web.Request) -> web.StreamResponse:
+        while True:
+            await asyncio.Event().wait()
 
     app = web.Application()
     app.router.add_route("GET", "/", handler)


### PR DESCRIPTION
## What do these changes do?

Add a `request_timeout` parameter to `ClientSession.ws_connect()` for the HTTP request used to establish the WebSocket handshake.

The existing `timeout` parameter remains the `ClientWSTimeout` for WebSocket receive/close behavior. `request_timeout` accepts a `ClientTimeout` and is passed to the internal opening `request()` call. If it is `None`, the normal session timeout behavior is preserved.

## Are there changes in behavior for the user?

Yes. Users can now set a per-call HTTP request timeout for a WebSocket handshake without mutating the `ClientSession` timeout and without overloading `ClientWSTimeout`, which controls different WebSocket operations.

## Is it a substantial burden for the maintainers to support this?

It is a small public API addition, documented and covered by both unit and functional tests. The change avoids changing the meaning of the existing `timeout` / `ClientWSTimeout` parameter.

## Related issue number

Closes #7220.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
- [x] Add a new news fragment into the `CHANGES/` folder

Tests run:

- `python -m pytest tests/test_client_ws.py tests/test_client_ws_functional.py::test_ws_connect_request_timeout -q` (`40 passed`)
- `python -m pytest tests/test_client_ws.py::test_ws_connect_passes_request_timeout_to_request tests/test_client_ws_functional.py::test_ws_connect_request_timeout -q` (`3 passed`)
- `python -m ruff check aiohttp\client.py tests\test_client_ws.py tests\test_client_ws_functional.py`
- `python -m compileall -q aiohttp\client.py tests\test_client_ws.py tests\test_client_ws_functional.py`
- `git diff --check`
- Verified `CONTRIBUTORS.txt` remains sorted case-insensitively with a local Python check.

Drafted with OpenAI Codex GPT-5; pending human review.