### PR TITLE
[PR #12746/ff38c236 backport][3.15] Tokenize Connection header in WebSocket client handshake

### DIFF
--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -1275,7 +1275,7 @@ class ClientSession:
                     headers=resp.headers,
                 )
 
-            if resp.headers.get(hdrs.CONNECTION, "").lower() != "upgrade":
+            if not resp._upgraded:
                 raise WSServerHandshakeError(
                     resp.request_info,
                     resp.history,

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -289,6 +289,7 @@ class ClientResponse(HeadersMixin):
     _headers: CIMultiDictProxy[str] = None  # type: ignore[assignment]
     _history: tuple["ClientResponse", ...] = ()
     _raw_headers: RawHeaders = None  # type: ignore[assignment]
+    _upgraded: bool = False  # parser saw a Connection: upgrade token
 
     _connection: Optional["Connection"] = None  # current connection
     _cookies: SimpleCookie | None = None
@@ -583,6 +584,7 @@ class ClientResponse(HeadersMixin):
         # headers
         self._headers = message.headers  # type is CIMultiDictProxy
         self._raw_headers = message.raw_headers  # type is Tuple[bytes, bytes]
+        self._upgraded = message.upgrade
 
         # payload
         self.content = payload

--- a/tests/test_client_proto.py
+++ b/tests/test_client_proto.py
@@ -385,3 +385,42 @@ async def test_abort_without_transport(loop: asyncio.AbstractEventLoop) -> None:
         # Should not raise and should still clean up
         assert proto._exception is None
         mock_drop_timeout.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("connection", "expected"),
+    [(b"upgrade, keep-alive", True), (b"keep-alive", False)],
+)
+async def test_response_start_records_upgrade(
+    connection: bytes, expected: bool
+) -> None:
+    """ClientResponse.start() preserves the parser's Connection upgrade flag."""
+    loop = asyncio.get_running_loop()
+    proto = ResponseHandler(loop=loop)
+    proto.connection_made(mock.Mock())
+    conn = mock.Mock(protocol=proto)
+    proto.set_response_params(read_until_eof=True)
+    proto.data_received(
+        b"HTTP/1.1 101 Switching Protocols\r\n"
+        b"Upgrade: websocket\r\n"
+        b"Connection: " + connection + b"\r\n\r\n"
+    )
+
+    url = URL("http://ws-upgrade.org")
+    response = ClientResponse(
+        "get",
+        url,
+        writer=mock.Mock(),
+        continue100=None,
+        timer=TimerNoop(),
+        request_info=mock.Mock(),
+        traces=[],
+        loop=loop,
+        session=mock.Mock(),
+        stream_writer=mock.create_autospec(
+            AbstractStreamWriter, spec_set=True, instance=True
+        ),
+    )
+    await response.start(conn)
+    assert response._upgraded is expected
+    response.close()

--- a/tests/test_client_ws.py
+++ b/tests/test_client_ws.py
@@ -22,6 +22,7 @@ async def test_ws_connect(ws_key: Any, loop: Any, key_data: Any) -> None:
         hdrs.SEC_WEBSOCKET_ACCEPT: ws_key,
         hdrs.SEC_WEBSOCKET_PROTOCOL: "chat",
     }
+    resp._upgraded = True
     resp.connection.protocol.read_timeout = None
     with mock.patch("aiohttp.client.os") as m_os:
         with mock.patch("aiohttp.client.ClientSession.request") as m_req:
@@ -247,6 +248,8 @@ async def test_ws_connect_err_upgrade(loop, ws_key, key_data) -> None:
 
 
 async def test_ws_connect_err_conn(loop, ws_key, key_data) -> None:
+    # The parser did not see a Connection: upgrade token (resp._upgraded is
+    # False), so the handshake must be rejected.
     resp = mock.Mock()
     resp.status = 101
     resp.headers = {
@@ -254,6 +257,7 @@ async def test_ws_connect_err_conn(loop, ws_key, key_data) -> None:
         hdrs.CONNECTION: "close",
         hdrs.SEC_WEBSOCKET_ACCEPT: ws_key,
     }
+    resp._upgraded = False
     with mock.patch("aiohttp.client.os") as m_os:
         with mock.patch("aiohttp.client.ClientSession.request") as m_req:
             m_os.urandom.return_value = key_data

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -789,6 +789,34 @@ def test_upgrade_header_non_ascii(parser: HttpRequestParser) -> None:
     assert not upgrade
 
 
+@pytest.mark.parametrize(
+    ("connection", "expected"),
+    [
+        ("upgrade", True),
+        ("upgrade, keep-alive", True),  # other tokens alongside upgrade
+        ("keep-alive, upgrade", True),  # upgrade not first
+        ("Upgrade, Keep-Alive", True),  # case-insensitive
+        ("keep-alive", False),  # no upgrade token
+        ("keep-alive, notupgrade", False),  # substring is not a token
+    ],
+)
+def test_response_upgrade_token_in_connection_list(
+    response: HttpResponseParser, connection: str, expected: bool
+) -> None:
+    # RFC 9110 §7.6.1: Connection is a comma-separated token list, so the parser
+    # must set msg.upgrade for a 101 response whenever "upgrade" appears as a
+    # token, regardless of position, case, or neighbouring tokens.
+    text = (
+        b"HTTP/1.1 101 Switching Protocols\r\n"
+        b"Upgrade: websocket\r\n"
+        b"Connection: " + connection.encode() + b"\r\n\r\n"
+    )
+    messages, upgrade, tail = response.feed_data(text)
+    msg = messages[0][0]
+    assert msg.upgrade == expected
+    assert upgrade == expected
+
+
 def test_request_te_chunked_with_content_length(parser: HttpRequestParser) -> None:
     text = (
         b"GET /test HTTP/1.1\r\n"


### PR DESCRIPTION
**This is a backport of PR #12746 as merged into master (ff38c236ce9cda3a05ae01e7a967012e05074fe6).**

## What do these changes do?

Fix the WebSocket *client* handshake's response ``Connection`` header check, which
was a strict ``resp.headers.get(hdrs.CONNECTION, "").lower() != "upgrade"`` and
therefore rejected spec-compliant responses such as
``Connection: upgrade, keep-alive`` (RFC 9110 §7.6.1 allows ``Connection`` to be
a comma-separated token list).

Rather than re-tokenise in ``client.py``, this PR uses the same trick #12723
applied on the server side: the HTTP parser already tokenises ``Connection``
and records the ``upgrade`` token in ``message.upgrade``. ``ClientResponse.start``
now copies that flag to a new ``_upgraded`` attribute, and ``_ws_connect`` reads
it directly:

```python
if not resp._upgraded:
    raise WSServerHandshakeError(..., message="Invalid connection header", ...)
```

## Are there changes in behavior for the user?

Yes, in the permissive direction only. ``aiohttp.ClientSession.ws_connect`` now
accepts successful WebSocket handshakes whose response ``Connection`` header
lists ``upgrade`` alongside other tokens (e.g. ``upgrade, keep-alive``).
Previously such responses raised ``WSServerHandshakeError("Invalid connection
header")``.

## Is it a substantial burden for the maintainers to support this?

No. The behaviour now flows through the single, already-tested parser path
(``HttpParser.parse_headers`` → ``message.upgrade`` → ``ClientResponse._upgraded``);
the WebSocket handshake just reads the flag.

## Related issue number

Companion to #12723 (server side). Worth adding the ``backport-3.14`` label at
merge so 3.14 doesn't ship with asymmetric behaviour (server accepts
``Connection: upgrade, keep-alive`` after #12724, client still rejects it).

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist (parser, ``ClientResponse.start``, and the WS handshake gate)
- [x] Documentation reflects the changes — N/A (no public API change)
- [x] If you provide code modification, please add yourself to ``CONTRIBUTORS.txt`` — already listed
- [x] Add a new news fragment into the ``CHANGES/`` folder
