### PR TITLE
drop every copy of credential headers on cross-origin redirect

### DIFF
--- a/CHANGES/13180.bugfix.rst
+++ b/CHANGES/13180.bugfix.rst
@@ -1,4 +1,2 @@
 Fixed the client dropping only the first ``Authorization``, ``Cookie`` and
-``Proxy-Authorization`` header when a redirect crosses an origin, so a request
-made with duplicate credential headers leaked the surviving copy to the new
-origin -- by :user:`arshsmith1`.
+``Proxy-Authorization`` header when a redirect crosses an origin -- by :user:`arshsmith1`.

--- a/CHANGES/13180.bugfix.rst
+++ b/CHANGES/13180.bugfix.rst
@@ -1,0 +1,4 @@
+Fixed the client dropping only the first ``Authorization``, ``Cookie`` and
+``Proxy-Authorization`` header when a redirect crosses an origin, so a request
+made with duplicate credential headers leaked the surviving copy to the new
+origin -- by :user:`arshsmith1`.

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -837,9 +837,9 @@ class ClientSession:
 
                         if url.origin() != redirect_origin:
                             cookies = None
-                            headers.pop(hdrs.AUTHORIZATION, None)
-                            headers.pop(hdrs.COOKIE, None)
-                            headers.pop(hdrs.PROXY_AUTHORIZATION, None)
+                            headers.popall(hdrs.AUTHORIZATION, None)
+                            headers.popall(hdrs.COOKIE, None)
+                            headers.popall(hdrs.PROXY_AUTHORIZATION, None)
 
                         url = parsed_redirect_url
                         params = {}

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -3577,18 +3577,16 @@ async def test_drop_auth_on_redirect_to_other_host(
 
 
 async def test_drop_duplicate_auth_headers_on_redirect_to_other_host(
-    create_server_for_url_and_handler: Callable[[URL, Handler], Awaitable[TestServer]],
+    aiohttp_server: AiohttpServer,
 ) -> None:
     """Every copy of a credential header is dropped, not just the first one."""
-    url_from = URL("http://host1.com/path1")
-    url_to = URL("http://host2.com/path2")
 
     async def srv_from(request: web.Request) -> NoReturn:
         assert list(request.headers.getall("Authorization")) == [
             "Basic first",
             "Basic second",
         ]
-        raise web.HTTPFound(url_to)
+        raise web.HTTPFound(server_to.make_url("/path2"))
 
     async def srv_to(request: web.Request) -> web.Response:
         assert "Authorization" not in request.headers, "Header wasn't dropped"
@@ -3596,40 +3594,16 @@ async def test_drop_duplicate_auth_headers_on_redirect_to_other_host(
         assert "Cookie" not in request.headers
         return web.Response()
 
-    server_from = await create_server_for_url_and_handler(url_from, srv_from)
-    server_to = await create_server_for_url_and_handler(url_to, srv_to)
+    app_from = web.Application()
+    app_from.router.add_get("/path1", srv_from)
+    server_from = await aiohttp_server(app_from)
 
-    etc_hosts = {
-        (url_from.host, url_from.port): server_from,
-        (url_to.host, url_to.port): server_to,
-    }
+    app_to = web.Application()
+    app_to.router.add_get("/path2", srv_to)
+    server_to = await aiohttp_server(app_to)
 
-    class FakeResolver(AbstractResolver):
-        async def resolve(
-            self,
-            host: str,
-            port: int = 0,
-            family: socket.AddressFamily = socket.AF_INET,
-        ) -> list[ResolveResult]:
-            server = etc_hosts[(host, port)]
-            assert server.port is not None
-
-            return [
-                {
-                    "hostname": host,
-                    "host": server.host,
-                    "port": server.port,
-                    "family": socket.AF_INET,
-                    "proto": 0,
-                    "flags": socket.AI_NUMERICHOST,
-                }
-            ]
-
-        async def close(self) -> None:
-            """Dummy"""
-
-    connector = aiohttp.TCPConnector(resolver=FakeResolver(), ssl=False)
-
+    # Two servers on the same host but different ports are different origins,
+    # so following the redirect must strip the credential headers.
     headers = CIMultiDict(
         (
             ("Authorization", "Basic first"),
@@ -3641,8 +3615,9 @@ async def test_drop_duplicate_auth_headers_on_redirect_to_other_host(
         )
     )
 
-    async with aiohttp.ClientSession(connector=connector) as client:
-        async with client.get(url_from, headers=headers) as resp:
+    url = server_from.make_url("/path1")
+    async with aiohttp.ClientSession() as client:
+        async with client.get(url, headers=headers) as resp:
             assert resp.status == 200
 
 

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -37,7 +37,7 @@ except ImportError:
     ZstdCompressor = None  # type: ignore[assignment,misc]  # pragma: no cover
 
 import pytest
-from multidict import MultiDict
+from multidict import CIMultiDict, MultiDict
 from pytest_aiohttp import AiohttpClient, AiohttpServer
 from pytest_mock import MockerFixture
 from yarl import URL, Query
@@ -3573,6 +3573,76 @@ async def test_drop_auth_on_redirect_to_other_host(
             },
             cookies={"a": "b"},
         ) as resp:
+            assert resp.status == 200
+
+
+async def test_drop_duplicate_auth_headers_on_redirect_to_other_host(
+    create_server_for_url_and_handler: Callable[[URL, Handler], Awaitable[TestServer]],
+) -> None:
+    """Every copy of a credential header is dropped, not just the first one."""
+    url_from = URL("http://host1.com/path1")
+    url_to = URL("http://host2.com/path2")
+
+    async def srv_from(request: web.Request) -> NoReturn:
+        assert list(request.headers.getall("Authorization")) == [
+            "Basic first",
+            "Basic second",
+        ]
+        raise web.HTTPFound(url_to)
+
+    async def srv_to(request: web.Request) -> web.Response:
+        assert "Authorization" not in request.headers, "Header wasn't dropped"
+        assert "Proxy-Authorization" not in request.headers
+        assert "Cookie" not in request.headers
+        return web.Response()
+
+    server_from = await create_server_for_url_and_handler(url_from, srv_from)
+    server_to = await create_server_for_url_and_handler(url_to, srv_to)
+
+    etc_hosts = {
+        (url_from.host, url_from.port): server_from,
+        (url_to.host, url_to.port): server_to,
+    }
+
+    class FakeResolver(AbstractResolver):
+        async def resolve(
+            self,
+            host: str,
+            port: int = 0,
+            family: socket.AddressFamily = socket.AF_INET,
+        ) -> list[ResolveResult]:
+            server = etc_hosts[(host, port)]
+            assert server.port is not None
+
+            return [
+                {
+                    "hostname": host,
+                    "host": server.host,
+                    "port": server.port,
+                    "family": socket.AF_INET,
+                    "proto": 0,
+                    "flags": socket.AI_NUMERICHOST,
+                }
+            ]
+
+        async def close(self) -> None:
+            """Dummy"""
+
+    connector = aiohttp.TCPConnector(resolver=FakeResolver(), ssl=False)
+
+    headers = CIMultiDict(
+        (
+            ("Authorization", "Basic first"),
+            ("Authorization", "Basic second"),
+            ("Proxy-Authorization", "Basic first"),
+            ("Proxy-Authorization", "Basic second"),
+            ("Cookie", "a=b"),
+            ("Cookie", "c=d"),
+        )
+    )
+
+    async with aiohttp.ClientSession(connector=connector) as client:
+        async with client.get(url_from, headers=headers) as resp:
             assert resp.status == 200
 
 


### PR DESCRIPTION
## What do these changes do?

The cross-origin guard in `ClientSession._request` strips `Authorization`, `Cookie` and `Proxy-Authorization` with `CIMultiDict.pop()`, which removes only the first entry for a key. `_prepare_headers` deliberately keeps caller-supplied duplicates (it calls `result.add()` when a name repeats), so a request made with a multidict holding two `Authorization` entries keeps the second one after the strip, and that surviving credential goes out to whatever origin the response redirected to. `popall()` removes all of them.

## Are there changes in behavior for the user?

Only for the leaking case. A single credential header behaves exactly as before; duplicates are now fully dropped when the redirect crosses an origin, same as the documented behaviour for one.

## Is it a substantial burden for the maintainers to support this?

No, it swaps three calls for their `popall` equivalents and adds one regression test next to the existing cross-origin drop tests.

## Related issue number

None.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes — N/A, no public API change
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
- [x] Add a new news fragment into the `CHANGES/` folder
