### PR TITLE
Fix IndexError in parse_content_disposition when param value is empty

### DIFF
--- a/CHANGES/12948.bugfix.rst
+++ b/CHANGES/12948.bugfix.rst
@@ -1,0 +1,3 @@
+Fixed ``IndexError: string index out of range`` in ``parse_content_disposition``
+when a header parameter has an empty value (e.g. ``filename=``).
+-- by :user:`JSap0914`.

--- a/aiohttp/multipart.py
+++ b/aiohttp/multipart.py
@@ -81,7 +81,7 @@ def parse_content_disposition(
         return bool(string) and TOKEN >= set(string)
 
     def is_quoted(string: str) -> bool:
-        return string[0] == string[-1] == '"'
+        return len(string) >= 2 and string[0] == string[-1] == '"'
 
     def is_rfc5987(string: str) -> bool:
         return is_token(string) and string.count("'") == 2

--- a/tests/test_multipart_helpers.py
+++ b/tests/test_multipart_helpers.py
@@ -643,6 +643,22 @@ class TestParseContentDisposition:
         assert "attachment" == disptype
         assert {} == params
 
+    def test_empty_param_value_no_crash(self) -> None:
+        """Empty param value (e.g. filename=) must not raise IndexError."""
+        with pytest.warns(aiohttp.BadContentDispositionHeader):
+            disptype, params = parse_content_disposition("attachment; filename=")
+        assert disptype is None
+        assert {} == params
+
+    def test_empty_param_value_multiple(self) -> None:
+        """Multiple params where one has empty value must not raise IndexError."""
+        with pytest.warns(aiohttp.BadContentDispositionHeader):
+            disptype, params = parse_content_disposition(
+                "attachment; name=foo; filename="
+            )
+        assert disptype is None
+        assert {} == params
+
 
 class TestContentDispositionFilename:
     # http://greenbytes.de/tech/tc2231/


### PR DESCRIPTION
## Bug

`parse_content_disposition` raises an unhandled `IndexError: string index out of range` when a `Content-Disposition` header contains a parameter with an empty value, such as:

```
attachment; filename=
```

The inner helper `is_quoted` indexes `string[0]` without first checking that the string is non-empty:

```python
def is_quoted(string: str) -> bool:
    return string[0] == string[-1] == '"'  # crashes on empty string
```

## Fix

Added a `len(string) >= 2` guard before indexing — a quoted-string requires at minimum two characters (the opening and closing `"`).

```python
def is_quoted(string: str) -> bool:
    return len(string) >= 2 and string[0] == string[-1] == '"'
```

The function now correctly warns with `BadContentDispositionHeader` and returns `(None, {})` for this malformed input instead of crashing.

## Verification

```
pytest tests/test_multipart_helpers.py -q
100 passed, 5 skipped in 0.38s
```

Two new tests were added:
- `test_empty_param_value_no_crash` — `attachment; filename=`
- `test_empty_param_value_multiple` — `attachment; name=foo; filename=`