### PR TITLE
Dependabot cooldown and versioning-strategy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,9 @@ updates:
   # Maintain dependencies for Python
   - package-ecosystem: "pip"
     directory: "/"
+    versioning-strategy: "increase-if-necessary"
+    cooldown:
+      default-days: 3
     allow:
       - dependency-type: "all"
     labels:
@@ -33,6 +36,9 @@ updates:
   # Maintain dependencies for Python aiohttp backport
   - package-ecosystem: "pip"
     directory: "/"
+    versioning-strategy: "increase-if-necessary"
+    cooldown:
+      default-days: 3
     allow:
       - dependency-type: "all"
     labels:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
   # Maintain dependencies for GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
+    cooldown:
+      default-days: 3
     labels:
       - dependencies
     schedule:
@@ -26,6 +28,8 @@ updates:
   # Maintain dependencies for GitHub Actions aiohttp backport
   - package-ecosystem: "github-actions"
     directory: "/"
+    cooldown:
+      default-days: 3
     labels:
       - dependencies
     target-branch: "3.15"
@@ -50,6 +54,8 @@ updates:
 
   - package-ecosystem: "docker"
     directory: "/tests/autobahn/"
+    cooldown:
+      default-days: 3
     labels:
       - dependencies
     schedule:
@@ -57,6 +63,8 @@ updates:
 
   - package-ecosystem: "docker"
     directory: "/tests/autobahn/"
+    cooldown:
+      default-days: 3
     labels:
       - dependencies
     target-branch: "3.15"


### PR DESCRIPTION
Dependabot auto versioning strategy has broken (and probably brittle generally), so we use an explicit one here.
Strategy should be widen (what auto uses when the check works correctly), but inexplicably that is not available for explicit configuration currently, so using the closest match to that one.

Also adding a cooldown for supply chain risks.