### PR TITLE
Add HTTP parser memory regression tests

### DIFF
--- a/CHANGES/12736.misc.rst
+++ b/CHANGES/12736.misc.rst
@@ -1,0 +1,1 @@
+Added HTTP parser memory regression tests for oversized request and header lines.

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -1,12 +1,13 @@
 # Tests for aiohttp/protocol.py
 
 import asyncio
+import gc
 import gzip
 import platform
 import re
 import sys
 import zlib
-from collections.abc import Iterable, Iterator
+from collections.abc import Callable, Iterable, Iterator
 from contextlib import suppress
 from typing import Any
 from unittest import mock
@@ -3121,3 +3122,44 @@ def test_response_content_length_zero_no_error(response: HttpResponseParser) -> 
 
     # This should NOT raise an error
     response.feed_eof()  # Should complete without exception
+
+
+def _get_peak_memory_used(func: Callable[[], None]) -> int:
+    tracemalloc = pytest.importorskip("tracemalloc")
+
+    gc.collect()
+    tracemalloc.start()
+    try:
+        func()
+        _, peak = tracemalloc.get_traced_memory()
+        return peak
+    finally:
+        tracemalloc.stop()
+
+
+def test_long_request_line_memory_usage(parser: HttpRequestParser) -> None:
+    text = b"GET /" + (b"-" * 1_000_000) + b" HTTP/1.1\r\nHost: a\r\n\r\n"
+
+    def parse() -> None:
+        with pytest.raises(http_exceptions.LineTooLong):
+            parser.feed_data(text)
+
+    peak = _get_peak_memory_used(parse)
+
+    assert peak < 5 * 1024 * 1024
+
+
+def test_long_header_line_memory_usage(parser: HttpRequestParser) -> None:
+    text = (
+        b"GET / HTTP/1.1\r\n"
+        b"Host: a\r\n"
+        b"X-Long-Header: " + (b"-" * 1_000_000) + b"\r\n\r\n"
+    )
+
+    def parse() -> None:
+        with pytest.raises(http_exceptions.LineTooLong):
+            parser.feed_data(text)
+
+    peak = _get_peak_memory_used(parse)
+
+    assert peak < 5 * 1024 * 1024


### PR DESCRIPTION
## What do these changes do?

This adds HTTP parser memory regression coverage for oversized inputs.

The new tests cover a small first slice of #12736:

* a very long request line
* a very long header line

The tests measure peak memory usage while feeding already-created input into the parser, so the large test input allocation itself is not included in the measured peak.

## Are there changes in behavior for the user?

No. This is a test-only change and does not change runtime behavior or public APIs.

## Is it a substantial burden for the maintainers to support this?

No. The change only adds focused regression tests for existing HTTP parser behavior.

The memory threshold is intentionally conservative to reduce the chance of CI flakiness across platforms and Python versions. The tests are also limited to a small HTTP parser scope, leaving the broader multipart and chunked-parser cases from #12736 for follow-up PRs.

## Related issue number

Part of #12736

## Checklist

* [x] I think the code is well written
* [x] Unit tests for the changes exist
* [x] Documentation reflects the changes
* [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
* [x] Add a new news fragment into the `CHANGES/` folder
