### PR TITLE
parse_mimetype: skip whitespace-only segments after semicolons

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -75,7 +75,7 @@ jobs:
       with:
         python-version: 3.11
     - name: Cache PyPI
-      uses: actions/cache@v6.1.0
+      uses: actions/cache@v5.0.5
       with:
         key: pip-lint-${{ hashFiles('requirements/*.txt') }}
         path: ~/.cache/pip
@@ -158,7 +158,7 @@ jobs:
       with:
         submodules: true
     - name: Cache llhttp generated files
-      uses: actions/cache@v6.1.0
+      uses: actions/cache@v5.0.5
       id: cache
       with:
         key: llhttp-${{ hashFiles('vendor/llhttp/package*.json', 'vendor/llhttp/src/**/*') }}

--- a/CHANGES/13009.bugfix.rst
+++ b/CHANGES/13009.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed :py:meth:`~aiohttp.helpers.parse_mimetype` ignoring whitespace-only segments after semicolons -- by :user:`HrachShah`.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -165,10 +165,10 @@ Hans Adema
 Harmon Y.
 Harry Liu
 Hiroshi Ogawa
+Hrach Shahumyan
 Hrishikesh Paranjape
 Hu Bo
 Hugh Young
-Hrach Shahumyan
 Hugo Herter
 Hugo Hromic
 Hugo van Kemenade

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -168,6 +168,7 @@ Hiroshi Ogawa
 Hrishikesh Paranjape
 Hu Bo
 Hugh Young
+Hrach Shahumyan
 Hugo Herter
 Hugo Hromic
 Hugo van Kemenade

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -332,7 +332,10 @@ def parse_mimetype(mimetype: str) -> MimeType:
     parts = mimetype.split(";")
     params: MultiDict[str] = MultiDict()
     for item in parts[1:]:
-        if not item:
+        # Skip both empty segments (bare trailing semicolon) and
+        # whitespace-only segments (e.g. "text/html; " or "text/html;\t"),
+        # which are not valid MIME parameters per RFC 2045.
+        if not item.strip():
             continue
         key, _, value = item.partition("=")
         params.add(key.lower().strip(), value.strip(' "'))

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -83,6 +83,34 @@ def test_parse_mimetype(mimetype: str, expected: helpers.MimeType) -> None:
     assert result == expected
 
 
+@pytest.mark.parametrize(
+    "mimetype",
+    [
+        "text/html; ",
+        "text/html;  ",
+        "text/html;\t",
+        "text/html; \t \t",
+        "text/html; charset=utf-8; ",
+        "text/html; charset=utf-8;  \t",
+    ],
+)
+def test_parse_mimetype_skips_whitespace_only_segments(
+    mimetype: str,
+) -> None:
+    """Whitespace-only segments after a semicolon are not valid MIME
+    parameters (RFC 2045) and should be ignored, not parsed as an empty
+    parameter key. Regression test for #13009.
+    """
+    result = helpers.parse_mimetype(mimetype)
+
+    # No spurious empty-key parameter.
+    assert "" not in result.parameters
+    if "charset" in mimetype:
+        assert result.parameters == MultiDictProxy(MultiDict({"charset": "utf-8"}))
+    else:
+        assert result.parameters == MultiDictProxy(MultiDict())
+
+
 # ------------------- parse_content_type ------------------------------
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Fix `aiohttp.helpers.parse_mimetype` returning
`MultiDict({'': ''})` for a MIME type string whose
semicolon-delimited segments include whitespace-only entries
(e.g. `text/html; ` or `text/html; charset=utf-8; \t`).

The pre-fix loop skips segments that are completely empty with
`if not item: continue`. A whitespace-only segment like ``
or `\t` is still truthy as a string, so it falls through to
the `partition('=')` branch and produces an `{'': ''}`
parameter entry — violating RFC 2045's requirement that
parameters have a name.

The fix is a one-character widening of the guard:
`if not item.strip(): continue`. Both empty and
whitespace-only segments are now skipped, so the spurious
`{'': ''}` entry is gone. Bare trailing `;` (which produced
an empty-string segment) is still handled.

A new parametrized test
`test_parse_mimetype_skips_whitespace_only_segments` covers
the cases from the issue (trailing space, multiple spaces,
tab, mixed spaces/tabs) and the mixed case where a real
parameter precedes the whitespace-only segment (verifying
`charset` is preserved and no empty key appears). The
existing `test_parse_mimetype` still passes unchanged.

`CHANGES/13009.bugfix.rst` and a `CONTRIBUTORS.txt` entry
added per the project conventions.

## Are there changes in behavior for the user?

Yes. `parse_mimetype("text/html; ").parameters` previously
returned `MultiDict({'': ''})`; it now returns an empty-params
`MultiDict`, matching the existing bare-trailing-semicolon
case. Downstream code that iterates the params dict no longer
sees the spurious empty-key entry.

## Is it a substantial burden for the maintainers to support this?

No. One-character guard widening plus a parametrized test
case and a towncrier fragment. No public API change.

## Related issue number

Fixes #13009.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes (N/A — internal helper)
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
- [x] Add a new news fragment into the `CHANGES/` folder
  * name: `13009.bugfix.rst`
  * category: `bugfix`

Drafted with Zo Bot; reviewed by keenrose.