### PR TITLE
escape backslashes in digest auth quoted-string values

### DIFF
--- a/CHANGES/13054.bugfix.rst
+++ b/CHANGES/13054.bugfix.rst
@@ -1,0 +1,4 @@
+Fixed ``escape_quotes`` in the Digest authentication middleware not escaping
+backslashes, so a ``WWW-Authenticate`` challenge value containing a backslash
+could break out of its quoted-string in the generated ``Authorization`` header
+-- by :user:`dxbjavid`.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -195,6 +195,7 @@ Jan Buchar
 Jan Gosmann
 Jarno Elonen
 Jashandeep Sohi
+Javid Khan
 Javier Torres
 Jean-Baptiste Estival
 Jens Steinhauser

--- a/aiohttp/client_middleware_digest_auth.py
+++ b/aiohttp/client_middleware_digest_auth.py
@@ -106,13 +106,13 @@ QUOTED_AUTH_FIELDS: Final[frozenset[str]] = frozenset(
 
 
 def escape_quotes(value: str) -> str:
-    """Escape double quotes for HTTP header values."""
-    return value.replace('"', '\\"')
+    """Escape backslashes and double quotes for HTTP quoted-strings."""
+    return value.replace("\\", "\\\\").replace('"', '\\"')
 
 
 def unescape_quotes(value: str) -> str:
-    """Unescape double quotes in HTTP header values."""
-    return value.replace('\\"', '"')
+    """Unescape backslashes and double quotes in HTTP quoted-strings."""
+    return value.replace('\\"', '"').replace("\\\\", "\\")
 
 
 def parse_header_pairs(header: str) -> dict[str, str]:

--- a/tests/test_client_middleware_digest_auth.py
+++ b/tests/test_client_middleware_digest_auth.py
@@ -525,6 +525,32 @@ async def test_escaping_quotes_in_auth_header() -> None:
     assert 'opaque="opaque\\"with\\"quotes"' in header
 
 
+async def test_backslash_in_challenge_cannot_break_quoting() -> None:
+    """A backslash in a server-supplied value must not escape the closing quote."""
+    auth = DigestAuthMiddleware("bob", "secret")
+    # A malicious/compromised server could return directives ending in a
+    # backslash; without escaping it the trailing quote of the field would be
+    # turned into an escaped quote, letting the value run into later directives.
+    auth._challenge = DigestAuthChallenge(
+        realm="realm\\",
+        nonce="n0",
+        qop="auth",
+        algorithm="MD5",
+        opaque="op\\",
+    )
+
+    header = await auth._encode("GET", URL("http://example.com/path"), b"")
+
+    assert 'realm="realm\\\\"' in header
+    assert 'opaque="op\\\\"' in header
+    # Re-parsing the header must recover the exact realm value, i.e. the
+    # backslash did not consume the closing quote and swallow ``nonce``.
+    params = parse_header_pairs(header[len("Digest ") :])
+    assert params["realm"] == "realm\\"
+    assert params["nonce"] == "n0"
+    assert params["opaque"] == "op\\"
+
+
 async def test_template_based_header_construction(
     auth_mw_with_challenge: DigestAuthMiddleware,
     mock_sha1_digest: mock.MagicMock,
@@ -598,7 +624,9 @@ async def test_template_based_header_construction(
         ),
         ('""', '\\"\\"', "Just double quotes"),
         ('"', '\\"', "Single double quote"),
-        ('already\\"escaped', 'already\\\\"escaped', "Already escaped quotes"),
+        ('already\\"escaped', 'already\\\\\\"escaped', "Already escaped quotes"),
+        ("back\\slash", "back\\\\slash", "Embedded backslash"),
+        ("trailing\\", "trailing\\\\", "Trailing backslash"),
     ],
 )
 def test_quote_escaping_functions(


### PR DESCRIPTION
## What do these changes do?

`escape_quotes` in the digest auth middleware only escaped double quotes and left backslashes untouched, so a value taken from a server's `WWW-Authenticate` challenge (realm, nonce or opaque) that ends in or contains a backslash produces a malformed quoted-string in the `Authorization` header the client sends back. A realm of `foo\` is emitted as `realm="foo\"`, where the intended closing quote now reads as an escaped quote, so a compliant quoted-string parser treats the realm as running on into the following `nonce`/`uri`/`response` directives. A malicious or compromised server can use this to corrupt or smuggle fields in the credentials header the client generates.

The rest of the codebase already escapes both characters when building HTTP quoted-strings (see `helpers.content_disposition_header` and the multipart writer), so this just brings `escape_quotes` in line with that, escaping the backslash before the quote, and makes `unescape_quotes` the exact inverse so the round-trip used when parsing challenges is preserved.

## Are there changes in behavior for the user?

Only for values that contain a backslash, which were previously encoded incorrectly. Values without a backslash are unchanged.

## Is it a substantial burden for the maintainers to support this?

No, it is a two-line change to a pair of helpers.

## Related issue number

N/A

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
- [x] Add a new news fragment into the `CHANGES/` folder
