### PR TITLE
Fix Python parser not rejecting LF early (#13136)

### DIFF
--- a/CHANGES/13136.bugfix.rst
+++ b/CHANGES/13136.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed Python parser not rejecting a bare ``LF`` in the request line -- by :user:`Dreamsorcerer`.

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -527,6 +527,11 @@ class HttpParser(abc.ABC, Generic[_MsgT]):
                         should_close = msg.should_close
                 else:
                     self._tail = data[start_pos:]
+                    # A bare LF here means CRLF was required:
+                    # reject instead of buffering, else a following request's
+                    # bytes get appended to this line and leak in the error.
+                    if b"\n" in self._tail:
+                        raise BadHttpMessage("Bad line ending, expected CRLF")
                     if len(self._tail) > self.max_line_size:
                         raise LineTooLong(self._tail[:100] + b"...", self.max_line_size)
                     data = EMPTY
@@ -1016,6 +1021,12 @@ class HttpPayloadParser:
                             self._chunk_size = size
                             self.payload.begin_http_chunk_receiving()
                     else:
+                        if b"\n" in chunk:
+                            exc = TransferEncodingError(
+                                "Bad chunk-size line ending, expected CRLF"
+                            )
+                            set_exception(self.payload, exc)
+                            raise exc
                         self._chunk_tail = chunk
                         return PayloadState.PAYLOAD_NEEDS_INPUT, b""
 
@@ -1062,6 +1073,12 @@ class HttpPayloadParser:
                 if self._chunk == ChunkState.PARSE_TRAILERS:
                     pos = chunk.find(SEP)
                     if pos < 0:  # No line found
+                        if b"\n" in chunk:
+                            exc = TransferEncodingError(
+                                "Bad trailer line ending, expected CRLF"
+                            )
+                            set_exception(self.payload, exc)
+                            raise exc
                         self._chunk_tail = chunk
                         return PayloadState.PAYLOAD_NEEDS_INPUT, b""
 

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -323,7 +323,42 @@ def test_invalid_linebreak(
         parser.feed_data(text)
 
 
-def test_cve_2023_37276(parser: Any) -> None:
+def test_partial_request_split_still_parses(parser: HttpRequestParser) -> None:
+    """A legitimate request split mid-line must still stream."""
+    messages, _, _ = parser.feed_data(b"GET /split HTTP/1.1\r\nHo")
+    assert not messages
+    messages, _, _ = parser.feed_data(b"st: a\r\n\r\n")
+    assert len(messages) == 1
+    assert messages[0][0].path == "/split"
+
+
+@pytest.mark.parametrize(
+    "attacker",
+    (
+        pytest.param(
+            b"GET /attacker HTTP/1.1\nHost: a\nX-Foo: bar\n\n", id="request_line"
+        ),
+        pytest.param(
+            b"POST /attacker HTTP/1.1\r\nHost: a\r\n"
+            b"Transfer-Encoding: chunked\r\n\r\n5\n",
+            id="chunk_size",
+        ),
+        pytest.param(
+            b"POST /attacker HTTP/1.1\r\nHost: a\r\n"
+            b"Transfer-Encoding: chunked\r\n\r\n0\r\nX-Trailer: bad\n",
+            id="trailer",
+        ),
+    ),
+)
+def test_reject_bare_lf_at_point_seen(
+    parser: HttpRequestParser, attacker: bytes
+) -> None:
+    """A bare LF where CRLF is required is rejected at the point it's seen."""
+    with pytest.raises(http_exceptions.BadHttpMessage):
+        parser.feed_data(attacker)
+
+
+def test_cve_2023_37276(parser: HttpRequestParser) -> None:
     text = b"""POST / HTTP/1.1\r\nHost: localhost:8080\r\nX-Abc: \rxTransfer-Encoding: chunked\r\n\r\n"""
     with pytest.raises(http_exceptions.BadHttpMessage):
         parser.feed_data(text)


### PR DESCRIPTION
(cherry picked from commit cba121d5864966d95b48f4a790ff0cefad7f041f)