### PR TITLE
[PR #12913/c2f4ac403 backport][3.15] Parameterize test_simple_web_file_response benchmarks by file size

### DIFF
--- a/CHANGES/12913.misc.rst
+++ b/CHANGES/12913.misc.rst
@@ -1,0 +1,2 @@
+Parameterized test_simple_web_file_response and test_simple_web_file_response_fallback benchmarks by file size (small, large)
+Previously, benchmarks only ran for a small (around 11 kb) file. -- by :user:`tarasko`.

--- a/tests/test_benchmarks_web_fileresponse.py
+++ b/tests/test_benchmarks_web_fileresponse.py
@@ -1,7 +1,9 @@
 """codspeed benchmarks for the web file responses."""
 
 import asyncio
+import os
 import pathlib
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 import pytest
@@ -17,26 +19,48 @@ else:
     BenchmarkFixture = pytest_codspeed.BenchmarkFixture
 
 
+@dataclass(frozen=True)
+class BenchmarkFile:
+    path: pathlib.Path
+    response_count: int
+
+
+@pytest.fixture(
+    params=((10 * 1024, 100), (1024 * 1024, 10)),
+    ids=("small", "large"),
+)
+def benchmark_file(
+    request: pytest.FixtureRequest, tmp_path: pathlib.Path
+) -> BenchmarkFile:
+    size, response_count = request.param
+    filepath = tmp_path / "sample.txt"
+    filepath.touch()
+    os.truncate(filepath, size)
+    return BenchmarkFile(filepath, response_count)
+
+
 def test_simple_web_file_response(
     loop: asyncio.AbstractEventLoop,
     aiohttp_client: AiohttpClient,
     benchmark: BenchmarkFixture,
     conn_type: ConnectionType,
+    benchmark_file: BenchmarkFile,
 ) -> None:
-    """Benchmark creating 100 simple web.FileResponse."""
-    response_count = 100
-    filepath = pathlib.Path(__file__).parent / "sample.txt"
+    """Benchmark simple web.FileResponse."""
 
     async def handler(request: web.Request) -> web.FileResponse:
-        return web.FileResponse(path=filepath)
+        return web.FileResponse(path=benchmark_file.path)
 
     app = web.Application()
     app.router.add_route("GET", "/", handler)
 
     async def run_file_response_benchmark() -> None:
         client = await aiohttp_client(app, server_kwargs=conn_type.s_kwargs)
-        for _ in range(response_count):
-            await client.get("/", **conn_type.c_kwargs)
+        for _ in range(benchmark_file.response_count):
+            response = await client.get("/", **conn_type.c_kwargs)
+            # Consume response.
+            # Large responses may leave transport unclosed on at least python 3.10.
+            await response.read()
         await client.close()
 
     @benchmark
@@ -49,24 +73,25 @@ def test_simple_web_file_sendfile_fallback_response(
     aiohttp_client: AiohttpClient,
     benchmark: BenchmarkFixture,
     conn_type: ConnectionType,
+    benchmark_file: BenchmarkFile,
 ) -> None:
-    """Benchmark creating 100 simple web.FileResponse without sendfile."""
-    response_count = 100
-    filepath = pathlib.Path(__file__).parent / "sample.txt"
+    """Benchmark simple web.FileResponse without sendfile."""
 
     async def handler(request: web.Request) -> web.FileResponse:
         transport = request.transport
         assert transport is not None
         transport._sendfile_compatible = False  # type: ignore[attr-defined]
-        return web.FileResponse(path=filepath)
+        return web.FileResponse(path=benchmark_file.path)
 
     app = web.Application()
     app.router.add_route("GET", "/", handler)
 
     async def run_file_response_benchmark() -> None:
         client = await aiohttp_client(app, server_kwargs=conn_type.s_kwargs)
-        for _ in range(response_count):
-            await client.get("/", **conn_type.c_kwargs)
+
+        for _ in range(benchmark_file.response_count):
+            response = await client.get("/", **conn_type.c_kwargs)
+            await response.read()
         await client.close()
 
     @benchmark


### PR DESCRIPTION
This is a backport of PR https://github.com/aio-libs/aiohttp/pull/12913 as merged into master (https://github.com/aio-libs/aiohttp/commit/c2f4ac4037753c4762dbf5e4e77a09adcd6932d7).