### PR TITLE
enforce __Host- and __Secure- cookie name prefixes in CookieJar

### DIFF
--- a/CHANGES/13168.bugfix.rst
+++ b/CHANGES/13168.bugfix.rst
@@ -1,0 +1,4 @@
+Enforced the ``__Secure-`` and ``__Host-`` cookie name prefixes
+(RFC 6265bis, section 4.1.3) in :class:`~aiohttp.CookieJar`, so a
+prefixed cookie that is not host-locked and secure is no longer stored
+-- by :user:`arshsmith1`.

--- a/aiohttp/cookiejar.py
+++ b/aiohttp/cookiejar.py
@@ -337,6 +337,21 @@ class CookieJar(AbstractCookieJar):
                 tmp[name] = cookie  # type: ignore[assignment]
                 cookie = tmp[name]
 
+            # RFC 6265bis 4.1.3: enforce the __Secure- and __Host- name
+            # prefixes so a related-origin (sibling subdomain) or on-path party
+            # cannot forge a cookie the target server trusts as host-locked and
+            # secure. Only applied to cookies from an actual response; a jar
+            # seeded programmatically has no response host to check against.
+            if hostname is not None:
+                lower_name = name.lower()
+                if lower_name.startswith(("__secure-", "__host-")):
+                    if not cookie["secure"] or not self._is_secure_origin(response_url):
+                        continue
+                    if lower_name.startswith("__host-") and (
+                        cookie["domain"] or cookie["path"] != "/"
+                    ):
+                        continue
+
             domain = cookie["domain"]
 
             # ignore domains with trailing dots
@@ -494,6 +509,15 @@ class CookieJar(AbstractCookieJar):
         # setting protected attributes directly.
         morsel.__setstate__({"key": cookie.key, "value": value, "coded_value": coded_value})  # type: ignore[attr-defined]
         return morsel
+
+    def _is_secure_origin(self, url: URL) -> bool:
+        """Whether cookies from url should be treated as a secure origin."""
+        if url.scheme in ("https", "wss"):
+            return True
+        if self._treat_as_secure_origin:
+            with contextlib.suppress(ValueError):
+                return url.origin() in self._treat_as_secure_origin
+        return False
 
     @staticmethod
     def _is_domain_match(domain: str, hostname: str) -> bool:

--- a/tests/test_cookiejar.py
+++ b/tests/test_cookiejar.py
@@ -421,6 +421,65 @@ async def test_ignore_domain_ending_with_dot() -> None:
     assert cookies_sent.output(header="Cookie:") == ""
 
 
+@pytest.mark.parametrize(
+    ("set_cookie", "url"),
+    [
+        # __Host- with a Domain attribute is not host-only.
+        (
+            "__Host-sid=x; Domain=example.com; Path=/; Secure",
+            "https://sub.example.com/",
+        ),
+        # __Host- without Path=/.
+        ("__Host-sid=x; Path=/admin; Secure", "https://example.com/admin"),
+        # __Host- without Secure.
+        ("__Host-sid=x; Path=/", "https://example.com/"),
+        # Prefixes must not be accepted over an insecure origin.
+        ("__Host-sid=x; Path=/; Secure", "http://example.com/"),
+        ("__Secure-sid=x; Secure", "http://example.com/"),
+        # __Secure- without the Secure attribute.
+        ("__Secure-sid=x", "https://example.com/"),
+        # Prefix match is case-insensitive, so casing cannot bypass it.
+        (
+            "__host-sid=x; Domain=example.com; Path=/; Secure",
+            "https://sub.example.com/",
+        ),
+    ],
+)
+async def test_cookie_prefix_rejected(set_cookie: str, url: str) -> None:
+    jar = CookieJar()
+    jar.update_cookies(SimpleCookie(set_cookie), URL(url))
+    assert len(jar) == 0
+
+
+@pytest.mark.parametrize(
+    ("set_cookie", "url"),
+    [
+        ("__Host-sid=x; Path=/; Secure", "https://example.com/"),
+        ("__Secure-sid=x; Secure", "https://example.com/"),
+        ("__Secure-sid=x; Domain=example.com; Secure", "https://www.example.com/"),
+    ],
+)
+async def test_cookie_prefix_accepted(set_cookie: str, url: str) -> None:
+    jar = CookieJar()
+    jar.update_cookies(SimpleCookie(set_cookie), URL(url))
+    assert len(jar) == 1
+
+
+async def test_cookie_prefix_programmatic_seed_unaffected() -> None:
+    # Seeding the jar without a response URL is a trusted path and keeps working.
+    jar = CookieJar()
+    jar.update_cookies(SimpleCookie("__Host-seed=x; Path=/; Secure"))
+    assert "__Host-seed" in jar.filter_cookies(URL("https://any.example/"))
+
+
+async def test_cookie_prefix_treat_as_secure_origin() -> None:
+    jar = CookieJar(treat_as_secure_origin=URL("http://example.com"))
+    jar.update_cookies(
+        SimpleCookie("__Host-sid=x; Path=/; Secure"), URL("http://example.com/")
+    )
+    assert "__Host-sid" in jar.filter_cookies(URL("http://example.com/"))
+
+
 class TestCookieJarSafe:
     @pytest.fixture(autouse=True)
     def setup_cookies(


### PR DESCRIPTION
## What do these changes do?

`CookieJar.update_cookies` stores cookies from a response without ever looking at the `__Secure-` / `__Host-` name prefixes defined in RFC 6265bis §4.1.3. Those prefixes exist so a server can trust that a cookie it sees really was set over HTTPS, host-locked (for `__Host-`), and with the `Secure` attribute. A sibling subdomain or an on-path party can currently forge one: sending `Set-Cookie: __Host-sid=attacker; Domain=example.com; Path=/` from `sub.example.com` gets stored as a domain cookie and later sent to the apex `https://example.com/`, which is the opposite of the host-only guarantee. A browser rejects that cookie outright.

The check now lives inside `update_cookies`, right where the incoming morsel is available: a name that case-insensitively begins with `__Secure-` or `__Host-` is dropped unless it arrived over a secure origin with the `Secure` attribute, and `__Host-` additionally requires host-only (no `Domain`) with `Path=/`. Cookies seeded programmatically (no response host) are untouched.

## Are there changes in behavior for the user?

A `__Secure-`/`__Host-` cookie that doesn't meet the prefix requirements is no longer accepted into the jar, matching browser behavior. Compliant cookies and all cookies without those prefixes are unaffected.

## Is it a substantial burden for the maintainers to support this?

No. It is a self-contained guard in one method plus a small `_is_secure_origin` helper that mirrors the secure-origin logic `filter_cookies` already uses.

## Related issue number

N/A

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
- [x] Add a new news fragment into the `CHANGES/` folder
