### PR TITLE
Fix parse_mimetype producing spurious empty-key parameter for whitespace-only segments after semicolons

### DIFF
--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -332,7 +332,7 @@ def parse_mimetype(mimetype: str) -> MimeType:
     parts = mimetype.split(";")
     params: MultiDict[str] = MultiDict()
     for item in parts[1:]:
-        if not item:
+        if not item.strip():
             continue
         key, _, value = item.partition("=")
         params.add(key.lower().strip(), value.strip(' "'))

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -74,6 +74,27 @@ from aiohttp.helpers import (
                 "text", "plain", "", MultiDictProxy(MultiDict({"base64": ""}))
             ),
         ),
+        (
+            "text/html; ",
+            helpers.MimeType("text", "html", "", MultiDictProxy(MultiDict())),
+        ),
+        (
+            "text/html;  ",
+            helpers.MimeType("text", "html", "", MultiDictProxy(MultiDict())),
+        ),
+        (
+            "text/html;\t",
+            helpers.MimeType("text", "html", "", MultiDictProxy(MultiDict())),
+        ),
+        (
+            "text/html; charset=utf-8; ",
+            helpers.MimeType(
+                "text",
+                "html",
+                "",
+                MultiDictProxy(MultiDict({"charset": "utf-8"})),
+            ),
+        ),
     ],
 )
 def test_parse_mimetype(mimetype: str, expected: helpers.MimeType) -> None:


### PR DESCRIPTION
## Summary

`parse_mimetype` incorrectly adds a spurious `{'': ''}` parameter entry when a MIME type string has a trailing semicolon followed by whitespace (e.g. `'text/html; '`).

Closes #13009

## Root cause

`aiohttp/helpers.py` splits on `;` and skips empty segments with:

```python
if not item:
    continue
```

A bare trailing `;` (like `text/html;`) produces an empty-string segment, which is correctly skipped. But `text/html; ` produces a whitespace-only segment (`' '`) which is truthy — so it is NOT skipped — and ends up as `params.add('', '')`.

## Fix

```diff
-        if not item:
+        if not item.strip():
```

## Reproduction / before

```python
from aiohttp.helpers import parse_mimetype

dict(parse_mimetype('text/html; ').parameters)         # {'': ''}  ← wrong
dict(parse_mimetype('text/html;  ').parameters)        # {'': ''}  ← wrong
dict(parse_mimetype('text/html;\t').parameters)        # {'': ''}  ← wrong
dict(parse_mimetype('text/html; charset=utf-8; ').parameters)  # {'charset': 'utf-8', '': ''}  ← wrong
```

## After fix

All four return the expected values with no empty-key parameter.

## Testing

Four new parametrize cases added to `tests/test_helpers.py::test_parse_mimetype`. All 141 existing tests continue to pass.