### PR TITLE
[PR #13122/bc3b5cf2 backport][3.15] Add the ssl parameter to ClientSession

### DIFF
--- a/CHANGES/13006.feature.rst
+++ b/CHANGES/13006.feature.rst
@@ -1,0 +1,4 @@
+Added the ``ssl`` parameter to :class:`~aiohttp.ClientSession`, setting the
+default SSL validation mode for every request made through the session; a
+per-request ``ssl`` argument still takes precedence -- by
+:user:`rodrigobnogueira`.

--- a/CHANGES/13122.feature.rst
+++ b/CHANGES/13122.feature.rst
@@ -1,0 +1,1 @@
+13006.feature.rst

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -69,6 +69,7 @@ from .client_exceptions import (
 )
 from .client_middlewares import ClientMiddlewareType, build_client_middlewares
 from .client_reqrep import (
+    SSL_ALLOWED_TYPES,
     ClientRequest as ClientRequest,
     ClientResponse as ClientResponse,
     Fingerprint as Fingerprint,
@@ -186,7 +187,7 @@ class _RequestOptions(TypedDict, total=False):
     proxy: StrOrURL | None
     proxy_auth: BasicAuth | None
     timeout: "ClientTimeout | _SENTINEL | None"
-    ssl: SSLContext | bool | Fingerprint
+    ssl: SSLContext | bool | Fingerprint | _SENTINEL
     server_hostname: str | None
     proxy_headers: LooseHeaders | None
     trace_request_ctx: object
@@ -212,7 +213,7 @@ class _WSConnectOptions(TypedDict, total=False):
     headers: LooseHeaders | None
     proxy: StrOrURL | None
     proxy_auth: BasicAuth | None
-    ssl: SSLContext | bool | Fingerprint
+    ssl: SSLContext | bool | Fingerprint | _SENTINEL
     verify_ssl: bool | None
     fingerprint: bytes | None
     ssl_context: SSLContext | None
@@ -291,6 +292,7 @@ class ClientSession:
             "_max_headers",
             "_resolve_charset",
             "_default_proxy",
+            "_default_ssl",
             "_default_proxy_auth",
             "_retry_connection",
             "_middlewares",
@@ -311,6 +313,7 @@ class ClientSession:
         headers: LooseHeaders | None = None,
         proxy: StrOrURL | None = None,
         proxy_auth: BasicAuth | None = None,
+        ssl: SSLContext | bool | Fingerprint = True,
         skip_auto_headers: Iterable[str] | None = None,
         auth: BasicAuth | None = None,
         json_serialize: JSONEncoder = json.dumps,
@@ -356,6 +359,12 @@ class ClientSession:
             assert self._base_url.absolute, "Only absolute URLs are supported"
         if self._base_url is not None and not self._base_url.path.endswith("/"):
             raise ValueError("base_url must have a trailing '/'")
+
+        if not isinstance(ssl, SSL_ALLOWED_TYPES):
+            raise TypeError(
+                "ssl should be SSLContext, bool, Fingerprint or None, "
+                f"got {ssl!r} instead."
+            )
 
         if timeout is sentinel or timeout is None:
             self._timeout = DEFAULT_TIMEOUT
@@ -474,6 +483,7 @@ class ClientSession:
 
         self._default_proxy = proxy
         self._default_proxy_auth = proxy_auth
+        self._default_ssl = ssl
         self._retry_connection: bool = True
         self._middlewares = middlewares
 
@@ -556,7 +566,7 @@ class ClientSession:
         verify_ssl: bool | None = None,
         fingerprint: bytes | None = None,
         ssl_context: SSLContext | None = None,
-        ssl: SSLContext | bool | Fingerprint = True,
+        ssl: SSLContext | bool | Fingerprint | _SENTINEL = sentinel,
         server_hostname: str | None = None,
         proxy_headers: LooseHeaders | None = None,
         trace_request_ctx: object = None,
@@ -576,6 +586,11 @@ class ClientSession:
             raise RuntimeError("Session is closed")
 
         method = method.upper()
+        # Resolve the session default before merging the legacy parameters:
+        # _merge_ssl_params treats any non-True ssl as explicit and would
+        # reject the sentinel when a legacy parameter is also given.
+        if ssl is sentinel:
+            ssl = self._default_ssl
         ssl = _merge_ssl_params(ssl, verify_ssl, ssl_context, fingerprint)
 
         if auth is not None:
@@ -1070,7 +1085,7 @@ class ClientSession:
         headers: LooseHeaders | None = None,
         proxy: StrOrURL | None = None,
         proxy_auth: BasicAuth | None = None,
-        ssl: SSLContext | bool | Fingerprint = True,
+        ssl: SSLContext | bool | Fingerprint | _SENTINEL = sentinel,
         verify_ssl: bool | None = None,
         fingerprint: bytes | None = None,
         ssl_context: SSLContext | None = None,
@@ -1155,7 +1170,7 @@ class ClientSession:
         headers: LooseHeaders | None = None,
         proxy: StrOrURL | None = None,
         proxy_auth: BasicAuth | None = None,
-        ssl: SSLContext | bool | Fingerprint = True,
+        ssl: SSLContext | bool | Fingerprint | _SENTINEL = sentinel,
         verify_ssl: bool | None = None,
         fingerprint: bytes | None = None,
         ssl_context: SSLContext | None = None,
@@ -1238,6 +1253,10 @@ class ClientSession:
                 stacklevel=2,
             )
             ssl = True
+        # Resolve the session default before merging the legacy parameters,
+        # mirroring _request (the merge treats any non-True ssl as explicit).
+        if ssl is sentinel:
+            ssl = self._default_ssl
         ssl = _merge_ssl_params(ssl, verify_ssl, ssl_context, fingerprint)
 
         # send request

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -50,6 +50,7 @@ The client session supports the context manager protocol for self closing.
                          raise_for_status=False, \
                          timeout=sentinel, \
                          auto_decompress=True, \
+                         ssl=True, \
                          trust_env=False, \
                          requote_redirect_url=True, \
                          trace_configs=None, \
@@ -195,6 +196,18 @@ The client session supports the context manager protocol for self closing.
    :param bool auto_decompress: Automatically decompress response body (``True`` by default).
 
       .. versionadded:: 2.3
+
+   :param ssl: Default SSL validation mode for requests made through this
+      session. ``True`` for default SSL check
+      (:func:`ssl.create_default_context` is used),
+      ``False`` for skip SSL certificate validation,
+      :class:`aiohttp.Fingerprint` for fingerprint
+      validation, :class:`ssl.SSLContext` for custom SSL
+      certificate validation (``True`` by default).
+
+      A per-request ``ssl`` argument overrides this value.
+
+      .. versionadded:: 3.15
 
    :param bool trust_env: Trust environment settings for proxy configuration if the parameter
       is ``True`` (``False`` by default). See :ref:`aiohttp-client-proxy-support` for
@@ -553,7 +566,14 @@ The client session supports the context manager protocol for self closing.
                   Supersedes *verify_ssl*, *ssl_context* and
                   *fingerprint* parameters.
 
+                  When not given, the session's ``ssl`` value is used
+                  (``True`` unless set).
+
          .. versionadded:: 3.0
+
+         .. versionchanged:: 3.15
+
+            Defaults to the session's ``ssl`` value.
 
       :param str server_hostname: Sets or overrides the host name that the
          target server's certificate will be matched against.
@@ -816,7 +836,14 @@ The client session supports the context manager protocol for self closing.
                   Supersedes *verify_ssl*, *ssl_context* and
                   *fingerprint* parameters.
 
+                  When not given, the session's ``ssl`` value is used
+                  (``True`` unless set).
+
          .. versionadded:: 3.0
+
+         .. versionchanged:: 3.15
+
+            Defaults to the session's ``ssl`` value.
 
       :param bool verify_ssl: Perform SSL certificate validation for
          *HTTPS* requests (enabled by default). May be disabled to

--- a/tests/test_client_session.py
+++ b/tests/test_client_session.py
@@ -3,6 +3,7 @@ import contextlib
 import gc
 import io
 import json
+import ssl
 import sys
 import warnings
 from collections import deque
@@ -938,6 +939,97 @@ async def test_default_proxy() -> None:
     assert (
         request_class_mock.call_args[1].get("proxy_auth") == proxy_auth2
     ), "`ClientSession._request` uses default proxy_auth not one used in ClientSession.get"
+
+    await session.close()
+
+
+async def test_default_ssl() -> None:
+    ssl_ctx = ssl.create_default_context()
+
+    class OnCall(Exception):
+        pass
+
+    request_class_mock = mock.Mock(side_effect=OnCall())
+    session = ClientSession(ssl=ssl_ctx, request_class=request_class_mock)
+
+    assert session._default_ssl is ssl_ctx, "`ClientSession._default_ssl` not set"
+
+    with pytest.raises(OnCall):
+        await session.get("http://example.com")
+
+    assert request_class_mock.called, "request class not called"
+    assert (
+        request_class_mock.call_args[1].get("ssl") is ssl_ctx
+    ), "`ClientSession._request` does not use the session default ssl"
+
+    request_class_mock.reset_mock()
+    with pytest.raises(OnCall):
+        await session.get("http://example.com", ssl=False)
+
+    assert request_class_mock.called, "request class not called"
+    assert (
+        request_class_mock.call_args[1].get("ssl") is False
+    ), "`ClientSession._request` uses session default ssl not the per-request one"
+
+    request_class_mock.reset_mock()
+    with pytest.raises(OnCall):
+        await session.get("http://example.com", ssl=True)
+
+    assert request_class_mock.called, "request class not called"
+    assert (
+        request_class_mock.call_args[1].get("ssl") is True
+    ), "explicit `ssl=True` should not be replaced by the session default"
+
+    await session.close()
+
+
+async def test_default_ssl_not_set() -> None:
+    class OnCall(Exception):
+        pass
+
+    request_class_mock = mock.Mock(side_effect=OnCall())
+    session = ClientSession(request_class=request_class_mock)
+
+    with pytest.raises(OnCall):
+        await session.get("http://example.com")
+
+    assert request_class_mock.called, "request class not called"
+    assert (
+        request_class_mock.call_args[1].get("ssl") is True
+    ), "the default ssl mode should stay `True` when not configured"
+
+    await session.close()
+
+
+async def test_default_ssl_invalid_type() -> None:
+    with pytest.raises(
+        TypeError, match="ssl should be SSLContext, bool, Fingerprint or None"
+    ):
+        ClientSession(ssl="/some/cert.pem")  # type: ignore[arg-type]
+
+
+async def test_request_ssl_invalid_type() -> None:
+    session = ClientSession()
+
+    with pytest.raises(
+        TypeError, match="ssl should be SSLContext, bool, Fingerprint or None"
+    ):
+        await session.get(
+            "http://example.com", ssl="/some/cert.pem"  # type: ignore[arg-type]
+        )
+
+    await session.close()
+
+
+async def test_ws_connect_ssl_invalid_type() -> None:
+    session = ClientSession()
+
+    with pytest.raises(
+        TypeError, match="ssl should be SSLContext, bool, Fingerprint or None"
+    ):
+        await session.ws_connect(
+            "http://example.com", ssl="/some/cert.pem"  # type: ignore[arg-type]
+        )
 
     await session.close()
 


### PR DESCRIPTION
Manual backport of #13122 (squash commit bc3b5cf27e1a1c19b3320c4f36ba1f0f4b3e2b70) to 3.15 — the `backport-3.15` label was on the PR at merge time but patchback never opened a bot PR.

Adaptations were needed because 3.15 still carries the deprecated `verify_ssl`/`fingerprint`/`ssl_context` parameters and `_merge_ssl_params()`:

1. **Session default resolved before `_merge_ssl_params()`** in both `_request()` and `_ws_connect()`. The merge helper treats any non-`True` `ssl` value as explicitly set and raises when a legacy parameter is also passed, so the sentinel must be replaced with the session default first (`if ssl is sentinel: ssl = self._default_ssl`). The legacy-parameter conflict detection is unchanged, and a per-request `ssl=` still overrides the session default.
2. **Master's per-request `isinstance` checks are not carried over.** On 3.15, `_merge_ssl_params()` already validates `ssl` unconditionally (raising the established `"ssl should be SSLContext, bool, Fingerprint or None"` `TypeError`), so duplicating master's check in `_request`/`_ws_connect` would be dead code — the merge raises first. Invalid values fail exactly as before, just via the existing 3.x path.
3. **The constructor validates the new session-level `ssl`** (no merge runs there) using `SSL_ALLOWED_TYPES` — imported into `client.py` — and the 3.x error message. Note that on 3.x `SSL_ALLOWED_TYPES` includes `type(None)`, so `ClientSession(ssl=None)` is accepted and behaves like the long-standing per-request `ssl=None` (treated as the default), unlike master which rejects `None`.
4. **Docs version tags** set to `3.15` (`versionadded` for the session parameter, `versionchanged` for the request/ws `ssl` parameters) instead of the original 4.0 tags.
5. **Tests** cover the constructor validation plus the request and `ws_connect` invalid-`ssl` paths through the session default seam (`test_default_ssl*`, `test_request_ssl_invalid_type`, `test_ws_connect_ssl_invalid_type`).

<details>
<summary>Local test evidence (CPython 3.13, pure-Python install)</summary>

- `tests/test_client_session.py`: 95 passed, 2 skipped
- `tests/test_client_session.py tests/test_client_ws.py tests/test_client_ws_functional.py`: 190 passed, 6 skipped
- Full suite with `--cov=aiohttp.client --cov-branch`: every executable added/changed line in `aiohttp/client.py` is hit, including both branches of the sentinel resolutions and the constructor `TypeError`

</details>
