### PR TITLE
feat: add ssl parameter to ClientSession

### DIFF
--- a/CHANGES/13021.feature.rst
+++ b/CHANGES/13021.feature.rst
@@ -1,0 +1,1 @@
+Added an ``ssl`` parameter to :py:class:`~aiohttp.ClientSession` allowing a default SSL configuration to be applied to all requests -- by :user:`NIK-TIGER-BILL`.

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -208,7 +208,7 @@ class _WSConnectOptions(TypedDict, total=False):
     params: Query
     headers: LooseHeaders | None
     proxy: StrOrURL | None
-    ssl: SSLContext | bool | Fingerprint
+    ssl: SSLContext | bool | Fingerprint | _SENTINEL
     server_hostname: str | None
     proxy_headers: LooseHeaders | None
     compress: int
@@ -481,7 +481,7 @@ class ClientSession:
         read_until_eof: bool = True,
         proxy: StrOrURL | None = None,
         timeout: ClientTimeout | _SENTINEL | None = sentinel,
-        ssl: SSLContext | bool | Fingerprint = sentinel,
+        ssl: SSLContext | bool | Fingerprint | _SENTINEL = sentinel,
         server_hostname: str | None = None,
         proxy_headers: LooseHeaders | None = None,
         trace_request_ctx: object = None,
@@ -930,7 +930,7 @@ class ClientSession:
         params: Query = None,
         headers: LooseHeaders | None = None,
         proxy: StrOrURL | None = None,
-        ssl: SSLContext | bool | Fingerprint = sentinel,
+        ssl: SSLContext | bool | Fingerprint | _SENTINEL = sentinel,
         server_hostname: str | None = None,
         proxy_headers: LooseHeaders | None = None,
         compress: int = 0,
@@ -1005,7 +1005,7 @@ class ClientSession:
         params: Query = None,
         headers: LooseHeaders | None = None,
         proxy: StrOrURL | None = None,
-        ssl: SSLContext | bool | Fingerprint = sentinel,
+        ssl: SSLContext | bool | Fingerprint | _SENTINEL = sentinel,
         server_hostname: str | None = None,
         proxy_headers: LooseHeaders | None = None,
         compress: int = 0,

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -208,7 +208,7 @@ class _WSConnectOptions(TypedDict, total=False):
     params: Query
     headers: LooseHeaders | None
     proxy: StrOrURL | None
-    ssl: SSLContext | bool | Fingerprint | _SENTINEL
+    ssl: SSLContext | bool | Fingerprint
     server_hostname: str | None
     proxy_headers: LooseHeaders | None
     compress: int

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -283,6 +283,7 @@ class ClientSession:
         "_max_headers",
         "_resolve_charset",
         "_default_proxy",
+        "_default_ssl",
         "_retry_connection",
         "_middlewares",
     )
@@ -317,6 +318,7 @@ class ClientSession:
         fallback_charset_resolver: _CharsetResolver = lambda r, b: "utf-8",
         middlewares: Sequence[ClientMiddlewareType] = (),
         ssl_shutdown_timeout: _SENTINEL | None | float = sentinel,
+        ssl: SSLContext | bool | Fingerprint = True,
     ) -> None:
         # We initialise _connector to None immediately, as it's referenced in __del__()
         # and could cause issues if an exception occurs during initialisation.
@@ -347,6 +349,12 @@ class ClientSession:
                 "The ssl_shutdown_timeout parameter is deprecated and will be removed in aiohttp 4.0",
                 DeprecationWarning,
                 stacklevel=2,
+            )
+
+        if not isinstance(ssl, SSL_ALLOWED_TYPES):
+            raise TypeError(
+                "ssl should be SSLContext, Fingerprint, or bool, "
+                f"got {ssl!r} instead."
             )
 
         if connector is None:
@@ -407,6 +415,7 @@ class ClientSession:
         self._resolve_charset = fallback_charset_resolver
 
         self._default_proxy = proxy
+        self._default_ssl = ssl
         self._retry_connection: bool = True
         self._middlewares = tuple(middlewares)
 
@@ -472,7 +481,7 @@ class ClientSession:
         read_until_eof: bool = True,
         proxy: StrOrURL | None = None,
         timeout: ClientTimeout | _SENTINEL | None = sentinel,
-        ssl: SSLContext | bool | Fingerprint = True,
+        ssl: SSLContext | bool | Fingerprint = sentinel,
         server_hostname: str | None = None,
         proxy_headers: LooseHeaders | None = None,
         trace_request_ctx: object = None,
@@ -492,6 +501,8 @@ class ClientSession:
 
         method = method.upper()
 
+        if ssl is sentinel:
+            ssl = self._default_ssl
         if not isinstance(ssl, SSL_ALLOWED_TYPES):
             raise TypeError(
                 "ssl should be SSLContext, Fingerprint, or bool, "
@@ -919,7 +930,7 @@ class ClientSession:
         params: Query = None,
         headers: LooseHeaders | None = None,
         proxy: StrOrURL | None = None,
-        ssl: SSLContext | bool | Fingerprint = True,
+        ssl: SSLContext | bool | Fingerprint = sentinel,
         server_hostname: str | None = None,
         proxy_headers: LooseHeaders | None = None,
         compress: int = 0,
@@ -994,7 +1005,7 @@ class ClientSession:
         params: Query = None,
         headers: LooseHeaders | None = None,
         proxy: StrOrURL | None = None,
-        ssl: SSLContext | bool | Fingerprint = True,
+        ssl: SSLContext | bool | Fingerprint = sentinel,
         server_hostname: str | None = None,
         proxy_headers: LooseHeaders | None = None,
         compress: int = 0,
@@ -1050,6 +1061,8 @@ class ClientSession:
             extstr = ws_ext_gen(compress=compress)
             real_headers[hdrs.SEC_WEBSOCKET_EXTENSIONS] = extstr
 
+        if ssl is sentinel:
+            ssl = self._default_ssl
         if not isinstance(ssl, SSL_ALLOWED_TYPES):
             raise TypeError(
                 "ssl should be SSLContext, Fingerprint, or bool, "

--- a/tests/test_client_session.py
+++ b/tests/test_client_session.py
@@ -946,6 +946,35 @@ async def test_default_proxy() -> None:
     await session.close()
 
 
+async def test_default_ssl() -> None:
+    class OnCall(Exception):
+        pass
+
+    request_class_mock = mock.Mock(side_effect=OnCall())
+    session = ClientSession(ssl=False, request_class=request_class_mock)
+
+    assert session._default_ssl is False, "`ClientSession._default_ssl` not set"
+
+    with pytest.raises(OnCall):
+        await session.get("http://example.com")
+
+    assert request_class_mock.called, "request class not called"
+    assert (
+        request_class_mock.call_args[1].get("ssl") is False
+    ), "`ClientSession._request` uses default ssl not one used in ClientSession.get"
+
+    request_class_mock.reset_mock()
+    with pytest.raises(OnCall):
+        await session.get("http://example.com", ssl=True)
+
+    assert request_class_mock.called, "request class not called"
+    assert (
+        request_class_mock.call_args[1].get("ssl") is True
+    ), "`ClientSession._request` does not use per-request ssl"
+
+    await session.close()
+
+
 async def test_request_tracing(aiohttp_client: AiohttpClient) -> None:
     async def handler(request: web.Request) -> web.Response:
         return web.json_response({"ok": True})

--- a/tests/test_client_session.py
+++ b/tests/test_client_session.py
@@ -975,6 +975,35 @@ async def test_default_ssl() -> None:
     await session.close()
 
 
+async def test_default_ssl_ws() -> None:
+    class OnCall(Exception):
+        pass
+
+    request_class_mock = mock.Mock(side_effect=OnCall())
+    session = ClientSession(ssl=False, request_class=request_class_mock)
+
+    assert session._default_ssl is False, "`ClientSession._default_ssl` not set"
+
+    with pytest.raises(OnCall):
+        await session.ws_connect("http://example.com")
+
+    assert request_class_mock.called, "request class not called"
+    assert (
+        request_class_mock.call_args[1].get("ssl") is False
+    ), "`ClientSession._ws_connect` uses default ssl not one used in ClientSession.ws_connect"
+
+    request_class_mock.reset_mock()
+    with pytest.raises(OnCall):
+        await session.ws_connect("http://example.com", ssl=True)
+
+    assert request_class_mock.called, "request class not called"
+    assert (
+        request_class_mock.call_args[1].get("ssl") is True
+    ), "`ClientSession._ws_connect` does not use per-request ssl"
+
+    await session.close()
+
+
 async def test_request_tracing(aiohttp_client: AiohttpClient) -> None:
     async def handler(request: web.Request) -> web.Response:
         return web.json_response({"ok": True})


### PR DESCRIPTION
Add an `ssl` parameter to `ClientSession` that is used as the default SSL setting for all requests made by the session.

Closes #13006.

## Summary

This allows users to configure SSL once on the session instead of either:

- Passing `ssl=...` to every request.
- Creating a `TCPConnector(ssl=...)` manually, which is less intuitive.

When a request is made without an explicit `ssl` argument, the session's default is used. Per-request `ssl` values still override the session default.

## Changes

- Added `ssl` parameter to `ClientSession.__init__`.
- Stored it as `_default_ssl`.
- Updated `_request` and `_ws_connect` to fall back to `_default_ssl` when `ssl` is not provided.
- Added `test_default_ssl` verifying both session default and per-request override.

## Tests

Ran the new test and existing proxy/ssl session tests locally:

```bash
python -m pytest tests/test_client_session.py::test_default_ssl tests/test_client_session.py::test_default_proxy tests/test_client_session.py::test_ssl_shutdown_timeout_passed_to_connector tests/test_client_session.py::test_proxy_str -v
```

Result: 3 passed, 1 skipped.
