### PR TITLE
Fix DeprecationWarning for BaseRequest._transport_sockname in debug mode

### DIFF
--- a/CHANGES/13029.bugfix.rst
+++ b/CHANGES/13029.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed :class:`~aiohttp.web.BaseRequest` emitting a ``DeprecationWarning`` about its own ``_transport_sockname`` attribute by adding it to ``BaseRequest.ATTRS`` -- by :user:`uttam12331`.

--- a/aiohttp/web_request.py
+++ b/aiohttp/web_request.py
@@ -132,6 +132,7 @@ class BaseRequest(MutableMapping[str | RequestKey[Any], Any], HeadersMixin):
             "_loop",
             "_transport_sslcontext",
             "_transport_peername",
+            "_transport_sockname",
         ]
     )
     _post: MultiDictProxy[_Post] | None = None

--- a/tests/test_web_request.py
+++ b/tests/test_web_request.py
@@ -1281,3 +1281,14 @@ def test_etag_headers(header, header_attr, header_val, expected) -> None:
 def test_datetime_headers(header, header_attr, header_val, expected) -> None:
     req = make_mocked_request("GET", "/", headers={header: header_val})
     assert getattr(req, header_attr) == expected
+
+
+def test_transport_sockname_in_attrs() -> None:
+    """Ensure _transport_sockname is listed in BaseRequest.ATTRS.
+
+    Without this, aiohttp emits a DeprecationWarning about its own code when
+    running with PYTHONASYNCIODEBUG=1 (issue #13029).
+    """
+    from aiohttp.web import BaseRequest
+
+    assert "_transport_sockname" in BaseRequest.ATTRS


### PR DESCRIPTION
## What do these changes do?

Adds  to `BaseRequest.ATTRS` so that aiohttp no longer emits a `DeprecationWarning` about its own code.

## Are there changes in behavior for the user?

No. This is an internal fix — no public API changes.

## Related issue / discussion

Fixes #13029.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] `CHANGES/` folder contains a changelog entry for this PR