### PR TITLE
fix: add missing 'to' in multipart docstring

### DIFF
--- a/aiohttp/multipart.py
+++ b/aiohttp/multipart.py
@@ -526,7 +526,7 @@ class BodyPartReader:
     def decode(self, data: bytes) -> bytes:
         """Decodes data synchronously.
 
-        Decodes data according the specified Content-Encoding
+        Decodes data according to the specified Content-Encoding
         or Content-Transfer-Encoding headers value.
 
         Note: For large payloads, consider using decode_iter() instead
@@ -540,7 +540,7 @@ class BodyPartReader:
     async def decode_iter(self, data: bytes) -> AsyncIterator[bytes]:
         """Async generator that yields decoded data chunks.
 
-        Decodes data according the specified Content-Encoding
+        Decodes data according to the specified Content-Encoding
         or Content-Transfer-Encoding headers value.
 
         This method offloads decompression to an executor for large payloads


### PR DESCRIPTION
## What do these changes do?

Fixes a missing word in multipart docstrings: 'according the specified' → 'according to the specified'.

## Are there changes in behavior for the user?

No — docstring-only change.

## Is it a substantial burden for the maintainers to support this?

No — trivial typo fix.

## Related issue number

N/A

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist (N/A — docstring fix)
- [ ] Documentation reflects the changes (N/A)
- [ ] Add a new news fragment into the `CHANGES/` folder (N/A — docstring-only)

Drafted with opencode; reviewed by human.