### PR TITLE
docs: fix double space in tracing reference

### DIFF
--- a/docs/tracing_reference.rst
+++ b/docs/tracing_reference.rst
@@ -346,7 +346,7 @@ Classes
 
    .. attribute:: method
 
-       Method that will be used  to make the request.
+       Method that will be used to make the request.
 
    .. attribute:: url
 
@@ -366,7 +366,7 @@ Classes
 
    .. attribute:: method
 
-       Method that will be used  to make the request.
+       Method that will be used to make the request.
 
    .. attribute:: url
 
@@ -386,7 +386,7 @@ Classes
 
    .. attribute:: method
 
-       Method that will be used  to make the request.
+       Method that will be used to make the request.
 
    .. attribute:: url
 


### PR DESCRIPTION
## What do these changes do?

Fixes a double space typo in the tracing reference documentation.

## Are there changes in behavior for the user?

No — docs-only change.

## Is it a substantial burden for the maintainers to support this?

No — trivial formatting fix.

## Related issue number

N/A

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist (N/A — docs fix)
- [ ] Documentation reflects the changes (N/A)
- [ ] Add a new news fragment into the `CHANGES/` folder (N/A — docs-only)

Drafted with opencode; reviewed by human.