### PR TITLE
[3.14] keep websocket compression state across interleaved control frames

### DIFF
--- a/CHANGES/12988.bugfix.rst
+++ b/CHANGES/12988.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed control frames breaking fragmented WebSocket messages -- by :user:`arshsmith1`.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -52,6 +52,7 @@ Anton Kasyanov
 Anton Zhdan-Pushkin
 Arcadiy Ivanov
 Arseny Timoniq
+Arsh Smith
 Arshiya Tabasum
 Artem Yushkovskiy
 Arthur Darcet

--- a/aiohttp/_websocket/reader_py.py
+++ b/aiohttp/_websocket/reader_py.py
@@ -404,7 +404,11 @@ class WebSocketReader:
                         "Received frame with non-zero reserved bits",
                     )
 
-                self._frame_fin = bool(fin)
+                # Control frames (opcode > 0x7) may be interleaved between the
+                # fragments of a data message.
+                # https://datatracker.ietf.org/doc/html/rfc6455#section-5.4
+                if opcode <= 0x7:
+                    self._frame_fin = bool(fin)
                 self._frame_opcode = opcode
                 self._has_mask = bool(has_mask)
                 self._payload_len_flag = length

--- a/tests/test_websocket_parser.py
+++ b/tests/test_websocket_parser.py
@@ -600,6 +600,34 @@ def test_parse_compress_frame_multi(parser: PatchableWebSocketReader) -> None:
     assert (1, 1, b"1234", False) == (fin, opcode, payload, not not compress)
 
 
+def test_compressed_continuation_with_ping(
+    out: WebSocketDataQueue, parser: PatchableWebSocketReader
+) -> None:
+    # A control frame may be interleaved between the fragments of a data
+    # message. The continuation must still be decompressed.
+    # https://datatracker.ietf.org/doc/html/rfc6455#section-5.4
+    message = b"hello compressed world " * 4
+    compressobj = ZLibBackend.compressobj(wbits=-9)
+    compressed = compressobj.compress(message)
+    compressed += compressobj.flush(ZLibBackend.Z_SYNC_FLUSH)
+    assert compressed.endswith(WS_DEFLATE_TRAILING)
+    compressed = compressed[:-4]
+    half = len(compressed) // 2
+
+    # first fragment: compressed binary, RSV1 set, not final
+    parser.feed_data(PACK_LEN1(0x40 | WSMsgType.BINARY, half) + compressed[:half])
+    # interleaved ping
+    parser.feed_data(PACK_LEN1(0x80 | WSMsgType.PING, 0))
+    # final continuation fragment
+    parser.feed_data(
+        PACK_LEN1(0x80 | WSMsgType.CONTINUATION, len(compressed) - half)
+        + compressed[half:]
+    )
+
+    assert out._buffer[0] == (WSMessage(WSMsgType.PING, b"", ""), 0)
+    assert out._buffer[1] == (WSMessage(WSMsgType.BINARY, message, ""), len(message))
+
+
 def test_parse_compress_error_frame(parser: PatchableWebSocketReader) -> None:
     parser.parse_frame(struct.pack("!BB", 0b01000001, 0b00000001))
     parser.parse_frame(b"1")


### PR DESCRIPTION
**Backport of #12988 to `3.14`.**

The auto-backport (#13133) applied the reader fix cleanly but its regression test asserted against `WSMessagePing`/`WSMessageBinary`, which only exist on `master`. On 3.x the queue holds `(WSMessage, size)` tuples, so the test failed to import. Switched the two assertions to the `WSMessage` NamedTuple form used by the other parser tests here; nothing else changed.

Verified locally: `test_compressed_continuation_with_ping` fails on the unpatched tree and passes with the fix, full `tests/test_websocket_parser.py` green.

## What do these changes do?

When a permessage-deflate message is split across several frames, a peer may interleave a control frame (ping/pong/close) between the fragments (RFC 6455 §5.4). Only data frames now advance the FIN tracker, so an interleaved control frame stays transparent to the message framing and the compression state carries across it.

## Are there changes in behavior for the user?

No public API change. A compressed message that previously came back corrupted (or dropped the connection) when a control frame landed mid-message now decodes correctly.

## Related issue number

Backport of #12988.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
- [x] Add a new news fragment into the `CHANGES/` folder
