### PR TITLE
Expose the request timeout to client middlewares

### DIFF
--- a/CHANGES/13176.feature.rst
+++ b/CHANGES/13176.feature.rst
@@ -1,0 +1,4 @@
+Exposed the request's timeout configuration to client middlewares as the
+read-only :attr:`ClientRequest.timeout <aiohttp.ClientRequest.timeout>`
+property, so a middleware can bound its own waits and retries by the
+caller's time budget -- by :user:`rodrigobnogueira`.

--- a/CHANGES/13176.feature.rst
+++ b/CHANGES/13176.feature.rst
@@ -1,4 +1,3 @@
 Exposed the request's timeout configuration to client middlewares as the
 read-only :attr:`ClientRequest.timeout <aiohttp.ClientRequest.timeout>`
-property, so a middleware can bound its own waits and retries by the
-caller's time budget -- by :user:`rodrigobnogueira`.
+property -- by :user:`rodrigobnogueira`.

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -1127,6 +1127,11 @@ class ClientRequest(ClientRequestBase):
         return self._skip_auto_headers or CIMultiDict()
 
     @property
+    def timeout(self) -> ClientTimeout:
+        """The timeout configuration this request runs under (read-only)."""
+        return self._timeout
+
+    @property
     def connection_key(self) -> ConnectionKey:
         if proxy_headers := self.proxy_headers:
             h: int | None = hash(tuple(proxy_headers.items()))

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -2106,6 +2106,16 @@ ClientRequest
       - :class:`ssl.SSLContext`: Custom SSL context
       - :class:`Fingerprint`: Verify specific certificate fingerprint
 
+   .. attribute:: timeout
+      :type: ClientTimeout
+
+      The timeout configuration this request runs under (read-only): the
+      per-request timeout when one was passed to the request method, the
+      session's default otherwise. Useful in middleware to bound waits or
+      retries by the caller's time budget.
+
+      .. versionadded:: 3.15
+
    .. attribute:: url
       :type: yarl.URL
 

--- a/tests/test_client_request.py
+++ b/tests/test_client_request.py
@@ -122,6 +122,12 @@ async def test_version_default(make_client_request: _RequestMaker) -> None:
     assert req.version == (1, 1)
 
 
+async def test_timeout_property(make_client_request: _RequestMaker) -> None:
+    timeout = ClientTimeout(total=42)
+    req = make_client_request("get", URL("http://python.org/"), timeout=timeout)
+    assert req.timeout is timeout
+
+
 async def test_request_info(make_client_request: _RequestMaker) -> None:
     req = make_client_request("get", URL("http://python.org/"))
     url = URL("http://python.org/")


### PR DESCRIPTION
## What do these changes do?

Adds a read-only `ClientRequest.timeout` property returning the effective `ClientTimeout` the request runs under (the per-request one when given, the session default otherwise). Client middlewares currently have no supported way to know the caller's time budget — the value only lives in the private `_timeout` attribute — so a middleware that sleeps (rate limiting) or retries cannot bail out early when its wait would exceed the total timeout.

Requested by Dreamsorcerer in the rate-limit middleware review: aio-libs/aiohttp-client-middlewares#12.

## Are there changes in behavior for the user?

No behavior changes — one new public read-only attribute, documented under `ClientRequest` in the client reference.

## Is it a substantial burden for the maintainers to support this?

No: a one-line property over the already-existing `_timeout`, which every request always sets.

## Related issue number

Requested in aio-libs/aiohttp-client-middlewares#12 (rate-limit middleware). Backport to 3.15 intended, so the middleware can rely on it.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt` — already listed
- [x] Add a new news fragment into the `CHANGES/` folder

<details>
<summary>Local test evidence</summary>

- `tests/test_client_request.py`: 194 passed, 6 skipped (includes the new `test_timeout_property`)

</details>
