### PR TITLE
fix: correct 'the the' double word in test comments

### DIFF
--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -2926,7 +2926,7 @@ async def test_multiple_dns_resolution_requests_success(
         ):
             await task1
 
-        # Verify the the task is finished
+        # Verify the task is finished
         assert len(conn._resolve_host_tasks) == 0
 
         with pytest.raises(
@@ -2982,7 +2982,7 @@ async def test_multiple_dns_resolution_requests_failure(
         ):
             await task1
 
-        # Verify the the task is finished
+        # Verify the task is finished
         assert len(conn._resolve_host_tasks) == 0
 
         with pytest.raises(
@@ -3046,7 +3046,7 @@ async def test_multiple_dns_resolution_requests_cancelled(
         ):
             await task3
 
-        # Verify the the task is finished
+        # Verify the task is finished
         assert len(conn._resolve_host_tasks) == 0
 
 
@@ -3112,7 +3112,7 @@ async def test_multiple_dns_resolution_requests_first_cancelled(
         ):
             await task3
 
-        # Verify the the task is finished
+        # Verify the task is finished
         assert len(conn._resolve_host_tasks) == 0
 
 
@@ -3195,7 +3195,7 @@ async def test_multiple_dns_resolution_requests_first_fails_second_successful(
         ):
             await task3
 
-        # Verify the the task is finished
+        # Verify the task is finished
         assert len(conn._resolve_host_tasks) == 0
 
 


### PR DESCRIPTION
## What do these changes do?

Fixes a repeated word typo ('the the' → 'the') in test comments across multiple test functions in `test_connector.py`.

## Are there changes in behavior for the user?

No — comment-only change in test files.

## Is it a substantial burden for the maintainers to support this?

No — trivial typo fix in existing test comments.

## Related issue number

N/A

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist (N/A — comment fix)
- [ ] Documentation reflects the changes (N/A)
- [ ] Add a new news fragment into the `CHANGES/` folder (N/A — comment-only)

Drafted with opencode; reviewed by human.