### PR TITLE
validate cookie Max-Age as -?digits before int()

### DIFF
--- a/CHANGES/12947.bugfix.rst
+++ b/CHANGES/12947.bugfix.rst
@@ -1,0 +1,3 @@
+Ignored a cookie ``Max-Age`` that is not a plain ``"-"`` prefixed sequence of
+digits (e.g. ``+1000``, ``1_000``), which a bare ``int()`` would otherwise
+honour, per :rfc:`6265#section-5.2.2` -- by :user:`dxbjavid`.

--- a/aiohttp/cookiejar.py
+++ b/aiohttp/cookiejar.py
@@ -31,6 +31,9 @@ CookieItem = Union[str, "Morsel[str]"]
 _FORMAT_PATH = "{}/{}".format
 _FORMAT_DOMAIN_REVERSED = "{1}.{0}".format
 
+# RFC 6265 5.2.2: a Max-Age value is an optional "-" followed by ASCII digits.
+_MAX_AGE_RE = re.compile(r"-?[0-9]+")
+
 # The minimum number of scheduled cookie expirations before we start cleaning up
 # the expiration heap. This is a performance optimization to avoid cleaning up the
 # heap too often when there are only a few scheduled expirations.
@@ -372,7 +375,13 @@ class CookieJar(AbstractCookieJar):
             path = path.rstrip("/")
 
             if max_age := cookie["max-age"]:
+                # int() would also accept sign prefixes, underscores and
+                # surrounding whitespace, so a Max-Age other clients treat as
+                # malformed (and ignore, leaving a session cookie) would
+                # otherwise be honoured here and persist the cookie.
                 try:
+                    if not _MAX_AGE_RE.fullmatch(max_age):
+                        raise ValueError
                     delta_seconds = int(max_age)
                     max_age_expiration = min(time.time() + delta_seconds, self.MAX_TIME)
                     self._expire_cookie(max_age_expiration, domain, path, name)

--- a/aiohttp/cookiejar.py
+++ b/aiohttp/cookiejar.py
@@ -380,7 +380,9 @@ class CookieJar(AbstractCookieJar):
                 # malformed (and ignore, leaving a session cookie) would
                 # otherwise be honoured here and persist the cookie.
                 try:
-                    if not _MAX_AGE_RE.fullmatch(max_age):
+                    # A Morsel built in Python may carry an int here, so
+                    # normalise to str before the RFC check.
+                    if not _MAX_AGE_RE.fullmatch(str(max_age)):
                         raise ValueError
                     delta_seconds = int(max_age)
                     max_age_expiration = min(time.time() + delta_seconds, self.MAX_TIME)

--- a/tests/test_cookiejar.py
+++ b/tests/test_cookiejar.py
@@ -1401,6 +1401,32 @@ def test_update_cookies_from_headers_overwrites_same_cookie() -> None:
     assert filtered["session"].value == "new-value"
 
 
+def test_update_cookies_ignores_non_rfc_max_age() -> None:
+    """Max-Age values RFC 6265 5.2.2 says to ignore must not persist a cookie."""
+    url: URL = URL("http://maxage.example.com/")
+    headers = [
+        "underscore=v; Max-Age=1_000",
+        "signed=v; Max-Age=+1000",
+        "valid=v; Max-Age=1000",
+    ]
+
+    with freeze_time("2024-01-01"):
+        jar: CookieJar = CookieJar()
+        jar.update_cookies_from_headers(headers, url)
+        sent_now: BaseCookie[str] = jar.filter_cookies(url)
+
+    assert {"underscore", "signed", "valid"} <= set(sent_now)
+
+    # 1800s later a real Max-Age=1000 cookie has expired, but the malformed
+    # ones were treated as session cookies (Max-Age ignored) and remain.
+    with freeze_time("2024-01-01 00:30:00"):
+        sent_later: BaseCookie[str] = jar.filter_cookies(url)
+
+    assert "valid" not in sent_later
+    assert "underscore" in sent_later
+    assert "signed" in sent_later
+
+
 def test_dummy_cookie_jar_update_cookies_from_headers() -> None:
     """Test that DummyCookieJar ignores update_cookies_from_headers."""
     jar: DummyCookieJar = DummyCookieJar()


### PR DESCRIPTION
## What do these changes do?

`CookieJar.update_cookies` reads a `Set-Cookie` `Max-Age` with a bare `int()`. Python's `int()` is more permissive than :rfc:`6265#section-5.2.2`, which says a `Max-Age` is `"-"? DIGIT+` and any other value must be ignored. So `Max-Age=+1000`, `Max-Age=1_000` and whitespace-padded values are honoured and persist the cookie with the given lifetime, whereas a browser drops the attribute and keeps it as a session cookie. The jar already clears a clearly non-numeric value (`Max-Age=string`), so this just completes that existing intent by validating against `-?[0-9]+` before parsing.

## Are there changes in behavior for the user?

A `Set-Cookie` whose `Max-Age` is not `-?DIGIT+` now leaves the cookie as a session cookie instead of giving it an expiry. Well-formed values, including negative ones, are unchanged.

## Is it a substantial burden for the maintainers to support this?

No, it is a small contained check next to the existing parse.

## Related issue number

N/A

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
- [x] Add a new news fragment into the `CHANGES/` folder
