### PR TITLE
keep websocket compression state across interleaved control frames

### DIFF
--- a/CHANGES/12988.bugfix.rst
+++ b/CHANGES/12988.bugfix.rst
@@ -1,1 +1,1 @@
-Stopped resetting the WebSocket per-message compression state when a control frame is interleaved between the fragments of a compressed message, which left continuation frames undecompressed -- by :user:`arshsmith1`.
+Fixed control frames breaking fragmented WebSocket messages -- by :user:`arshsmith1`.

--- a/CHANGES/12988.bugfix.rst
+++ b/CHANGES/12988.bugfix.rst
@@ -1,0 +1,1 @@
+Stopped resetting the WebSocket per-message compression state when a control frame is interleaved between the fragments of a compressed message, which left continuation frames undecompressed -- by :user:`arshsmith1`.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -55,6 +55,7 @@ Anton Zhdan-Pushkin
 Arcadiy Ivanov
 Arie Bovenberg
 Arseny Timoniq
+Arsh Smith
 Artem Yushkovskiy
 Arthur Darcet
 Ashutosh Kumar Singh

--- a/aiohttp/_websocket/reader_py.py
+++ b/aiohttp/_websocket/reader_py.py
@@ -411,12 +411,8 @@ class WebSocketReader:
                     )
 
                 # Control frames (opcode > 0x7) may be interleaved between the
-                # fragments of a data message (RFC 6455 §5.4). They must stay
-                # transparent to the message framing, so only data frames move
-                # the fin tracker that marks the start of the next message.
-                # Otherwise an interleaved ping/pong/close (always FIN) re-latches
-                # _compressed above and the following continuation gets handled as
-                # uncompressed.
+                # fragments of a data message.
+                # https://datatracker.ietf.org/doc/html/rfc6455#section-5.4
                 if opcode <= 0x7:
                     self._frame_fin = bool(fin)
                 self._frame_opcode = opcode

--- a/aiohttp/_websocket/reader_py.py
+++ b/aiohttp/_websocket/reader_py.py
@@ -410,7 +410,15 @@ class WebSocketReader:
                         "Received frame with non-zero reserved bits",
                     )
 
-                self._frame_fin = bool(fin)
+                # Control frames (opcode > 0x7) may be interleaved between the
+                # fragments of a data message (RFC 6455 §5.4). They must stay
+                # transparent to the message framing, so only data frames move
+                # the fin tracker that marks the start of the next message.
+                # Otherwise an interleaved ping/pong/close (always FIN) re-latches
+                # _compressed above and the following continuation gets handled as
+                # uncompressed.
+                if opcode <= 0x7:
+                    self._frame_fin = bool(fin)
                 self._frame_opcode = opcode
                 self._has_mask = bool(has_mask)
                 self._payload_len_flag = length

--- a/tests/test_websocket_parser.py
+++ b/tests/test_websocket_parser.py
@@ -594,6 +594,33 @@ def test_parse_compress_frame_multi(parser: PatchableWebSocketReader) -> None:
     assert (1, 1, b"1234", False) == (fin, opcode, payload, not not compress)
 
 
+def test_compressed_continuation_with_ping(
+    out: WebSocketDataQueue, parser: PatchableWebSocketReader
+) -> None:
+    # A control frame may be interleaved between the fragments of a data
+    # message (RFC 6455 §5.4). The continuation must still be decompressed.
+    message = b"hello compressed world " * 4
+    compressobj = ZLibBackend.compressobj(wbits=-9)
+    compressed = compressobj.compress(message)
+    compressed += compressobj.flush(ZLibBackend.Z_SYNC_FLUSH)
+    assert compressed.endswith(WS_DEFLATE_TRAILING)
+    compressed = compressed[:-4]
+    half = len(compressed) // 2
+
+    # first fragment: compressed binary, RSV1 set, not final
+    parser._feed_data(PACK_LEN1(0x40 | WSMsgType.BINARY, half) + compressed[:half])
+    # interleaved ping
+    parser._feed_data(PACK_LEN1(0x80 | WSMsgType.PING, 0))
+    # final continuation fragment
+    parser._feed_data(
+        PACK_LEN1(0x80 | WSMsgType.CONTINUATION, len(compressed) - half)
+        + compressed[half:]
+    )
+
+    assert out._buffer[0] == WSMessagePing(data=b"", size=0, extra="")
+    assert out._buffer[1] == WSMessageBinary(data=message, size=len(message), extra="")
+
+
 def test_parse_compress_error_frame(parser: PatchableWebSocketReader) -> None:
     parser.parse_frame(struct.pack("!BB", 0b01000001, 0b00000001))
     parser.parse_frame(b"1")

--- a/tests/test_websocket_parser.py
+++ b/tests/test_websocket_parser.py
@@ -598,7 +598,9 @@ def test_compressed_continuation_with_ping(
     out: WebSocketDataQueue, parser: PatchableWebSocketReader
 ) -> None:
     # A control frame may be interleaved between the fragments of a data
-    # message (RFC 6455 §5.4). The continuation must still be decompressed.
+    # A control frame may be interleaved between the fragments of a data
+    # message. The continuation must still be decompressed.
+    # https://datatracker.ietf.org/doc/html/rfc6455#section-5.4
     message = b"hello compressed world " * 4
     compressobj = ZLibBackend.compressobj(wbits=-9)
     compressed = compressobj.compress(message)

--- a/tests/test_websocket_parser.py
+++ b/tests/test_websocket_parser.py
@@ -598,7 +598,6 @@ def test_compressed_continuation_with_ping(
     out: WebSocketDataQueue, parser: PatchableWebSocketReader
 ) -> None:
     # A control frame may be interleaved between the fragments of a data
-    # A control frame may be interleaved between the fragments of a data
     # message. The continuation must still be decompressed.
     # https://datatracker.ietf.org/doc/html/rfc6455#section-5.4
     message = b"hello compressed world " * 4
@@ -610,11 +609,11 @@ def test_compressed_continuation_with_ping(
     half = len(compressed) // 2
 
     # first fragment: compressed binary, RSV1 set, not final
-    parser._feed_data(PACK_LEN1(0x40 | WSMsgType.BINARY, half) + compressed[:half])
+    parser.feed_data(PACK_LEN1(0x40 | WSMsgType.BINARY, half) + compressed[:half])
     # interleaved ping
-    parser._feed_data(PACK_LEN1(0x80 | WSMsgType.PING, 0))
+    parser.feed_data(PACK_LEN1(0x80 | WSMsgType.PING, 0))
     # final continuation fragment
-    parser._feed_data(
+    parser.feed_data(
         PACK_LEN1(0x80 | WSMsgType.CONTINUATION, len(compressed) - half)
         + compressed[half:]
     )


### PR DESCRIPTION
## What do these changes do?

When a permessage-deflate message is split across several frames, a peer may interleave a control frame (ping/pong/close) between the fragments (RFC 6455 §5.4). The reader uses `_frame_fin` to spot the start of a new message and (re)latch the per-message compression flag, but control frames always carry FIN, so an interleaved one makes the following continuation look like a fresh message and clears that flag. The continuation is then handled as uncompressed: raw deflate bytes are delivered for a binary message, or a UTF-8 error closes the connection for a text one.

The fix lets only data frames advance that tracker, so control frames stay transparent to the message framing and the compression state carries across them. The added test feeds a compressed first fragment, a ping, then the continuation and checks the binary message still decompresses.

## Are there changes in behavior for the user?

No public API change. A compressed message that previously came back corrupted (or dropped the connection) when a control frame landed mid-message now decodes correctly.

## Is it a substantial burden for the maintainers to support this?

No, it is a few lines in the reader plus one regression test.

## Related issue number

N/A

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
- [x] Add a new news fragment into the `CHANGES/` folder
