### PR TITLE
Add docstring to public `fetch` function in example

### DIFF
--- a/examples/client_json.py
+++ b/examples/client_json.py
@@ -5,6 +5,7 @@ import aiohttp
 
 
 async def fetch(session: aiohttp.ClientSession) -> None:
+    """Asynchronously fetch JSON data from httpbin.org and print status and content."""
     print("Query http://httpbin.org/get")
     async with session.get("http://httpbin.org/get") as resp:
         print(resp.status)


### PR DESCRIPTION
The public `fetch` function in the example file `examples/client_json.py` lacked a docstring, which is important for code clarity and discoverability. This PR adds a concise, descriptive docstring to the function, explaining its purpose and behavior.

### Problem Background
Public functions in example code serve as documentation for users learning the library. A missing docstring can leave the function's purpose unclear.

### Changes Made
- Added a single-line docstring to the `fetch` function to describe its action of fetching and printing JSON data.

### Verification
The change can be verified by viewing the modified file and confirming the presence of the docstring on the `fetch` function definition.