### PR TITLE
Fix _transport_sockname request initialization warning

### DIFF
--- a/CHANGES/13029.bugfix.rst
+++ b/CHANGES/13029.bugfix.rst
@@ -1,0 +1,3 @@
+Fixed a deprecation warning during request initialization by allowing
+``BaseRequest`` to assign ``_transport_sockname``.
+-- by :user:`nightcityblade`.

--- a/aiohttp/web_request.py
+++ b/aiohttp/web_request.py
@@ -132,6 +132,7 @@ class BaseRequest(MutableMapping[str | RequestKey[Any], Any], HeadersMixin):
             "_loop",
             "_transport_sslcontext",
             "_transport_peername",
+            "_transport_sockname",
         ]
     )
     _post: MultiDictProxy[_Post] | None = None

--- a/tests/test_web_request.py
+++ b/tests/test_web_request.py
@@ -167,6 +167,29 @@ def test_host_with_no_transport_sockname() -> None:
     assert req.host == ""
 
 
+def test_request_init_allows_transport_sockname_assignment() -> None:
+    message = make_mocked_request("GET", "/")._message
+    payload = mock.Mock()
+    payload_writer = mock.Mock()
+    task = mock.Mock()
+    loop = mock.Mock()
+    protocol = mock.Mock()
+    protocol.ssl_context = None
+    protocol.peername = None
+    protocol.sockname = ("127.0.0.1", 8080)
+
+    req = BaseRequest(
+        message,
+        payload,
+        protocol,
+        payload_writer,
+        task,
+        loop,
+    )
+
+    assert req._transport_sockname == ("127.0.0.1", 8080)
+
+
 def test_doubleslashes() -> None:
     # NB: //foo/bar is an absolute URL with foo netloc and /bar path
     req = make_mocked_request("GET", "/bar//foo/")


### PR DESCRIPTION
## What do these changes do?

Adds `_transport_sockname` to `BaseRequest.ATTRS` so request initialization can assign it without triggering the custom attribute deprecation warning, and adds a regression test.

## Are there changes in behavior for the user?

Users no longer get the deprecation warning when `BaseRequest` captures the transport socket name during initialization.

## Is it a substantial burden for the maintainers to support this?

No. The change keeps the existing private attribute assignment behavior aligned with the class's allowed attribute set.

## Related issue number

Fixes #13029

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
- [x] Add a new news fragment into the `CHANGES/` folder
