### PR TITLE
Fix parse_content_disposition rejecting headers with OWS around disposition type

### DIFF
--- a/CHANGES/12996.bugfix.rst
+++ b/CHANGES/12996.bugfix.rst
@@ -1,0 +1,5 @@
+Fixed ``parse_content_disposition`` rejecting otherwise-valid
+``Content-Disposition`` header values that contain optional whitespace (OWS)
+around the disposition type (e.g. ``"form-data ; name=\"field\""``).
+The disposition type is now stripped before token validation, consistent with
+how parameter keys are already handled -- by :user:`JSap0914`.

--- a/aiohttp/multipart.py
+++ b/aiohttp/multipart.py
@@ -103,6 +103,7 @@ def parse_content_disposition(
         return None, {}
 
     disptype, *parts = header.split(";")
+    disptype = disptype.strip()
     if not is_token(disptype):
         warnings.warn(BadContentDispositionHeader(header))
         return None, {}

--- a/aiohttp/multipart.py
+++ b/aiohttp/multipart.py
@@ -102,6 +102,7 @@ def parse_content_disposition(
     if not header:
         return None, {}
 
+    # https://www.rfc-editor.org/info/rfc9110/#section-5.6.6-2
     disptype, *parts = header.split(";")
     disptype = disptype.strip()
     if not is_token(disptype):

--- a/tests/test_multipart_helpers.py
+++ b/tests/test_multipart_helpers.py
@@ -658,6 +658,7 @@ class TestParseContentDisposition:
             )
         assert disptype is None
         assert {} == params
+
     def test_disptype_with_trailing_space_before_semicolon(self) -> None:
         """OWS before first ';' must not cause disptype validation to fail.
 
@@ -674,6 +675,7 @@ class TestParseContentDisposition:
         disptype, params = parse_content_disposition("inline ")
         assert disptype == "inline"
         assert params == {}
+
 
 class TestContentDispositionFilename:
     # http://greenbytes.de/tech/tc2231/

--- a/tests/test_multipart_helpers.py
+++ b/tests/test_multipart_helpers.py
@@ -658,7 +658,22 @@ class TestParseContentDisposition:
             )
         assert disptype is None
         assert {} == params
+    def test_disptype_with_trailing_space_before_semicolon(self) -> None:
+        """OWS before first ';' must not cause disptype validation to fail.
 
+        'form-data ; name="field"' is a valid Content-Disposition value per
+        RFC 7230 BWS rules.  The disposition type should be stripped before
+        the is_token check, just as parameter keys already are.
+        """
+        disptype, params = parse_content_disposition('form-data ; name="field"')
+        assert disptype == "form-data"
+        assert params == {"name": "field"}
+
+    def test_disptype_with_trailing_space_no_params(self) -> None:
+        """Trailing OWS on disptype with no params is also valid."""
+        disptype, params = parse_content_disposition("inline ")
+        assert disptype == "inline"
+        assert params == {}
 
 class TestContentDispositionFilename:
     # http://greenbytes.de/tech/tc2231/

--- a/tests/test_multipart_helpers.py
+++ b/tests/test_multipart_helpers.py
@@ -660,12 +660,6 @@ class TestParseContentDisposition:
         assert {} == params
 
     def test_disptype_with_trailing_space_before_semicolon(self) -> None:
-        """OWS before first ';' must not cause disptype validation to fail.
-
-        'form-data ; name="field"' is a valid Content-Disposition value per
-        RFC 7230 BWS rules.  The disposition type should be stripped before
-        the is_token check, just as parameter keys already are.
-        """
         disptype, params = parse_content_disposition('form-data ; name="field"')
         assert disptype == "form-data"
         assert params == {"name": "field"}

--- a/tests/test_multipart_helpers.py
+++ b/tests/test_multipart_helpers.py
@@ -665,7 +665,6 @@ class TestParseContentDisposition:
         assert params == {"name": "field"}
 
     def test_disptype_with_trailing_space_no_params(self) -> None:
-        """Trailing OWS on disptype with no params is also valid."""
         disptype, params = parse_content_disposition("inline ")
         assert disptype == "inline"
         assert params == {}


### PR DESCRIPTION
## What does this PR do?

Fixes **#12996** — `parse_content_disposition` was rejecting `Content-Disposition` headers that contain optional whitespace (OWS) around the disposition type, such as:

```
Content-Disposition: form-data ; name="field"
```

The disposition type `"form-data "` (trailing space) failed the `is_token()` check, causing the function to emit a `BadContentDispositionHeader` warning and return `(None, {})` instead of `('form-data', {'name': 'field'})`.

## Root cause

In `parse_content_disposition`:

```python
disptype, *parts = header.split(";")
if not is_token(disptype):   # disptype not stripped; 'form-data ' fails is_token
    warnings.warn(BadContentDispositionHeader(header))
    return None, {}
```

Parameter *keys* already receive `.lower().strip()`, but `disptype` was not stripped at all.

## Fix

One line — strip `disptype` before the token check:

```python
disptype = disptype.strip()
```

## Verification

```
pytest tests/test_multipart_helpers.py -v
# 102 passed, 5 skipped  (0 regressions)
```

New tests (RED before, GREEN after):
- `test_disptype_with_trailing_space_before_semicolon`
- `test_disptype_with_trailing_space_no_params`

Closes #12996

> AI-assisted implementation (GJC/Claude).