### PR TITLE
reject non-ascii chunked transfer-encoding in response parser

### DIFF
--- a/CHANGES/12891.bugfix.rst
+++ b/CHANGES/12891.bugfix.rst
@@ -1,0 +1,4 @@
+Stopped treating a response ``Transfer-Encoding`` whose final token contains
+non-ascii characters as ``chunked``; the token is now required to be ascii
+before case-folding, matching the request parser and :rfc:`9112#section-6.3`
+-- by :user:`dxbjavid`.

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -815,7 +815,9 @@ class HttpResponseParser(HttpParser[RawResponseMessage]):
 
     def _is_chunked_te(self, te: str) -> bool:
         # https://www.rfc-editor.org/rfc/rfc9112#section-6.3-2.4.2
-        return te.rsplit(",", maxsplit=1)[-1].strip(" \t").lower() == "chunked"
+        last = te.rsplit(",", maxsplit=1)[-1].strip(" \t")
+        # .lower() transforms some non-ascii chars, so must check first.
+        return last.isascii() and last.lower() == "chunked"
 
 
 class HttpPayloadParser:

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -935,6 +935,16 @@ def test_request_te_duplicate_chunked(parser: HttpRequestParser) -> None:
         parser.feed_data(text)
 
 
+def test_response_te_non_ascii_not_chunked(response: HttpResponseParser) -> None:
+    # The "k" is U+212A KELVIN SIGN, which str.lower() folds to ascii "k",
+    # so a naive te.lower() == "chunked" check would treat this as chunked.
+    # https://www.rfc-editor.org/rfc/rfc9112#section-6.3-2.4.2
+    text = b"HTTP/1.1 200 OK\r\nTransfer-Encoding: chun\xe2\x84\xaaed\r\n\r\nspam"
+    messages, upgraded, tail = response.feed_data(text)
+    msg = messages[0][0]
+    assert msg.chunked is False
+
+
 def test_conn_upgrade(parser: HttpRequestParser) -> None:
     text = (
         b"GET /test HTTP/1.1\r\n"


### PR DESCRIPTION
## What do these changes do?

The response parser decides whether a body is chunked by lowercasing the last Transfer-Encoding token and comparing it against "chunked". Header field values are decoded with surrogateescape, so a server can place a non-ascii character that folds to an ascii letter under str.lower(): U+212A (kelvin sign) lowercases to "k", so a value of chun⟨U+212A⟩ed becomes "chunked" and the response gets parsed as chunked. The request-side _is_chunked_te already guards this with an isascii() check, and so does every other token comparison in this module (connection tokens, content-encoding, the upgrade check) — the response variant was the one place that missed it. That asymmetry is the kind of thing that lets aiohttp and a stricter intermediary disagree about message framing, so it felt worth tightening. The fix just adds the same isascii() guard before lowering, so a non-ascii token is no longer read as chunked.

## Are there changes in behavior for the user?

A response whose final Transfer-Encoding token contains non-ascii bytes is no longer treated as chunked; it falls back to read-until-close like any other unrecognised coding. Plain ascii values such as "chunked" or "CHUNKED" behave exactly as before.

## Is it a substantial burden for the maintainers to support this?

No. It is a two-line guard that mirrors logic already present on the request path.

## Related issue number

None. Noticed while reading through the Transfer-Encoding handling.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes — N/A
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt` — N/A, already listed via an earlier contribution
- [x] Add a new news fragment into the `CHANGES/` folder

<details>
<summary>local test run (pure-python parser)</summary>

```
# before the patch
response chunked flag: True

# after the patch
response chunked flag: False

# request parser already rejects the same token
request: rejected -> 400 Request has invalid `Transfer-Encoding`

# regression sweep over Transfer-Encoding variants
b'chunked'              chunked=True   OK
b'gzip, chunked'        chunked=True   OK
b'chunked , '           chunked=False  OK
b'gzip'                 chunked=False  OK
b'chun\xe2\x84\xaaed'   chunked=False  OK
b'CHUNKED'              chunked=True   OK
```

</details>
