### PR TITLE
Deprecate naive datetime in StreamResponse.last_modified setter

### DIFF
--- a/CHANGES/5304.deprecation.rst
+++ b/CHANGES/5304.deprecation.rst
@@ -1,0 +1,4 @@
+Deprecated passing a naive :class:`datetime.datetime` to
+:attr:`~aiohttp.web.StreamResponse.last_modified`. Use a timezone-aware
+datetime instead, e.g. ``datetime.now(datetime.timezone.utc)`` -- by
+:user:`amitmishra11`.

--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -267,6 +267,14 @@ class StreamResponse(
                 "%a, %d %b %Y %H:%M:%S GMT", time.gmtime(math.ceil(value))
             )
         elif isinstance(value, datetime.datetime):
+            if value.tzinfo is None:
+                warnings.warn(
+                    "Passing a naive datetime to last_modified is deprecated. "
+                    "Use a timezone-aware datetime instead, e.g. "
+                    "datetime.now(datetime.timezone.utc).",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
             self._headers[hdrs.LAST_MODIFIED] = time.strftime(
                 "%a, %d %b %Y %H:%M:%S GMT", value.utctimetuple()
             )

--- a/tests/test_web_response.py
+++ b/tests/test_web_response.py
@@ -302,6 +302,14 @@ def test_last_modified_datetime() -> None:
     assert resp.last_modified == dt
 
 
+def test_last_modified_datetime_naive_warns() -> None:
+    resp = web.StreamResponse()
+
+    naive_dt = datetime.datetime(2001, 2, 3, 4, 5, 6, 0)
+    with pytest.warns(DeprecationWarning, match="naive datetime"):
+        resp.last_modified = naive_dt
+
+
 def test_last_modified_reset() -> None:
     resp = web.StreamResponse()
 


### PR DESCRIPTION
## What do these changes do?

Emit a `DeprecationWarning` when a naive `datetime.datetime` is passed
to `StreamResponse.last_modified`. Previously, naive datetimes were
silently accepted, but `utctimetuple()` on a naive datetime returns the
local time fields unchanged, which then gets labelled as GMT in the
`Last-Modified` HTTP header. This means that calling
`resp.last_modified = datetime.now()` (which returns local time) would
produce an incorrect header value -- the local time would be stored
verbatim as if it were UTC.

The fix adds a clear deprecation warning directing users to timezone-aware
datetimes (e.g. `datetime.now(datetime.timezone.utc)`).

## Are there changes in behavior for the user?

Yes: passing a naive `datetime` now emits a `DeprecationWarning`. The
actual value stored in the header is unchanged from the previous
behaviour. A future release can raise a `TypeError` or `ValueError` for
naive datetimes once the deprecation period has elapsed.

## Is it a substantial burden for the maintainers to support this?

No. It is a one-line guard plus a warning in one setter, with a single
new test. The warning text is self-explanatory and points directly to
the fix.

## Related issue number

Fixes #5304

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] Add a new news fragment into the `CHANGES/` folder

<details>
<summary>Test output</summary>

```
============================= test session starts =============================
collected 10 items

tests/test_web_response.py::test_last_modified_initial PASSED
tests/test_web_response.py::test_last_modified_string PASSED
tests/test_web_response.py::test_last_modified_timestamp PASSED
tests/test_web_response.py::test_last_modified_datetime PASSED
tests/test_web_response.py::test_last_modified_datetime_naive_warns PASSED
tests/test_web_response.py::test_last_modified_reset PASSED
tests/test_web_response.py::test_last_modified_invalid_type PASSED
tests/test_web_response.py::test_last_modified_string_invalid[xxyyzz] PASSED
tests/test_web_response.py::test_last_modified_string_invalid[...] PASSED
tests/test_web_response.py::test_last_modified_string_invalid[...] PASSED
===================== 10 passed in 0.29s ==============================
```
</details>

Drafted with Claude Sonnet 4.6; reviewed by amitmishra11.