### PR TITLE
Fix C parser folding fragment into query_string for empty-query origin-form target

### DIFF
--- a/CHANGES/13171.bugfix.rst
+++ b/CHANGES/13171.bugfix.rst
@@ -1,0 +1,3 @@
+Fixed the C HTTP parser folding the fragment into the query string for an
+origin-form request target with an empty query (e.g. ``/path?#frag``),
+which diverged from the pure-Python parser -- by :user:`GiulioDER`.

--- a/aiohttp/_http_parser.pyx
+++ b/aiohttp/_http_parser.pyx
@@ -736,7 +736,7 @@ cdef class HttpRequestParser(HttpParser):
                 else:
                     path = self._path[0:idx1]
                     idx1 += 1
-                    idx2 = self._path.find("#", idx1+1)
+                    idx2 = self._path.find("#", idx1)
                     if idx2 == -1:
                         query = self._path[idx1:]
                         fragment = ""

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -2536,6 +2536,19 @@ def test_parse_uri_utf8_percent_encoded(parser: HttpRequestParser) -> None:
     assert msg.url.fragment == "фраг"
 
 
+def test_parse_uri_empty_query_with_fragment(parser: HttpRequestParser) -> None:
+    # Origin-form target with an empty query but a fragment: the ``#`` sits
+    # immediately after ``?``. Regression for the C parser folding ``#frag``
+    # into the query string instead of the fragment.
+    text = ("GET /path?#frag HTTP/1.1\r\nHost: a\r\n\r\n").encode()
+    messages, upgrade, tail = parser.feed_data(text)
+    msg = messages[0][0]
+
+    assert msg.url.path == "/path"
+    assert msg.url.query == {}
+    assert msg.url.fragment == "frag"
+
+
 @pytest.mark.skipif(
     "HttpRequestParserC" not in dir(aiohttp.http_parser),
     reason="C based HTTP parser not available",

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -2540,7 +2540,7 @@ def test_parse_uri_empty_query_with_fragment(parser: HttpRequestParser) -> None:
     # Origin-form target with an empty query but a fragment: the ``#`` sits
     # immediately after ``?``. Regression for the C parser folding ``#frag``
     # into the query string instead of the fragment.
-    text = ("GET /path?#frag HTTP/1.1\r\nHost: a\r\n\r\n").encode()
+    text = (b"GET /path?#frag HTTP/1.1\r\nHost: a\r\n\r\n")
     messages, upgrade, tail = parser.feed_data(text)
     msg = messages[0][0]
 

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -2540,7 +2540,7 @@ def test_parse_uri_empty_query_with_fragment(parser: HttpRequestParser) -> None:
     # Origin-form target with an empty query but a fragment: the ``#`` sits
     # immediately after ``?``. Regression for the C parser folding ``#frag``
     # into the query string instead of the fragment.
-    text = (b"GET /path?#frag HTTP/1.1\r\nHost: a\r\n\r\n")
+    text = b"GET /path?#frag HTTP/1.1\r\nHost: a\r\n\r\n"
     messages, upgrade, tail = parser.feed_data(text)
     msg = messages[0][0]
 


### PR DESCRIPTION
### What do these changes do?

For an origin-form request target with an **empty query but a fragment** — e.g.
`GET /path?#frag HTTP/1.1` — the C parser's `_on_status_complete` searched for `#`
starting one character past the query start (`find("#", idx1+1)`), skipping a `#`
sitting exactly at the query start. The fragment was folded into the query string and
lost as `url.fragment`, diverging from the pure-Python parser (which uses `str.partition`).

This searches from the query start instead (`find("#", idx1)`). One character; no change
for any other target shape.

Before / after (C parser):

| target | before | after / Python parser |
| --- | --- | --- |
| `/path?#frag` | query=`#frag`, fragment=`` | query=``, fragment=`frag` |
| `/path?#` | query=`#`, fragment=`` | query=``, fragment=`` |
| `/path?q=1#frag`, `/path#frag`, … | unchanged | unchanged |

### Are there changes in behavior for the user?

Only for the empty-query-with-fragment target, which now matches the pure-Python parser.

### Related issue number

Refs #13171. It was closed as not-planned (clients don't send fragments), and
@Dreamsorcerer invited a fix "if it's not complex or affecting performance" — this is a
one-character change plus a regression test that runs under both parsers.

### Checklist

- [x] Regression test added (`test_parse_uri_empty_query_with_fragment`)
- [x] `CHANGES/13171.bugfix.rst` added

---

_Note: I wasn't able to build the C extension locally (no MSVC toolchain), so I verified
via source analysis and a transcription of the branch against the Python parser; CI
exercises the built parser. Found with AI assistance and reviewed by me before opening._
