### PR TITLE
[PR #12826/36df6c13 backport][3.15] Enforce max_line_size on fragmented request target and reason in C parser

### DIFF
--- a/CHANGES/12826.bugfix.rst
+++ b/CHANGES/12826.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed the C HTTP parser not enforcing ``max_line_size`` on a request target or response reason phrase that is split across multiple reads; each fragment was checked on its own, so an accumulated line could exceed the limit without raising ``LineTooLong``. The accumulated length is now checked, matching the pure-Python parser -- by :user:`bdraco`.

--- a/aiohttp/_http_parser.pyx
+++ b/aiohttp/_http_parser.pyx
@@ -779,7 +779,7 @@ cdef int cb_on_url(cparser.llhttp_t* parser,
                    const char *at, size_t length) except -1:
     cdef HttpParser pyparser = <HttpParser>parser.data
     try:
-        if length > pyparser._max_line_size:
+        if len(pyparser._buf) + length > pyparser._max_line_size:
             status = pyparser._buf + at[:length]
             raise LineTooLong(status[:100] + b"...", pyparser._max_line_size)
         extend(pyparser._buf, at, length)
@@ -794,7 +794,7 @@ cdef int cb_on_status(cparser.llhttp_t* parser,
                       const char *at, size_t length) except -1:
     cdef HttpParser pyparser = <HttpParser>parser.data
     try:
-        if length > pyparser._max_line_size:
+        if len(pyparser._buf) + length > pyparser._max_line_size:
             reason = pyparser._buf + at[:length]
             raise LineTooLong(reason[:100] + b"...", pyparser._max_line_size)
         extend(pyparser._buf, at, length)

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -1574,6 +1574,17 @@ def test_http_request_max_status_line_under_limit(parser: HttpRequestParser) -> 
     assert msg.url == URL("/path" + path.decode())
 
 
+def test_http_request_max_status_line_fragmented(
+    parser: HttpRequestParser,
+) -> None:
+    # Split an overlong request target across reads so that each callback
+    # fragment is under the limit but the accumulated target is not.
+    match = "400, message:\n  Got more than 8190 bytes when reading"
+    with pytest.raises(http_exceptions.LineTooLong, match=match):
+        parser.feed_data(b"GET /" + b"a" * 8000)
+        parser.feed_data(b"a" * 8000 + b" HTTP/1.1\r\nHost: a\r\n\r\n")
+
+
 def test_http_response_parser_utf8(response) -> None:
     text = "HTTP/1.1 200 Ok\r\nx-test:тест\r\n\r\n".encode()
 
@@ -1649,6 +1660,17 @@ def test_http_response_parser_status_line_under_limit(
     assert msg.version == (1, 1)
     assert msg.code == 200
     assert msg.reason == reason.decode()
+
+
+def test_http_response_parser_status_line_too_long_fragmented(
+    response: HttpResponseParser,
+) -> None:
+    # Split an overlong reason phrase across reads so that each callback
+    # fragment is under the limit but the accumulated reason is not.
+    match = "400, message:\n  Got more than 8190 bytes when reading"
+    with pytest.raises(http_exceptions.LineTooLong, match=match):
+        response.feed_data(b"HTTP/1.1 200 " + b"a" * 8000)
+        response.feed_data(b"a" * 8000 + b"\r\n\r\n")
 
 
 def test_http_response_parser_bad_version(response) -> None:


### PR DESCRIPTION
**This is a backport of PR #12826 as merged into master (36df6c138d10c5776a25c69b698c41153d84d571).**

## What do these changes do?

The C HTTP parser receives the request target and response reason phrase through `on_url` and `on_status` callbacks, which can fire multiple times for a single line when it is split across reads. Each callback only compared its own fragment against `max_line_size`, so a line split into small enough pieces could accumulate past the limit without raising `LineTooLong`. This checks the accumulated buffer length plus the new fragment instead, so the limit is enforced on the whole line, matching the pure-Python parser.

## Are there changes in behavior for the user?

A request target or response reason phrase that exceeds `max_line_size` is now rejected with `LineTooLong` even when it arrives split across multiple reads; previously the C parser accepted it. Lines within the limit are unaffected.

## Is it a substantial burden for the maintainers to support this?

No.

## Related issue number

N/A

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes  N/A
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`  N/A, already listed
- [x] Add a new news fragment into the `CHANGES/` folder
