### PR TITLE
Revert "Drop list compression (#12857)"

### DIFF
--- a/aiohttp/streams.py
+++ b/aiohttp/streams.py
@@ -549,7 +549,7 @@ class StreamReader:
             count = len(self._buffer)
             if count == 1:
                 return self._read_nowait_chunk(-1)
-            return b"".join(self._read_nowait_chunk(-1) for _ in range(count))
+            return b"".join([self._read_nowait_chunk(-1) for _ in range(count)])
 
         chunks: list[bytes] = []
         while self._buffer:


### PR DESCRIPTION
This reverts commit 69dff14d94b11c81bca6df3982c09a1176a1ca12.

Seems that list comprehensions are actually twice as fast in modern Python:
https://github.com/aio-libs/aiohttp/pull/12857#issuecomment-4643284098