### PR TITLE
Fix StreamResponse.last_modified rounding inconsistency between datetime and timestamp

### DIFF
--- a/CHANGES/5303.bugfix.rst
+++ b/CHANGES/5303.bugfix.rst
@@ -1,0 +1,7 @@
+Fixed :py:attr:`~aiohttp.web.StreamResponse.last_modified` rounding a
+:class:`datetime.datetime` with a fractional second down while rounding an
+equivalent :class:`float` timestamp up, so the two produced different
+``Last-Modified`` headers for the same instant. Both now round up to the
+next whole second, consistent with how :py:class:`~aiohttp.web.FileResponse`
+relies on this rounding to avoid falsely reporting a resource as
+unmodified.

--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -267,6 +267,17 @@ class StreamResponse(
                 "%a, %d %b %Y %H:%M:%S GMT", time.gmtime(math.ceil(value))
             )
         elif isinstance(value, datetime.datetime):
+            # Round up to the next whole second when there's a
+            # fractional part, matching math.ceil() used for the
+            # int/float branch above. This keeps both branches
+            # consistent, and ensures the header is never earlier than
+            # the true modification time -- which matters because
+            # FileResponse sets this property from a file's mtime
+            # (a float) via the branch above, relying on rounding up
+            # to avoid falsely reporting "not modified" for conditional
+            # requests. See issue #5303.
+            if value.microsecond:
+                value = value.replace(microsecond=0) + datetime.timedelta(seconds=1)
             self._headers[hdrs.LAST_MODIFIED] = time.strftime(
                 "%a, %d %b %Y %H:%M:%S GMT", value.utctimetuple()
             )

--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -267,15 +267,6 @@ class StreamResponse(
                 "%a, %d %b %Y %H:%M:%S GMT", time.gmtime(math.ceil(value))
             )
         elif isinstance(value, datetime.datetime):
-            # Round up to the next whole second when there's a
-            # fractional part, matching math.ceil() used for the
-            # int/float branch above. This keeps both branches
-            # consistent, and ensures the header is never earlier than
-            # the true modification time -- which matters because
-            # FileResponse sets this property from a file's mtime
-            # (a float) via the branch above, relying on rounding up
-            # to avoid falsely reporting "not modified" for conditional
-            # requests. See issue #5303.
             if value.microsecond:
                 value = value.replace(microsecond=0) + datetime.timedelta(seconds=1)
             self._headers[hdrs.LAST_MODIFIED] = time.strftime(

--- a/tests/test_web_response.py
+++ b/tests/test_web_response.py
@@ -312,8 +312,8 @@ def test_last_modified_datetime_and_timestamp_round_consistently() -> None:
     resp_ts.last_modified = dt.timestamp()
 
     assert resp_dt.headers["Last-Modified"] == resp_ts.headers["Last-Modified"]
-    # Both should round up to the next whole second, so that
-    # Last-Modified is never earlier than the file's true st_mtime.
+    # Both should round up to the next whole second, so that Last-Modified
+    # is never earlier than the file's true st_mtime, invalidating the caching.
     assert resp_dt.last_modified == datetime.datetime(
         2020, 12, 2, 9, 51, 3, 0, datetime.timezone.utc
     )

--- a/tests/test_web_response.py
+++ b/tests/test_web_response.py
@@ -302,6 +302,33 @@ def test_last_modified_datetime() -> None:
     assert resp.last_modified == dt
 
 
+def test_last_modified_datetime_and_timestamp_round_consistently() -> None:
+    """Regression test for
+    https://github.com/aio-libs/aiohttp/issues/5303
+
+    Setting last_modified from a float timestamp with a fractional
+    second and from an equivalent datetime with the same fractional
+    second must produce the same header. Previously the timestamp
+    branch rounded up (math.ceil) while the datetime branch truncated
+    (utctimetuple() drops microseconds), so the same instant produced
+    two different Last-Modified headers depending on which type was
+    used to set it.
+    """
+    dt = datetime.datetime(2020, 12, 2, 9, 51, 2, 500000, datetime.timezone.utc)
+
+    resp_dt = web.StreamResponse()
+    resp_dt.last_modified = dt
+
+    resp_ts = web.StreamResponse()
+    resp_ts.last_modified = dt.timestamp()
+
+    assert resp_dt.headers["Last-Modified"] == resp_ts.headers["Last-Modified"]
+    # Both should round up to the next whole second.
+    assert resp_dt.last_modified == datetime.datetime(
+        2020, 12, 2, 9, 51, 3, 0, datetime.timezone.utc
+    )
+
+
 def test_last_modified_reset() -> None:
     resp = web.StreamResponse()
 

--- a/tests/test_web_response.py
+++ b/tests/test_web_response.py
@@ -323,7 +323,8 @@ def test_last_modified_datetime_and_timestamp_round_consistently() -> None:
     resp_ts.last_modified = dt.timestamp()
 
     assert resp_dt.headers["Last-Modified"] == resp_ts.headers["Last-Modified"]
-    # Both should round up to the next whole second.
+    # Both should round up to the next whole second, so that
+    # Last-Modified is never earlier than the file's true st_mtime.
     assert resp_dt.last_modified == datetime.datetime(
         2020, 12, 2, 9, 51, 3, 0, datetime.timezone.utc
     )

--- a/tests/test_web_response.py
+++ b/tests/test_web_response.py
@@ -303,17 +303,6 @@ def test_last_modified_datetime() -> None:
 
 
 def test_last_modified_datetime_and_timestamp_round_consistently() -> None:
-    """Regression test for
-    https://github.com/aio-libs/aiohttp/issues/5303
-
-    Setting last_modified from a float timestamp with a fractional
-    second and from an equivalent datetime with the same fractional
-    second must produce the same header. Previously the timestamp
-    branch rounded up (math.ceil) while the datetime branch truncated
-    (utctimetuple() drops microseconds), so the same instant produced
-    two different Last-Modified headers depending on which type was
-    used to set it.
-    """
     dt = datetime.datetime(2020, 12, 2, 9, 51, 2, 500000, datetime.timezone.utc)
 
     resp_dt = web.StreamResponse()


### PR DESCRIPTION
Fixes #5303.

Setting `last_modified` from a float/int timestamp with a fractional second rounded **up** (`math.ceil`), while setting it from an equivalent `datetime.datetime` with the same fractional second **truncated** (`utctimetuple()` drops microseconds). The same instant therefore produced two different `Last-Modified` headers depending on which type was used to set it, as shown in the issue.

The float/int path's round-up behavior isn't arbitrary: `FileResponse` sets `last_modified` from a file's `st_mtime` (a float) through that exact branch, and rounding up guarantees the advertised `Last-Modified` is never earlier than the file's true modification time. Rounding down there could cause a conditional GET (`If-Modified-Since`) to falsely report a resource as unmodified within the same second it actually changed.

**Fix**: make the `datetime` branch match -- round up to the next whole second when there's a fractional part, using the same reasoning and producing the same result as the float/int branch.

**Testing**: added a regression test that sets `last_modified` from a `datetime` and from a numerically equivalent timestamp with the same fractional second, and asserts both produce the same header. I confirmed the test fails without the fix (datetime path stays at the truncated second) and passes with it.

A note on how I verified this in my sandbox, in case it's useful context: a depth-1 clone can't build aiohttp's C extensions (needs the full llhttp vendor build), so I built and ran the actual test suite against a matching `v3.14.1` tag checkout (same source line, buildable) with the fix applied, overlaid onto that installed package. All 9 existing `last_modified` tests plus the new one pass, and the full `test_web_response.py` suite (182 tests, 33 skips for optional compression libs not installed there) passes.