### PR TITLE
Handle request body decode errors as HTTP 415

### DIFF
--- a/CHANGES/13099.bugfix.rst
+++ b/CHANGES/13099.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed ``BaseRequest.text()`` and ``application/x-www-form-urlencoded`` request parsing to return HTTP 415 when body bytes fail to decode with the declared charset -- by :user:`cyphercodes`.

--- a/CHANGES/13099.bugfix.rst
+++ b/CHANGES/13099.bugfix.rst
@@ -1,1 +1,1 @@
-Fixed ``BaseRequest.text()`` and ``application/x-www-form-urlencoded`` request parsing to return HTTP 415 when body bytes fail to decode with the declared charset -- by :user:`cyphercodes`.
+Fixed ``BaseRequest.text()`` and ``application/x-www-form-urlencoded`` request parsing to return HTTP 415 when body bytes fail to decode with the default charset -- by :user:`cyphercodes`.

--- a/aiohttp/web_request.py
+++ b/aiohttp/web_request.py
@@ -665,7 +665,7 @@ class BaseRequest(MutableMapping[str | RequestKey[Any], Any], HeadersMixin):
         encoding = self.charset or "utf-8"
         try:
             return bytes_body.decode(encoding)
-        except LookupError:
+        except (LookupError, UnicodeDecodeError):
             raise HTTPUnsupportedMediaType()
 
     async def json(
@@ -790,7 +790,7 @@ class BaseRequest(MutableMapping[str | RequestKey[Any], Any], HeadersMixin):
                 bytes_query = data.rstrip()
                 try:
                     query = bytes_query.decode(charset)
-                except LookupError:
+                except (LookupError, UnicodeDecodeError):
                     raise HTTPUnsupportedMediaType()
                 out.extend(
                     parse_qsl(qs=query, keep_blank_values=True, encoding=charset)

--- a/tests/test_web_request.py
+++ b/tests/test_web_request.py
@@ -993,7 +993,7 @@ async def test_multipart_formdata(protocol: BaseProtocol) -> None:
     assert dict(result) == {"a": "b", "c": "d"}
 
 
-async def test_urlencoded_form_with_invalid_content_type_encoding(
+async def test_urlencoded_form_with_invalid_default_encoding(
     protocol: BaseProtocol,
 ) -> None:
     payload = StreamReader(
@@ -1002,7 +1002,7 @@ async def test_urlencoded_form_with_invalid_content_type_encoding(
     payload.feed_data(b"a=1&b=\xff")
     payload.feed_eof()
     headers = {
-        "Content-Type": "application/x-www-form-urlencoded; charset=utf-8",
+        "Content-Type": "application/x-www-form-urlencoded",
     }
     req = make_mocked_request("POST", "/", payload=payload, headers=headers)
 

--- a/tests/test_web_request.py
+++ b/tests/test_web_request.py
@@ -930,6 +930,22 @@ async def test_request_with_wrong_content_type_encoding(protocol: BaseProtocol) 
     assert err.value.status_code == 415
 
 
+async def test_request_text_with_invalid_content_type_encoding(
+    protocol: BaseProtocol,
+) -> None:
+    payload = StreamReader(
+        protocol, DEFAULT_CHUNK_SIZE, loop=asyncio.get_running_loop()
+    )
+    payload.feed_data(b"\xff")
+    payload.feed_eof()
+    headers = {"Content-Type": "text/html; charset=utf-8"}
+    req = make_mocked_request("POST", "/", payload=payload, headers=headers)
+
+    with pytest.raises(web.HTTPUnsupportedMediaType) as err:
+        await req.text()
+    assert err.value.status_code == 415
+
+
 async def test_make_too_big_request_same_size_to_max(protocol: BaseProtocol) -> None:
     payload = StreamReader(protocol, 2**16, loop=asyncio.get_running_loop())
     large_file = 1024**2 * b"x"
@@ -975,6 +991,24 @@ async def test_multipart_formdata(protocol: BaseProtocol) -> None:
     )
     result = await req.post()
     assert dict(result) == {"a": "b", "c": "d"}
+
+
+async def test_urlencoded_form_with_invalid_content_type_encoding(
+    protocol: BaseProtocol,
+) -> None:
+    payload = StreamReader(
+        protocol, DEFAULT_CHUNK_SIZE, loop=asyncio.get_running_loop()
+    )
+    payload.feed_data(b"a=1&b=\xff")
+    payload.feed_eof()
+    headers = {
+        "Content-Type": "application/x-www-form-urlencoded; charset=utf-8",
+    }
+    req = make_mocked_request("POST", "/", payload=payload, headers=headers)
+
+    with pytest.raises(web.HTTPUnsupportedMediaType) as err:
+        await req.post()
+    assert err.value.status_code == 415
 
 
 async def test_multipart_formdata_field_missing_name(protocol: BaseProtocol) -> None:

--- a/tests/test_web_request.py
+++ b/tests/test_web_request.py
@@ -930,7 +930,7 @@ async def test_request_with_wrong_content_type_encoding(protocol: BaseProtocol) 
     assert err.value.status_code == 415
 
 
-async def test_request_text_with_invalid_content_type_encoding(
+async def test_request_text_with_invalid_default_encoding(
     protocol: BaseProtocol,
 ) -> None:
     payload = StreamReader(
@@ -938,7 +938,7 @@ async def test_request_text_with_invalid_content_type_encoding(
     )
     payload.feed_data(b"\xff")
     payload.feed_eof()
-    headers = {"Content-Type": "text/html; charset=utf-8"}
+    headers = {"Content-Type": "text/html"}
     req = make_mocked_request("POST", "/", payload=payload, headers=headers)
 
     with pytest.raises(web.HTTPUnsupportedMediaType) as err:


### PR DESCRIPTION
Fixes #13099.

## Summary
- map body `UnicodeDecodeError`s to `HTTPUnsupportedMediaType` in `BaseRequest.text()`
- apply the same handling to `application/x-www-form-urlencoded` request parsing
- add regression tests and a changelog fragment

## Tests
- `python -m pytest tests/test_web_request.py -k 'invalid_content_type_encoding or wrong_content_type_encoding' -v`
- `python -m pytest tests/test_web_request.py -v`
- `git diff --check`
