### PR TITLE
[PR #13180/ee53d655 backport][3.15] drop every copy of credential headers on cross-origin redirect

### DIFF
--- a/CHANGES/13180.bugfix.rst
+++ b/CHANGES/13180.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed the client dropping only the first ``Authorization``, ``Cookie`` and
+``Proxy-Authorization`` header when a redirect crosses an origin -- by :user:`arshsmith1`.

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -984,9 +984,9 @@ class ClientSession:
                         if url.origin() != redirect_origin:
                             auth = None
                             cookies = None
-                            headers.pop(hdrs.AUTHORIZATION, None)
-                            headers.pop(hdrs.COOKIE, None)
-                            headers.pop(hdrs.PROXY_AUTHORIZATION, None)
+                            headers.popall(hdrs.AUTHORIZATION, None)
+                            headers.popall(hdrs.COOKIE, None)
+                            headers.popall(hdrs.PROXY_AUTHORIZATION, None)
 
                         url = parsed_redirect_url
                         params = {}

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -34,7 +34,7 @@ except ImportError:
     ZstdCompressor = None  # type: ignore[assignment,misc]  # pragma: no cover
 
 import pytest
-from multidict import MultiDict
+from multidict import CIMultiDict, MultiDict
 from pytest_mock import MockerFixture
 from yarl import URL
 
@@ -3675,6 +3675,51 @@ async def test_auth_persist_on_redirect_to_other_host_with_global_auth(
             headers={"Proxy-Authorization": "Basic dXNlcjpwYXNz"},
             cookies={"a": "b"},
         ) as resp:
+            assert resp.status == 200
+
+
+async def test_drop_duplicate_auth_headers_on_redirect_to_other_host(
+    aiohttp_server: AiohttpServer,
+) -> None:
+    """Every copy of a credential header is dropped, not just the first one."""
+
+    async def srv_from(request: web.Request) -> NoReturn:
+        assert list(request.headers.getall("Authorization")) == [
+            "Basic first",
+            "Basic second",
+        ]
+        raise web.HTTPFound(server_to.make_url("/path2"))
+
+    async def srv_to(request: web.Request) -> web.Response:
+        assert "Authorization" not in request.headers, "Header wasn't dropped"
+        assert "Proxy-Authorization" not in request.headers
+        assert "Cookie" not in request.headers
+        return web.Response()
+
+    app_from = web.Application()
+    app_from.router.add_get("/path1", srv_from)
+    server_from = await aiohttp_server(app_from)
+
+    app_to = web.Application()
+    app_to.router.add_get("/path2", srv_to)
+    server_to = await aiohttp_server(app_to)
+
+    # Two servers on the same host but different ports are different origins,
+    # so following the redirect must strip the credential headers.
+    headers = CIMultiDict(
+        (
+            ("Authorization", "Basic first"),
+            ("Authorization", "Basic second"),
+            ("Proxy-Authorization", "Basic first"),
+            ("Proxy-Authorization", "Basic second"),
+            ("Cookie", "a=b"),
+            ("Cookie", "c=d"),
+        )
+    )
+
+    url = server_from.make_url("/path1")
+    async with aiohttp.ClientSession() as client:
+        async with client.get(url, headers=headers) as resp:
             assert resp.status == 200
 
 


### PR DESCRIPTION
**This is a backport of PR #13180 as merged into master (ee53d6558083e245f3aae7e864ed5523d138c9db).**

## What do these changes do?

The cross-origin guard in `ClientSession._request` strips `Authorization`, `Cookie` and `Proxy-Authorization` with `CIMultiDict.pop()`, which removes only the first entry for a key. `_prepare_headers` deliberately keeps caller-supplied duplicates (it calls `result.add()` when a name repeats), so a request made with a multidict holding two `Authorization` entries keeps the second one after the strip, and that surviving credential goes out to whatever origin the response redirected to. `popall()` removes all of them.

## Are there changes in behavior for the user?

Only for the leaking case. A single credential header behaves exactly as before; duplicates are now fully dropped when the redirect crosses an origin, same as the documented behaviour for one.

## Is it a substantial burden for the maintainers to support this?

No, it swaps three calls for their `popall` equivalents and adds one regression test next to the existing cross-origin drop tests.

## Related issue number

None.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes — N/A, no public API change
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
- [x] Add a new news fragment into the `CHANGES/` folder

