### PR TITLE
Add the ssl parameter to ClientSession

### DIFF
--- a/CHANGES/13006.feature.rst
+++ b/CHANGES/13006.feature.rst
@@ -1,0 +1,4 @@
+Added the ``ssl`` parameter to :class:`~aiohttp.ClientSession`, setting the
+default SSL validation mode for every request made through the session; a
+per-request ``ssl`` argument still takes precedence -- by
+:user:`rodrigobnogueira`.

--- a/CHANGES/13122.feature.rst
+++ b/CHANGES/13122.feature.rst
@@ -1,0 +1,1 @@
+13006.feature.rst

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -184,7 +184,7 @@ class _RequestOptions(TypedDict, total=False):
     read_until_eof: bool
     proxy: StrOrURL | None
     timeout: "ClientTimeout | _SENTINEL | None"
-    ssl: SSLContext | bool | Fingerprint
+    ssl: SSLContext | bool | Fingerprint | _SENTINEL
     server_hostname: str | None
     proxy_headers: LooseHeaders | None
     trace_request_ctx: object
@@ -208,7 +208,7 @@ class _WSConnectOptions(TypedDict, total=False):
     params: Query
     headers: LooseHeaders | None
     proxy: StrOrURL | None
-    ssl: SSLContext | bool | Fingerprint
+    ssl: SSLContext | bool | Fingerprint | _SENTINEL
     server_hostname: str | None
     proxy_headers: LooseHeaders | None
     compress: int
@@ -283,6 +283,7 @@ class ClientSession:
         "_max_headers",
         "_resolve_charset",
         "_default_proxy",
+        "_default_ssl",
         "_retry_connection",
         "_middlewares",
     )
@@ -295,6 +296,7 @@ class ClientSession:
         cookies: LooseCookies | None = None,
         headers: LooseHeaders | None = None,
         proxy: StrOrURL | None = None,
+        ssl: SSLContext | bool | Fingerprint = True,
         skip_auto_headers: Iterable[str] | None = None,
         json_serialize: JSONEncoder = json.dumps,
         json_serialize_bytes: JSONBytesEncoder | None = None,
@@ -330,6 +332,12 @@ class ClientSession:
             assert self._base_url.absolute, "Only absolute URLs are supported"
         if self._base_url is not None and not self._base_url.path.endswith("/"):
             raise ValueError("base_url must have a trailing '/'")
+
+        if not isinstance(ssl, SSL_ALLOWED_TYPES):
+            raise TypeError(
+                "ssl should be SSLContext, Fingerprint, or bool, "
+                f"got {ssl!r} instead."
+            )
 
         loop = asyncio.get_running_loop()
 
@@ -407,6 +415,7 @@ class ClientSession:
         self._resolve_charset = fallback_charset_resolver
 
         self._default_proxy = proxy
+        self._default_ssl = ssl
         self._retry_connection: bool = True
         self._middlewares = tuple(middlewares)
 
@@ -472,7 +481,7 @@ class ClientSession:
         read_until_eof: bool = True,
         proxy: StrOrURL | None = None,
         timeout: ClientTimeout | _SENTINEL | None = sentinel,
-        ssl: SSLContext | bool | Fingerprint = True,
+        ssl: SSLContext | bool | Fingerprint | _SENTINEL = sentinel,
         server_hostname: str | None = None,
         proxy_headers: LooseHeaders | None = None,
         trace_request_ctx: object = None,
@@ -492,6 +501,8 @@ class ClientSession:
 
         method = method.upper()
 
+        if ssl is sentinel:
+            ssl = self._default_ssl
         if not isinstance(ssl, SSL_ALLOWED_TYPES):
             raise TypeError(
                 "ssl should be SSLContext, Fingerprint, or bool, "
@@ -923,7 +934,7 @@ class ClientSession:
         params: Query = None,
         headers: LooseHeaders | None = None,
         proxy: StrOrURL | None = None,
-        ssl: SSLContext | bool | Fingerprint = True,
+        ssl: SSLContext | bool | Fingerprint | _SENTINEL = sentinel,
         server_hostname: str | None = None,
         proxy_headers: LooseHeaders | None = None,
         compress: int = 0,
@@ -998,7 +1009,7 @@ class ClientSession:
         params: Query = None,
         headers: LooseHeaders | None = None,
         proxy: StrOrURL | None = None,
-        ssl: SSLContext | bool | Fingerprint = True,
+        ssl: SSLContext | bool | Fingerprint | _SENTINEL = sentinel,
         server_hostname: str | None = None,
         proxy_headers: LooseHeaders | None = None,
         compress: int = 0,
@@ -1054,7 +1065,7 @@ class ClientSession:
             extstr = ws_ext_gen(compress=compress)
             real_headers[hdrs.SEC_WEBSOCKET_EXTENSIONS] = extstr
 
-        if not isinstance(ssl, SSL_ALLOWED_TYPES):
+        if ssl is not sentinel and not isinstance(ssl, SSL_ALLOWED_TYPES):
             raise TypeError(
                 "ssl should be SSLContext, Fingerprint, or bool, "
                 f"got {ssl!r} instead."

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -184,7 +184,7 @@ The client session supports the context manager protocol for self closing.
 
       A per-request ``ssl`` argument overrides this value.
 
-      .. versionadded:: 4.0
+      .. versionadded:: 3.15
 
    :param bool trust_env: Trust environment settings for proxy configuration if the parameter
       is ``True`` (``False`` by default). See :ref:`aiohttp-client-proxy-support` for
@@ -534,7 +534,7 @@ The client session supports the context manager protocol for self closing.
 
          .. versionadded:: 3.0
 
-         .. versionchanged:: 4.0
+         .. versionchanged:: 3.15
 
             Defaults to the session's ``ssl`` value.
 
@@ -797,7 +797,7 @@ The client session supports the context manager protocol for self closing.
 
          .. versionadded:: 3.0
 
-         .. versionchanged:: 4.0
+         .. versionchanged:: 3.15
 
             Defaults to the session's ``ssl`` value.
 

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -50,6 +50,7 @@ The client session supports the context manager protocol for self closing.
                          raise_for_status=False, \
                          timeout=sentinel, \
                          auto_decompress=True, \
+                         ssl=True, \
                          trust_env=False, \
                          requote_redirect_url=True, \
                          trace_configs=None, \
@@ -172,6 +173,18 @@ The client session supports the context manager protocol for self closing.
    :param bool auto_decompress: Automatically decompress response body (``True`` by default).
 
       .. versionadded:: 2.3
+
+   :param ssl: Default SSL validation mode for requests made through this
+      session. ``True`` for default SSL check
+      (:func:`ssl.create_default_context` is used),
+      ``False`` for skip SSL certificate validation,
+      :class:`aiohttp.Fingerprint` for fingerprint
+      validation, :class:`ssl.SSLContext` for custom SSL
+      certificate validation (``True`` by default).
+
+      A per-request ``ssl`` argument overrides this value.
+
+      .. versionadded:: 4.0
 
    :param bool trust_env: Trust environment settings for proxy configuration if the parameter
       is ``True`` (``False`` by default). See :ref:`aiohttp-client-proxy-support` for
@@ -516,7 +529,14 @@ The client session supports the context manager protocol for self closing.
                   Supersedes *verify_ssl*, *ssl_context* and
                   *fingerprint* parameters.
 
+                  When not given, the session's ``ssl`` value is used
+                  (``True`` unless set).
+
          .. versionadded:: 3.0
+
+         .. versionchanged:: 4.0
+
+            Defaults to the session's ``ssl`` value.
 
       :param str server_hostname: Sets or overrides the host name that the
          target server's certificate will be matched against.
@@ -772,7 +792,14 @@ The client session supports the context manager protocol for self closing.
                   Supersedes *verify_ssl*, *ssl_context* and
                   *fingerprint* parameters.
 
+                  When not given, the session's ``ssl`` value is used
+                  (``True`` unless set).
+
          .. versionadded:: 3.0
+
+         .. versionchanged:: 4.0
+
+            Defaults to the session's ``ssl`` value.
 
       :param bool verify_ssl: Perform SSL certificate validation for
          *HTTPS* requests (enabled by default). May be disabled to

--- a/tests/test_client_session.py
+++ b/tests/test_client_session.py
@@ -3,6 +3,7 @@ import contextlib
 import gc
 import io
 import json
+import ssl
 import sys
 import warnings
 from collections import deque
@@ -944,6 +945,71 @@ async def test_default_proxy() -> None:
     ), "`ClientSession._request` uses per-request proxy not session default"
 
     await session.close()
+
+
+async def test_default_ssl() -> None:
+    ssl_ctx = ssl.create_default_context()
+
+    class OnCall(Exception):
+        pass
+
+    request_class_mock = mock.Mock(side_effect=OnCall())
+    session = ClientSession(ssl=ssl_ctx, request_class=request_class_mock)
+
+    assert session._default_ssl is ssl_ctx, "`ClientSession._default_ssl` not set"
+
+    with pytest.raises(OnCall):
+        await session.get("http://example.com")
+
+    assert request_class_mock.called, "request class not called"
+    assert (
+        request_class_mock.call_args[1].get("ssl") is ssl_ctx
+    ), "`ClientSession._request` does not use the session default ssl"
+
+    request_class_mock.reset_mock()
+    with pytest.raises(OnCall):
+        await session.get("http://example.com", ssl=False)
+
+    assert request_class_mock.called, "request class not called"
+    assert (
+        request_class_mock.call_args[1].get("ssl") is False
+    ), "`ClientSession._request` uses session default ssl not the per-request one"
+
+    request_class_mock.reset_mock()
+    with pytest.raises(OnCall):
+        await session.get("http://example.com", ssl=True)
+
+    assert request_class_mock.called, "request class not called"
+    assert (
+        request_class_mock.call_args[1].get("ssl") is True
+    ), "explicit `ssl=True` should not be replaced by the session default"
+
+    await session.close()
+
+
+async def test_default_ssl_not_set() -> None:
+    class OnCall(Exception):
+        pass
+
+    request_class_mock = mock.Mock(side_effect=OnCall())
+    session = ClientSession(request_class=request_class_mock)
+
+    with pytest.raises(OnCall):
+        await session.get("http://example.com")
+
+    assert request_class_mock.called, "request class not called"
+    assert (
+        request_class_mock.call_args[1].get("ssl") is True
+    ), "the default ssl mode should stay `True` when not configured"
+
+    await session.close()
+
+
+async def test_default_ssl_invalid_type() -> None:
+    with pytest.raises(
+        TypeError, match="ssl should be SSLContext, Fingerprint, or bool"
+    ):
+        ClientSession(ssl="/some/cert.pem")  # type: ignore[arg-type]
 
 
 async def test_request_tracing(aiohttp_client: AiohttpClient) -> None:


### PR DESCRIPTION
## What do these changes do?

Add an `ssl` parameter to `ClientSession`, setting the default SSL validation mode for every request made through the session. Today the only session-wide alternative is `connector=aiohttp.TCPConnector(ssl=...)`, which is not intuitive, or repeating `ssl=` on each request.

The per-request `ssl` default moves from `True` to `sentinel` (the same pattern `timeout` uses), so an explicit per-request `ssl=True` still means "use the default SSL check" and is never replaced by the session value; any explicit per-request value takes precedence over the session default. `ws_connect()` follows the same rule. The invalid-type `TypeError` is raised at session creation for the session value and unchanged for per-request values.

## Are there changes in behavior for the user?

No behavior change for existing code: with the parameter unset, the session default is `True`, which resolves exactly as before. New behavior is opt-in.

## Is it a substantial burden for the maintainers to support this?

I believe not: it is one stored attribute plus a two-line sentinel resolution in `_request()`, mirroring the existing session-level `proxy` default. No new code path beyond the substitution.

Note: `THREAT_MODEL.md` was reviewed; it has no client TLS-validation chunk, so no update seemed warranted. Happy to add one if you prefer, since `ssl=False` can now be set session-wide.

## Related issue number

Fixes #13006

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * Already listed.
- [x] Add a new news fragment into the `CHANGES/` folder
  * `CHANGES/13006.feature.rst`, PR-number symlink added after PR creation.

<details>
<summary>Test and lint runs</summary>

```
$ python -m pytest tests/test_client_session.py tests/test_client_ws.py
134 passed, 1 skipped

$ python -m mypy aiohttp/client.py   # 0 errors in aiohttp/client.py (13 pre-existing baseline errors in other files)

$ pre-commit run --files aiohttp/client.py tests/test_client_session.py docs/client_reference.rst CHANGES/13006.feature.rst
all hooks passed
```

</details>
