### PR TITLE
Improve FileResponse performance by always using aiohttp's sendfile fallback if native sendfile is not available

### DIFF
--- a/CHANGES/12945.feature.rst
+++ b/CHANGES/12945.feature.rst
@@ -1,1 +1,2 @@
-Always use aiohttp's sendfile fallback if native sendfile is not available -- by :user:`tarasko`.
+Changed FileResponse to always use aiohttp's sendfile fallback if native sendfile is not available
+-- by :user:`tarasko`.

--- a/CHANGES/12945.feature.rst
+++ b/CHANGES/12945.feature.rst
@@ -1,2 +1,2 @@
-Changed FileResponse to always use aiohttp's sendfile fallback if native sendfile is not available
+Improved performance of FileResponse by always using aiohttp's sendfile fallback if native sendfile is not available
 -- by :user:`tarasko`.

--- a/CHANGES/12945.feature.rst
+++ b/CHANGES/12945.feature.rst
@@ -1,0 +1,1 @@
+Always use aiohttp's sendfile fallback if native sendfile is not available -- by :user:`tarasko`.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -367,6 +367,7 @@ Sunit Deshpande
 Sviatoslav Bulbakha
 Sviatoslav Sydorenko
 Taha Jahangir
+Taras Kozlov
 Taras Voinarovskyi
 Terence Honles
 Thanos Lefteris

--- a/aiohttp/web_fileresponse.py
+++ b/aiohttp/web_fileresponse.py
@@ -131,12 +131,21 @@ class FileResponse(StreamResponse):
         if transport is None:
             raise ConnectionResetError("Connection lost")
 
-        # We want to use loop.sendfile only if it supports native sendfile
-        # Otherwise we want to use our fallback.
+        # Use loop.sendfile() only when it can use native sendfile.
+        # Otherwise, use aiohttp's fallback, which is more efficient than
+        # asyncio's fallback for FileResponse.
+        #
+        # asyncio does not provide a public API for checking whether native
+        # sendfile is available for a transport. Calling loop.sendfile() with
+        # fallback=False is not enough: for fallback-only transports, asyncio
+        # raises a generic RuntimeError instead of SendfileNotAvailableError.
+        #
+        # The private _SendfileMode marker is the most reliable signal for
+        # asyncio transports, but third-party loops may not provide it.
 
         SendfileMode = asyncio.constants._SendfileMode  # type: ignore[attr-defined]
         mode = getattr(transport, "_sendfile_compatible", SendfileMode.TRY_NATIVE)
-        if mode in (SendfileMode.UNSUPPORTED, SendfileMode.FALLBACK):
+        if mode in (False, SendfileMode.UNSUPPORTED, SendfileMode.FALLBACK):
             return await self._sendfile_fallback(writer, fobj, offset, count)
 
         try:

--- a/aiohttp/web_fileresponse.py
+++ b/aiohttp/web_fileresponse.py
@@ -132,8 +132,8 @@ class FileResponse(StreamResponse):
             raise ConnectionResetError("Connection lost")
 
         try:
-            await loop.sendfile(transport, fobj, offset, count)
-        except NotImplementedError:
+            await loop.sendfile(transport, fobj, offset, count, fallback=False)
+        except (NotImplementedError, asyncio.SendfileNotAvailableError):
             return await self._sendfile_fallback(writer, fobj, offset, count)
 
         await super().write_eof()

--- a/aiohttp/web_fileresponse.py
+++ b/aiohttp/web_fileresponse.py
@@ -134,7 +134,7 @@ class FileResponse(StreamResponse):
         # We want to use loop.sendfile only if it supports native sendfile
         # Otherwise we want to use our fallback.
 
-        SendfileMode = asyncio.constants._SendfileMode # type: ignore[attr-defined]
+        SendfileMode = asyncio.constants._SendfileMode  # type: ignore[attr-defined]
         mode = getattr(transport, "_sendfile_compatible", SendfileMode.TRY_NATIVE)
         if mode in (SendfileMode.UNSUPPORTED, SendfileMode.FALLBACK):
             return await self._sendfile_fallback(writer, fobj, offset, count)

--- a/aiohttp/web_fileresponse.py
+++ b/aiohttp/web_fileresponse.py
@@ -133,7 +133,7 @@ class FileResponse(StreamResponse):
 
         # Use loop.sendfile() only when it can use native sendfile.
         # Otherwise, use aiohttp's fallback, which is more efficient than
-        # asyncio's fallback for FileResponse. 
+        # asyncio's fallback for FileResponse.
         #
         # asyncio does not provide a public API for checking whether native
         # sendfile is available for a transport. Calling loop.sendfile() with

--- a/aiohttp/web_fileresponse.py
+++ b/aiohttp/web_fileresponse.py
@@ -133,7 +133,7 @@ class FileResponse(StreamResponse):
 
         # Use loop.sendfile() only when it can use native sendfile.
         # Otherwise, use aiohttp's fallback, which is more efficient than
-        # asyncio's fallback for FileResponse.
+        # asyncio's fallback for FileResponse. 
         #
         # asyncio does not provide a public API for checking whether native
         # sendfile is available for a transport. Calling loop.sendfile() with

--- a/aiohttp/web_fileresponse.py
+++ b/aiohttp/web_fileresponse.py
@@ -131,6 +131,14 @@ class FileResponse(StreamResponse):
         if transport is None:
             raise ConnectionResetError("Connection lost")
 
+        # We want to use loop.sendfile only if it supports native sendfile
+        # Otherwise we want to use our fallback.
+
+        SendfileMode = asyncio.constants._SendfileMode # type: ignore[attr-defined]
+        mode = getattr(transport, "_sendfile_compatible", SendfileMode.TRY_NATIVE)
+        if mode in (SendfileMode.UNSUPPORTED, SendfileMode.FALLBACK):
+            return await self._sendfile_fallback(writer, fobj, offset, count)
+
         try:
             await loop.sendfile(transport, fobj, offset, count, fallback=False)
         except (NotImplementedError, asyncio.SendfileNotAvailableError):

--- a/tests/test_benchmarks_web_fileresponse.py
+++ b/tests/test_benchmarks_web_fileresponse.py
@@ -139,7 +139,7 @@ def test_simple_web_file_sendfile_fallback_response(
     async def handler(request: web.Request) -> web.FileResponse:
         transport = request.transport
         assert transport is not None
-        transport._sendfile_compatible = asyncio.constants._SendfileMode.UNSUPPORTED  # type: ignore[attr-defined]
+        transport._sendfile_compatible = False  # type: ignore[attr-defined]
         return web.FileResponse(path=benchmark_file.path)
 
     app = web.Application()

--- a/tests/test_benchmarks_web_fileresponse.py
+++ b/tests/test_benchmarks_web_fileresponse.py
@@ -139,7 +139,7 @@ def test_simple_web_file_sendfile_fallback_response(
     async def handler(request: web.Request) -> web.FileResponse:
         transport = request.transport
         assert transport is not None
-        transport._sendfile_compatible = asyncio.constants._SendfileMode.UNSUPPORTED # type: ignore[attr-defined]
+        transport._sendfile_compatible = asyncio.constants._SendfileMode.UNSUPPORTED  # type: ignore[attr-defined]
         return web.FileResponse(path=benchmark_file.path)
 
     app = web.Application()

--- a/tests/test_benchmarks_web_fileresponse.py
+++ b/tests/test_benchmarks_web_fileresponse.py
@@ -139,7 +139,7 @@ def test_simple_web_file_sendfile_fallback_response(
     async def handler(request: web.Request) -> web.FileResponse:
         transport = request.transport
         assert transport is not None
-        transport._sendfile_compatible = False  # type: ignore[attr-defined]
+        transport._sendfile_compatible = asyncio.constants._SendfileMode.UNSUPPORTED # type: ignore[attr-defined]
         return web.FileResponse(path=benchmark_file.path)
 
     app = web.Application()


### PR DESCRIPTION
I made a curious finding while looking at ``sendfile`` benchmarks. 
aiohttp's ``_sendfile_fallback`` is much more efficient than asyncio's ``loop.sendfile`` fallback mode for large files. 

Unfortunately, I had to use a non-public asyncio API to reliably detect when loop provides native sendfile. 

Just reject this PR if you are not comfortable with it.

<!-- Thank you for your contribution! -->

## What do these changes do?

Make aiohttp to use its own sendfile fallback instead of loop fallback when native sendfile is not available for the transport. 

aiohttp version of ``_sendfile_fallback`` is much more efficient and agile than asyncio's fallback.
Both implementations use another thread to read chunks:
```
        chunk = await loop.run_in_executor(
            None, self._seek_and_read, fobj, offset, min(chunk_size, count)
        )
```
Because of the GIL and time it takes to transfer task to/from another thread it is much more efficient to do it with bigger chunk size. 
asyncio has hardcoded chunk size of 16 Kb
aiohttp chunk size is 256 Kb by default and can be adjusted.

## Are there changes in behavior for the user?

No

## Is it a substantial burden for the maintainers to support this?

No, aiohttp _sendfile_fallback is currently used anyway if compression is enabled, or with uvloop SSL transports. 

## Related issue number

<!-- Will this resolve any open issues? -->
<!-- Remember to prefix with 'Fixes' if it closes an issue (e.g. 'Fixes #123'). -->

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] Add yourself to `CONTRIBUTORS.txt`
- [x] Add a new news fragment into the `CHANGES/` folder

