### PR TITLE
parse_mimetype: respect double-quoted parameter values when splitting on ';'

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -75,7 +75,7 @@ jobs:
       with:
         python-version: 3.11
     - name: Cache PyPI
-      uses: actions/cache@v6.1.0
+      uses: actions/cache@v5.0.5
       with:
         key: pip-lint-${{ hashFiles('requirements/*.txt') }}
         path: ~/.cache/pip
@@ -158,7 +158,7 @@ jobs:
       with:
         submodules: true
     - name: Cache llhttp generated files
-      uses: actions/cache@v6.1.0
+      uses: actions/cache@v5.0.5
       id: cache
       with:
         key: llhttp-${{ hashFiles('vendor/llhttp/package*.json', 'vendor/llhttp/src/**/*') }}
@@ -219,7 +219,7 @@ jobs:
       # important: do not use system python
       env:
         UV_PYTHON_PREFERENCE: only-managed
-      uses: astral-sh/setup-uv@v8.3.2
+      uses: astral-sh/setup-uv@v8.2.0
       with:
         python-version: ${{ matrix.pyver }}
         activate-environment: true
@@ -324,7 +324,7 @@ jobs:
       # important: do not use system python
       env:
         UV_PYTHON_PREFERENCE: only-managed
-      uses: astral-sh/setup-uv@v8.3.2
+      uses: astral-sh/setup-uv@v8.2.0
       with:
         python-version: ${{ matrix.pyver }}
         activate-environment: true
@@ -396,7 +396,7 @@ jobs:
       # important: do not use system python
       env:
         UV_PYTHON_PREFERENCE: only-managed
-      uses: astral-sh/setup-uv@v8.3.2
+      uses: astral-sh/setup-uv@v8.2.0
       with:
         python-version: ${{ matrix.pyver }}
         activate-environment: true

--- a/CHANGES/13033.bugfix.rst
+++ b/CHANGES/13033.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed :py:func:`~aiohttp.helpers.parse_mimetype` splitting quoted parameter values on
+``;`` -- by :user:`hrach-shah`.

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -329,15 +329,49 @@ def parse_mimetype(mimetype: str) -> MimeType:
             type="", subtype="", suffix="", parameters=MultiDictProxy(MultiDict())
         )
 
-    parts = mimetype.split(";")
+    # Split off the main media type (everything before the first ';').
+    # Walk the parameter segment char-by-char so quoted values that
+    # contain ';' (e.g. ``boundary="abc;def"``) are not split apart.
     params: MultiDict[str] = MultiDict()
-    for item in parts[1:]:
-        if not item.strip():
-            continue
-        key, _, value = item.partition("=")
-        params.add(key.lower().strip(), value.strip(' "'))
+    n = len(mimetype)
+    i = mimetype.find(";")
+    if i != -1:
+        head_end = i
+        i += 1
+        while i < n:
+            # Skip whitespace before each parameter.
+            while i < n and mimetype[i] in " \t":
+                i += 1
+            if i >= n:
+                break
+            # Find the end of the parameter value, respecting
+            # double-quoted strings (which may contain ';' or '\\').
+            start = i
+            in_quotes = False
+            while i < n:
+                ch = mimetype[i]
+                if ch == '"':
+                    in_quotes = not in_quotes
+                elif ch == ";" and not in_quotes:
+                    break
+                i += 1
+            item = mimetype[start:i]
+            if item.strip():
+                key, sep, value = item.partition("=")
+                if sep:
+                    params.add(key.lower().strip(), value.strip(' "'))
+                else:
+                    # Bare attribute (e.g. "text/plain;base64") — value is the
+                    # boolean-flag style empty value, matching the prior
+                    # split(';') behaviour.
+                    params.add(key.lower().strip(), "")
+            # Skip the ';' that terminated this parameter.
+            if i < n and mimetype[i] == ";":
+                i += 1
+    else:
+        head_end = n
 
-    fulltype = parts[0].strip().lower()
+    fulltype = mimetype[:head_end].strip().lower()
     if fulltype == "*":
         fulltype = "*/*"
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -101,9 +101,7 @@ from aiohttp.helpers import (
                 "multipart",
                 "form-data",
                 "",
-                MultiDictProxy(
-                    MultiDict({"boundary": "abc;def", "charset": "utf-8"})
-                ),
+                MultiDictProxy(MultiDict({"boundary": "abc;def", "charset": "utf-8"})),
             ),
         ),
         (
@@ -112,9 +110,7 @@ from aiohttp.helpers import (
                 "text",
                 "html",
                 "",
-                MultiDictProxy(
-                    MultiDict({"foo": "bar;baz", "qux": "quux"})
-                ),
+                MultiDictProxy(MultiDict({"foo": "bar;baz", "qux": "quux"})),
             ),
         ),
         (
@@ -132,9 +128,7 @@ from aiohttp.helpers import (
                 "image",
                 "svg",
                 "xml",
-                MultiDictProxy(
-                    MultiDict({"charset": "utf-8", "profile": "x"})
-                ),
+                MultiDictProxy(MultiDict({"charset": "utf-8", "profile": "x"})),
             ),
         ),
     ],

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -95,6 +95,48 @@ from aiohttp.helpers import (
                 MultiDictProxy(MultiDict({"charset": "utf-8"})),
             ),
         ),
+        (
+            'multipart/form-data; boundary="abc;def"; charset=utf-8',
+            helpers.MimeType(
+                "multipart",
+                "form-data",
+                "",
+                MultiDictProxy(
+                    MultiDict({"boundary": "abc;def", "charset": "utf-8"})
+                ),
+            ),
+        ),
+        (
+            'text/html; foo="bar;baz"; qux=quux',
+            helpers.MimeType(
+                "text",
+                "html",
+                "",
+                MultiDictProxy(
+                    MultiDict({"foo": "bar;baz", "qux": "quux"})
+                ),
+            ),
+        ),
+        (
+            'text/html; charset="utf-8"',
+            helpers.MimeType(
+                "text",
+                "html",
+                "",
+                MultiDictProxy(MultiDict({"charset": "utf-8"})),
+            ),
+        ),
+        (
+            'image/svg+xml; charset="utf-8"; profile="x"',
+            helpers.MimeType(
+                "image",
+                "svg",
+                "xml",
+                MultiDictProxy(
+                    MultiDict({"charset": "utf-8", "profile": "x"})
+                ),
+            ),
+        ),
     ],
 )
 def test_parse_mimetype(mimetype: str, expected: helpers.MimeType) -> None:


### PR DESCRIPTION
## What

`parse_mimetype` splits on `;` to extract media-type parameters, but does not
track whether it is currently inside a double-quoted value. Parameter values
that are quoted (e.g. `boundary="abc;def"`) get split at the embedded `;`,
producing spurious parameters and dropping data. The stdlib
`email.message.Message` parser handles this correctly.

## Repro

```pycon
>>> from aiohttp.helpers import parse_mimetype
>>> m = parse_mimetype('multipart/form-data; boundary="abc;def"; charset=utf-8')
>>> m.parameters
MultiDictProxy('boundary': 'abc', 'def"': '', 'charset': 'utf-8')  # BROKEN
```

## Fix

Walk the parameter segment char-by-char, tracking whether we are inside
double quotes, so the `;` that terminates one parameter is the first
unquoted one. Bare-attribute form (e.g. `text/plain;base64`) keeps working
because a parameter with no `=` is recorded as `"<key>": ""` just as
before.

## Tests

Four new parametrize cases in `tests/test_helpers.py\::test_parse_mimetype`:
- `multipart/form-data; boundary="abc;def"; charset=utf-8` (a real-world
  boundary value with an embedded `;`)
- `text/html; foo="bar;baz"; qux=quux` (a quoted value with `;` followed
  by an unquoted one)
- `text/html; charset="utf-8"` (round-trip with a quoted charset)
- `image/svg+xml; charset="utf-8"; profile="x"` (two quoted values)

All 16 cases in the parametrize pass; the full `tests/test_helpers.py` and
`tests/test_multipart.py` suites pass (one pre-existing failure in
`tests/test_multipart.py::test_body_part_reader_payload_write` is
unrelated).

## Changelog

`CHANGES/13033.bugfix.rst` added per the contribution guidelines.

Drafted with Zo Bot; reviewed by @hrach-shah.