### PR TITLE
Enforce max_line_size on complete chunk-size lines in pure-Python parser

### DIFF
--- a/CHANGES/12832.bugfix.rst
+++ b/CHANGES/12832.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed the pure-Python HTTP parser not enforcing ``max_line_size`` on a chunk-size line when the whole line arrived in a single read; the limit was only applied to chunk-size metadata split across reads. The complete-line case is now checked too, matching the split-line behavior -- by :user:`bdraco`.

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -938,9 +938,7 @@ class HttpPayloadParser:
                     pos = chunk.find(SEP)
                     if pos >= 0:
                         if pos > self._max_line_size:
-                            raise LineTooLong(
-                                chunk[:pos][:100] + b"...", self._max_line_size
-                            )
+                            raise LineTooLong(chunk[:100] + b"...", self._max_line_size)
                         i = chunk.find(CHUNK_EXT, 0, pos)
                         if i >= 0:
                             size_b = chunk[:i]  # strip chunk-extensions

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -937,6 +937,8 @@ class HttpPayloadParser:
                 if self._chunk == ChunkState.PARSE_CHUNKED_SIZE:
                     pos = chunk.find(SEP)
                     if pos >= 0:
+                        # Only chunk-size lines reach here; trailers enforce
+                        # _max_field_size separately in PARSE_TRAILERS below.
                         if pos > self._max_line_size:
                             raise LineTooLong(chunk[:100] + b"...", self._max_line_size)
                         i = chunk.find(CHUNK_EXT, 0, pos)

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -937,6 +937,10 @@ class HttpPayloadParser:
                 if self._chunk == ChunkState.PARSE_CHUNKED_SIZE:
                     pos = chunk.find(SEP)
                     if pos >= 0:
+                        if pos > self._max_line_size:
+                            raise LineTooLong(
+                                chunk[:pos][:100] + b"...", self._max_line_size
+                            )
                         i = chunk.find(CHUNK_EXT, 0, pos)
                         if i >= 0:
                             size_b = chunk[:i]  # strip chunk-extensions

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -2401,6 +2401,35 @@ class TestParsePayload:
         assert out.is_eof()
         assert b"x" == b"".join(out._buffer)
 
+    async def test_chunked_chunk_size_line_at_limit(
+        self, protocol: BaseProtocol
+    ) -> None:
+        """A chunk-size line of exactly max_line_size bytes is accepted (>, not >=)."""
+        out = aiohttp.StreamReader(protocol, 2**16, loop=asyncio.get_running_loop())
+        p = HttpPayloadParser(
+            out, chunked=True, headers_parser=HeadersParser(), max_line_size=32
+        )
+        # "1;" + 30 * "a" is exactly 32 bytes before the CRLF.
+        size_line = b"1;" + b"a" * 30
+        assert len(size_line) == 32
+        p.feed_data(size_line + b"\r\nx\r\n0\r\n\r\n")
+        assert out.is_eof()
+        assert b"x" == b"".join(out._buffer)
+
+    async def test_chunked_chunk_size_line_one_over_limit(
+        self, protocol: BaseProtocol
+    ) -> None:
+        """A chunk-size line one byte over max_line_size is rejected."""
+        out = aiohttp.StreamReader(protocol, 2**16, loop=asyncio.get_running_loop())
+        p = HttpPayloadParser(
+            out, chunked=True, headers_parser=HeadersParser(), max_line_size=32
+        )
+        # "1;" + 31 * "a" is 33 bytes before the CRLF.
+        size_line = b"1;" + b"a" * 31
+        assert len(size_line) == 33
+        with pytest.raises(http_exceptions.LineTooLong):
+            p.feed_data(size_line + b"\r\nx\r\n0\r\n\r\n")
+
     async def test_parse_chunked_payload_size_data_mismatch(
         self, protocol: BaseProtocol
     ) -> None:

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -2377,6 +2377,30 @@ class TestParsePayload:
             p.feed_data(b"blah\r\n")
         assert isinstance(out.exception(), http_exceptions.TransferEncodingError)
 
+    async def test_chunked_chunk_size_line_too_long(
+        self, protocol: BaseProtocol
+    ) -> None:
+        """A complete oversized chunk-size line is rejected with LineTooLong."""
+        out = aiohttp.StreamReader(protocol, 2**16, loop=asyncio.get_running_loop())
+        p = HttpPayloadParser(
+            out, chunked=True, headers_parser=HeadersParser(), max_line_size=32
+        )
+        size_line = b"1;" + b"a" * 4096 + b"\r\n"
+        with pytest.raises(http_exceptions.LineTooLong):
+            p.feed_data(size_line)
+
+    async def test_chunked_chunk_size_line_within_limit(
+        self, protocol: BaseProtocol
+    ) -> None:
+        """A small chunk-size line still parses when max_line_size is low."""
+        out = aiohttp.StreamReader(protocol, 2**16, loop=asyncio.get_running_loop())
+        p = HttpPayloadParser(
+            out, chunked=True, headers_parser=HeadersParser(), max_line_size=32
+        )
+        p.feed_data(b"1\r\nx\r\n0\r\n\r\n")
+        assert out.is_eof()
+        assert b"x" == b"".join(out._buffer)
+
     async def test_parse_chunked_payload_size_data_mismatch(
         self, protocol: BaseProtocol
     ) -> None:


### PR DESCRIPTION
## What do these changes do?

The pure-Python HTTP parser applies `max_line_size` to a chunk-size line that is split across reads (the stored chunk tail), but when the whole chunk-size line is already in the current buffer it parsed the line without checking its length. This adds the same check on the complete-line path so both cases behave consistently and reject an oversized chunk-size line with `LineTooLong`.

The C parser already handles this and is unchanged.

## Are there changes in behavior for the user?

A chunked request whose chunk-size line is longer than `max_line_size` is now rejected by the pure-Python parser even when the whole line arrives in one read; previously only split lines were checked. Chunk-size lines within the limit are unaffected.

## Is it a substantial burden for the maintainers to support this?

No.

## Related issue number

N/A

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes  N/A
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`  N/A, already listed
- [x] Add a new news fragment into the `CHANGES/` folder