### PR TITLE
Guard response Transfer-Encoding chunked check with isascii for parser parity

### DIFF
--- a/CHANGES/13200.bugfix.rst
+++ b/CHANGES/13200.bugfix.rst
@@ -1,0 +1,4 @@
+Stopped treating a non-ascii ``Transfer-Encoding`` value that
+case-folds to ``chunked`` (e.g. one containing ``U+212A KELVIN SIGN``) as
+chunked in the pure-Python HTTP response parser, matching the existing
+``.isascii()`` guard in the request parser -- by :user:`Kropiunig`.

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -834,7 +834,9 @@ class HttpResponseParser(HttpParser[RawResponseMessage]):
 
     def _is_chunked_te(self, te: str) -> bool:
         # https://www.rfc-editor.org/rfc/rfc9112#section-6.3-2.4.2
-        return te.rsplit(",", maxsplit=1)[-1].strip(" \t").lower() == "chunked"
+        last = te.rsplit(",", maxsplit=1)[-1].strip(" \t")
+        # .lower() transforms some non-ascii chars, so must check first.
+        return last.isascii() and last.lower() == "chunked"
 
 
 class HttpPayloadParser:

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -2155,6 +2155,35 @@ async def test_http_response_parser_last_chunked(
     assert await messages[0][1].read() == b"Test"
 
 
+async def test_http_response_parser_te_non_ascii() -> None:
+    # "\N{KELVIN SIGN}".lower() == "k", so "chun\N{KELVIN SIGN}ed".lower()
+    # == "chunked", but the value is not an ascii token and must not be
+    # treated as chunked. Mirrors the HttpRequestParser handling and its
+    # ``.isascii()`` guard (see test_te_header_non_ascii).
+    protocol = ResponseHandler(asyncio.get_running_loop())
+    response = HttpResponseParserPy(
+        protocol,
+        asyncio.get_running_loop(),
+        DEFAULT_CHUNK_SIZE,
+        max_line_size=8190,
+        max_field_size=8190,
+        read_until_eof=True,
+    )
+    protocol._parser = response
+    te = "chun\N{KELVIN SIGN}ed"
+    text = (
+        f"HTTP/1.1 200 OK\r\nTransfer-Encoding: {te}\r\n\r\n"
+        "1\r\nT\r\n3\r\nest\r\n0\r\n\r\n"
+    ).encode()
+    messages, upgrade, tail = response.feed_data(text)
+    response.feed_eof()
+
+    msg = messages[0][0]
+    assert not msg.chunked
+    # Body must be returned raw, not de-chunked.
+    assert await messages[0][1].read() == b"1\r\nT\r\n3\r\nest\r\n0\r\n\r\n"
+
+
 def test_http_response_parser_bad(response: HttpResponseParser) -> None:
     with pytest.raises(http_exceptions.BadHttpMessage):
         response.feed_data(b"HTT/1\r\n\r\n")


### PR DESCRIPTION
## What do these changes do?

`HttpResponseParser._is_chunked_te` decides whether a response body is
chunked with:

```python
return te.rsplit(",", maxsplit=1)[-1].strip(" \t").lower() == "chunked"
```

It calls `.lower()` without first checking `.isascii()`. Because
`str.lower()` case-folds some non-ascii characters into ascii, a
non-ascii Transfer-Encoding value can be misclassified as `chunked`.
For example a value containing U+212A KELVIN SIGN:

```python
>>> "chun\N{KELVIN SIGN}ed".isascii()
False
>>> "chun\N{KELVIN SIGN}ed".lower() == "chunked"
True
```

The sibling `HttpRequestParser._is_chunked_te` guards against exactly this
and even documents it:

```python
last = parts[-1]
# .lower() transforms some non-ascii chars, so must check first.
if last.isascii() and last.lower() == "chunked":
    return True
```

The same `.isascii()` guard is applied to the shared Content-Encoding
check and to `_is_supported_upgrade`. Only the response
`_is_chunked_te` was left without it (it was not updated in #11886, which
added the guard everywhere else). Transfer-coding names are ascii tokens
(:rfc:`9110#section-5.6.2`), so a non-ascii value must not be treated as
`chunked`. This is a parser parity/correctness fix: the response parser now
handles this input the same, stricter way the request parser already does.

This changes behaviour only for non-ascii Transfer-Encoding values that
case-fold to `chunked` — previously treated as chunked, now (correctly)
not chunked. It does not weaken any existing check; it makes response
parsing consistent with request parsing.

The C parser (`_http_parser.pyx`) is not affected: it determines chunked
from llhttp's `F_CHUNKED` flag rather than a Python `.lower()` comparison,
so it already rejects non-ascii transfer-coding tokens at the C level.

## Are there changes in behavior for the user?

Only the corner case above: a response whose last Transfer-Encoding token
is a non-ascii string that lowercases to `chunked` is no longer decoded as
chunked.

## Related issue number

None.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] Add a new news fragment into the `CHANGES` folder
