### PR TITLE
fix open redirect in normalize_path_middleware for absolute-form URLs

### DIFF
--- a/CHANGES/13153.bugfix.rst
+++ b/CHANGES/13153.bugfix.rst
@@ -1,0 +1,5 @@
+Fixed :func:`~aiohttp.web.normalize_path_middleware` redirecting to an
+attacker-supplied origin when a request is made with an absolute-form
+target (:rfc:`9112#section-3.2.2`), e.g. ``GET http://example.org/foo``.
+The ``Location`` header is now built from the request path alone
+-- by :user:`arshsmith1`.

--- a/aiohttp/web_middlewares.py
+++ b/aiohttp/web_middlewares.py
@@ -89,12 +89,12 @@ def normalize_path_middleware(
             request.match_info.http_exception, (HTTPNotFound, HTTPMethodNotAllowed)
         ):
             paths_to_check = []
-            if "?" in request.raw_path:
-                path, query = request.raw_path.split("?", 1)
-                query = "?" + query
-            else:
-                query = ""
-                path = request.raw_path
+            # rel_url drops the scheme and authority an absolute-form target
+            # (RFC 9112 3.2.2) carries, which must not reach Location.
+            rel_url = request.rel_url
+            raw_query_string = rel_url.raw_query_string
+            query = "?" + raw_query_string if raw_query_string else ""
+            path = rel_url.raw_path
 
             if merge_slashes:
                 paths_to_check.append(re.sub("//+", "/", path))

--- a/tests/test_web_middleware.py
+++ b/tests/test_web_middleware.py
@@ -416,8 +416,15 @@ class TestNormalizePathMiddleware:
         assert resp.headers["Location"] == "/google.com"
         assert resp.url.query == URL("//google.com").query
 
+    @pytest.mark.parametrize(
+        "target, location",
+        [
+            (b"http://google.com/google.com", "/google.com/"),
+            (b"http://google.com/google.com?p1=1&p2=2", "/google.com/?p1=1&p2=2"),
+        ],
+    )
     async def test_open_redirect_absolute_form_target(
-        self, aiohttp_server: AiohttpServer
+        self, target: bytes, location: str, aiohttp_server: AiohttpServer
     ) -> None:
         async def handle(request: web.Request) -> web.Response:
             return web.Response(text="OK")
@@ -429,8 +436,8 @@ class TestNormalizePathMiddleware:
         reader, writer = await asyncio.open_connection(server.host, server.port)
         try:
             writer.write(
-                b"GET http://google.com/google.com HTTP/1.1\r\n"
-                b"Host: localhost\r\nConnection: close\r\n\r\n"
+                b"GET %s HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n"
+                % target
             )
             await writer.drain()
             head = (await reader.readuntil(b"\r\n\r\n")).decode("ascii")
@@ -440,7 +447,7 @@ class TestNormalizePathMiddleware:
                 await writer.wait_closed()
 
         assert head.startswith("HTTP/1.1 308 ")
-        assert "\r\nLocation: /google.com/\r\n" in head
+        assert f"\r\nLocation: {location}\r\n" in head
 
 
 async def test_normalize_path_skips_parser_error(

--- a/tests/test_web_middleware.py
+++ b/tests/test_web_middleware.py
@@ -1,5 +1,6 @@
 import asyncio
 from collections.abc import Awaitable, Callable, Iterable
+from contextlib import suppress
 from typing import NoReturn
 
 import pytest
@@ -414,6 +415,32 @@ class TestNormalizePathMiddleware:
         assert resp.status == 308
         assert resp.headers["Location"] == "/google.com"
         assert resp.url.query == URL("//google.com").query
+
+    async def test_open_redirect_absolute_form_target(
+        self, aiohttp_server: AiohttpServer
+    ) -> None:
+        async def handle(request: web.Request) -> web.Response:
+            return web.Response(text="OK")
+
+        app = web.Application(middlewares=[web.normalize_path_middleware()])
+        app.add_routes([web.get("/google.com/", handle)])
+        server = await aiohttp_server(app)
+
+        reader, writer = await asyncio.open_connection(server.host, server.port)
+        try:
+            writer.write(
+                b"GET http://google.com/google.com HTTP/1.1\r\n"
+                b"Host: localhost\r\nConnection: close\r\n\r\n"
+            )
+            await writer.drain()
+            head = (await reader.readuntil(b"\r\n\r\n")).decode("ascii")
+        finally:
+            writer.close()
+            with suppress(ConnectionResetError, BrokenPipeError):
+                await writer.wait_closed()
+
+        assert head.startswith("HTTP/1.1 308 ")
+        assert "\r\nLocation: /google.com/\r\n" in head
 
 
 async def test_normalize_path_skips_parser_error(

--- a/tests/test_web_middleware.py
+++ b/tests/test_web_middleware.py
@@ -427,7 +427,7 @@ class TestNormalizePathMiddleware:
         self, target: bytes, location: str, aiohttp_server: AiohttpServer
     ) -> None:
         async def handle(request: web.Request) -> web.Response:
-            return web.Response(text="OK")
+            return web.Response(text="OK")  # pragma: no cover
 
         app = web.Application(middlewares=[web.normalize_path_middleware()])
         app.add_routes([web.get("/google.com/", handle)])


### PR DESCRIPTION
## What do these changes do?

`normalize_path_middleware` derived both the paths it normalizes and the `Location` it redirects to from `request.raw_path`, which holds the raw request target rather than a path. RFC 9112 section 3.2.2 has origin servers accept absolute-form targets, so `GET http://google.com/google.com HTTP/1.1` makes `raw_path` a full URL, and once the router resolved the normalized variant the middleware answered `308 Location: http://google.com/google.com/`, sending the client to an origin the requester picked. The leading-`//` collapse added for GHSA-v6wp-4m6f-gcjg does not cover this shape. Reading the path and query from `request.rel_url` instead drops the scheme and authority, which lines up with the host-less `request.path` this same function already uses for its append/remove slash checks.

## Are there changes in behavior for the user?

Only for absolute-form targets, where `Location` is now a path rather than the absolute URL taken from the request line. I compared origin-form requests, the `//` merge-slash handling behind GHSA-v6wp-4m6f-gcjg, and query preservation before and after, and they are identical. `normalize_path_middleware` is the only consumer of `BaseRequest.raw_path` in the package, so no other caller shifts.

## Is it a substantial burden for the maintainers to support this?

I don't think so. It swaps one attribute read for another inside a single middleware, with no new API, and the regression test sits next to the existing GHSA-v6wp-4m6f-gcjg case it extends.

## Related issue number

None, this came up while reading the middleware. Happy to file one if you'd prefer it tracked.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes — N/A, no documented behavior changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt` (already listed)
- [x] Add a new news fragment into the `CHANGES/` folder

<details>
<summary>Verification</summary>

Regression test fails on master and passes with the fix:

```
$ pytest "tests/test_web_middleware.py::TestNormalizePathMiddleware::test_open_redirect_absolute_form_target"

# master
E  AssertionError: assert '\r\nLocation: /google.com/\r\n' in
   'HTTP/1.1 308 Permanent Redirect\r\n...\r\nLocation: http://google.com/google.com/...'
1 failed

# with this patch
1 passed
```

Suites green with the C extensions built (`make cythonize-nodeps`, `make generate-llhttp`, `pip install -e .`):

```
$ pytest tests/test_web_middleware.py tests/test_web_request.py \
         tests/test_web_urldispatcher.py tests/test_http_parser.py
1098 passed, 4 skipped, 10 deselected, 3 xfailed

$ pytest tests/test_web_functional.py tests/test_web_response.py \
         tests/test_web_exceptions.py tests/test_web_server.py
365 passed, 42 skipped, 2 deselected
```

Same via the pure-Python parser (`AIOHTTP_NO_EXTENSIONS=1`), plus black/isort/flake8/mypy clean on the touched files.

Live before/after against `add_get("/foo/")` with `normalize_path_middleware()`:

```
target                       master                          patched
/foo?a=1&b=%21            -> 308 /foo/?a=1&b=!               308 /foo/?a=1&b=!
/foo?a=1                  -> 308 /foo/?a=1                   308 /foo/?a=1
//evil.example/foo        -> 404                             404
http://evil.example/foo   -> 308 http://evil.example/foo/    308 /foo/
```
</details>
