### PR TITLE
Add SSL/TLS handshake detection to close HTTP connection

### DIFF
--- a/aiohttp/web_protocol.py
+++ b/aiohttp/web_protocol.py
@@ -464,7 +464,7 @@ class RequestHandler(BaseProtocol, Generic[_Request]):
                                "ClientHello" if data[2] < 0x03 else "TLSv1.0+",
                                self._peername,
                                )
-                self.close()
+                self.force_close()
                 return
             try:
                 messages, upgraded, tail = self._parser.feed_data(data)

--- a/aiohttp/web_protocol.py
+++ b/aiohttp/web_protocol.py
@@ -459,21 +459,18 @@ class RequestHandler(BaseProtocol, Generic[_Request]):
         messages: Sequence[_MsgType]
         if self._payload_parser is None and not self._upgraded:
             assert self._parser is not None
-            if len(data) >= 6 and data[0] == 0x16 and data[1] == 0x03:
-                tls_version = {
-                    0x00: "SSLv3",
-                    0x01: "TLSv1.0",
-                    0x02: "TLSv1.1",
-                    0x03: "TLSv1.2",
-                    0x04: "TLSv1.3",
-                }.get(data[2], "Unknown TLS")
+            TLS_HANDSHAKE_CONTENT_TYPE = 0x16
+            TLS_MAJOR_VERSION = 0x03
+            TLS_CLIENT_HELLO = 0x01
 
-                handshake_type = "ClientHello" if data[5] == 0x01 else "TLS handshake"
-
+            if (
+                len(data) >= 6
+                and data[0] == TLS_HANDSHAKE_CONTENT_TYPE
+                and data[1] == TLS_MAJOR_VERSION
+                and data[5] == TLS_CLIENT_HELLO
+            ):
                 self.log_debug(
-                    "SSL/TLS %s (%s) detected from %s on HTTP connection, closing connection",
-                    handshake_type,
-                    tls_version,
+                    "SSL/TLS ClientHello detected from %s on HTTP connection, closing connection",
                     self._peername,
                 )
                 self.force_close()

--- a/aiohttp/web_protocol.py
+++ b/aiohttp/web_protocol.py
@@ -459,11 +459,23 @@ class RequestHandler(BaseProtocol, Generic[_Request]):
         messages: Sequence[_MsgType]
         if self._payload_parser is None and not self._upgraded:
             assert self._parser is not None
-            if len(data) >= 3 and data[0] == 0x16 and data[1] == 0x03:
-                self.log_debug("SSL/TLS %s handshake detected from %s on HTTP connection, closing connection",
-                               "ClientHello" if data[2] < 0x03 else "TLSv1.0+",
-                               self._peername,
-                               )
+            if len(data) >= 6 and data[0] == 0x16 and data[1] == 0x03:
+                tls_version = {
+                    0x00: "SSLv3",
+                    0x01: "TLSv1.0",
+                    0x02: "TLSv1.1",
+                    0x03: "TLSv1.2",
+                    0x04: "TLSv1.3",
+                }.get(data[2], "Unknown TLS")
+
+                handshake_type = "ClientHello" if data[5] == 0x01 else "TLS handshake"
+
+                self.log_debug(
+                    "SSL/TLS %s (%s) detected from %s on HTTP connection, closing connection",
+                    handshake_type,
+                    tls_version,
+                    self._peername,
+                )
                 self.force_close()
                 return
             try:

--- a/aiohttp/web_protocol.py
+++ b/aiohttp/web_protocol.py
@@ -471,7 +471,7 @@ class RequestHandler(BaseProtocol, Generic[_Request]):
             ):
                 self.log_debug(
                     "SSL/TLS ClientHello detected from %s on HTTP connection, closing connection",
-                    self._peername,
+                    self.peername,
                 )
                 self.force_close()
                 return

--- a/aiohttp/web_protocol.py
+++ b/aiohttp/web_protocol.py
@@ -459,6 +459,13 @@ class RequestHandler(BaseProtocol, Generic[_Request]):
         messages: Sequence[_MsgType]
         if self._payload_parser is None and not self._upgraded:
             assert self._parser is not None
+            if len(data) >= 3 and data[0] == 0x16 and data[1] == 0x03:
+                self.log_debug("SSL/TLS %s handshake detected from %s on HTTP connection, closing connection",
+                               "ClientHello" if data[2] < 0x03 else "TLSv1.0+",
+                               self._peername,
+                               )
+                self.close()
+                return
             try:
                 messages, upgraded, tail = self._parser.feed_data(data)
             except HttpProcessingError as exc:

--- a/aiohttp/web_protocol.py
+++ b/aiohttp/web_protocol.py
@@ -460,12 +460,14 @@ class RequestHandler(BaseProtocol, Generic[_Request]):
         if self._payload_parser is None and not self._upgraded:
             assert self._parser is not None
             if len(data) >= 3 and data[0] == 0x16 and data[1] == 0x03:
+                _tls_minor = data[2]
+                _tls_version = {0x00: "SSLv3", 0x01: "TLSv1.0", 0x02: "TLSv1.1", 0x03: "TLSv1.2", 0x04: "TLSv1.3"}.get(_tls_minor, f"TLSv1.{_tls_minor}")
                 self.log_debug("SSL/TLS %s handshake detected from %s on HTTP connection, closing connection",
-                               "ClientHello" if data[2] < 0x03 else "TLSv1.0+",
+                               _tls_version,
                                self._peername,
                                )
                 self.force_close()
-                return
+
             try:
                 messages, upgraded, tail = self._parser.feed_data(data)
             except HttpProcessingError as exc:


### PR DESCRIPTION
This change detects incoming TLS handshake data on a plain HTTP connection by inspecting the initial bytes. If a TLS ClientHello is detected, the connection is immediately closed, and a debug log entry notes the event. This avoids unnecessary HTTP parsing errors and provides clearer logging when TLS traffic hits an HTTP endpoint.

<!-- Thank you for your contribution! -->

## What do these changes do?

Detect TLS/SSL handshake attempts on HTTP connections by inspecting the initial packet bytes. When TLS traffic is detected, the connection is closed early and a clear debug message is logged instead of raising a BadHttpMethod exception. This reduces log noise and makes the cause of the connection failure easier to understand.

## Are there changes in behavior for the user?

User Impact

No functional changes for end users.

Connections that mistakenly send TLS/SSL traffic to an HTTP endpoint were already rejected. This change only improves handling by detecting the TLS handshake earlier, closing the connection immediately, and logging a clearer message instead of generating a BadHttpMethod exception and traceback.

Before:

Invalid method encountered:
b'\x16\x03\x01...'

After:

SSL/TLS handshake detected on HTTP connection, closing connection

The connection is still rejected; only the logging and internal handling change.

## Is it a substantial burden for the maintainers to support this?

No significant maintenance burden is expected. The change is localized, does not affect normal HTTP processing, and only improves handling of a common case where TLS traffic is sent to an HTTP endpoint. The primary ongoing cost would be maintaining a small set of tests covering TLS handshake detection.
## Related issue number

<!-- Will this resolve any open issues? -->
This may resolve or reduce reports related to BadHttpMethod: Invalid method encountered errors caused by TLS/SSL traffic reaching an HTTP endpoint.

## Checklist

- [X ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES/` folder
  * name it `<issue_or_pr_num>.<type>.rst` (e.g. `588.bugfix.rst`)
  * if you don't have an issue number, change it to the pull request
    number after creating the PR
    * `.bugfix`: A bug fix for something the maintainers deemed an
      improper undesired behavior that got corrected to match
      pre-agreed expectations.
    * `.feature`: A new behavior, public APIs. That sort of stuff.
    * `.deprecation`: A declaration of future API removals and breaking
      changes in behavior.
    * `.breaking`: When something public is removed in a breaking way.
      Could be deprecated in an earlier release.
    * `.doc`: Notable updates to the documentation structure or build
      process.
    * `.packaging`: Notes for downstreams about unobvious side effects
      and tooling. Changes in the test invocation considerations and
      runtime assumptions.
    * `.contrib`: Stuff that affects the contributor experience. e.g.
      Running tests, building the docs, setting up the development
      environment.
    * `.misc`: Changes that are hard to assign to any of the above
      categories.
  * Make sure to use full sentences with correct case and punctuation,
    for example:
    ```rst
    Fixed issue with non-ascii contents in doctest text files
    -- by :user:`contributor-gh-handle`.
    ```

    Use the past tense or the present tense a non-imperative mood,
    referring to what's changed compared to the last released version
    of this project.
