### PR TITLE
docs: fix double spacing in documentation

### DIFF
--- a/docs/client_advanced.rst
+++ b/docs/client_advanced.rst
@@ -479,7 +479,7 @@ To tweak or change *transport* layer of requests you can pass a custom
    By default *session* object takes the ownership of the connector, among
    other things closing the connections once the *session* is closed. If
    you are keen on share the same *connector* through different *session*
-   instances you must give the  *connector_owner* parameter as **False**
+   instances you must give the *connector_owner* parameter as **False**
    for each *session* instance.
 
 .. seealso:: :ref:`aiohttp-client-reference-connectors` section for

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -1264,7 +1264,7 @@ is controlled by *force_close* constructor's parameter).
 
    :param int family: TCP socket family, both IPv4 and IPv6 by default.
                       For *IPv4* only use :data:`socket.AF_INET`,
-                      for  *IPv6* only -- :data:`socket.AF_INET6`.
+                      for *IPv6* only -- :data:`socket.AF_INET6`.
 
                       *family* is ``0`` by default, that means both
                       IPv4 and IPv6 are accepted. To specify only

--- a/docs/tracing_reference.rst
+++ b/docs/tracing_reference.rst
@@ -346,7 +346,7 @@ Classes
 
    .. attribute:: method
 
-       Method that will be used  to make the request.
+       Method that will be used to make the request.
 
    .. attribute:: url
 
@@ -366,7 +366,7 @@ Classes
 
    .. attribute:: method
 
-       Method that will be used  to make the request.
+       Method that will be used to make the request.
 
    .. attribute:: url
 
@@ -386,7 +386,7 @@ Classes
 
    .. attribute:: method
 
-       Method that will be used  to make the request.
+       Method that will be used to make the request.
 
    .. attribute:: url
 


### PR DESCRIPTION
## What do these changes do?

Fixes double spacing in documentation files.

## Are there changes in behavior for the user?

No — docs-only change.

## Is it a substantial burden for the maintainers to support this?

No — trivial formatting fix.

## Related issue number

N/A

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist (N/A)
- [ ] Documentation reflects the changes (N/A)
- [ ] Add a new news fragment into the `CHANGES/` folder (N/A)

Drafted with opencode; reviewed by human.