### PR TITLE
Fix nested parameter formatting in client reference

### DIFF
--- a/CHANGES/4127.doc.rst
+++ b/CHANGES/4127.doc.rst
@@ -1,0 +1,1 @@
+Moved nested parameter details out of reference field lists to avoid awkward documentation formatting.

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -2103,15 +2103,17 @@ ClientRequest
       This method is particularly useful in middleware when you need to modify the
       request body after the request has been created but before it's sent.
 
-      :param body: The new body content. Can be:
+      :param body: The new body content.
 
-                   - ``bytes``/``bytearray``: Raw binary data
-                   - ``str``: Text data (encoded using charset from Content-Type)
-                   - :class:`FormData`: Form data encoded as multipart/form-data
-                   - :class:`Payload`: A pre-configured payload object
-                   - ``AsyncIterable[bytes]``: Async iterable of bytes chunks
-                   - File-like object: Will be read and sent as binary data
-                   - ``None``: Clears the body
+      Accepted body values:
+
+      - ``bytes``/``bytearray``: Raw binary data
+      - ``str``: Text data (encoded using charset from Content-Type)
+      - :class:`FormData`: Form data encoded as multipart/form-data
+      - :class:`Payload`: A pre-configured payload object
+      - ``AsyncIterable[bytes]``: Async iterable of bytes chunks
+      - File-like object: Will be read and sent as binary data
+      - ``None``: Clears the body
 
       .. code-block:: python
 
@@ -2649,11 +2651,13 @@ on being called.
 
       Add one or more fields to the form.
 
-      :param fields: An iterable containing:
+      :param fields: An iterable containing fields to add.
 
-                     - :class:`io.IOBase`, e.g. a file-like object
-                     - :class:`multidict.MultiDict` or :class:`multidict.MultiDictProxy`
-                     - :class:`tuple` or :class:`list` of length two, containing a name-value pair
+      Accepted field values:
+
+      - :class:`io.IOBase`, e.g. a file-like object
+      - :class:`multidict.MultiDict` or :class:`multidict.MultiDictProxy`
+      - :class:`tuple` or :class:`list` of length two, containing a name-value pair
 
 Client exceptions
 -----------------


### PR DESCRIPTION
## What do these changes do?

Move nested parameter value details out of Sphinx field-list parameter bodies in the client reference. This keeps the ``:param:`` entries short and places the longer accepted-value lists as normal content below them.

Closes aio-libs/aiohttp-theme#117.

## Are there changes in behavior for the user?

No. This is documentation-only.

## Related issue number

aio-libs/aiohttp-theme#117

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] Add a new news fragment into the CHANGES folder

## Validation

- `git diff --check -- docs/client_reference.rst CHANGES/4127.doc.rst`
- `PATH=".venv-docs/bin:$PATH" make -C docs html SPHINXOPTS="-W --keep-going -n -E"` reached the full HTML build and only failed because local Graphviz `dot` is not installed; the warning is unrelated to this RST change.
