### PR TITLE
Env proxy redirect cred leak

### DIFF
--- a/CHANGES/12829.bugfix.rst
+++ b/CHANGES/12829.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed :class:`~aiohttp.ClientSession` with ``trust_env=True`` carrying a proxy's ``Proxy-Authorization`` header across a redirect; the environment proxy and its credentials are now re-resolved for each request, so a redirect that selects a different proxy no longer reuses the previous proxy's authentication -- by :user:`bdraco`.

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -549,10 +549,11 @@ class ClientSession:
         if proxy is None:
             proxy = self._default_proxy
 
+        resolved_proxy_headers: CIMultiDict[str] | None
         if proxy is None:
-            proxy_headers = None
+            resolved_proxy_headers = None
         else:
-            proxy_headers = self._prepare_headers(proxy_headers)
+            resolved_proxy_headers = self._prepare_headers(proxy_headers)
             try:
                 proxy = URL(proxy)
             except ValueError as e:
@@ -654,16 +655,17 @@ class ClientSession:
                     if proxy is not None:
                         proxy_ = URL(proxy)
                     elif self._trust_env:
+                        # Re-resolve per iteration; drop stale env-proxy auth so
+                        # a redirect that switches proxies can't leak credentials.
+                        resolved_proxy_headers = None
                         with suppress(LookupError):
                             proxy_, env_proxy_auth = await asyncio.to_thread(
                                 get_env_proxy_for_url, url
                             )
-                            if env_proxy_auth is not None and (
-                                proxy_headers is None
-                                or hdrs.PROXY_AUTHORIZATION not in proxy_headers
-                            ):
-                                proxy_headers = proxy_headers or CIMultiDict()
-                                proxy_headers[hdrs.PROXY_AUTHORIZATION] = env_proxy_auth
+                            if env_proxy_auth is not None:
+                                resolved_proxy_headers = CIMultiDict(
+                                    {hdrs.PROXY_AUTHORIZATION: env_proxy_auth}
+                                )
 
                     req = self._request_class(
                         method,
@@ -684,7 +686,7 @@ class ClientSession:
                         session=self,
                         ssl=ssl,
                         server_hostname=server_hostname,
-                        proxy_headers=proxy_headers,
+                        proxy_headers=resolved_proxy_headers,
                         traces=traces,
                         trust_env=self.trust_env,
                     )

--- a/tests/test_proxy_functional.py
+++ b/tests/test_proxy_functional.py
@@ -12,6 +12,7 @@ from unittest import mock
 from uuid import uuid4
 
 import pytest
+from multidict import CIMultiDict
 from pytest_aiohttp import AiohttpRawServer, AiohttpServer
 from pytest_mock import MockerFixture
 from yarl import URL
@@ -906,6 +907,58 @@ async def test_proxy_from_env_http_without_auth_from_wrong_netrc(
     assert proxy.request.host == "aiohttp.io"
     assert proxy.request.path_qs == "/path"
     assert "Proxy-Authorization" not in proxy.request.headers
+
+
+async def test_proxy_from_env_auth_scoped_to_redirect_selected_proxy(
+    aiohttp_raw_server: AiohttpRawServer,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: pathlib.Path,
+) -> None:
+    # Redirect from an authenticated http_proxy to an HTTPS target served by a
+    # separate https_proxy must not leak the first proxy's Proxy-Authorization
+    # onto the second proxy's CONNECT request.
+    auth_header = aiohttp.encode_basic_auth("user", "pass")
+    http_proxy_requests: list[CIMultiDict[str]] = []
+    https_proxy_requests: list[CIMultiDict[str]] = []
+
+    async def http_proxy_handler(request: web.Request) -> web.Response:
+        http_proxy_requests.append(CIMultiDict(request.headers))
+        return web.Response(
+            status=302, headers={"Location": "https://attacker.example/secret"}
+        )
+
+    async def https_proxy_handler(request: web.Request) -> web.Response:
+        https_proxy_requests.append(CIMultiDict(request.headers))
+        return web.Response(status=502)
+
+    http_proxy = await aiohttp_raw_server(http_proxy_handler)
+    https_proxy = await aiohttp_raw_server(https_proxy_handler)
+
+    for name in (
+        "http_proxy",
+        "https_proxy",
+        "all_proxy",
+        "no_proxy",
+        "HTTP_PROXY",
+        "HTTPS_PROXY",
+        "ALL_PROXY",
+        "NO_PROXY",
+    ):
+        monkeypatch.delenv(name, raising=False)
+    netrc_file = tmp_path / "empty_netrc"
+    netrc_file.write_text("")
+    http_proxy_url = http_proxy.make_url("/").with_user("user").with_password("pass")
+    monkeypatch.setenv("http_proxy", str(http_proxy_url))
+    monkeypatch.setenv("https_proxy", str(https_proxy.make_url("/")))
+    monkeypatch.setenv("NETRC", str(netrc_file))
+
+    with pytest.raises(aiohttp.ClientHttpProxyError):
+        await get_request(url="http://victim.example/redirect", trust_env=True)
+
+    assert len(http_proxy_requests) == 1
+    assert http_proxy_requests[0]["Proxy-Authorization"] == auth_header
+    assert len(https_proxy_requests) == 1
+    assert "Proxy-Authorization" not in https_proxy_requests[0]
 
 
 @pytest.mark.xfail


### PR DESCRIPTION
## What do these changes do?

With `trust_env=True`, aiohttp resolves the proxy from the environment per request URL and stores any proxy credentials in `proxy_headers`. That value was prepared once and reused across redirect iterations, so after a redirect that selected a different environment proxy the request could still carry the first proxy's `Proxy-Authorization`.

This re-resolves the environment proxy headers inside the redirect loop. Each iteration starts fresh and only sets `Proxy-Authorization` from the proxy the environment selects for the current URL. An explicitly passed `proxy`/`proxy_headers` is unchanged.

## Are there changes in behavior for the user?

When `trust_env=True` and the environment selects different proxies before and after a redirect, the request after the redirect no longer reuses the previous proxy's `Proxy-Authorization`. Single-proxy setups and explicit `proxy=`/`proxy_headers=` usage behave as before.

## Is it a substantial burden for the maintainers to support this?

No.

## Related issue number

N/A

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes  N/A
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`  N/A, already listed
- [x] Add a new news fragment into the `CHANGES/` folder
