### PR TITLE
escape backslashes in digest auth quoted header values

### DIFF
--- a/CHANGES/13111.bugfix.rst
+++ b/CHANGES/13111.bugfix.rst
@@ -1,0 +1,4 @@
+Fixed ``DigestAuthMiddleware`` leaving backslashes unescaped in quoted
+``Authorization`` header values, which corrupted logins such as
+``WORKGROUP\user`` and let a challenge value ending in a backslash escape its
+own closing quote -- by :user:`arshsmith1`.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -55,6 +55,7 @@ Anton Zhdan-Pushkin
 Arcadiy Ivanov
 Arie Bovenberg
 Arseny Timoniq
+Arshiya Tabasum
 Artem Yushkovskiy
 Arthur Darcet
 Ashutosh Kumar Singh

--- a/aiohttp/client_middleware_digest_auth.py
+++ b/aiohttp/client_middleware_digest_auth.py
@@ -102,13 +102,13 @@ QUOTED_AUTH_FIELDS: Final[frozenset[str]] = frozenset(
 
 
 def escape_quotes(value: str) -> str:
-    """Escape double quotes for HTTP header values."""
-    return value.replace('"', '\\"')
+    """Escape backslashes and double quotes for HTTP header values."""
+    return value.replace("\\", "\\\\").replace('"', '\\"')
 
 
 def unescape_quotes(value: str) -> str:
-    """Unescape double quotes in HTTP header values."""
-    return value.replace('\\"', '"')
+    """Unescape quoted-pairs (backslash escapes) in HTTP header values."""
+    return re.sub(r"\\(.)", r"\1", value)
 
 
 def parse_header_pairs(header: str) -> dict[str, str]:

--- a/tests/test_client_middleware_digest_auth.py
+++ b/tests/test_client_middleware_digest_auth.py
@@ -570,8 +570,8 @@ async def test_escaping_backslash_in_auth_header() -> None:
     assert 'realm="realm\\\\"' in header
     assert 'opaque="op\\\\aque"' in header
     # Every quoted field must still be closed by a lone quote followed by ", " or EOL.
+    params = parse_header_pairs(header[len("Digest ") :])
     for field in ("username", "realm", "nonce", "opaque"):
-        params = parse_header_pairs(header[len("Digest ") :])
         assert field in params
     assert params["username"] == "WORKGROUP\\user"
     assert params["realm"] == "realm\\"

--- a/tests/test_client_middleware_digest_auth.py
+++ b/tests/test_client_middleware_digest_auth.py
@@ -551,6 +551,33 @@ async def test_escaping_quotes_in_auth_header() -> None:
     assert 'opaque="opaque\\"with\\"quotes"' in header
 
 
+async def test_escaping_backslash_in_auth_header() -> None:
+    """A backslash in a quoted value must be escaped, not left to escape the quote."""
+    # WORKGROUP\user is a common Windows-style login; a challenge value ending in
+    # a backslash is attacker-controlled (realm/nonce/opaque come from the server).
+    auth = DigestAuthMiddleware("WORKGROUP\\user", "pass")
+    auth._challenge = DigestAuthChallenge(
+        realm="realm\\",
+        nonce="abc",
+        algorithm="MD5",
+        opaque="op\\aque",
+    )
+
+    header = await auth._encode("GET", URL("http://example.com/path"), b"")
+
+    # Backslashes are doubled so the closing quote is not swallowed.
+    assert 'username="WORKGROUP\\\\user"' in header
+    assert 'realm="realm\\\\"' in header
+    assert 'opaque="op\\\\aque"' in header
+    # Every quoted field must still be closed by a lone quote followed by ", " or EOL.
+    for field in ("username", "realm", "nonce", "opaque"):
+        params = parse_header_pairs(header[len("Digest ") :])
+        assert field in params
+    assert params["username"] == "WORKGROUP\\user"
+    assert params["realm"] == "realm\\"
+    assert params["opaque"] == "op\\aque"
+
+
 async def test_template_based_header_construction(
     auth_mw_with_challenge: DigestAuthMiddleware,
     mock_sha1_digest: mock.MagicMock,
@@ -624,7 +651,10 @@ async def test_template_based_header_construction(
         ),
         ('""', '\\"\\"', "Just double quotes"),
         ('"', '\\"', "Single double quote"),
-        ('already\\"escaped', 'already\\\\"escaped', "Already escaped quotes"),
+        ('already\\"escaped', 'already\\\\\\"escaped', "Already escaped quotes"),
+        ("WORKGROUP\\user", "WORKGROUP\\\\user", "Backslash in value"),
+        ("trail\\", "trail\\\\", "Trailing backslash"),
+        ('a\\b"c', 'a\\\\b\\"c', "Backslash and quote"),
     ],
 )
 def test_quote_escaping_functions(


### PR DESCRIPTION
## What do these changes do?

`escape_quotes` in the digest auth middleware only escaped double quotes, not backslashes, when building the `Authorization` header. A quoted value that contains a backslash then reaches the server unescaped, and a value ending in a backslash escapes its own closing quote so the rest of the header is swallowed into that field. `content_disposition_header` in `helpers.py` already escapes both characters; this brings the digest writer in line with it and makes `unescape_quotes` a proper inverse (any quoted-pair, not just `\"`).

A common trigger is a Windows-style login such as `WORKGROUP\user`: today it goes out as `username="WORKGROUP\user"` and the server unescapes it back to `WORKGROUPuser`. The `realm`, `nonce` and `opaque` values are taken from the server's challenge, so a value ending in a backslash also lets the challenge issuer break the structure of the header that gets sent back.

## Are there changes in behavior for the user?

Values containing backslashes are now emitted correctly. Values without backslashes are unchanged.

## Is it a substantial burden for the maintainers to support this?

No, it is two small helpers with a regression test.

## Related issue number

N/A

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
- [x] Add a new news fragment into the `CHANGES/` folder