### PR TITLE
Try firewalled test

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -189,7 +189,7 @@ jobs:
       matrix:
         pyver: ['3.10', '3.11', '3.12', '3.13', '3.14']
         no-extensions: ['', 'Y']
-        os: [ubuntu, macos, windows]
+        os: [ubuntu-24.04-firewall, macos-latest, windows-latest]
         experimental: [false]
         exclude:
           - os: macos
@@ -206,7 +206,7 @@ jobs:
             no-extensions: ''
             experimental: false
       fail-fast: true
-    runs-on: ${{ matrix.os }}-latest
+    runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.experimental }}
     timeout-minutes: 15
     steps:

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -192,16 +192,16 @@ jobs:
         os: [ubuntu-24.04-firewall, macos-latest, windows-latest]
         experimental: [false]
         exclude:
-          - os: macos
+          - os: macos-latest
             no-extensions: 'Y'
-          - os: windows
+          - os: windows-latest
             no-extensions: 'Y'
         include:
           - pyver: pypy-3.11
             no-extensions: 'Y'
-            os: ubuntu
+            os: ubuntu-latest
             experimental: false
-          - os: ubuntu
+          - os: ubuntu-latest
             pyver: "3.14t"
             no-extensions: ''
             experimental: false


### PR DESCRIPTION
This will allow us to stop network access in the tests, which breaks downstream testing and introduces flakiness.

This is audit mode only currently, so just testing out performance etc. right now.