### PR TITLE
Parameterize some codspeed benchmarks by connection type (tcp vs ssl)

### DIFF
--- a/CHANGES/12823.misc.rst
+++ b/CHANGES/12823.misc.rst
@@ -1,0 +1,2 @@
+Parameterize some codspeed benchmark on connection type (SSL + TCP).
+Current benchmarks only run for TCP connection type. -- by :user:`tarasko`.

--- a/CHANGES/12823.misc.rst
+++ b/CHANGES/12823.misc.rst
@@ -1,2 +1,2 @@
-Parameterize some codspeed benchmark on connection type (SSL + TCP).
-Current benchmarks only run for TCP connection type. -- by :user:`tarasko`.
+Parameterized some codspeed benchmark on connection type (SSL + TCP).
+Previously, benchmarks only ran for TCP connection type. -- by :user:`tarasko`.

--- a/CHANGES/12823.misc.rst
+++ b/CHANGES/12823.misc.rst
@@ -1,2 +1,2 @@
-Parameterized some codspeed benchmark on connection type (SSL + TCP).
+Parameterized some codspeed benchmarks on connection type (SSL + TCP).
 Previously, benchmarks only ran for TCP connection type. -- by :user:`tarasko`.

--- a/CHANGES/12823.misc.rst
+++ b/CHANGES/12823.misc.rst
@@ -1,2 +1,2 @@
-Parameterized some codspeed benchmarks on connection type (SSL + TCP).
+Parameterized some codspeed benchmarks by connection type (SSL + TCP).
 Previously, benchmarks only ran for TCP connection type. -- by :user:`tarasko`.

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -77,6 +77,7 @@ cmd
 codecov
 codebase
 codec
+codspeed
 Codings
 committer
 committers

--- a/tests/test_benchmarks_client.py
+++ b/tests/test_benchmarks_client.py
@@ -4,7 +4,7 @@ import asyncio
 import ssl
 from collections.abc import Awaitable, Callable, Iterator
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, TypedDict
 
 import pytest
 from pytest_aiohttp import AiohttpClient, AiohttpServer
@@ -46,13 +46,17 @@ def aiohttp_client_sync(
         event_loop.run_until_complete(clients.pop().close())
 
 
+class _ConnArgs(TypedDict, total=False):
+    ssl: ssl.SSLContext
+
+
 @dataclass(frozen=True)
 class ConnectionType:
-    s_kwargs: dict[str, Any]
-    c_kwargs: dict[str, Any]
+    s_kwargs: _ConnArgs
+    c_kwargs: _ConnArgs
 
 
-@pytest.fixture(params=["tcp", "ssl"], ids=["tcp", "ssl"])
+@pytest.fixture(params=("tcp", "ssl"), ids=("tcp", "ssl"))
 def conn_type(
     request: pytest.FixtureRequest,
     ssl_ctx: ssl.SSLContext,

--- a/tests/test_benchmarks_client.py
+++ b/tests/test_benchmarks_client.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any
 
 import pytest
 from pytest_aiohttp import AiohttpClient, AiohttpServer
+from yarl import URL
 
 from aiohttp import hdrs, request, web
 from aiohttp.test_utils import TestClient, TestServer
@@ -118,9 +119,8 @@ def test_one_hundred_simple_get_requests(
 
 def test_one_hundred_simple_get_requests_alternating_clients(
     event_loop: asyncio.AbstractEventLoop,
-    aiohttp_client_sync: AiohttpClient,
+    aiohttp_client: AiohttpClient,
     benchmark: BenchmarkFixture,
-    conn_type: ConnectionType,
 ) -> None:
     """Benchmark 100 simple GET requests with alternating clients."""
     message_count = 100
@@ -132,13 +132,13 @@ def test_one_hundred_simple_get_requests_alternating_clients(
     app.router.add_route("GET", "/", handler)
 
     async def run_client_benchmark() -> None:
-        client1 = await aiohttp_client_sync(app, server_kwargs=conn_type.s_kwargs)
-        client2 = await aiohttp_client_sync(app, server_kwargs=conn_type.s_kwargs)
+        client1 = await aiohttp_client(app)
+        client2 = await aiohttp_client(app)
         for i in range(message_count):
             if i % 2 == 0:
-                await client1.get("/", **conn_type.c_kwargs)
+                await client1.get("/")
             else:
-                await client2.get("/", **conn_type.c_kwargs)
+                await client2.get("/")
         await client1.close()
         await client2.close()
 
@@ -151,7 +151,6 @@ def test_one_hundred_simple_get_requests_no_session(
     event_loop: asyncio.AbstractEventLoop,
     aiohttp_server_sync: AiohttpServer,
     benchmark: BenchmarkFixture,
-    conn_type: ConnectionType,
 ) -> None:
     """Benchmark 100 simple GET requests without a session."""
     message_count = 100
@@ -161,14 +160,12 @@ def test_one_hundred_simple_get_requests_no_session(
 
     app = web.Application()
     app.router.add_route("GET", "/", handler)
-    server = event_loop.run_until_complete(
-        aiohttp_server_sync(app, **conn_type.s_kwargs)
-    )
-    url = server.make_url("/")
+    server = event_loop.run_until_complete(aiohttp_server_sync(app))
+    url = URL(f"http://{server.host}:{server.port}/")
 
     async def run_client_benchmark() -> None:
         for _ in range(message_count):
-            async with request("GET", url, **conn_type.c_kwargs):
+            async with request("GET", url):
                 pass
 
     @benchmark
@@ -296,9 +293,8 @@ def test_one_hundred_get_requests_with_1mb_chunked_payload(
 
 def test_one_hundred_get_requests_iter_chunks_on_1mb_chunked_payload(
     event_loop: asyncio.AbstractEventLoop,
-    aiohttp_client_sync: AiohttpClient,
+    aiohttp_client: AiohttpClient,
     benchmark: BenchmarkFixture,
-    conn_type: ConnectionType,
 ) -> None:
     """Benchmark 100 GET requests with a 1 MiB chunked payload using iter_chunks."""
     message_count = 100
@@ -313,9 +309,9 @@ def test_one_hundred_get_requests_iter_chunks_on_1mb_chunked_payload(
     app.router.add_route("GET", "/", handler)
 
     async def run_client_benchmark() -> None:
-        client = await aiohttp_client_sync(app, server_kwargs=conn_type.s_kwargs)
+        client = await aiohttp_client(app)
         for _ in range(message_count):
-            resp = await client.get("/", **conn_type.c_kwargs)
+            resp = await client.get("/")
             async for _ in resp.content.iter_chunks():
                 pass
         await client.close()
@@ -362,9 +358,8 @@ def test_get_request_with_251308_compressed_chunked_payload(
 
 def test_one_hundred_get_requests_with_1024_content_length_payload(
     event_loop: asyncio.AbstractEventLoop,
-    aiohttp_client_sync: AiohttpClient,
+    aiohttp_client: AiohttpClient,
     benchmark: BenchmarkFixture,
-    conn_type: ConnectionType,
 ) -> None:
     """Benchmark 100 GET requests with a small payload of 1024 bytes."""
     message_count = 100
@@ -378,9 +373,9 @@ def test_one_hundred_get_requests_with_1024_content_length_payload(
     app.router.add_route("GET", "/", handler)
 
     async def run_client_benchmark() -> None:
-        client = await aiohttp_client_sync(app, server_kwargs=conn_type.s_kwargs)
+        client = await aiohttp_client(app)
         for _ in range(message_count):
-            resp = await client.get("/", **conn_type.c_kwargs)
+            resp = await client.get("/")
             await resp.read()
         await client.close()
 
@@ -391,9 +386,8 @@ def test_one_hundred_get_requests_with_1024_content_length_payload(
 
 def test_one_hundred_get_requests_with_30000_content_length_payload(
     event_loop: asyncio.AbstractEventLoop,
-    aiohttp_client_sync: AiohttpClient,
+    aiohttp_client: AiohttpClient,
     benchmark: BenchmarkFixture,
-    conn_type: ConnectionType,
 ) -> None:
     """Benchmark 100 GET requests with a payload of 30000 bytes."""
     message_count = 100
@@ -407,9 +401,9 @@ def test_one_hundred_get_requests_with_30000_content_length_payload(
     app.router.add_route("GET", "/", handler)
 
     async def run_client_benchmark() -> None:
-        client = await aiohttp_client_sync(app, server_kwargs=conn_type.s_kwargs)
+        client = await aiohttp_client(app)
         for _ in range(message_count):
-            resp = await client.get("/", **conn_type.c_kwargs)
+            resp = await client.get("/")
             await resp.read()
         await client.close()
 
@@ -420,9 +414,8 @@ def test_one_hundred_get_requests_with_30000_content_length_payload(
 
 def test_one_hundred_get_requests_with_1mb_content_length_payload(
     event_loop: asyncio.AbstractEventLoop,
-    aiohttp_client_sync: AiohttpClient,
+    aiohttp_client: AiohttpClient,
     benchmark: BenchmarkFixture,
-    conn_type: ConnectionType,
 ) -> None:
     """Benchmark 100 GET requests with a content-length payload of 1 MiB."""
     message_count = 100
@@ -436,9 +429,9 @@ def test_one_hundred_get_requests_with_1mb_content_length_payload(
     app.router.add_route("GET", "/", handler)
 
     async def run_client_benchmark() -> None:
-        client = await aiohttp_client_sync(app, server_kwargs=conn_type.s_kwargs)
+        client = await aiohttp_client(app)
         for _ in range(message_count):
-            resp = await client.get("/", **conn_type.c_kwargs)
+            resp = await client.get("/")
             await resp.read()
         await client.close()
 
@@ -449,9 +442,8 @@ def test_one_hundred_get_requests_with_1mb_content_length_payload(
 
 def test_one_hundred_simple_post_requests(
     event_loop: asyncio.AbstractEventLoop,
-    aiohttp_client_sync: AiohttpClient,
+    aiohttp_client: AiohttpClient,
     benchmark: BenchmarkFixture,
-    conn_type: ConnectionType,
 ) -> None:
     """Benchmark 100 simple POST requests."""
     message_count = 100
@@ -463,9 +455,9 @@ def test_one_hundred_simple_post_requests(
     app.router.add_route("POST", "/", handler)
 
     async def run_client_benchmark() -> None:
-        client = await aiohttp_client_sync(app, server_kwargs=conn_type.s_kwargs)
+        client = await aiohttp_client(app)
         for _ in range(message_count):
-            await client.post("/", data=b"any", **conn_type.c_kwargs)
+            await client.post("/", data=b"any")
         await client.close()
 
     @benchmark
@@ -475,9 +467,8 @@ def test_one_hundred_simple_post_requests(
 
 def test_one_hundred_json_post_requests(
     event_loop: asyncio.AbstractEventLoop,
-    aiohttp_client_sync: AiohttpClient,
+    aiohttp_client: AiohttpClient,
     benchmark: BenchmarkFixture,
-    conn_type: ConnectionType,
 ) -> None:
     """Benchmark 100 JSON POST requests that check the content-type."""
     message_count = 100
@@ -491,9 +482,9 @@ def test_one_hundred_json_post_requests(
     app.router.add_route("POST", "/", handler)
 
     async def run_client_benchmark() -> None:
-        client = await aiohttp_client_sync(app, server_kwargs=conn_type.s_kwargs)
+        client = await aiohttp_client(app)
         for _ in range(message_count):
-            await client.post("/", json={"key": "value"}, **conn_type.c_kwargs)
+            await client.post("/", json={"key": "value"})
         await client.close()
 
     @benchmark
@@ -503,9 +494,8 @@ def test_one_hundred_json_post_requests(
 
 def test_ten_streamed_responses_iter_any(
     event_loop: asyncio.AbstractEventLoop,
-    aiohttp_client_sync: AiohttpClient,
+    aiohttp_client: AiohttpClient,
     benchmark: BenchmarkFixture,
-    conn_type: ConnectionType,
 ) -> None:
     """Benchmark 10 streamed responses using iter_any."""
     message_count = 10
@@ -522,9 +512,9 @@ def test_ten_streamed_responses_iter_any(
     app.router.add_route("GET", "/", handler)
 
     async def run_client_benchmark() -> None:
-        client = await aiohttp_client_sync(app, server_kwargs=conn_type.s_kwargs)
+        client = await aiohttp_client(app)
         for _ in range(message_count):
-            resp = await client.get("/", **conn_type.c_kwargs)
+            resp = await client.get("/")
             async for _ in resp.content.iter_any():
                 pass
         await client.close()
@@ -536,9 +526,8 @@ def test_ten_streamed_responses_iter_any(
 
 def test_ten_streamed_responses_iter_chunked_4096(
     event_loop: asyncio.AbstractEventLoop,
-    aiohttp_client_sync: AiohttpClient,
+    aiohttp_client: AiohttpClient,
     benchmark: BenchmarkFixture,
-    conn_type: ConnectionType,
 ) -> None:
     """Benchmark 10 streamed responses using iter_chunked 4096."""
     message_count = 10
@@ -555,9 +544,9 @@ def test_ten_streamed_responses_iter_chunked_4096(
     app.router.add_route("GET", "/", handler)
 
     async def run_client_benchmark() -> None:
-        client = await aiohttp_client_sync(app, server_kwargs=conn_type.s_kwargs)
+        client = await aiohttp_client(app)
         for _ in range(message_count):
-            resp = await client.get("/", **conn_type.c_kwargs)
+            resp = await client.get("/")
             async for _ in resp.content.iter_chunked(4096):
                 pass
         await client.close()
@@ -569,9 +558,8 @@ def test_ten_streamed_responses_iter_chunked_4096(
 
 def test_ten_streamed_responses_iter_chunked_1mb(
     event_loop: asyncio.AbstractEventLoop,
-    aiohttp_client_sync: AiohttpClient,
+    aiohttp_client: AiohttpClient,
     benchmark: BenchmarkFixture,
-    conn_type: ConnectionType,
 ) -> None:
     """Benchmark 10 streamed responses using iter_chunked 1 MiB."""
     message_count = 10
@@ -589,9 +577,9 @@ def test_ten_streamed_responses_iter_chunked_1mb(
     app.router.add_route("GET", "/", handler)
 
     async def run_client_benchmark() -> None:
-        client = await aiohttp_client_sync(app, server_kwargs=conn_type.s_kwargs)
+        client = await aiohttp_client(app)
         for _ in range(message_count):
-            resp = await client.get("/", **conn_type.c_kwargs)
+            resp = await client.get("/")
             async for _ in resp.content.iter_chunked(MB):
                 pass
         await client.close()
@@ -633,9 +621,8 @@ def test_ten_compressed_responses_iter_chunked_1mb(
 
 def test_ten_streamed_responses_iter_chunks(
     event_loop: asyncio.AbstractEventLoop,
-    aiohttp_client_sync: AiohttpClient,
+    aiohttp_client: AiohttpClient,
     benchmark: BenchmarkFixture,
-    conn_type: ConnectionType,
 ) -> None:
     """Benchmark 10 streamed responses using iter_chunks."""
     message_count = 10
@@ -652,9 +639,9 @@ def test_ten_streamed_responses_iter_chunks(
     app.router.add_route("GET", "/", handler)
 
     async def run_client_benchmark() -> None:
-        client = await aiohttp_client_sync(app, server_kwargs=conn_type.s_kwargs)
+        client = await aiohttp_client(app)
         for _ in range(message_count):
-            resp = await client.get("/", **conn_type.c_kwargs)
+            resp = await client.get("/")
             async for _ in resp.content.iter_chunks():
                 pass
         await client.close()

--- a/tests/test_benchmarks_client.py
+++ b/tests/test_benchmarks_client.py
@@ -119,7 +119,7 @@ def test_one_hundred_simple_get_requests(
 
 def test_one_hundred_simple_get_requests_alternating_clients(
     event_loop: asyncio.AbstractEventLoop,
-    aiohttp_client: AiohttpClient,
+    aiohttp_client_sync: AiohttpClient,
     benchmark: BenchmarkFixture,
 ) -> None:
     """Benchmark 100 simple GET requests with alternating clients."""
@@ -132,8 +132,8 @@ def test_one_hundred_simple_get_requests_alternating_clients(
     app.router.add_route("GET", "/", handler)
 
     async def run_client_benchmark() -> None:
-        client1 = await aiohttp_client(app)
-        client2 = await aiohttp_client(app)
+        client1 = await aiohttp_client_sync(app)
+        client2 = await aiohttp_client_sync(app)
         for i in range(message_count):
             if i % 2 == 0:
                 await client1.get("/")
@@ -233,9 +233,8 @@ def test_one_hundred_get_requests_with_1024_chunked_payload(
 
 def test_one_hundred_get_requests_with_30000_chunked_payload(
     event_loop: asyncio.AbstractEventLoop,
-    aiohttp_client_sync: AiohttpClient,
+    aiohttp_client: AiohttpClient,
     benchmark: BenchmarkFixture,
-    conn_type: ConnectionType,
 ) -> None:
     """Benchmark 100 GET requests with a payload of 30000 bytes."""
     message_count = 100
@@ -250,9 +249,9 @@ def test_one_hundred_get_requests_with_30000_chunked_payload(
     app.router.add_route("GET", "/", handler)
 
     async def run_client_benchmark() -> None:
-        client = await aiohttp_client_sync(app, server_kwargs=conn_type.s_kwargs)
+        client = await aiohttp_client(app)
         for _ in range(message_count):
-            resp = await client.get("/", **conn_type.c_kwargs)
+            resp = await client.get("/")
             await resp.read()
         await client.close()
 

--- a/tests/test_benchmarks_client.py
+++ b/tests/test_benchmarks_client.py
@@ -1,21 +1,68 @@
 """codspeed benchmarks for HTTP client."""
 
 import asyncio
-from collections.abc import Iterator
+import ssl
+from collections.abc import Awaitable, Callable, Iterator
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 import pytest
 from pytest_aiohttp import AiohttpClient, AiohttpServer
-from yarl import URL
 
 from aiohttp import hdrs, request, web
-from aiohttp.test_utils import TestServer
+from aiohttp.test_utils import TestClient, TestServer
 
 if TYPE_CHECKING:
     from pytest_codspeed import BenchmarkFixture
 else:
     pytest_codspeed = pytest.importorskip("pytest_codspeed")
     BenchmarkFixture = pytest_codspeed.BenchmarkFixture
+
+
+@pytest.fixture
+def aiohttp_client_sync(
+    event_loop: asyncio.AbstractEventLoop,
+) -> Iterator[
+    Callable[[web.Application], Awaitable[TestClient[web.Request, web.Application]]]
+]:
+    clients = []
+
+    async def go(
+        app: web.Application,
+        *,
+        server_kwargs: dict[str, Any] | None = None,
+    ) -> TestClient[web.Request, web.Application]:
+        server = TestServer(app)
+        client = TestClient(server)
+        await server.start_server(**(server_kwargs or {}))
+        await client.start_server()
+        clients.append(client)
+        return client
+
+    yield go
+
+    while clients:
+        event_loop.run_until_complete(clients.pop().close())
+
+
+@dataclass(frozen=True)
+class ConnectionType:
+    s_kwargs: dict[str, Any]
+    c_kwargs: dict[str, Any]
+
+
+@pytest.fixture(params=["tcp", "ssl"], ids=["tcp", "ssl"])
+def conn_type(
+    request: pytest.FixtureRequest,
+    ssl_ctx: ssl.SSLContext,
+    client_ssl_ctx: ssl.SSLContext,
+) -> ConnectionType:
+    if request.param == "ssl":
+        return ConnectionType(
+            s_kwargs={"ssl": ssl_ctx},
+            c_kwargs={"ssl": client_ssl_ctx},
+        )
+    return ConnectionType(s_kwargs={}, c_kwargs={})
 
 
 @pytest.fixture
@@ -45,8 +92,9 @@ def aiohttp_server_sync(
 
 def test_one_hundred_simple_get_requests(
     event_loop: asyncio.AbstractEventLoop,
-    aiohttp_client: AiohttpClient,
+    aiohttp_client_sync: AiohttpClient,
     benchmark: BenchmarkFixture,
+    conn_type: ConnectionType,
 ) -> None:
     """Benchmark 100 simple GET requests."""
     message_count = 100
@@ -58,9 +106,9 @@ def test_one_hundred_simple_get_requests(
     app.router.add_route("GET", "/", handler)
 
     async def run_client_benchmark() -> None:
-        client = await aiohttp_client(app)
+        client = await aiohttp_client_sync(app, server_kwargs=conn_type.s_kwargs)
         for _ in range(message_count):
-            await client.get("/")
+            await client.get("/", **conn_type.c_kwargs)
         await client.close()
 
     @benchmark
@@ -70,8 +118,9 @@ def test_one_hundred_simple_get_requests(
 
 def test_one_hundred_simple_get_requests_alternating_clients(
     event_loop: asyncio.AbstractEventLoop,
-    aiohttp_client: AiohttpClient,
+    aiohttp_client_sync: AiohttpClient,
     benchmark: BenchmarkFixture,
+    conn_type: ConnectionType,
 ) -> None:
     """Benchmark 100 simple GET requests with alternating clients."""
     message_count = 100
@@ -83,13 +132,13 @@ def test_one_hundred_simple_get_requests_alternating_clients(
     app.router.add_route("GET", "/", handler)
 
     async def run_client_benchmark() -> None:
-        client1 = await aiohttp_client(app)
-        client2 = await aiohttp_client(app)
+        client1 = await aiohttp_client_sync(app, server_kwargs=conn_type.s_kwargs)
+        client2 = await aiohttp_client_sync(app, server_kwargs=conn_type.s_kwargs)
         for i in range(message_count):
             if i % 2 == 0:
-                await client1.get("/")
+                await client1.get("/", **conn_type.c_kwargs)
             else:
-                await client2.get("/")
+                await client2.get("/", **conn_type.c_kwargs)
         await client1.close()
         await client2.close()
 
@@ -102,6 +151,7 @@ def test_one_hundred_simple_get_requests_no_session(
     event_loop: asyncio.AbstractEventLoop,
     aiohttp_server_sync: AiohttpServer,
     benchmark: BenchmarkFixture,
+    conn_type: ConnectionType,
 ) -> None:
     """Benchmark 100 simple GET requests without a session."""
     message_count = 100
@@ -111,12 +161,14 @@ def test_one_hundred_simple_get_requests_no_session(
 
     app = web.Application()
     app.router.add_route("GET", "/", handler)
-    server = event_loop.run_until_complete(aiohttp_server_sync(app))
-    url = URL(f"http://{server.host}:{server.port}/")
+    server = event_loop.run_until_complete(
+        aiohttp_server_sync(app, **conn_type.s_kwargs)
+    )
+    url = server.make_url("/")
 
     async def run_client_benchmark() -> None:
         for _ in range(message_count):
-            async with request("GET", url):
+            async with request("GET", url, **conn_type.c_kwargs):
                 pass
 
     @benchmark
@@ -154,8 +206,9 @@ def test_one_hundred_simple_get_requests_multiple_methods_route(
 
 def test_one_hundred_get_requests_with_1024_chunked_payload(
     event_loop: asyncio.AbstractEventLoop,
-    aiohttp_client: AiohttpClient,
+    aiohttp_client_sync: AiohttpClient,
     benchmark: BenchmarkFixture,
+    conn_type: ConnectionType,
 ) -> None:
     """Benchmark 100 GET requests with a small payload of 1024 bytes."""
     message_count = 100
@@ -170,9 +223,9 @@ def test_one_hundred_get_requests_with_1024_chunked_payload(
     app.router.add_route("GET", "/", handler)
 
     async def run_client_benchmark() -> None:
-        client = await aiohttp_client(app)
+        client = await aiohttp_client_sync(app, server_kwargs=conn_type.s_kwargs)
         for _ in range(message_count):
-            resp = await client.get("/")
+            resp = await client.get("/", **conn_type.c_kwargs)
             await resp.read()
         await client.close()
 
@@ -183,8 +236,9 @@ def test_one_hundred_get_requests_with_1024_chunked_payload(
 
 def test_one_hundred_get_requests_with_30000_chunked_payload(
     event_loop: asyncio.AbstractEventLoop,
-    aiohttp_client: AiohttpClient,
+    aiohttp_client_sync: AiohttpClient,
     benchmark: BenchmarkFixture,
+    conn_type: ConnectionType,
 ) -> None:
     """Benchmark 100 GET requests with a payload of 30000 bytes."""
     message_count = 100
@@ -199,9 +253,9 @@ def test_one_hundred_get_requests_with_30000_chunked_payload(
     app.router.add_route("GET", "/", handler)
 
     async def run_client_benchmark() -> None:
-        client = await aiohttp_client(app)
+        client = await aiohttp_client_sync(app, server_kwargs=conn_type.s_kwargs)
         for _ in range(message_count):
-            resp = await client.get("/")
+            resp = await client.get("/", **conn_type.c_kwargs)
             await resp.read()
         await client.close()
 
@@ -212,8 +266,9 @@ def test_one_hundred_get_requests_with_30000_chunked_payload(
 
 def test_one_hundred_get_requests_with_1mb_chunked_payload(
     event_loop: asyncio.AbstractEventLoop,
-    aiohttp_client: AiohttpClient,
+    aiohttp_client_sync: AiohttpClient,
     benchmark: BenchmarkFixture,
+    conn_type: ConnectionType,
 ) -> None:
     """Benchmark 100 GET requests with a 1 MiB chunked payload using read."""
     message_count = 100
@@ -228,9 +283,9 @@ def test_one_hundred_get_requests_with_1mb_chunked_payload(
     app.router.add_route("GET", "/", handler)
 
     async def run_client_benchmark() -> None:
-        client = await aiohttp_client(app)
+        client = await aiohttp_client_sync(app, server_kwargs=conn_type.s_kwargs)
         for _ in range(message_count):
-            resp = await client.get("/")
+            resp = await client.get("/", **conn_type.c_kwargs)
             await resp.read()
         await client.close()
 
@@ -241,8 +296,9 @@ def test_one_hundred_get_requests_with_1mb_chunked_payload(
 
 def test_one_hundred_get_requests_iter_chunks_on_1mb_chunked_payload(
     event_loop: asyncio.AbstractEventLoop,
-    aiohttp_client: AiohttpClient,
+    aiohttp_client_sync: AiohttpClient,
     benchmark: BenchmarkFixture,
+    conn_type: ConnectionType,
 ) -> None:
     """Benchmark 100 GET requests with a 1 MiB chunked payload using iter_chunks."""
     message_count = 100
@@ -257,9 +313,9 @@ def test_one_hundred_get_requests_iter_chunks_on_1mb_chunked_payload(
     app.router.add_route("GET", "/", handler)
 
     async def run_client_benchmark() -> None:
-        client = await aiohttp_client(app)
+        client = await aiohttp_client_sync(app, server_kwargs=conn_type.s_kwargs)
         for _ in range(message_count):
-            resp = await client.get("/")
+            resp = await client.get("/", **conn_type.c_kwargs)
             async for _ in resp.content.iter_chunks():
                 pass
         await client.close()
@@ -306,8 +362,9 @@ def test_get_request_with_251308_compressed_chunked_payload(
 
 def test_one_hundred_get_requests_with_1024_content_length_payload(
     event_loop: asyncio.AbstractEventLoop,
-    aiohttp_client: AiohttpClient,
+    aiohttp_client_sync: AiohttpClient,
     benchmark: BenchmarkFixture,
+    conn_type: ConnectionType,
 ) -> None:
     """Benchmark 100 GET requests with a small payload of 1024 bytes."""
     message_count = 100
@@ -321,9 +378,9 @@ def test_one_hundred_get_requests_with_1024_content_length_payload(
     app.router.add_route("GET", "/", handler)
 
     async def run_client_benchmark() -> None:
-        client = await aiohttp_client(app)
+        client = await aiohttp_client_sync(app, server_kwargs=conn_type.s_kwargs)
         for _ in range(message_count):
-            resp = await client.get("/")
+            resp = await client.get("/", **conn_type.c_kwargs)
             await resp.read()
         await client.close()
 
@@ -334,8 +391,9 @@ def test_one_hundred_get_requests_with_1024_content_length_payload(
 
 def test_one_hundred_get_requests_with_30000_content_length_payload(
     event_loop: asyncio.AbstractEventLoop,
-    aiohttp_client: AiohttpClient,
+    aiohttp_client_sync: AiohttpClient,
     benchmark: BenchmarkFixture,
+    conn_type: ConnectionType,
 ) -> None:
     """Benchmark 100 GET requests with a payload of 30000 bytes."""
     message_count = 100
@@ -349,9 +407,9 @@ def test_one_hundred_get_requests_with_30000_content_length_payload(
     app.router.add_route("GET", "/", handler)
 
     async def run_client_benchmark() -> None:
-        client = await aiohttp_client(app)
+        client = await aiohttp_client_sync(app, server_kwargs=conn_type.s_kwargs)
         for _ in range(message_count):
-            resp = await client.get("/")
+            resp = await client.get("/", **conn_type.c_kwargs)
             await resp.read()
         await client.close()
 
@@ -362,8 +420,9 @@ def test_one_hundred_get_requests_with_30000_content_length_payload(
 
 def test_one_hundred_get_requests_with_1mb_content_length_payload(
     event_loop: asyncio.AbstractEventLoop,
-    aiohttp_client: AiohttpClient,
+    aiohttp_client_sync: AiohttpClient,
     benchmark: BenchmarkFixture,
+    conn_type: ConnectionType,
 ) -> None:
     """Benchmark 100 GET requests with a content-length payload of 1 MiB."""
     message_count = 100
@@ -377,9 +436,9 @@ def test_one_hundred_get_requests_with_1mb_content_length_payload(
     app.router.add_route("GET", "/", handler)
 
     async def run_client_benchmark() -> None:
-        client = await aiohttp_client(app)
+        client = await aiohttp_client_sync(app, server_kwargs=conn_type.s_kwargs)
         for _ in range(message_count):
-            resp = await client.get("/")
+            resp = await client.get("/", **conn_type.c_kwargs)
             await resp.read()
         await client.close()
 
@@ -390,8 +449,9 @@ def test_one_hundred_get_requests_with_1mb_content_length_payload(
 
 def test_one_hundred_simple_post_requests(
     event_loop: asyncio.AbstractEventLoop,
-    aiohttp_client: AiohttpClient,
+    aiohttp_client_sync: AiohttpClient,
     benchmark: BenchmarkFixture,
+    conn_type: ConnectionType,
 ) -> None:
     """Benchmark 100 simple POST requests."""
     message_count = 100
@@ -403,9 +463,9 @@ def test_one_hundred_simple_post_requests(
     app.router.add_route("POST", "/", handler)
 
     async def run_client_benchmark() -> None:
-        client = await aiohttp_client(app)
+        client = await aiohttp_client_sync(app, server_kwargs=conn_type.s_kwargs)
         for _ in range(message_count):
-            await client.post("/", data=b"any")
+            await client.post("/", data=b"any", **conn_type.c_kwargs)
         await client.close()
 
     @benchmark
@@ -415,8 +475,9 @@ def test_one_hundred_simple_post_requests(
 
 def test_one_hundred_json_post_requests(
     event_loop: asyncio.AbstractEventLoop,
-    aiohttp_client: AiohttpClient,
+    aiohttp_client_sync: AiohttpClient,
     benchmark: BenchmarkFixture,
+    conn_type: ConnectionType,
 ) -> None:
     """Benchmark 100 JSON POST requests that check the content-type."""
     message_count = 100
@@ -430,9 +491,11 @@ def test_one_hundred_json_post_requests(
     app.router.add_route("POST", "/", handler)
 
     async def run_client_benchmark() -> None:
-        client = await aiohttp_client(app)
+        client = await aiohttp_client_sync(app, server_kwargs=conn_type.s_kwargs)
         for _ in range(message_count):
-            await client.post("/", json={"key": "value"})
+            await client.post(
+                "/", json={"key": "value"}, **conn_type.c_kwargs
+            )
         await client.close()
 
     @benchmark
@@ -442,8 +505,9 @@ def test_one_hundred_json_post_requests(
 
 def test_ten_streamed_responses_iter_any(
     event_loop: asyncio.AbstractEventLoop,
-    aiohttp_client: AiohttpClient,
+    aiohttp_client_sync: AiohttpClient,
     benchmark: BenchmarkFixture,
+    conn_type: ConnectionType,
 ) -> None:
     """Benchmark 10 streamed responses using iter_any."""
     message_count = 10
@@ -460,9 +524,9 @@ def test_ten_streamed_responses_iter_any(
     app.router.add_route("GET", "/", handler)
 
     async def run_client_benchmark() -> None:
-        client = await aiohttp_client(app)
+        client = await aiohttp_client_sync(app, server_kwargs=conn_type.s_kwargs)
         for _ in range(message_count):
-            resp = await client.get("/")
+            resp = await client.get("/", **conn_type.c_kwargs)
             async for _ in resp.content.iter_any():
                 pass
         await client.close()
@@ -474,8 +538,9 @@ def test_ten_streamed_responses_iter_any(
 
 def test_ten_streamed_responses_iter_chunked_4096(
     event_loop: asyncio.AbstractEventLoop,
-    aiohttp_client: AiohttpClient,
+    aiohttp_client_sync: AiohttpClient,
     benchmark: BenchmarkFixture,
+    conn_type: ConnectionType,
 ) -> None:
     """Benchmark 10 streamed responses using iter_chunked 4096."""
     message_count = 10
@@ -492,9 +557,9 @@ def test_ten_streamed_responses_iter_chunked_4096(
     app.router.add_route("GET", "/", handler)
 
     async def run_client_benchmark() -> None:
-        client = await aiohttp_client(app)
+        client = await aiohttp_client_sync(app, server_kwargs=conn_type.s_kwargs)
         for _ in range(message_count):
-            resp = await client.get("/")
+            resp = await client.get("/", **conn_type.c_kwargs)
             async for _ in resp.content.iter_chunked(4096):
                 pass
         await client.close()
@@ -506,8 +571,9 @@ def test_ten_streamed_responses_iter_chunked_4096(
 
 def test_ten_streamed_responses_iter_chunked_1mb(
     event_loop: asyncio.AbstractEventLoop,
-    aiohttp_client: AiohttpClient,
+    aiohttp_client_sync: AiohttpClient,
     benchmark: BenchmarkFixture,
+    conn_type: ConnectionType,
 ) -> None:
     """Benchmark 10 streamed responses using iter_chunked 1 MiB."""
     message_count = 10
@@ -525,9 +591,9 @@ def test_ten_streamed_responses_iter_chunked_1mb(
     app.router.add_route("GET", "/", handler)
 
     async def run_client_benchmark() -> None:
-        client = await aiohttp_client(app)
+        client = await aiohttp_client_sync(app, server_kwargs=conn_type.s_kwargs)
         for _ in range(message_count):
-            resp = await client.get("/")
+            resp = await client.get("/", **conn_type.c_kwargs)
             async for _ in resp.content.iter_chunked(MB):
                 pass
         await client.close()
@@ -569,8 +635,9 @@ def test_ten_compressed_responses_iter_chunked_1mb(
 
 def test_ten_streamed_responses_iter_chunks(
     event_loop: asyncio.AbstractEventLoop,
-    aiohttp_client: AiohttpClient,
+    aiohttp_client_sync: AiohttpClient,
     benchmark: BenchmarkFixture,
+    conn_type: ConnectionType,
 ) -> None:
     """Benchmark 10 streamed responses using iter_chunks."""
     message_count = 10
@@ -587,9 +654,9 @@ def test_ten_streamed_responses_iter_chunks(
     app.router.add_route("GET", "/", handler)
 
     async def run_client_benchmark() -> None:
-        client = await aiohttp_client(app)
+        client = await aiohttp_client_sync(app, server_kwargs=conn_type.s_kwargs)
         for _ in range(message_count):
-            resp = await client.get("/")
+            resp = await client.get("/", **conn_type.c_kwargs)
             async for _ in resp.content.iter_chunks():
                 pass
         await client.close()

--- a/tests/test_benchmarks_client.py
+++ b/tests/test_benchmarks_client.py
@@ -493,9 +493,7 @@ def test_one_hundred_json_post_requests(
     async def run_client_benchmark() -> None:
         client = await aiohttp_client_sync(app, server_kwargs=conn_type.s_kwargs)
         for _ in range(message_count):
-            await client.post(
-                "/", json={"key": "value"}, **conn_type.c_kwargs
-            )
+            await client.post("/", json={"key": "value"}, **conn_type.c_kwargs)
         await client.close()
 
     @benchmark

--- a/tests/test_benchmarks_client_ws.py
+++ b/tests/test_benchmarks_client_ws.py
@@ -76,7 +76,6 @@ def test_one_thousand_round_trip_websocket_text_messages(
     event_loop: asyncio.AbstractEventLoop,
     aiohttp_client_sync: AiohttpClient,
     benchmark: BenchmarkFixture,
-    conn_type: ConnectionType,
 ) -> None:
     """Benchmark round trip of 1000 WebSocket text messages."""
     message_count = 1000
@@ -93,8 +92,8 @@ def test_one_thousand_round_trip_websocket_text_messages(
     app.router.add_route("GET", "/", handler)
 
     async def run_websocket_benchmark() -> None:
-        client = await aiohttp_client_sync(app, server_kwargs=conn_type.s_kwargs)
-        resp = await client.ws_connect("/", **conn_type.c_kwargs)
+        client = await aiohttp_client_sync(app)
+        resp = await client.ws_connect("/")
         for _ in range(message_count):
             await resp.receive()
         await resp.close()
@@ -143,7 +142,6 @@ def test_one_thousand_large_round_trip_websocket_text_messages(
     event_loop: asyncio.AbstractEventLoop,
     aiohttp_client_sync: AiohttpClient,
     benchmark: BenchmarkFixture,
-    conn_type: ConnectionType,
 ) -> None:
     """Benchmark round trip of 100 large WebSocket text messages."""
     message_count = 100
@@ -161,8 +159,8 @@ def test_one_thousand_large_round_trip_websocket_text_messages(
     app.router.add_route("GET", "/", handler)
 
     async def run_websocket_benchmark() -> None:
-        client = await aiohttp_client_sync(app, server_kwargs=conn_type.s_kwargs)
-        resp = await client.ws_connect("/", **conn_type.c_kwargs)
+        client = await aiohttp_client_sync(app)
+        resp = await client.ws_connect("/")
         for _ in range(message_count):
             await resp.receive()
         await resp.close()

--- a/tests/test_benchmarks_client_ws.py
+++ b/tests/test_benchmarks_client_ws.py
@@ -1,7 +1,9 @@
 """codspeed benchmarks for websocket client."""
 
 import asyncio
+import ssl
 from collections.abc import Awaitable, Callable, Iterator
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 import pytest
@@ -34,10 +36,12 @@ def aiohttp_client_sync(
         server_kwargs: dict[str, Any] | None = None,
         **kwargs: Any,
     ) -> TestClient[web.Request, web.Application]:
-        server_kwargs = server_kwargs or {}
+        server_kwargs = dict(server_kwargs or {})
+        server_ssl_context = server_kwargs.pop("ssl", None)
         server = TestServer(__param, **server_kwargs)
         client = aiohttp_client_cls(server, **kwargs)
 
+        await server.start_server(ssl=server_ssl_context)
         await client.start_server()
         clients.append(client)
         return client
@@ -48,10 +52,31 @@ def aiohttp_client_sync(
         event_loop.run_until_complete(clients.pop().close())
 
 
+@dataclass(frozen=True)
+class ConnectionType:
+    s_kwargs: dict[str, Any]
+    c_kwargs: dict[str, Any]
+
+
+@pytest.fixture(params=["tcp", "ssl"], ids=["tcp", "ssl"])
+def conn_type(
+    request: pytest.FixtureRequest,
+    ssl_ctx: ssl.SSLContext,
+    client_ssl_ctx: ssl.SSLContext,
+) -> ConnectionType:
+    if request.param == "ssl":
+        return ConnectionType(
+            s_kwargs={"ssl": ssl_ctx},
+            c_kwargs={"ssl": client_ssl_ctx},
+        )
+    return ConnectionType(s_kwargs={}, c_kwargs={})
+
+
 def test_one_thousand_round_trip_websocket_text_messages(
     event_loop: asyncio.AbstractEventLoop,
     aiohttp_client_sync: AiohttpClient,
     benchmark: BenchmarkFixture,
+    conn_type: ConnectionType,
 ) -> None:
     """Benchmark round trip of 1000 WebSocket text messages."""
     message_count = 1000
@@ -68,8 +93,8 @@ def test_one_thousand_round_trip_websocket_text_messages(
     app.router.add_route("GET", "/", handler)
 
     async def run_websocket_benchmark() -> None:
-        client = await aiohttp_client_sync(app)
-        resp = await client.ws_connect("/")
+        client = await aiohttp_client_sync(app, server_kwargs=conn_type.s_kwargs)
+        resp = await client.ws_connect("/", **conn_type.c_kwargs)
         for _ in range(message_count):
             await resp.receive()
         await resp.close()
@@ -84,6 +109,7 @@ def test_one_thousand_round_trip_websocket_binary_messages(
     event_loop: asyncio.AbstractEventLoop,
     aiohttp_client_sync: AiohttpClient,
     benchmark: BenchmarkFixture,
+    conn_type: ConnectionType,
     msg_size: int,
 ) -> None:
     """Benchmark round trip of 1000 WebSocket binary messages."""
@@ -102,8 +128,8 @@ def test_one_thousand_round_trip_websocket_binary_messages(
     app.router.add_route("GET", "/", handler)
 
     async def run_websocket_benchmark() -> None:
-        client = await aiohttp_client_sync(app)
-        resp = await client.ws_connect("/")
+        client = await aiohttp_client_sync(app, server_kwargs=conn_type.s_kwargs)
+        resp = await client.ws_connect("/", **conn_type.c_kwargs)
         for _ in range(message_count):
             await resp.receive()
         await resp.close()
@@ -117,6 +143,7 @@ def test_one_thousand_large_round_trip_websocket_text_messages(
     event_loop: asyncio.AbstractEventLoop,
     aiohttp_client_sync: AiohttpClient,
     benchmark: BenchmarkFixture,
+    conn_type: ConnectionType,
 ) -> None:
     """Benchmark round trip of 100 large WebSocket text messages."""
     message_count = 100
@@ -134,8 +161,8 @@ def test_one_thousand_large_round_trip_websocket_text_messages(
     app.router.add_route("GET", "/", handler)
 
     async def run_websocket_benchmark() -> None:
-        client = await aiohttp_client_sync(app)
-        resp = await client.ws_connect("/")
+        client = await aiohttp_client_sync(app, server_kwargs=conn_type.s_kwargs)
+        resp = await client.ws_connect("/", **conn_type.c_kwargs)
         for _ in range(message_count):
             await resp.receive()
         await resp.close()

--- a/tests/test_benchmarks_client_ws.py
+++ b/tests/test_benchmarks_client_ws.py
@@ -4,7 +4,7 @@ import asyncio
 import ssl
 from collections.abc import Awaitable, Callable, Iterator
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, TypedDict
 
 import pytest
 from pytest_aiohttp import AiohttpClient
@@ -52,13 +52,17 @@ def aiohttp_client_sync(
         event_loop.run_until_complete(clients.pop().close())
 
 
+class _ConnArgs(TypedDict, total=False):
+    ssl: ssl.SSLContext
+
+
 @dataclass(frozen=True)
 class ConnectionType:
-    s_kwargs: dict[str, Any]
-    c_kwargs: dict[str, Any]
+    s_kwargs: _ConnArgs
+    c_kwargs: _ConnArgs
 
 
-@pytest.fixture(params=["tcp", "ssl"], ids=["tcp", "ssl"])
+@pytest.fixture(params=("tcp", "ssl"), ids=("tcp", "ssl"))
 def conn_type(
     request: pytest.FixtureRequest,
     ssl_ctx: ssl.SSLContext,

--- a/tests/test_benchmarks_web_fileresponse.py
+++ b/tests/test_benchmarks_web_fileresponse.py
@@ -5,7 +5,7 @@ import pathlib
 import ssl
 from collections.abc import Awaitable, Callable, Iterator
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, TypedDict
 
 import pytest
 from multidict import CIMultiDict
@@ -53,13 +53,17 @@ def aiohttp_client_sync(
         event_loop.run_until_complete(clients.pop().close())
 
 
+class _ConnArgs(TypedDict, total=False):
+    ssl: ssl.SSLContext
+
+
 @dataclass(frozen=True)
 class ConnectionType:
-    s_kwargs: dict[str, Any]
-    c_kwargs: dict[str, Any]
+    s_kwargs: _ConnArgs
+    c_kwargs: _ConnArgs
 
 
-@pytest.fixture(params=["tcp", "ssl"], ids=["tcp", "ssl"])
+@pytest.fixture(params=("tcp", "ssl"), ids=("tcp", "ssl"))
 def conn_type(
     request: pytest.FixtureRequest,
     ssl_ctx: ssl.SSLContext,

--- a/tests/test_benchmarks_web_fileresponse.py
+++ b/tests/test_benchmarks_web_fileresponse.py
@@ -2,7 +2,9 @@
 
 import asyncio
 import pathlib
+import ssl
 from collections.abc import Awaitable, Callable, Iterator
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 import pytest
@@ -35,10 +37,12 @@ def aiohttp_client_sync(
         server_kwargs: dict[str, Any] | None = None,
         **kwargs: Any,
     ) -> TestClient[web.Request, web.Application]:
-        server_kwargs = server_kwargs or {}
+        server_kwargs = dict(server_kwargs or {})
+        server_ssl_context = server_kwargs.pop("ssl", None)
         server = TestServer(__param, **server_kwargs)
         client = aiohttp_client_cls(server, **kwargs)
 
+        await server.start_server(ssl=server_ssl_context)
         await client.start_server()
         clients.append(client)
         return client
@@ -49,10 +53,31 @@ def aiohttp_client_sync(
         event_loop.run_until_complete(clients.pop().close())
 
 
+@dataclass(frozen=True)
+class ConnectionType:
+    s_kwargs: dict[str, Any]
+    c_kwargs: dict[str, Any]
+
+
+@pytest.fixture(params=["tcp", "ssl"], ids=["tcp", "ssl"])
+def conn_type(
+    request: pytest.FixtureRequest,
+    ssl_ctx: ssl.SSLContext,
+    client_ssl_ctx: ssl.SSLContext,
+) -> ConnectionType:
+    if request.param == "ssl":
+        return ConnectionType(
+            s_kwargs={"ssl": ssl_ctx},
+            c_kwargs={"ssl": client_ssl_ctx},
+        )
+    return ConnectionType(s_kwargs={}, c_kwargs={})
+
+
 def test_simple_web_file_response(
     event_loop: asyncio.AbstractEventLoop,
-    aiohttp_client: AiohttpClient,
+    aiohttp_client_sync: AiohttpClient,
     benchmark: BenchmarkFixture,
+    conn_type: ConnectionType,
 ) -> None:
     """Benchmark creating 100 simple web.FileResponse."""
     response_count = 100
@@ -65,9 +90,9 @@ def test_simple_web_file_response(
     app.router.add_route("GET", "/", handler)
 
     async def run_file_response_benchmark() -> None:
-        client = await aiohttp_client(app)
+        client = await aiohttp_client_sync(app, server_kwargs=conn_type.s_kwargs)
         for _ in range(response_count):
-            await client.get("/")
+            await client.get("/", **conn_type.c_kwargs)
         await client.close()
 
     @benchmark
@@ -77,8 +102,9 @@ def test_simple_web_file_response(
 
 def test_simple_web_file_sendfile_fallback_response(
     event_loop: asyncio.AbstractEventLoop,
-    aiohttp_client: AiohttpClient,
+    aiohttp_client_sync: AiohttpClient,
     benchmark: BenchmarkFixture,
+    conn_type: ConnectionType,
 ) -> None:
     """Benchmark creating 100 simple web.FileResponse without sendfile."""
     response_count = 100
@@ -94,9 +120,9 @@ def test_simple_web_file_sendfile_fallback_response(
     app.router.add_route("GET", "/", handler)
 
     async def run_file_response_benchmark() -> None:
-        client = await aiohttp_client(app)
+        client = await aiohttp_client_sync(app, server_kwargs=conn_type.s_kwargs)
         for _ in range(response_count):
-            await client.get("/")
+            await client.get("/", **conn_type.c_kwargs)
         await client.close()
 
     @benchmark


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Parameterize some codspeed benchmarks by connection type (TCP vs SSL). 
This will help to establish baseline for the other PR https://github.com/aio-libs/aiohttp/pull/12822 and let us see how much ``aiofastnet`` improves TCP and SSL results. 

``aiofastnet`` improves SSL performance more than TCP and current benchmarks only track TCP performance.

I haven't parameterize all possible tests, because this will substantially increase benchmark run time, I only selected a few the most representative tests.

The following tests have been parameterized:

test_benchmarks_client_ws.py

  - test_one_thousand_round_trip_websocket_binary_messages

test_benchmarks_client.py

  - test_one_hundred_simple_get_requests
  - test_one_hundred_get_requests_with_1024_chunked_payload
  - test_one_hundred_get_requests_with_1mb_chunked_payload

test_benchmarks_web_fileresponse.py

  - test_simple_web_file_response
  - test_simple_web_file_sendfile_fallback_response


## Are there changes in behavior for the user?

No

## Is it a substantial burden for the maintainers to support this?

No

But, there is one caveat.

Parametrized tests will change their codspeed id. For example, instead of ``test_simple_web_file_response``, there will be 
``test_simple_web_file_response[tcp]`` and ``test_simple_web_file_response[ssl]``. Codspeed won't be able to link ``test_simple_web_file_response`` to ``test_simple_web_file_response[tcp]``, so history will start over for the affected tests.

## Related issue number

No

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] Added a new news fragment CHANGES/12823.misc.rst
 

