### PR TITLE
docs: fix 'according the' → 'according to the' in multipart docs

### DIFF
--- a/aiohttp/multipart.py
+++ b/aiohttp/multipart.py
@@ -526,7 +526,7 @@ class BodyPartReader:
     def decode(self, data: bytes) -> bytes:
         """Decodes data synchronously.
 
-        Decodes data according the specified Content-Encoding
+        Decodes data according to the specified Content-Encoding
         or Content-Transfer-Encoding headers value.
 
         Note: For large payloads, consider using decode_iter() instead
@@ -540,7 +540,7 @@ class BodyPartReader:
     async def decode_iter(self, data: bytes) -> AsyncIterator[bytes]:
         """Async generator that yields decoded data chunks.
 
-        Decodes data according the specified Content-Encoding
+        Decodes data according to the specified Content-Encoding
         or Content-Transfer-Encoding headers value.
 
         This method offloads decompression to an executor for large payloads

--- a/docs/multipart_reference.rst
+++ b/docs/multipart_reference.rst
@@ -104,7 +104,7 @@ Multipart reference
 
    .. method:: decode(data)
 
-      Decodes data synchronously according the specified ``Content-Encoding``
+      Decodes data synchronously according to the specified ``Content-Encoding``
       or ``Content-Transfer-Encoding`` headers value.
 
       Supports ``gzip``, ``deflate`` and ``identity`` encodings for
@@ -127,7 +127,7 @@ Multipart reference
    .. method:: decode_iter(data)
       :async:
 
-      Decodes data asynchronously according the specified ``Content-Encoding``
+      Decodes data asynchronously according to the specified ``Content-Encoding``
       or ``Content-Transfer-Encoding`` headers value.
 
       This is an async iterator and will return decoded data in chunks. This

--- a/docs/web_advanced.rst
+++ b/docs/web_advanced.rst
@@ -318,7 +318,7 @@ to :func:`aiohttp_jinja2.setup`::
 
 After that you may use the template engine in your
 :ref:`handlers <aiohttp-web-handler>`. The most convenient way is to simply
-wrap your handlers with the  :func:`aiohttp_jinja2.template` decorator::
+wrap your handlers with the :func:`aiohttp_jinja2.template` decorator::
 
     @aiohttp_jinja2.template('tmpl.jinja2')
     async def handler(request):


### PR DESCRIPTION
## What do these changes do?

Fixes missing preposition 'to' in multipart docstrings and docs: 'according the specified' → 'according to the specified'.

Also fixes a double space in web_advanced.rst.

## Are there changes in behavior for the user?

No — docs-only change.

## Related issue number

N/A

Drafted with opencode; reviewed by human.