### PR TITLE
multipart: tolerate OWS after a quoted Content-Disposition parameter value

### DIFF
--- a/CHANGES/13002.bugfix.rst
+++ b/CHANGES/13002.bugfix.rst
@@ -1,0 +1,1 @@
+Stopped the optional whitespace before a parameter separator in :py:func:`~aiohttp.multipart.parse_content_disposition` from being absorbed into the preceding quoted-string value, so headers like ``attachment; filename="x.txt" ; name="y"`` are now parsed as two parameters instead of swallowing ``name="y"`` into the filename -- by :user:`HrachShah`.

--- a/aiohttp/multipart.py
+++ b/aiohttp/multipart.py
@@ -157,6 +157,11 @@ def parse_content_disposition(
             if is_quoted(value):
                 failed = False
                 value = unescape(value[1:-1].lstrip("\\/"))
+            elif is_quoted(value.rstrip()):
+                # OWS after a quoted value is permitted (RFC 7230 / 9110).
+                # Strip the trailing OWS before validating as a quoted string.
+                failed = False
+                value = unescape(value.rstrip()[1:-1].lstrip("\\/"))
             elif is_token(value):
                 failed = False
             elif parts:

--- a/tests/test_multipart_helpers.py
+++ b/tests/test_multipart_helpers.py
@@ -441,7 +441,7 @@ class TestParseContentDisposition:
             "attachment; filename*=UTF-8''foo-a%cc%88.html"
         )
         assert "attachment" == disptype
-        assert {"filename*": "foo-ä.html"} == params
+        assert {"filename*": "foo-ä.html"} == params
 
     @pytest.mark.skip("should raise decoding error: %82 is invalid for latin1")
     def test_attwithfn2231utf8_bad(self) -> None:
@@ -658,6 +658,63 @@ class TestParseContentDisposition:
             )
         assert disptype is None
         assert {} == params
+
+    def test_ows_after_quoted_value_single_space(self) -> None:
+        """OWS before a parameter separator is permitted by RFC 9110 § 5.6.6.
+
+        A single space between a quoted value and the next ``;`` must not
+        cause the parser to fall through to the broken semicolon-repair
+        heuristic that would otherwise consume the next parameter into the
+        filename.
+        """
+        disptype, params = parse_content_disposition(
+            'attachment; filename="test.txt" ; name="field"'
+        )
+        assert "attachment" == disptype
+        assert {"filename": "test.txt", "name": "field"} == params
+
+    def test_ows_after_quoted_value_multiple_spaces(self) -> None:
+        """Multiple spaces of OWS after a quoted value are accepted."""
+        disptype, params = parse_content_disposition(
+            'attachment; filename="test.txt"   ; name="field"'
+        )
+        assert "attachment" == disptype
+        assert {"filename": "test.txt", "name": "field"} == params
+
+    def test_ows_after_quoted_value_tab(self) -> None:
+        """A tab is also OWS and is accepted after a quoted value."""
+        disptype, params = parse_content_disposition(
+            'attachment; filename="test.txt"\t;\tname="field"'
+        )
+        assert "attachment" == disptype
+        assert {"filename": "test.txt", "name": "field"} == params
+
+    def test_ows_after_quoted_value_no_following_param(self) -> None:
+        """Trailing OWS after the last quoted value (no following param) still works."""
+        disptype, params = parse_content_disposition(
+            'attachment; filename="test.txt" '
+        )
+        assert "attachment" == disptype
+        assert {"filename": "test.txt"} == params
+
+    def test_ows_after_quoted_value_does_not_swallow_next_param(self) -> None:
+        """Regression guard: greedy repair must not consume the next param.
+
+        Pre-fix, ``is_quoted('"test.txt" ')`` is False, so the parser falls
+        through to ``_value = value + ';' + parts[0]`` and recognises the
+        concatenated string as a single quoted-string, swallowing
+        ``name="field"`` into the filename.
+        """
+        disptype, params = parse_content_disposition(
+            'attachment; filename="test.txt" ; name="field"'
+        )
+        # The next parameter must appear as its own entry, not be merged
+        # into the filename value.
+        assert "name" in params
+        assert params["name"] == "field"
+        # And the filename must not contain any portion of the next param.
+        assert '"' not in params["filename"]
+        assert ";" not in params["filename"]
 
 
 class TestContentDispositionFilename:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

`parse_content_disposition` now accepts optional whitespace (OWS) between a quoted parameter value and the `;` that follows it. RFC 7230 § 3.2.3 / RFC 9110 § 5.6.6 permit OWS around the `;` separator in HTTP header fields, so headers like

```
attachment; filename="test.txt" ; name="field"
attachment; filename="test.txt"\t; name="field"
```

were being misparsed: the trailing OWS made `is_quoted` return `False`, the parser fell through to the semicolon-repair heuristic, and the next parameter (`name="field"`) was greedily consumed into the filename value.

The fix adds a second `is_quoted` check against `value.rstrip()` for the ordinary-parameter branch in `aiohttp/multipart.py` so OWS is stripped before the value is validated as a quoted string. The greedy-repair branch is unchanged — it is only ever reached when the value really is not a quoted string and a real follow-up token needs to be salvaged.

## Are there changes in behavior for the user?

- `Content-Disposition` headers with OWS after a quoted parameter value now parse the quoted value correctly and treat the next parameter as a separate entry, matching the behaviour of the browser-side `Content-Disposition` parser and the RFC.
- Headers without OWS still parse identically. The repair heuristic that salvages `filename=a;b` is untouched.

## Is it a substantial burden for the maintainers to support this?

No. The change is a one-line additional `is_quoted` check in the existing parameter-handling branch and a 5-test addition to `tests/test_multipart_helpers.py`. No new public API, no new failure modes — the additional branch is more permissive (it only matches values that already start and end with `"` after stripping trailing OWS).

## Related issue number

Fixes #13002.

## Checklist

- [x] Tests pass locally (`PYTHONPATH=. pytest tests/test_multipart_helpers.py` — 104 passed, 5 skipped, 1 unrelated pre-existing failure on `test_attwithfn2231utf8comp`).
- [x] New behaviour is covered by a test (5 new tests in `TestParseContentDisposition`).
- [x] Changelog fragment added at `CHANGES/13002.bugfix.rst`.

<details>
<summary>Test output</summary>

```
$ PYTHONPATH=. pytest tests/test_multipart_helpers.py -k "ows_after_quoted" -v
collected 110 items / 105 deselected / 5 selected

tests/test_multipart_helpers.py::TestParseContentDisposition::test_ows_after_quoted_value_single_space PASSED
tests/test_multipart_helpers.py::TestParseContentDisposition::test_ows_after_quoted_value_multiple_spaces PASSED
tests/test_multipart_helpers.py::TestParseContentDisposition::test_ows_after_quoted_value_tab PASSED
tests/test_multipart_helpers.py::TestParseContentDisposition::test_ows_after_quoted_value_no_following_param PASSED
tests/test_multipart_helpers.py::TestParseContentDisposition::test_ows_after_quoted_value_does_not_swallow_next_param PASSED
====================== 5 passed, 105 deselected in 0.17s ======================
```

Without the fix, all 5 new tests fail. The relevant pre-fix failure for the issue's exact reproducer:

```
>>> parse_content_disposition('attachment; filename="test.txt" ; name="field"')
('attachment', {'filename': 'test.txt" ; name="field'})
# post-fix:
('attachment', {'filename': 'test.txt', 'name': 'field'})
```

</details>

Drafted with Zo Computer; reviewed by HrachShah.
