### PR TITLE
Restrict Dependabot to requirements/

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,8 @@ updates:
 
   # Maintain dependencies for Python
   - package-ecosystem: "pip"
-    directory: "/"
+    directories:
+    - "/requirements"
     allow:
       - dependency-type: "all"
     labels:
@@ -32,7 +33,8 @@ updates:
 
   # Maintain dependencies for Python aiohttp backport
   - package-ecosystem: "pip"
-    directory: "/"
+    directories:
+    - "/requirements"
     allow:
       - dependency-type: "all"
     labels:


### PR DESCRIPTION
Like other repos, it's starting to bump pyproject.toml stupidly.