### PR TITLE
parse_mimetype: skip whitespace-only segments after a semicolon

### DIFF
--- a/CHANGES/13009.bugfix.rst
+++ b/CHANGES/13009.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed :py:func:`~aiohttp.helpers.parse_mimetype` inserting a spurious empty-key

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -332,7 +332,7 @@ def parse_mimetype(mimetype: str) -> MimeType:
     parts = mimetype.split(";")
     params: MultiDict[str] = MultiDict()
     for item in parts[1:]:
-        if not item:
+        if not item.strip():
             continue
         key, _, value = item.partition("=")
         params.add(key.lower().strip(), value.strip(' "'))

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -83,6 +83,33 @@ def test_parse_mimetype(mimetype: str, expected: helpers.MimeType) -> None:
     assert result == expected
 
 
+@pytest.mark.parametrize(
+    "mimetype",
+    [
+        "text/html; ",
+        "text/html;  ",
+        "text/html;\t",
+        "text/html; \t",
+        "text/html; charset=utf-8; ",
+        "text/html; charset=utf-8;\t\t",
+    ],
+)
+def test_parse_mimetype_skips_whitespace_only_segments(
+    mimetype: str,
+) -> None:
+    # https://github.com/aio-libs/aiohttp/issues/13009
+    # A trailing ';' followed by whitespace (e.g. 'text/html; ') was being
+    # treated as a parameter with an empty key, producing {'': ''} in the
+    # parsed parameters. RFC 2045 says whitespace-only segments after a ';'
+    # are not valid parameters; a bare trailing ';' was already skipped
+    # because it becomes an empty string, but 'text/html; ' was truthy
+    # and slipped through.
+    result = helpers.parse_mimetype(mimetype)
+    assert "" not in result.parameters
+    if "charset=utf-8" in mimetype:
+        assert result.parameters.get("charset") == "utf-8"
+
+
 # ------------------- parse_content_type ------------------------------
 
 


### PR DESCRIPTION
## What changed

`parse_mimetype` now skips whitespace-only segments after a `;`, matching the
behavior for the already-handled empty segment from a bare trailing `;`.

A MIME type like `text/html; ` previously produced `{'': ''}` in the parsed
parameters; it now produces `{}`.

## Why

Per RFC 2045 a MIME type parameter is a `token=value` pair, and a bare
trailing `;` was already being skipped as an empty segment. A `;` followed
by whitespace was being treated as a parameter with an empty key, which is
not a valid MIME parameter. The check was `if not item: continue`; a
whitespace-only string is truthy, so it slipped through. Switching to
`if not item.strip(): continue` handles both cases the same way.

## Testing

- Added `test_parse_mimetype_skips_whitespace_only_segments` covering
  trailing whitespace, tabs, OWS between a real parameter and the
  trailing segment, and a real parameter that should still parse.
- All pre-existing parse_mimetype tests continue to pass.

Closes https://github.com/aio-libs/aiohttp/issues/13009

Drafted with Zo Bot; reviewed by <human handle>.
