### PR TITLE
helpers: skip whitespace-only segments after semicolons in parse_mimetype

### DIFF
--- a/CHANGES/13009.bugfix.rst
+++ b/CHANGES/13009.bugfix.rst
@@ -1,0 +1,1 @@
+Skipped whitespace-only segments after a semicolon in :py:func:`~aiohttp.helpers.parse_mimetype` so that stray ``; ``, ``;  ``, and ``;\t`` no longer pollute the parameter dict with a spurious empty key -- by :user:`HrachShah`.

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -332,7 +332,7 @@ def parse_mimetype(mimetype: str) -> MimeType:
     parts = mimetype.split(";")
     params: MultiDict[str] = MultiDict()
     for item in parts[1:]:
-        if not item:
+        if not item.strip():
             continue
         key, _, value = item.partition("=")
         params.add(key.lower().strip(), value.strip(' "'))

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -76,21 +76,15 @@ from aiohttp.helpers import (
         ),
         (
             "application/json; ",
-            helpers.MimeType(
-                "application", "json", "", MultiDictProxy(MultiDict())
-            ),
+            helpers.MimeType("application", "json", "", MultiDictProxy(MultiDict())),
         ),
         (
             "application/json;  ",
-            helpers.MimeType(
-                "application", "json", "", MultiDictProxy(MultiDict())
-            ),
+            helpers.MimeType("application", "json", "", MultiDictProxy(MultiDict())),
         ),
         (
             "application/json;\t",
-            helpers.MimeType(
-                "application", "json", "", MultiDictProxy(MultiDict())
-            ),
+            helpers.MimeType("application", "json", "", MultiDictProxy(MultiDict())),
         ),
         (
             "application/json; charset=utf-8; ",

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -74,6 +74,33 @@ from aiohttp.helpers import (
                 "text", "plain", "", MultiDictProxy(MultiDict({"base64": ""}))
             ),
         ),
+        (
+            "application/json; ",
+            helpers.MimeType(
+                "application", "json", "", MultiDictProxy(MultiDict())
+            ),
+        ),
+        (
+            "application/json;  ",
+            helpers.MimeType(
+                "application", "json", "", MultiDictProxy(MultiDict())
+            ),
+        ),
+        (
+            "application/json;\t",
+            helpers.MimeType(
+                "application", "json", "", MultiDictProxy(MultiDict())
+            ),
+        ),
+        (
+            "application/json; charset=utf-8; ",
+            helpers.MimeType(
+                "application",
+                "json",
+                "",
+                MultiDictProxy(MultiDict({"charset": "utf-8"})),
+            ),
+        ),
     ],
 )
 def test_parse_mimetype(mimetype: str, expected: helpers.MimeType) -> None:


### PR DESCRIPTION
## What do these changes do?

`parse_mimetype` (in `aiohttp/helpers.py`) splits the MIME type string on `;` and skips empty segments to ignore a bare trailing semicolon. The check `if not item: continue` only fires for empty strings — when a segment is whitespace-only (e.g. `text/html; `, `text/html;  `, `text/html;\t`), the loop falls through and `key, _, value = item.partition("=")` parses a single whitespace-only segment as an empty key with an empty value. The resulting `parameters` MultiDict contains a spurious `{'': ''}` entry that callers then have to filter out, and any subsequent parameter on the same MIME type (e.g. `text/html; charset=utf-8; `) ends up next to the bogus entry in the dict.

This change makes the guard `if not item.strip(): continue` so that whitespace-only segments are treated the same as fully empty ones and dropped.

## Are there changes in behavior for the user?

The user-visible effect is that the `MimeType.parameters` MultiDict for inputs like `text/html; `, `text/html;  `, or `text/html;\t` no longer contains a spurious `{'': ''}` entry. This is the behaviour the issue reporter and any other caller of `parse_mimetype` already expects.

## Is it a substantial burden for the maintainers to support this?

No. The change is a one-line tweak to a single helper plus matching test cases. The function's contract for empty segments already exists; this just extends it to whitespace-only segments.

## Related issue number

Fixes #13009

## Checklist

- [x] New code is fully covered by tests (4 new parametrize cases)
- [x] Changes are documented in `CHANGES/13009.bugfix.rst`
- [x] All existing tests still pass locally

<details>
<summary>Test output</summary>

```
$ PYTHONPATH=. python3 -m pytest tests/test_helpers.py -k parse_mimetype -v -p no:hypothesispytest
...
tests/test_helpers.py::test_parse_mimetype[application/json; -expected8] PASSED
tests/test_helpers.py::test_parse_mimetype[application/json;  -expected9] PASSED
tests/test_helpers.py::test_parse_mimetype[application/json;\t-expected10] PASSED
tests/test_helpers.py::test_parse_mimetype[application/json; charset=utf-8; -expected11] PASSED
====================== 12 passed, 129 deselected in 0.18s ======================
```

Pre-fix the 4 new parametrize cases fail with `AssertionError` because the parameters dict still contains `{'': ''}`. Post-fix all 12 pass.
</details>

Drafted with zo-computer (github-automation@zo.computer); reviewed by HrachShah.