### PR TITLE
fix: exclude .hash directories from wheels

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -17,5 +17,8 @@ global-exclude *.lib
 global-exclude *.dll
 global-exclude *.a
 global-exclude *.obj
+graft vendor
+global-exclude .hash
+prune **/.hash
 exclude aiohttp/*.html
 prune docs/_build


### PR DESCRIPTION
Fixes #10860: .hash directories are build artifacts that
shouldn't be included in published wheels.