### PR TITLE
catch unknown charset when decoding content-disposition params

### DIFF
--- a/CHANGES/13042.bugfix.rst
+++ b/CHANGES/13042.bugfix.rst
@@ -1,0 +1,4 @@
+Fixed :exc:`LookupError` (and an unguarded :exc:`UnicodeDecodeError`) escaping
+``Content-Disposition`` parsing when a multipart part supplies an extended
+parameter with an unknown charset, e.g. ``filename*=unknown-8bit''...``
+-- by :user:`arshsmith1`.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -55,6 +55,7 @@ Anton Zhdan-Pushkin
 Arcadiy Ivanov
 Arie Bovenberg
 Arseny Timoniq
+Arshiya Tabasum
 Artem Yushkovskiy
 Arthur Darcet
 Ashutosh Kumar Singh

--- a/aiohttp/multipart.py
+++ b/aiohttp/multipart.py
@@ -1,5 +1,6 @@
 import base64
 import binascii
+import builtins
 import json
 import re
 import sys
@@ -150,7 +151,10 @@ def parse_content_disposition(
 
             try:
                 value = unquote(value, encoding, "strict")
-            except UnicodeDecodeError:  # pragma: nocover
+            except (builtins.LookupError, UnicodeDecodeError):
+                # The charset is attacker-controlled here; an unknown name
+                # raises the builtin LookupError (the bare name is shadowed in
+                # this module by payload.LookupError).
                 warnings.warn(BadContentDispositionParam(item))
                 continue
 
@@ -208,7 +212,14 @@ def content_disposition_filename(
         if "'" in value:
             encoding, _, value = value.split("'", 2)
             encoding = encoding or "utf-8"
-            return unquote(value, encoding, "strict")
+            try:
+                return unquote(value, encoding, "strict")
+            except (builtins.LookupError, UnicodeDecodeError):
+                # Both the charset name and the octets are attacker-controlled
+                # here; an unknown encoding raises the builtin LookupError
+                # (shadowed in this module by payload.LookupError) and
+                # undecodable bytes raise UnicodeDecodeError.
+                return None
         return value
 
 

--- a/tests/test_multipart_helpers.py
+++ b/tests/test_multipart_helpers.py
@@ -525,21 +525,19 @@ class TestParseContentDisposition:
         assert "attachment" == disptype
         assert {} == params
 
-    def test_attwithfn2231unknowncharset(self) -> None:
-        # An unknown charset name is attacker-controlled and makes
-        # urllib.parse.unquote raise the builtin LookupError.
+    @pytest.mark.parametrize(
+        "header",
+        (
+            # An unknown charset name is attacker-controlled and makes
+            # urllib.parse.unquote raise the builtin LookupError.
+            "attachment; filename*=unknown-8bit''foo-%c3%a4.html",
+            # Undecodable octets raise UnicodeDecodeError.
+            "attachment; filename*=UTF-8''%ff.html",
+        ),
+    )
+    def test_attwithfn2231baddecode(self, header: str) -> None:
         with pytest.warns(aiohttp.BadContentDispositionParam):
-            disptype, params = parse_content_disposition(
-                "attachment; filename*=unknown-8bit''foo-%c3%a4.html"
-            )
-        assert "attachment" == disptype
-        assert {} == params
-
-    def test_attwithfn2231undecodable(self) -> None:
-        with pytest.warns(aiohttp.BadContentDispositionParam):
-            disptype, params = parse_content_disposition(
-                "attachment; filename*=UTF-8''%ff.html"
-            )
+            disptype, params = parse_content_disposition(header)
         assert "attachment" == disptype
         assert {} == params
 
@@ -715,12 +713,16 @@ class TestContentDispositionFilename:
         params = {"filename*0*": "UTF-8''foo-%c3%a4", "filename*1": ".html"}
         assert "foo-ä.html" == content_disposition_filename(params)
 
-    def test_attfncontenc_unknown_charset(self) -> None:
-        params = {"filename*0*": "unknown-8bit''foo-%c3%a4", "filename*1": ".html"}
-        assert content_disposition_filename(params) is None
-
-    def test_attfncontenc_undecodable(self) -> None:
-        params = {"filename*0*": "UTF-8''%ff", "filename*1": ".html"}
+    @pytest.mark.parametrize(
+        "params",
+        (
+            # Unknown charset name raises the builtin LookupError.
+            {"filename*0*": "unknown-8bit''foo-%c3%a4", "filename*1": ".html"},
+            # Undecodable octets raise UnicodeDecodeError.
+            {"filename*0*": "UTF-8''%ff", "filename*1": ".html"},
+        ),
+    )
+    def test_attfncontenc_baddecode(self, params: dict[str, str]) -> None:
         assert content_disposition_filename(params) is None
 
     def test_attfncontlz(self) -> None:

--- a/tests/test_multipart_helpers.py
+++ b/tests/test_multipart_helpers.py
@@ -525,6 +525,24 @@ class TestParseContentDisposition:
         assert "attachment" == disptype
         assert {} == params
 
+    def test_attwithfn2231unknowncharset(self) -> None:
+        # An unknown charset name is attacker-controlled and makes
+        # urllib.parse.unquote raise the builtin LookupError.
+        with pytest.warns(aiohttp.BadContentDispositionParam):
+            disptype, params = parse_content_disposition(
+                "attachment; filename*=unknown-8bit''foo-%c3%a4.html"
+            )
+        assert "attachment" == disptype
+        assert {} == params
+
+    def test_attwithfn2231undecodable(self) -> None:
+        with pytest.warns(aiohttp.BadContentDispositionParam):
+            disptype, params = parse_content_disposition(
+                "attachment; filename*=UTF-8''%ff.html"
+            )
+        assert "attachment" == disptype
+        assert {} == params
+
     def test_attwithfn2231dpct(self) -> None:
         disptype, params = parse_content_disposition(
             "attachment; filename*=UTF-8''A-%2541.html"
@@ -696,6 +714,14 @@ class TestContentDispositionFilename:
     def test_attfncontenc(self) -> None:
         params = {"filename*0*": "UTF-8''foo-%c3%a4", "filename*1": ".html"}
         assert "foo-ä.html" == content_disposition_filename(params)
+
+    def test_attfncontenc_unknown_charset(self) -> None:
+        params = {"filename*0*": "unknown-8bit''foo-%c3%a4", "filename*1": ".html"}
+        assert content_disposition_filename(params) is None
+
+    def test_attfncontenc_undecodable(self) -> None:
+        params = {"filename*0*": "UTF-8''%ff", "filename*1": ".html"}
+        assert content_disposition_filename(params) is None
 
     def test_attfncontlz(self) -> None:
         params = {"filename*0": "foo", "filename*01": "bar"}


### PR DESCRIPTION
## What do these changes do?

`parse_content_disposition` and `content_disposition_filename` decode RFC 5987 / 2231 extended parameters with `unquote(value, encoding, "strict")`, where the charset name comes straight from the (attacker-controlled) `Content-Disposition` header of a multipart part.

1. In `parse_content_disposition` the decode is wrapped in `except UnicodeDecodeError`, but an unknown charset name makes `unquote` raise the builtin `LookupError`, which slips past it. The bare name `LookupError` in this module is shadowed by `payload.LookupError`, so I reference `builtins.LookupError` to catch the real one.
2. `content_disposition_filename` runs the same decode on the reassembled continuation value with no guard at all, so both `LookupError` and `UnicodeDecodeError` propagate.

Reading `part.filename` / `part.name` on a crafted part then raises out of the parser. Both sites now give up the same way the existing `UnicodeDecodeError` branch already intended: the parameter is dropped, and no filename is returned.

Repro `Content-Disposition: form-data; name="x"; filename*=unknown-8bit''foo`: before, `LookupError: unknown encoding: unknown-8bit`; after, the parameter is ignored.

## Are there changes in behavior for the user?

Only for malformed input: an extended-parameter filename with an unknown charset, or undecodable bytes in the continuation form, is ignored instead of raising. Valid values are unchanged.

## Is it a substantial burden for the maintainers to support this?

No. It extends the existing exception handling by a few lines and adds unit tests next to the sibling cases.

## Related issue number

N/A

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes (N/A, internal parser behavior, no public API change)
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
- [x] Add a new news fragment into the `CHANGES/` folder
