### PR TITLE
[PR #12895/64313cfc backport][3.15] reject websocket close codes above the valid range

### DIFF
--- a/CHANGES/12895.bugfix.rst
+++ b/CHANGES/12895.bugfix.rst
@@ -1,0 +1,4 @@
+Rejected WebSocket ``CLOSE`` frames carrying a status code above the
+valid range (greater than ``4999``) with a protocol error, matching the
+existing handling of out-of-range low codes, per :rfc:`6455#section-7.4.1`
+-- by :user:`dxbjavid`.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -117,6 +117,7 @@ Dmitry Trofimov
 Dmytro Bohomiakov
 Dmytro Kuznetsov
 Dustin J. Mitchell
+dxbjavid
 Earle Lowe
 Eduard Iskandarov
 Eli Ribble

--- a/aiohttp/_websocket/reader_py.py
+++ b/aiohttp/_websocket/reader_py.py
@@ -291,7 +291,10 @@ class WebSocketReader:
         elif opcode == OP_CODE_CLOSE:
             if len(payload) >= 2:
                 close_code = UNPACK_CLOSE_CODE(payload[:2])[0]
-                if close_code < 3000 and close_code not in ALLOWED_CLOSE_CODES:
+                # https://datatracker.ietf.org/doc/html/rfc6455#section-7.4.2
+                if close_code > 4999 or (
+                    close_code < 3000 and close_code not in ALLOWED_CLOSE_CODES
+                ):
                     raise WebSocketError(
                         WSCloseCode.PROTOCOL_ERROR,
                         f"Invalid close code: {close_code}",

--- a/tests/test_websocket_parser.py
+++ b/tests/test_websocket_parser.py
@@ -283,9 +283,9 @@ def test_close_frame(out: WebSocketDataQueue, parser: PatchableWebSocketReader) 
 def test_close_frame_info(
     out: WebSocketDataQueue, parser: PatchableWebSocketReader
 ) -> None:
-    parser._handle_frame(True, WSMsgType.CLOSE, b"0112345", 0)
+    parser._handle_frame(True, WSMsgType.CLOSE, b"\x03\xe912345", 0)
     res = out._buffer[0]
-    assert res == (WSMessage(WSMsgType.CLOSE, 12337, "12345"), 0)
+    assert res == (WSMessage(WSMsgType.CLOSE, 1001, "12345"), 0)
 
 
 def test_close_frame_invalid(
@@ -300,6 +300,18 @@ def test_close_frame_invalid_2(
     out: WebSocketDataQueue, parser: PatchableWebSocketReader
 ) -> None:
     data = build_close_frame(code=1)
+
+    with pytest.raises(WebSocketError) as ctx:
+        parser._feed_data(data)
+
+    assert ctx.value.code == WSCloseCode.PROTOCOL_ERROR
+
+
+@pytest.mark.parametrize("code", (5000, 9999, 65535))
+def test_close_frame_invalid_code_above_range(
+    parser: PatchableWebSocketReader, code: int
+) -> None:
+    data = build_close_frame(code=code)
 
     with pytest.raises(WebSocketError) as ctx:
         parser._feed_data(data)


### PR DESCRIPTION
**This is a backport of PR #12895 as merged into master (64313cfc5024a316d85f34e7e77c9995a683e35f).**

## What do these changes do?

The websocket reader already rejects invalid close codes when it parses a CLOSE frame, but only at the low end of the range: a code under 3000 that isn't one of the registered ones raises a protocol error. There's no matching check at the top, so anything from 5000 up to 65535 is treated as a perfectly normal close code. :rfc:`6455#section-7.4.1` only defines status codes up to 4999, so a peer can send a CLOSE frame carrying e.g. 65535 and we hand that straight through to the application as the close code rather than failing the connection. I noticed it while reading the close handling next to the lower-bound guard and the upper half just wasn't there. This adds the missing `> 4999` check alongside the existing one so out-of-range codes are rejected the same way the low ones are.

## Are there changes in behavior for the user?

A CLOSE frame whose status code is above 4999 now raises a protocol error instead of being delivered as a valid close. Codes in the permitted 1000-4999 range behave exactly as before.

## Is it a substantial burden for the maintainers to support this?

No, it's a one-line addition to a check that already exists.

## Related issue number

None. Spotted while reading through the close-frame handling.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes — N/A
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
- [x] Add a new news fragment into the `CHANGES/` folder