### PR TITLE
Support SHA-512-256 digest auth

### DIFF
--- a/CHANGES/13007.bugfix.rst
+++ b/CHANGES/13007.bugfix.rst
@@ -1,0 +1,3 @@
+Added support for ``SHA-512-256`` digest authentication challenges and
+their session variant in :class:`aiohttp.DigestAuthMiddleware`
+-- by :user:`nyxst4ck`.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -292,6 +292,7 @@ Night Cityblade
 Nikolay Kim
 Nikolay Novik
 Nikolay Tiunov
+nyxst4ck
 Nándor Mátravölgyi
 Oisin Aylward
 Olaf Conradi

--- a/aiohttp/client_middleware_digest_auth.py
+++ b/aiohttp/client_middleware_digest_auth.py
@@ -34,6 +34,10 @@ class DigestAuthChallenge(TypedDict, total=False):
     stale: str
 
 
+def _sha512_256(data: bytes) -> "hashlib._Hash":
+    return hashlib.new("sha512_256", data)
+
+
 DigestFunctions: dict[str, Callable[[bytes], "hashlib._Hash"]] = {
     "MD5": hashlib.md5,
     "MD5-SESS": hashlib.md5,
@@ -43,8 +47,12 @@ DigestFunctions: dict[str, Callable[[bytes], "hashlib._Hash"]] = {
     "SHA256-SESS": hashlib.sha256,
     "SHA-256": hashlib.sha256,
     "SHA-256-SESS": hashlib.sha256,
+    "SHA512-256": _sha512_256,
+    "SHA512-256-SESS": _sha512_256,
     "SHA512": hashlib.sha512,
     "SHA512-SESS": hashlib.sha512,
+    "SHA-512-256": _sha512_256,
+    "SHA-512-256-SESS": _sha512_256,
     "SHA-512": hashlib.sha512,
     "SHA-512-SESS": hashlib.sha512,
 }

--- a/docs/client_advanced.rst
+++ b/docs/client_advanced.rst
@@ -83,8 +83,8 @@ For HTTP digest authentication, use the :class:`DigestAuthMiddleware` client mid
 
 The :class:`DigestAuthMiddleware` implements HTTP Digest Authentication according to RFC 7616,
 providing a more secure alternative to Basic Authentication. It supports all
-standard hash algorithms including MD5, SHA, SHA-256, SHA-512 and their session
-variants, as well as both 'auth' and 'auth-int' quality of protection (qop) options.
+standard hash algorithms including MD5, SHA, SHA-256, SHA-512, SHA-512-256 and
+their session variants, as well as both 'auth' and 'auth-int' quality of protection (qop) options.
 The middleware automatically handles the authentication flow by intercepting 401 responses
 and retrying with proper credentials.
 

--- a/tests/test_client_middleware_digest_auth.py
+++ b/tests/test_client_middleware_digest_auth.py
@@ -231,7 +231,8 @@ async def test_encode_uri_uses_wire_encoded_request_target(
 
 
 @pytest.mark.parametrize(
-    "algorithm", ["MD5-SESS", "SHA-SESS", "SHA-256-SESS", "SHA-512-SESS"]
+    "algorithm",
+    ["MD5-SESS", "SHA-SESS", "SHA-256-SESS", "SHA-512-SESS", "SHA-512-256-SESS"],
 )
 async def test_encode_digest_with_sess_algorithms(
     digest_auth_mw: DigestAuthMiddleware,
@@ -248,6 +249,24 @@ async def test_encode_digest_with_sess_algorithms(
         "GET", URL("http://example.com/resource"), b""
     )
     assert f"algorithm={algorithm}" in header
+
+
+@pytest.mark.parametrize("algorithm", ["SHA-512-256", "SHA-512-256-SESS"])
+async def test_encode_digest_with_sha512_256_algorithms(
+    digest_auth_mw: DigestAuthMiddleware,
+    qop_challenge: DigestAuthChallenge,
+    algorithm: str,
+) -> None:
+    challenge = qop_challenge.copy()
+    challenge["algorithm"] = algorithm
+    digest_auth_mw._challenge = challenge
+
+    header = await digest_auth_mw._encode(
+        "GET", URL("http://example.com/resource"), b""
+    )
+
+    assert f"algorithm={algorithm}" in header
+    assert 'response="' in header
 
 
 async def test_encode_unsupported_algorithm(


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Add support for HTTP Digest Authentication challenges that use the RFC 7616 `SHA-512-256` algorithm and its `-SESS` variant.

The middleware already advertises RFC 7616 digest support, but `SHA-512-256` was missing from the supported algorithm table and was rejected with `Unsupported hash algorithm`.

## Are there changes in behavior for the user?

Yes. `DigestAuthMiddleware` can now answer servers that send `WWW-Authenticate: Digest ... algorithm=SHA-512-256` or `algorithm=SHA-512-256-SESS`.

Existing digest algorithms keep their current behavior.

## Is it a substantial burden for the maintainers to support this?

No. This reuses Python's `hashlib.new("sha512_256", ...)` support and the existing digest algorithm dispatch path.

## Related issue number

No duplicate issue or PR found for `SHA-512-256` / `sha512_256` digest support.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
- [x] Add a new news fragment into the `CHANGES/` folder

<details>
<summary>Verification</summary>

Red on clean upstream with only the new test applied:

```console
$ AIOHTTP_NO_EXTENSIONS=1 PYTHONPATH=. python -m pytest tests/test_client_middleware_digest_auth.py::test_encode_digest_with_sha512_256_algorithms tests/test_client_middleware_digest_auth.py::test_encode_digest_with_sess_algorithms -q
3 failed, 4 passed
```

Green on this branch:

```console
$ AIOHTTP_NO_EXTENSIONS=1 PYTHONPATH=. python -m pytest tests/test_client_middleware_digest_auth.py -q
221 passed
```

Other checks:

```console
$ git diff --check
$ LC_ALL=C sort --check --ignore-case CONTRIBUTORS.txt
```

Duplicate search:

```console
$ gh search issues --repo aio-libs/aiohttp "SHA-512-256" --state open --include-prs
$ gh search issues --repo aio-libs/aiohttp "SHA-512-256" --state closed --include-prs
$ gh search issues --repo aio-libs/aiohttp "sha512_256" --state open --include-prs
$ gh search issues --repo aio-libs/aiohttp "sha512_256" --state closed --include-prs
$ gh search issues --repo aio-libs/aiohttp "DigestAuthMiddleware SHA" --state open --include-prs
$ gh search issues --repo aio-libs/aiohttp "DigestAuthMiddleware SHA" --state closed --include-prs
```

Only the original merged Digest middleware PRs (#10725 and #10894 backport) appeared; neither adds `SHA-512-256` support.

</details>

Drafted with Codex GPT-5; reviewed by nyxst4ck.
