### PR TITLE
Fix datetime last_modified rounding

### DIFF
--- a/CHANGES/5303.bugfix.rst
+++ b/CHANGES/5303.bugfix.rst
@@ -1,0 +1,3 @@
+Aligned ``StreamResponse.last_modified`` datetime handling with the timestamp
+path so sub-second values round up consistently.
+-- by :user:`nightcityblade`.

--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -372,7 +372,7 @@ class StreamResponse(MutableMapping[str | ResponseKey[Any], Any], HeadersMixin):
             )
         elif isinstance(value, datetime.datetime):
             self._headers[hdrs.LAST_MODIFIED] = time.strftime(
-                "%a, %d %b %Y %H:%M:%S GMT", value.utctimetuple()
+                "%a, %d %b %Y %H:%M:%S GMT", time.gmtime(math.ceil(value.timestamp()))
             )
         elif isinstance(value, str):
             self._headers[hdrs.LAST_MODIFIED] = value

--- a/tests/test_web_response.py
+++ b/tests/test_web_response.py
@@ -339,6 +339,17 @@ def test_last_modified_datetime() -> None:
     assert resp.last_modified == dt
 
 
+def test_last_modified_datetime_rounds_like_timestamp() -> None:
+    resp = StreamResponse()
+
+    dt = datetime.datetime(2001, 2, 3, 4, 5, 6, 1000, datetime.timezone.utc)
+    resp.last_modified = dt
+
+    assert resp.last_modified == datetime.datetime(
+        2001, 2, 3, 4, 5, 7, tzinfo=datetime.timezone.utc
+    )
+
+
 def test_last_modified_reset() -> None:
     resp = StreamResponse()
 


### PR DESCRIPTION
## What do these changes do?

Makes `StreamResponse.last_modified` round `datetime` inputs the same way the numeric timestamp path already does, and adds a regression test for the sub-second case.

## Are there changes in behavior for the user?

Yes. Datetime values with fractional seconds now round up consistently instead of truncating the fractional part.

## Is it a substantial burden for the maintainers to support this?

No. This aligns two existing code paths that set the same header.

## Related issue number

Fixes #5303

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
- [x] Add a new news fragment into the `CHANGES/` folder
