### PR TITLE
`client_exceptions` attribute annotations

### DIFF
--- a/CHANGES/12878.misc.rst
+++ b/CHANGES/12878.misc.rst
@@ -1,0 +1,2 @@
+Added type annotations to the exception classes in the ``aiohttp.client_exceptions`` to
+increase type coverage -- by :user:`jorenham`.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -215,6 +215,7 @@ Jonathan Wright
 Jonny Tan
 Joongi Kim
 Jordan Borean
+Joren Hammudoglu
 Josep Cugat
 Josh Junon
 Joshu Coats

--- a/aiohttp/client_exceptions.py
+++ b/aiohttp/client_exceptions.py
@@ -65,6 +65,13 @@ class ClientResponseError(ClientError):
     headers: Response headers.
     """
 
+    request_info: RequestInfo
+    status: int
+    message: str
+    headers: Mapping[str, str] | None
+    history: tuple[ClientResponse, ...]
+    args: tuple[RequestInfo, tuple[ClientResponse, ...]]
+
     def __init__(
         self,
         request_info: RequestInfo,
@@ -137,6 +144,8 @@ class ClientConnectorError(ClientOSError):
     Raised in :class:`aiohttp.connector.TCPConnector` if
         a connection can not be established.
     """
+
+    args: tuple[ConnectionKey, OSError]
 
     def __init__(self, connection_key: ConnectionKey, os_error: OSError) -> None:
         self._conn_key = connection_key
@@ -215,6 +224,9 @@ class ServerConnectionError(ClientConnectionError):
 class ServerDisconnectedError(ServerConnectionError):
     """Server disconnected."""
 
+    args: tuple[RawResponseMessage | str]
+    message: RawResponseMessage | str
+
     def __init__(self, message: RawResponseMessage | str | None = None) -> None:
         if message is None:
             message = "Server disconnected"
@@ -237,6 +249,12 @@ class SocketTimeoutError(ServerTimeoutError):
 
 class ServerFingerprintMismatch(ServerConnectionError):
     """SSL certificate does not match expected fingerprint."""
+
+    expected: bytes
+    got: bytes
+    host: str
+    port: int
+    args: tuple[bytes, bytes, str, int]
 
     def __init__(self, expected: bytes, got: bytes, host: str, port: int) -> None:
         self.expected = expected
@@ -342,6 +360,7 @@ class ClientConnectorCertificateError(*cert_errors_bases):  # type: ignore[misc]
     """Response certificate error."""
 
     _conn_key: ConnectionKey
+    args: tuple[ConnectionKey, Exception]
 
     def __init__(
         # TODO: If we require ssl in future, this can become ssl.CertificateError


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

This adds type annotations for the attributes of the classes in `aiohttp.client_exceptions`, increasing type coverage from 96.04% to 96.68% (according to typestats, see https://jorenham.github.io/typestats/dashboard/report/#aiohttp).

## Are there changes in behavior for the user?

Nope

## Is it a substantial burden for the maintainers to support this?

Nope

## Related issue number

None that I'm aware of

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES/` folder
  * name it `<issue_or_pr_num>.<type>.rst` (e.g. `588.bugfix.rst`)
  * if you don't have an issue number, change it to the pull request
    number after creating the PR
    * `.bugfix`: A bug fix for something the maintainers deemed an
      improper undesired behavior that got corrected to match
      pre-agreed expectations.
    * `.feature`: A new behavior, public APIs. That sort of stuff.
    * `.deprecation`: A declaration of future API removals and breaking
      changes in behavior.
    * `.breaking`: When something public is removed in a breaking way.
      Could be deprecated in an earlier release.
    * `.doc`: Notable updates to the documentation structure or build
      process.
    * `.packaging`: Notes for downstreams about unobvious side effects
      and tooling. Changes in the test invocation considerations and
      runtime assumptions.
    * `.contrib`: Stuff that affects the contributor experience. e.g.
      Running tests, building the docs, setting up the development
      environment.
    * `.misc`: Changes that are hard to assign to any of the above
      categories.
  * Make sure to use full sentences with correct case and punctuation,
    for example:
    ```rst
    Fixed issue with non-ascii contents in doctest text files
    -- by :user:`contributor-gh-handle`.
    ```

    Use the past tense or the present tense a non-imperative mood,
    referring to what's changed compared to the last released version
    of this project.
