### PR TITLE
fix: exclude .hash directories from distribution packages (#10860)

### DIFF
--- a/CHANGES/10860.misc.rst
+++ b/CHANGES/10860.misc.rst
@@ -1,3 +1,4 @@
-Excluded ``.hash`` directories from distribution packages (sdist and wheel).
+Excluded ``.hash`` directories from distribution packages (sdist and wheel)
 
-``.hash`` directories are Cython build artifacts that are not needed by end users.
+``.hash`` directories are Cython build artifacts not needed by end users.
+-- by :user:`cmw-creator`.

--- a/CHANGES/10860.misc.rst
+++ b/CHANGES/10860.misc.rst
@@ -1,0 +1,3 @@
+Excluded ``.hash`` directories from distribution packages (sdist and wheel).
+
+``.hash`` directories are Cython build artifacts that are not needed by end users.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -17,5 +17,6 @@ global-exclude *.lib
 global-exclude *.dll
 global-exclude *.a
 global-exclude *.obj
+global-exclude .hash
 exclude aiohttp/*.html
 prune docs/_build


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Exclude `.hash` directories from distribution packages (sdist and wheel).

`.hash` directories are Cython build artifacts generated during `cythonize`.
They contain hash verification files (e.g. `b01999d...  /path/to/file.pxd`)
that are only needed during incremental Cython builds and serve no purpose
for end users. Including them in published wheels is unnecessary bloat.

## Are there changes in behavior for the user?

No user-facing changes — `.hash` directories have no runtime effect.

## Is it a substantial burden for the maintainers to support this?

No. Adding `global-exclude .hash` to `MANIFEST.in` is a standard exclusion
that prevents build artifacts from leaking into distributions.

## Related issue number

Fixes #10860

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES/` folder
  * name it `<issue_or_pr_num>.<type>.rst` (e.g. `588.bugfix.rst`)
  * if you don't have an issue number, change it to the pull request
    number after creating the PR
    * `.bugfix`: A bug fix for something the maintainers deemed an
      improper undesired behavior that got corrected to match
      pre-agreed expectations.
    * `.feature`: A new behavior, public APIs. That sort of stuff.
    * `.deprecation`: A declaration of future API removals and breaking
      changes in behavior.
    * `.breaking`: When something public is removed in a breaking way.
      Could be deprecated in an earlier release.
    * `.doc`: Notable updates to the documentation structure or build
      process.
    * `.packaging`: Notes for downstreams about unobvious side effects
      and tooling. Changes in the test invocation considerations and
      runtime assumptions.
    * `.contrib`: Stuff that affects the contributor experience. e.g.
      Running tests, building the docs, setting up the development
      environment.
    * `.misc`: Changes that are hard to assign to any of the above
      categories.
  * Make sure to use full sentences with correct case and punctuation,
    for example:
    ```rst
    Fixed issue with non-ascii contents in doctest text files
    -- by :user:`contributor-gh-handle`.
    ```

    Use the past tense or the present tense a non-imperative mood,
    referring to what's changed compared to the last released version
    of this project.
