### PR TITLE
return 415 for unknown charset in multipart form field

### DIFF
--- a/CHANGES/13140.bugfix.rst
+++ b/CHANGES/13140.bugfix.rst
@@ -1,0 +1,5 @@
+Fixed :py:meth:`Request.post() <aiohttp.web.BaseRequest.post>` raising an
+unhandled :exc:`LookupError` (surfacing as a 500) when a ``multipart/form-data``
+text field declared an unknown charset; it now returns ``415 Unsupported Media
+Type`` like the urlencoded branch and :py:meth:`~aiohttp.web.BaseRequest.text`
+-- by :user:`arshsmith1`.

--- a/CHANGES/13140.bugfix.rst
+++ b/CHANGES/13140.bugfix.rst
@@ -1,5 +1,6 @@
 Fixed :py:meth:`Request.post() <aiohttp.web.BaseRequest.post>` raising an
-unhandled :exc:`LookupError` (surfacing as a 500) when a ``multipart/form-data``
-text field declared an unknown charset; it now returns ``415 Unsupported Media
-Type`` like the urlencoded branch and :py:meth:`~aiohttp.web.BaseRequest.text`
+unhandled ``LookupError`` (surfacing as a ``500``) when a ``multipart/form-data``
+text field declared an unknown charset; it now returns
+``415 Unsupported Media Type``, matching the ``application/x-www-form-urlencoded``
+branch and :py:meth:`Request.text() <aiohttp.web.BaseRequest.text>`
 -- by :user:`arshsmith1`.

--- a/aiohttp/web_request.py
+++ b/aiohttp/web_request.py
@@ -776,7 +776,11 @@ class BaseRequest(MutableMapping[str | RequestKey[Any], Any], HeadersMixin):
 
                         if field_ct is None or field_ct.startswith("text/"):
                             charset = field.get_charset(default="utf-8")
-                            out.add(field.name, value.decode(charset))
+                            try:
+                                decoded = value.decode(charset)
+                            except LookupError:
+                                raise HTTPUnsupportedMediaType()
+                            out.add(field.name, decoded)
                         else:
                             out.add(field.name, value)  # type: ignore[arg-type]
                 else:

--- a/tests/test_web_request.py
+++ b/tests/test_web_request.py
@@ -977,6 +977,29 @@ async def test_multipart_formdata(protocol: BaseProtocol) -> None:
     assert dict(result) == {"a": "b", "c": "d"}
 
 
+async def test_multipart_formdata_unknown_charset(protocol: BaseProtocol) -> None:
+    # An unknown charset on a text part must yield 415, not a raw LookupError.
+    payload = StreamReader(protocol, 2**16, loop=asyncio.get_running_loop())
+    payload.feed_data(
+        b"-----------------------------326931944431359\r\n"
+        b'Content-Disposition: form-data; name="a"\r\n'
+        b"Content-Type: text/plain; charset=unknown-8bit\r\n"
+        b"\r\n"
+        b"b\r\n"
+        b"-----------------------------326931944431359--\r\n"
+    )
+    content_type = (
+        "multipart/form-data; boundary=---------------------------326931944431359"
+    )
+    payload.feed_eof()
+    req = make_mocked_request(
+        "POST", "/", headers={"CONTENT-TYPE": content_type}, payload=payload
+    )
+    with pytest.raises(web.HTTPUnsupportedMediaType) as err:
+        await req.post()
+    assert err.value.status_code == 415
+
+
 async def test_multipart_formdata_field_missing_name(protocol: BaseProtocol) -> None:
     # Ensure ValueError is raised when Content-Disposition has no name
     payload = StreamReader(


### PR DESCRIPTION
## What do these changes do?

1. `post()` decodes each text multipart field body with that part's own charset from `field.get_charset()`, which is taken verbatim from the request.
2. Unlike the urlencoded branch and `text()` right beside it, this decode had no guard, so a part sent with an unrecognised charset (e.g. `Content-Type: text/plain; charset=unknown-8bit`) raised a bare `LookupError` out of `post()` and surfaced as a 500.

Wrapped it in the same `except LookupError -> HTTPUnsupportedMediaType` the neighbouring branches already use, so it returns a 415.

## Are there changes in behavior for the user?

A multipart field declaring an unknown charset now yields a 415 rather than a 500. Valid requests are unchanged.

## Is it a substantial burden for the maintainers to support this?

No. It matches the existing charset handling in the same method.

## Related issue number

N/A

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
- [x] Add a new news fragment into the `CHANGES/` folder
