### PR TITLE
Avoid removing labels on maintainer comments

### DIFF
--- a/.github/workflows/label-remove.yml
+++ b/.github/workflows/label-remove.yml
@@ -10,6 +10,9 @@ on:
 jobs:
   clear-pr-unfinished:
     runs-on: ubuntu-latest
+    if: >-
+      github.event_name != 'issue_comment' ||
+      !contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
     permissions:
       id-token: write
       issues: write


### PR DESCRIPTION
This is partly to avoid the annoying race condition caused when leaving a comment and immediately adding the needs-info label before the workflow has completed.