### PR TITLE
DeflateBuffer: skip header sniff on empty chunks

### DIFF
--- a/CHANGES/12994.bugfix.rst
+++ b/CHANGES/12994.bugfix.rst
@@ -1,0 +1,6 @@
+Fixed ``IndexError: string index out of range`` raised from
+``DeflateBuffer.feed_data`` when the underlying transport resumed a
+paused decoder by calling ``feed_data(b"")`` -- the deflate header
+sniff at the top of the method now short-circuits on empty chunks,
+matching the ``StreamReader.feed_data`` behaviour for empty input.
+-- by :user:`HrachShah`.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -168,6 +168,7 @@ Hiroshi Ogawa
 Hrishikesh Paranjape
 Hu Bo
 Hugh Young
+Hrach Shah
 Hugo Herter
 Hugo Hromic
 Hugo van Kemenade

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -165,10 +165,10 @@ Hans Adema
 Harmon Y.
 Harry Liu
 Hiroshi Ogawa
+Hrach Shah
 Hrishikesh Paranjape
 Hu Bo
 Hugh Young
-Hrach Shah
 Hugo Herter
 Hugo Hromic
 Hugo van Kemenade

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -1136,8 +1136,11 @@ class DeflateBuffer:
         # RFC1950
         # bits 0..3 = CM = 0b1000 = 8 = "deflate"
         # bits 4..7 = CINFO = 1..7 = windows size.
+        # Skip the header sniff on empty chunks: the parser can resume a paused
+        # stream by calling feed_data(b""), and we have no header byte to read.
         if (
-            not self._started_decoding
+            chunk
+            and not self._started_decoding
             and self.encoding == "deflate"
             and chunk[0] & 0xF != 8
         ):

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -3045,6 +3045,41 @@ class TestDeflateBuffer:
 
         assert buf.at_eof()
 
+    async def test_feed_empty_chunk_before_any_data(
+        self, protocol: BaseProtocol
+    ) -> None:
+        # The parser resumes paused decoders via feed_data(b""). On the first
+        # such resume the deflate FSM sniffs chunk[0] to decide whether to
+        # enable suppress_deflate_header; an empty chunk used to raise
+        # IndexError. The empty chunk must be a no-op: no exception, decoder
+        # untouched, no bytes pushed downstream, data_available False.
+        buf = aiohttp.StreamReader(
+            protocol, DEFAULT_CHUNK_SIZE, loop=asyncio.get_running_loop()
+        )
+        dbuf = DeflateBuffer(buf, "deflate")
+
+        original_decompressor = dbuf.decompressor
+        assert dbuf.feed_data(b"") is False
+        assert dbuf.decompressor is original_decompressor
+        assert list(buf._buffer) == []
+
+    async def test_feed_empty_chunk_after_real_data(
+        self, protocol: BaseProtocol
+    ) -> None:
+        # Once the decoder is running, a follow-up empty chunk must still be a
+        # no-op: no exception, no empty bytes appended to the downstream buffer.
+        buf = aiohttp.StreamReader(
+            protocol, DEFAULT_CHUNK_SIZE, loop=asyncio.get_running_loop()
+        )
+        dbuf = DeflateBuffer(buf, "deflate")
+
+        dbuf.decompressor = mock.Mock()
+        dbuf.decompressor.decompress_sync.side_effect = [b"hello ", b""]
+        dbuf.decompressor.data_available = False
+        assert dbuf.feed_data(b"hi") is False
+        assert dbuf.feed_data(b"") is False
+        assert list(buf._buffer) == [b"hello "]
+
     @pytest.mark.skipif(platform.python_implementation() == "PyPy", reason="Broken")
     @pytest.mark.parametrize(
         "chunk_size",


### PR DESCRIPTION
## What do these changes do?

``DeflateBuffer.feed_data`` raised `IndexError: string index out of range` from the RFC1950 header sniff whenever the underlying transport resumed a paused decoder with `feed_data(b"")`. The sniff is only meaningful when the first byte of the chunk actually arrived, so an empty chunk must be a no-op.

The guard now reads `if (chunk and not self._started_decoding and self.encoding == "deflate" and chunk[0] & 0xF != 8):` instead of `if (not self._started_decoding and self.encoding == "deflate" and chunk[0] & 0xF != 8):`. With `chunk` short-circuiting to `False` on `b""`, the branch is skipped before `chunk[0]` is read. The downstream `decompress_sync(b"")` already handles the empty payload correctly (the new test `test_feed_empty_chunk_after_real_data` covers this).

## Are there changes in behavior for the user?

Yes — bugfix. A response that previously crashed with `IndexError` now decodes normally. No public API change.

## Is it a substantial burden for the maintainers to support this?

No. The change is local to a single private class, has two new regression tests, and a CHANGES fragment. No new public API, no new dependencies, no new defaults.

## Related issue number

Fixes #12994

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes (CHANGES/12994.bugfix.rst added)
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
- [x] Add a new news fragment into the `CHANGES/` folder

<details>
<summary>Test log</summary>

```
$ PYTHONPATH=/home/workspace/yarl:/home/workspace/aiohttp AIOHTTP_NO_EXTENSIONS=1 python3 -m pytest tests/test_http_parser.py::TestDeflateBuffer -v
...
======================== 12 passed, 1 skipped in 0.74s =========================
```

`test_feed_empty_chunk_before_any_data` fails on master with `IndexError: index out of range` from `aiohttp/http_parser.py:1142` and passes with this fix. `test_feed_empty_chunk_after_real_data` passes both ways (regression-of-regression: the pre-existing `decompress_sync(b"")` path is left alone).
</details>

Drafted with Zo Computer (MiniMax M3); reviewed by HrachShah.