### PR TITLE
[PR #12830/93a2b1c3 backport][3.15] Bound pipelined request queue per connection

### DIFF
--- a/CHANGES/12830.bugfix.rst
+++ b/CHANGES/12830.bugfix.rst
@@ -1,0 +1,1 @@
+Bounded the number of parsed-but-unhandled pipelined HTTP/1 requests buffered per connection on the server; once the queue reaches an internal limit the parser stops emitting and the transport is paused, resuming as the request handler drains the queue, so a client keeping one handler busy can no longer accumulate an unbounded backlog of pipelined requests -- by :user:`bdraco`.

--- a/aiohttp/_http_parser.pyx
+++ b/aiohttp/_http_parser.pyx
@@ -323,6 +323,8 @@ cdef class HttpParser:
         list    _messages
         bint    _more_data_available
         bint    _paused
+        Py_ssize_t _msg_in_flight
+        Py_ssize_t _max_msg_queue_size
         bint    _eof_pending
         object  _payload
         unsigned long long _content_length_expected
@@ -359,6 +361,7 @@ cdef class HttpParser:
         size_t max_field_size=8190, payload_exception=None,
         bint response_with_body=True, bint read_until_eof=False,
         bint auto_decompress=True,
+        Py_ssize_t max_msg_queue_size=0,
     ):
         cparser.llhttp_settings_init(self._csettings)
         cparser.llhttp_init(self._cparser, mode, self._csettings)
@@ -373,6 +376,8 @@ cdef class HttpParser:
         self._buf = bytearray()
         self._more_data_available = False
         self._paused = False
+        self._msg_in_flight = 0
+        self._max_msg_queue_size = max_msg_queue_size
         self._eof_pending = False
         self._payload = None
         self._payload_error = 0
@@ -556,6 +561,11 @@ cdef class HttpParser:
         assert self._payload is not None
         self._paused = True
 
+    def message_consumed(self):
+        # Protocol drained a queued message; free a slot for parsing.
+        if self._msg_in_flight > 0:
+            self._msg_in_flight -= 1
+
     def feed_eof(self):
         cdef bytes desc
 
@@ -678,12 +688,12 @@ cdef class HttpRequestParser(HttpParser):
         size_t max_line_size=8190, size_t max_headers=128,
         size_t max_field_size=8190, payload_exception=None,
         bint response_with_body=True, bint read_until_eof=False,
-        bint auto_decompress=True,
+        bint auto_decompress=True, Py_ssize_t max_msg_queue_size=0,
     ):
         self._init(cparser.HTTP_REQUEST, protocol, loop, limit, timer,
                    max_line_size, max_headers, max_field_size,
                    payload_exception, response_with_body, read_until_eof,
-                   auto_decompress)
+                   auto_decompress, max_msg_queue_size)
 
     cdef object _on_status_complete(self):
         cdef int idx1, idx2
@@ -893,6 +903,12 @@ cdef int cb_on_message_complete(cparser.llhttp_t* parser) except -1:
         pyparser._last_error = exc
         return -1
     else:
+        if pyparser._max_msg_queue_size:
+            pyparser._msg_in_flight += 1
+            if pyparser._msg_in_flight >= pyparser._max_msg_queue_size:
+                # Queue full: pause llhttp between messages. feed_data() buffers
+                # the remainder as tail; resumes once the queue drains.
+                return cparser.HPE_PAUSED
         return 0
 
 

--- a/aiohttp/base_protocol.py
+++ b/aiohttp/base_protocol.py
@@ -8,6 +8,13 @@ from .tcp_helpers import tcp_nodelay
 if TYPE_CHECKING:
     from .http_parser import HttpParser
 
+# Raised by transport.pause_reading()/resume_reading() when the transport
+# does not support flow control; safe to ignore.
+# NOTE: Catch these with a plain try/except/pass, never contextlib.suppress():
+# pause/resume run on the hot read path and suppress() is ~6x slower than
+# try/except here (it builds a context manager and unpacks this tuple per call).
+PAUSE_RESUME_READING_ERRORS = (AttributeError, NotImplementedError, RuntimeError)
+
 
 class BaseProtocol(asyncio.Protocol):
     __slots__ = (
@@ -65,8 +72,14 @@ class BaseProtocol(asyncio.Protocol):
         if self.transport is not None:
             try:
                 self.transport.pause_reading()
-            except (AttributeError, NotImplementedError, RuntimeError):
+            except PAUSE_RESUME_READING_ERRORS:
+                # Transport lacks flow control; nothing to pause. Intentionally
+                # ignored (see PAUSE_RESUME_READING_ERRORS; do not use suppress).
                 pass
+
+    def _reading_paused_for_msg_queue(self) -> bool:
+        """Keep the transport paused for protocol-specific reasons (overridden)."""
+        return False
 
     def resume_reading(self, resume_parser: bool = True) -> None:
         self._reading_paused = False
@@ -77,10 +90,16 @@ class BaseProtocol(asyncio.Protocol):
 
         # Reading may have been paused again in the above call if there was a lot of
         # compressed data still pending.
-        if not self._reading_paused and self.transport is not None:
+        if (
+            not self._reading_paused
+            and not self._reading_paused_for_msg_queue()
+            and self.transport is not None
+        ):
             try:
                 self.transport.resume_reading()
-            except (AttributeError, NotImplementedError, RuntimeError):
+            except PAUSE_RESUME_READING_ERRORS:
+                # Transport lacks flow control; nothing to resume. Intentionally
+                # ignored (see PAUSE_RESUME_READING_ERRORS; do not use suppress).
                 pass
             self._reading_paused = False
 

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -275,6 +275,7 @@ class HttpParser(abc.ABC, Generic[_MsgT]):
         response_with_body: bool = True,
         read_until_eof: bool = False,
         auto_decompress: bool = True,
+        max_msg_queue_size: int = 0,
     ) -> None:
         self.protocol = protocol
         self.loop = loop
@@ -300,6 +301,9 @@ class HttpParser(abc.ABC, Generic[_MsgT]):
         self._headers_parser = HeadersParser(
             max_line_size, max_headers, max_field_size, self.lax
         )
+        # Stop emitting messages once this many are queued unconsumed (0 = off).
+        self._max_msg_queue_size = max_msg_queue_size
+        self._msg_in_flight = 0
 
     @abc.abstractmethod
     def parse_message(self, lines: list[bytes]) -> _MsgT: ...
@@ -310,6 +314,11 @@ class HttpParser(abc.ABC, Generic[_MsgT]):
     def pause_reading(self) -> None:
         assert self._payload_parser is not None
         self._payload_parser.pause_reading()
+
+    def message_consumed(self) -> None:
+        """Protocol drained a queued message; free a slot for parsing."""
+        if self._msg_in_flight > 0:
+            self._msg_in_flight -= 1
 
     def feed_eof(self) -> _MsgT | None:
         if self._payload_parser is not None:
@@ -353,6 +362,15 @@ class HttpParser(abc.ABC, Generic[_MsgT]):
             # read HTTP message (request/response line + headers), \r\n\r\n
             # and split by lines
             if self._payload_parser is None and not self._upgraded:
+                if (
+                    self._max_msg_queue_size
+                    and self._msg_in_flight >= self._max_msg_queue_size
+                ):
+                    # Queue full: buffer the rest and stop. Safe pause point;
+                    # any preceding body is consumed before the next request
+                    # line. Resumes via feed_data(b"") when the queue drains.
+                    self._tail = data[start_pos:]
+                    break
                 pos = data.find(SEP, start_pos)
                 # consume \r\n
                 if pos == start_pos and not self._lines:
@@ -497,6 +515,8 @@ class HttpParser(abc.ABC, Generic[_MsgT]):
                             payload = EMPTY_PAYLOAD
 
                         messages.append((msg, payload))
+                        if self._max_msg_queue_size:
+                            self._msg_in_flight += 1
                         should_close = msg.should_close
                 else:
                     self._tail = data[start_pos:]

--- a/aiohttp/web_protocol.py
+++ b/aiohttp/web_protocol.py
@@ -16,7 +16,7 @@ import yarl
 from propcache import under_cached_property
 
 from .abc import AbstractAccessLogger, AbstractStreamWriter
-from .base_protocol import BaseProtocol
+from .base_protocol import PAUSE_RESUME_READING_ERRORS, BaseProtocol
 from .helpers import DEFAULT_CHUNK_SIZE, ceil_timeout
 from .http import (
     HttpProcessingError,
@@ -36,6 +36,11 @@ from .web_request import BaseRequest
 from .web_response import Response, StreamResponse
 
 __all__ = ("RequestHandler", "RequestPayloadError", "PayloadAccessError")
+
+# Max parsed-but-unhandled pipelined requests buffered per connection before
+# reading is paused. Bounds memory a client can pin by keeping one handler busy
+# and pipelining behind it; reading resumes as the queue drains.
+MAX_MSG_QUEUE_SIZE = 32
 
 if TYPE_CHECKING:
     import ssl
@@ -146,6 +151,9 @@ class RequestHandler(BaseProtocol):
         "_keepalive_timeout",
         "_lingering_time",
         "_messages",
+        "_max_msg_queue_size",
+        "_msg_queue_resume_size",
+        "_msg_queue_paused",
         "_message_tail",
         "_handler_waiter",
         "_waiter",
@@ -186,6 +194,13 @@ class RequestHandler(BaseProtocol):
         auto_decompress: bool = True,
         timeout_ceil_threshold: float = 5,
     ):
+        self._max_msg_queue_size = MAX_MSG_QUEUE_SIZE
+        # Low-water mark: resume reading once the queue drains to half the limit
+        # so we refill in batches instead of churning pause/resume per request.
+        self._msg_queue_resume_size = MAX_MSG_QUEUE_SIZE // 2
+        # Set before super().__init__ so _reading_paused_for_msg_queue() is safe
+        # if BaseProtocol ever triggers a resume during init.
+        self._msg_queue_paused = False
         parser = HttpRequestParser(
             self,
             loop,
@@ -195,6 +210,7 @@ class RequestHandler(BaseProtocol):
             max_headers=max_headers,
             payload_exception=RequestPayloadError,
             auto_decompress=auto_decompress,
+            max_msg_queue_size=MAX_MSG_QUEUE_SIZE,
         )
         super().__init__(loop, parser)
 
@@ -431,6 +447,14 @@ class RequestHandler(BaseProtocol):
                 # don't set result twice
                 waiter.set_result(None)
 
+            # Queue full: pause the transport (the parser already stopped
+            # emitting). start() resumes as it drains the queue.
+            if (
+                not self._msg_queue_paused
+                and len(self._messages) >= self._max_msg_queue_size
+            ):
+                self._pause_msg_queue_reading()
+
             self._upgraded = upgraded
             if upgraded and tail:
                 self._message_tail = tail
@@ -446,6 +470,36 @@ class RequestHandler(BaseProtocol):
             eof, tail = self._payload_parser.feed_data(data)
             if eof:
                 self.close()
+
+    def _reading_paused_for_msg_queue(self) -> bool:
+        return self._msg_queue_paused
+
+    def _pause_msg_queue_reading(self) -> None:
+        self._msg_queue_paused = True
+        if self.transport is not None:
+            try:
+                self.transport.pause_reading()
+            except PAUSE_RESUME_READING_ERRORS:
+                # Transport lacks flow control; nothing to pause. Intentionally
+                # ignored (see PAUSE_RESUME_READING_ERRORS; do not use suppress).
+                pass
+
+    def _resume_msg_queue_reading(self) -> None:
+        if not self._upgraded:
+            # Reparse buffered pipelined requests while still marked paused so
+            # a refill past the limit does not re-pause an already-paused
+            # transport; only resume below once it stayed under the limit.
+            self.data_received(b"")
+            if len(self._messages) >= self._max_msg_queue_size:
+                return
+        self._msg_queue_paused = False
+        if not self._reading_paused and self.transport is not None:
+            try:
+                self.transport.resume_reading()
+            except PAUSE_RESUME_READING_ERRORS:
+                # Transport lacks flow control; nothing to resume. Intentionally
+                # ignored (see PAUSE_RESUME_READING_ERRORS; do not use suppress).
+                pass
 
     def keep_alive(self, val: bool) -> None:
         """Set keep-alive connection mode.
@@ -578,6 +632,18 @@ class RequestHandler(BaseProtocol):
                     self._waiter = None
 
             message, payload = self._messages.popleft()
+
+            # Free a parser slot; resume reading once drained to low water so
+            # pipelining keeps flowing while this request is handled.
+            # no branch: _parser is only None after connection_lost, whose path
+            # exits this loop, so the None case is not reachably exercisable.
+            if self._parser is not None:  # pragma: no branch
+                self._parser.message_consumed()
+            if (
+                self._msg_queue_paused
+                and len(self._messages) <= self._msg_queue_resume_size
+            ):
+                self._resume_msg_queue_reading()
 
             # time is only fetched if logging is enabled as otherwise
             # its thrown away and never used.

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -250,6 +250,7 @@ peername
 performant
 pickleable
 ping
+pipelined
 pipelining
 pluggable
 plugin

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -159,6 +159,78 @@ def test_c_parser_loaded():
     assert "RawResponseMessageC" in dir(aiohttp.http_parser)
 
 
+_PIPELINED_GET = b"GET / HTTP/1.1\r\nHost: a\r\n\r\n"
+
+
+def _build_request_parser(
+    request_cls: type[HttpRequestParser],
+    protocol: BaseProtocol,
+    loop: asyncio.AbstractEventLoop,
+    max_msg_queue_size: int,
+) -> HttpRequestParser:
+    return request_cls(
+        protocol,
+        loop,
+        DEFAULT_CHUNK_SIZE,
+        max_line_size=8190,
+        max_headers=128,
+        max_field_size=8190,
+        max_msg_queue_size=max_msg_queue_size,
+    )
+
+
+def test_max_msg_queue_size_caps_emitted_messages(
+    request_cls: type[HttpRequestParser],
+    protocol: BaseProtocol,
+    loop: asyncio.AbstractEventLoop,
+) -> None:
+    parser = _build_request_parser(request_cls, protocol, loop, 4)
+    messages, upgraded, _tail = parser.feed_data(_PIPELINED_GET * 10)
+    assert len(messages) == 4
+    assert not upgraded
+
+
+def test_max_msg_queue_size_resumes_after_consume(
+    request_cls: type[HttpRequestParser],
+    protocol: BaseProtocol,
+    loop: asyncio.AbstractEventLoop,
+) -> None:
+    limit = 4
+    total = 10
+    parser = _build_request_parser(request_cls, protocol, loop, limit)
+    messages, _upgraded, _tail = parser.feed_data(_PIPELINED_GET * total)
+    seen = 0
+    while messages:
+        assert len(messages) <= limit
+        seen += len(messages)
+        for _msg, _payload in messages:
+            parser.message_consumed()
+        messages, _upgraded, _tail = parser.feed_data(b"")
+    assert seen == total
+
+
+def test_max_msg_queue_size_zero_is_unbounded(
+    request_cls: type[HttpRequestParser],
+    protocol: BaseProtocol,
+    loop: asyncio.AbstractEventLoop,
+) -> None:
+    parser = _build_request_parser(request_cls, protocol, loop, 0)
+    messages, _upgraded, _tail = parser.feed_data(_PIPELINED_GET * 50)
+    assert len(messages) == 50
+
+
+def test_message_consumed_underflow_is_ignored(
+    request_cls: type[HttpRequestParser],
+    protocol: BaseProtocol,
+    loop: asyncio.AbstractEventLoop,
+) -> None:
+    parser = _build_request_parser(request_cls, protocol, loop, 4)
+    # No message is in flight; consuming must not underflow the counter.
+    parser.message_consumed()
+    messages, _upgraded, _tail = parser.feed_data(_PIPELINED_GET * 4)
+    assert len(messages) == 4
+
+
 def test_parse_headers(parser: Any) -> None:
     text = b"""GET /test HTTP/1.1\r
 Host: a\r

--- a/tests/test_web_functional.py
+++ b/tests/test_web_functional.py
@@ -30,7 +30,7 @@ from aiohttp.helpers import DEFAULT_CHUNK_SIZE
 from aiohttp.pytest_plugin import AiohttpClient, AiohttpServer
 from aiohttp.streams import StreamReader
 from aiohttp.typedefs import Handler
-from aiohttp.web_protocol import RequestHandler
+from aiohttp.web_protocol import MAX_MSG_QUEUE_SIZE, RequestHandler
 
 try:
     import brotlicffi as brotli
@@ -1713,6 +1713,136 @@ async def test_response_prepared_with_clone(aiohttp_client) -> None:
     assert 200 == resp.status
 
     await resp.release()
+
+
+async def test_http1_pipelined_requests_are_count_limited(
+    aiohttp_server: AiohttpServer,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Requests pipelined behind a busy handler must not grow unbounded.
+
+    A client can keep one handler active and pipeline many complete requests
+    behind it; the per-connection queue stays bounded by MAX_MSG_QUEUE_SIZE.
+    """
+    pipelined_requests = 500
+    slow_handler_started = asyncio.Event()
+    queue_observed = asyncio.Event()
+    max_queued = 0
+    data_received = RequestHandler.data_received
+
+    def observe_data_received(self: RequestHandler, data: bytes) -> None:
+        nonlocal max_queued
+        data_received(self, data)
+        if self._request_in_progress and self._messages:
+            max_queued = max(max_queued, len(self._messages))
+            queue_observed.set()
+
+    monkeypatch.setattr(RequestHandler, "data_received", observe_data_received)
+
+    async def slow_handler(request: web.Request) -> web.Response:
+        slow_handler_started.set()
+        await asyncio.sleep(0.5)
+        return web.Response(text="slow")
+
+    async def fast_handler(request: web.Request) -> NoReturn:
+        # The pipelined requests are only counted, never handled: the test
+        # closes the connection while the slow handler still holds the loop.
+        assert False
+
+    app = web.Application()
+    app.router.add_get("/slow", slow_handler)
+    app.router.add_get("/x", fast_handler)
+    server = await aiohttp_server(app)
+
+    def raw_get(path: str) -> bytes:
+        return (
+            f"GET {path} HTTP/1.1\r\nHost: localhost\r\n"
+            "Connection: keep-alive\r\n\r\n"
+        ).encode("ascii")
+
+    reader, writer = await asyncio.open_connection(server.host, server.port)
+    try:
+        writer.write(raw_get("/slow"))
+        await writer.drain()
+        await asyncio.wait_for(slow_handler_started.wait(), 1)
+
+        writer.write(raw_get("/x") * pipelined_requests)
+        await writer.drain()
+        await asyncio.wait_for(queue_observed.wait(), 1)
+    finally:
+        writer.close()
+        with suppress(ConnectionResetError, BrokenPipeError):
+            await writer.wait_closed()
+
+    # Tight lower bound also catches over-aggressive pausing (e.g. clamping to 1).
+    assert MAX_MSG_QUEUE_SIZE // 2 < max_queued <= MAX_MSG_QUEUE_SIZE
+
+
+async def test_http1_pipelined_queue_resumes_after_drain(
+    aiohttp_server: AiohttpServer,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A paused pipeline queue resumes reading once handlers drain it.
+
+    Once enough requests are pipelined behind a busy handler to fill the queue,
+    reading is paused; as the handlers drain the queue past the low-water mark
+    reading must resume so the remaining buffered requests are still served.
+    """
+    # Several times the limit so the queue refills and re-pauses while draining.
+    pipelined_requests = MAX_MSG_QUEUE_SIZE * 3
+    first_started = asyncio.Event()
+    release_first = asyncio.Event()
+    resumed = asyncio.Event()
+    handled: list[str] = []
+    all_handled = asyncio.Event()
+
+    resume = RequestHandler._resume_msg_queue_reading
+
+    def observe_resume(self: RequestHandler) -> None:
+        resume(self)
+        resumed.set()
+
+    monkeypatch.setattr(RequestHandler, "_resume_msg_queue_reading", observe_resume)
+
+    async def handler(request: web.Request) -> web.Response:
+        if request.path == "/first":
+            first_started.set()
+            await release_first.wait()
+        handled.append(request.path)
+        if len(handled) == pipelined_requests + 1:
+            all_handled.set()
+        return web.Response()
+
+    app = web.Application()
+    app.router.add_get("/{tail:.*}", handler)
+    server = await aiohttp_server(app)
+
+    def raw_get(path: str) -> bytes:
+        return (
+            f"GET {path} HTTP/1.1\r\nHost: localhost\r\n"
+            "Connection: keep-alive\r\n\r\n"
+        ).encode("ascii")
+
+    reader, writer = await asyncio.open_connection(server.host, server.port)
+    try:
+        writer.write(raw_get("/first"))
+        await writer.drain()
+        await asyncio.wait_for(first_started.wait(), 1)
+
+        writer.write(b"".join(raw_get(f"/r{i}") for i in range(pipelined_requests)))
+        await writer.drain()
+
+        # Let the busy handler finish so the queue drains and reading resumes.
+        release_first.set()
+        await asyncio.wait_for(resumed.wait(), 5)
+        # Every pipelined request is still served only if reading resumed.
+        await asyncio.wait_for(all_handled.wait(), 5)
+    finally:
+        writer.close()
+        with suppress(ConnectionResetError, BrokenPipeError):
+            await writer.wait_closed()
+
+    assert len(handled) == pipelined_requests + 1
 
 
 @pytest.mark.parametrize("decompressed_size", [4 * 1024 * 1024, 32 * 1024 * 1024])

--- a/tests/test_web_protocol.py
+++ b/tests/test_web_protocol.py
@@ -48,3 +48,96 @@ def test_data_received_calls_data_received_cb(
 
     cb.assert_called_once()
     dummy_reader[1].feed_data.assert_called_once_with(b"x")
+
+
+def test_pause_msg_queue_reading_without_transport(
+    loop: asyncio.AbstractEventLoop,
+    dummy_manager: Server,
+) -> None:
+    """Pausing with no transport still records the paused state."""
+    handler = RequestHandler(dummy_manager, loop=loop)
+    handler.transport = None
+
+    handler._pause_msg_queue_reading()
+
+    assert handler._msg_queue_paused is True
+
+
+def test_resume_msg_queue_reading_after_upgrade_skips_reparse(
+    loop: asyncio.AbstractEventLoop,
+    dummy_manager: Server,
+) -> None:
+    """Resume after an upgrade clears the pause and resumes without reparsing."""
+    handler = RequestHandler(dummy_manager, loop=loop)
+    transport = mock.Mock()
+    handler.transport = transport
+    handler._upgraded = True
+    handler._msg_queue_paused = True
+    handler._reading_paused = False
+
+    with mock.patch.object(RequestHandler, "data_received") as data_received:
+        handler._resume_msg_queue_reading()
+
+    data_received.assert_not_called()
+    assert handler._msg_queue_paused is False
+    transport.resume_reading.assert_called_once_with()
+
+
+def test_resume_msg_queue_reading_without_transport(
+    loop: asyncio.AbstractEventLoop,
+    dummy_manager: Server,
+) -> None:
+    """Resume clears the pause but does not touch a missing transport."""
+    handler = RequestHandler(dummy_manager, loop=loop)
+    handler.transport = None
+    handler._upgraded = True  # skip the reparse branch
+    handler._msg_queue_paused = True
+
+    handler._resume_msg_queue_reading()
+
+    assert handler._msg_queue_paused is False
+
+
+def test_resume_reading_stays_paused_for_msg_queue(
+    loop: asyncio.AbstractEventLoop,
+    dummy_manager: Server,
+) -> None:
+    """Base resume_reading must not un-pause the transport while queue-paused."""
+    handler = RequestHandler(dummy_manager, loop=loop)
+    transport = mock.Mock()
+    handler.transport = transport
+    handler._msg_queue_paused = True
+
+    handler.resume_reading()
+
+    transport.resume_reading.assert_not_called()
+
+
+def test_pause_msg_queue_reading_ignores_unsupported_transport(
+    loop: asyncio.AbstractEventLoop,
+    dummy_manager: Server,
+) -> None:
+    """A transport without flow control raising on pause is ignored."""
+    handler = RequestHandler(dummy_manager, loop=loop)
+    # Bare asyncio.Transport.pause_reading() raises NotImplementedError.
+    handler.transport = asyncio.Transport()
+
+    handler._pause_msg_queue_reading()
+
+    assert handler._msg_queue_paused is True
+
+
+def test_resume_msg_queue_reading_ignores_unsupported_transport(
+    loop: asyncio.AbstractEventLoop,
+    dummy_manager: Server,
+) -> None:
+    """A transport without flow control raising on resume is ignored."""
+    handler = RequestHandler(dummy_manager, loop=loop)
+    # Bare asyncio.Transport.resume_reading() raises NotImplementedError.
+    handler.transport = asyncio.Transport()
+    handler._upgraded = True  # skip the reparse branch
+    handler._msg_queue_paused = True
+
+    handler._resume_msg_queue_reading()
+
+    assert handler._msg_queue_paused is False


### PR DESCRIPTION
**This is a backport of PR #12830 as merged into master (93a2b1c369d69ca6fcdabea9a7c29cfc7947817c).**

## What do these changes do?

On the server, parsed HTTP/1 requests are queued per connection while one handler is active. There was no bound on how many complete pipelined requests could be buffered behind a busy handler.

This adds a per-connection cap (`MAX_MSG_QUEUE_SIZE`, 32) that works at two layers:

- The parser stops emitting messages once that many are queued unconsumed. The C parser pauses llhttp between messages and buffers the remainder as tail; the pure-Python parser does the same with its tail buffer. A new `message_consumed()` frees a slot.
- `RequestHandler` pauses the transport when the queue is full and resumes once the handler drains it to half the limit, reparsing the buffered pipeline in batches.

A `max_msg_queue_size` of `0` keeps the old unbounded behavior, so the parser classes are unchanged for other callers.

## Are there changes in behavior for the user?

A single connection can now have at most `MAX_MSG_QUEUE_SIZE` parsed pipelined requests waiting behind the active handler; reading is paused past that and resumes as the queue drains. Normal request/response and pipelining within the bound behave as before.

## Is it a substantial burden for the maintainers to support this?

No.

## Related issue number

N/A

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes  N/A
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`  N/A, already listed
- [x] Add a new news fragment into the `CHANGES/` folder

