### PR TITLE
Run prepare hooks for parser errors

### DIFF
--- a/CHANGES/6463.bugfix
+++ b/CHANGES/6463.bugfix
@@ -1,0 +1,1 @@
+Allowed application-level ``on_response_prepare`` callbacks to run for parser-error responses so applications can adjust response headers such as ``Server`` consistently.

--- a/aiohttp/web_app.py
+++ b/aiohttp/web_app.py
@@ -364,11 +364,13 @@ class Application(MutableMapping[str | AppKey[Any], Any]):
         yield _fix_request_current_app(self)
 
     async def _handle(self, request: Request) -> StreamResponse:
-        match_info = await self._router.resolve(request)
-        match_info.add_app(self)
-        match_info.freeze()
+        match_info = request._match_info
+        if match_info is None:
+            match_info = await self._router.resolve(request)
+            match_info.add_app(self)
+            match_info.freeze()
 
-        request._match_info = match_info
+            request._match_info = match_info
 
         if request.headers.get(hdrs.EXPECT):
             resp = await match_info.expect_handler(request)

--- a/aiohttp/web_protocol.py
+++ b/aiohttp/web_protocol.py
@@ -612,11 +612,10 @@ class RequestHandler(BaseProtocol, Generic[_Request]):
 
             manager.requests_count += 1
             writer = StreamWriter(self, loop)
-            if not isinstance(message, _ErrInfo):
-                request_handler = self._request_handler
-            else:
+            err_info = None
+            if isinstance(message, _ErrInfo):
                 # make request_factory work
-                request_handler = self._make_error_handler(message)
+                err_info = message
                 message = ERROR
 
             # Important don't hold a reference to the current task
@@ -629,6 +628,12 @@ class RequestHandler(BaseProtocol, Generic[_Request]):
                 writer,
                 self._task_handler or asyncio.current_task(loop),  # type: ignore[arg-type]
             )
+            if err_info is not None and getattr(request, "_match_info", None) is None:
+                request_handler: _RequestHandler[_Request] = cast(
+                    _RequestHandler[_Request], self._make_error_handler(err_info)
+                )
+            else:
+                request_handler = self._request_handler
             try:
                 # a new task is used for copy context vars (#3406)
                 coro = self._handle_request(request, start, request_handler)

--- a/aiohttp/web_runner.py
+++ b/aiohttp/web_runner.py
@@ -11,10 +11,12 @@ from .http_parser import RawRequestMessage
 from .streams import StreamReader
 from .typedefs import PathLike
 from .web_app import Application
+from .web_exceptions import HTTPBadRequest
 from .web_log import AccessLogger
-from .web_protocol import RequestHandler
+from .web_protocol import ERROR, RequestHandler
 from .web_request import BaseRequest, Request
 from .web_server import Server
+from .web_urldispatcher import MatchInfoError
 
 try:
     from ssl import SSLContext
@@ -439,7 +441,7 @@ class AppRunner(BaseRunner[Request]):
         _cls: type[Request] = Request,
     ) -> Request:
         loop = asyncio.get_running_loop()
-        return _cls(
+        request = _cls(
             message,
             payload,
             protocol,
@@ -448,6 +450,12 @@ class AppRunner(BaseRunner[Request]):
             loop,
             client_max_size=self.app._client_max_size,
         )
+        if message is ERROR:
+            match_info = MatchInfoError(HTTPBadRequest())
+            match_info.add_app(self._app)
+            match_info.freeze()
+            request._match_info = match_info
+        return request
 
     async def _cleanup_server(self) -> None:
         await self._app.cleanup()

--- a/tests/test_web_functional.py
+++ b/tests/test_web_functional.py
@@ -2227,6 +2227,42 @@ async def test_signal_on_error_handler(aiohttp_client: AiohttpClient) -> None:
     resp.release()
 
 
+async def test_signal_on_parser_error_handler(
+    aiohttp_server: AiohttpServer,
+) -> None:
+    async def middleware(
+        request: web.Request,
+        handler: Handler,
+    ) -> web.StreamResponse:
+        try:
+            return await handler(request)
+        except web.HTTPBadRequest as exc:
+            exc.headers["X-Middleware"] = "val"
+            raise
+
+    async def on_prepare(request: web.Request, response: web.StreamResponse) -> None:
+        response.headers["X-Custom"] = "val"
+        response.headers.pop("Server", None)
+
+    app = web.Application(middlewares=[middleware])
+    app.on_response_prepare.append(on_prepare)
+
+    server = await aiohttp_server(app)
+    reader, writer = await asyncio.open_connection(server.host, server.port)
+    try:
+        writer.write(b"GE T / HTTP/1.1\r\nHost: localhost\r\n\r\n")
+        await writer.drain()
+        response = await asyncio.wait_for(reader.readuntil(b"\r\n\r\n"), timeout=5)
+    finally:
+        writer.close()
+        await writer.wait_closed()
+
+    assert b"400 Bad Request" in response
+    assert b"X-Middleware: val" in response
+    assert b"X-Custom: val" in response
+    assert b"\r\nServer:" not in response
+
+
 @pytest.mark.skipif(
     "HttpRequestParserC" not in dir(aiohttp.http_parser),
     reason="C based HTTP parser not available",


### PR DESCRIPTION
## What

Parser-error responses now flow through the application system-route path when the request factory can attach app match info. This lets middleware handle the 400 response and lets `on_response_prepare` callbacks adjust headers such as `Server`.

Fixes #6463.

## Tests

- `python3 -m compileall -q aiohttp/web_app.py aiohttp/web_protocol.py aiohttp/web_runner.py tests/test_web_functional.py`
- `git diff --check`
- `PYTHONPATH=$PWD uv run --no-project --with pytest --with pytest-aiohttp --with pytest-mock --with pytest-timeout --with trustme --with cryptography --with proxy.py --with gunicorn --with uvloop --with dirty-equals --with coverage pytest tests/test_web_functional.py::test_signal_on_error_handler tests/test_web_functional.py::test_signal_on_parser_error_handler tests/test_web_functional.py::test_bad_method_for_c_http_parser_not_hangs -q`

The C-parser-specific test is skipped locally because the C HTTP parser is unavailable in this checkout.

## Risk

The change keeps the fallback protocol error handler for custom request factories that do not attach application match info.