### PR TITLE
Remove unsupported View.connect from docs

### DIFF
--- a/CHANGES/4571.doc.rst
+++ b/CHANGES/4571.doc.rst
@@ -1,1 +1,1 @@
-Removed the unsupported ``View.connect()`` method from the list of overridable class-based view methods.
+Removed the unsupported ``View.connect()`` method from class-based view method documentation.

--- a/CHANGES/4571.doc.rst
+++ b/CHANGES/4571.doc.rst
@@ -1,0 +1,1 @@
+Removed the unsupported ``View.connect()`` method from the list of overridable class-based view methods.

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -2723,9 +2723,8 @@ View
       Request sent to view's constructor, read-only property.
 
 
-   Overridable coroutine methods: ``connect()``, ``delete()``,
-   ``get()``, ``head()``, ``options()``, ``patch()``, ``post()``,
-   ``put()``, ``trace()``.
+   Overridable coroutine methods: ``delete()``, ``get()``, ``head()``,
+   ``options()``, ``patch()``, ``post()``, ``put()``, ``trace()``.
 
 .. seealso:: :ref:`aiohttp-web-class-based-views`
 


### PR DESCRIPTION
## What do these changes do?

Remove ``connect()`` from the documented list of overridable ``web.View`` methods.

## Are there changes in behavior for the user?

No runtime behavior changes. This aligns the reference docs with aiohttp's current behavior and the maintainer note in #4571 that proxy-style CONNECT support is not intended for class-based views.

## Is it a substantial burden for the maintainers to support this?

No. This is a documentation-only correction plus the required changelog fragment.

## Related issue number

Fixes #4571.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * No code modification in this PR.
- [x] Add a new news fragment into the `CHANGES/` folder

Verification:

- `! rg -n "Overridable coroutine methods: .*connect\\(\\)" docs/web_reference.rst`
- `git diff --check`
