### PR TITLE
Free up some disk space to hopefully fix the sporadic Android CI errors.

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -344,6 +344,17 @@ jobs:
         echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
         sudo udevadm control --reload-rules
         sudo udevadm trigger --name-match=kvm
+    - name: Free up disk space
+      if: ${{ matrix.config.platform == 'android' }}
+      # There have been issues to install the Android emulator. Probably this is due to the
+      # disk being full. To hopefully work around this, we free up some disk space. See also
+      # https://github.com/pybind/pybind11/pull/5914#issuecomment-3607856613
+      run: |
+        df -m
+        sudo rm -rf $ANDROID_HOME/ndk /opt/hostedtoolcache/CodeQL \
+          /usr/local/lib/node_modules /usr/local/share/chromium \
+          /usr/local/share/powershell
+        df -m
     - name: Install cibuildwheel
       run: uv pip install cibuildwheel==3.4.1
     - name: Build wheels and test


### PR DESCRIPTION
## What do these changes do?

As noted [here](https://github.com/aio-libs/aiohttp/pull/12879#issuecomment-4653813088) the Android CI seems flaky. I found a [maybe similar issue](https://github.com/pybind/pybind11/pull/5914#issuecomment-3607856613), that had problems because of running out of free disk space when installing the Android emulator. Maybe this is the same error here. We can try it and see if this is also fixing our issue.