### PR TITLE
Fix a flaky test on Windows

### DIFF
--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -4,6 +4,7 @@ import gc
 import ipaddress
 import itertools
 import sys
+import time
 import weakref
 from collections.abc import Iterator
 from math import ceil, modf
@@ -352,6 +353,10 @@ def test_timeout_handle(event_loop: asyncio.AbstractEventLoop) -> None:
     assert not handle._callbacks
 
 
+@pytest.mark.skipif(
+    time.get_clock_info("monotonic").resolution > 0.001,
+    reason="loop.time() resolution is coarser than the test's 1ms tolerance",
+)
 def test_when_timeout_smaller_second(event_loop: asyncio.AbstractEventLoop) -> None:
     timeout = 0.1
 


### PR DESCRIPTION
Apparently Windows monotonic clock has a resolution of 15.6ms! So, if the clock ticks over in this test, then it fails when it tries to compare with an accuracy of 1ms.