### PR TITLE
strip leading separators in all content-disposition filename forms

### DIFF
--- a/CHANGES/13206.bugfix.rst
+++ b/CHANGES/13206.bugfix.rst
@@ -1,0 +1,4 @@
+Fixed ``Content-Disposition`` parsing stripping leading path separators from a
+quoted ``filename`` but not from the RFC 5987 ``filename*`` or the RFC 2231
+``filename*0``/``filename*0*`` continuation forms, so the sender chose whether
+that normalisation applied -- by :user:`arshsmith1`.

--- a/CHANGES/13206.bugfix.rst
+++ b/CHANGES/13206.bugfix.rst
@@ -1,4 +1,1 @@
-Fixed ``Content-Disposition`` parsing stripping leading path separators from a
-quoted ``filename`` but not from the RFC 5987 ``filename*`` or the RFC 2231
-``filename*0``/``filename*0*`` continuation forms, so the sender chose whether
-that normalisation applied -- by :user:`arshsmith1`.
+Fixed leading path separators in ``Content-Disposition`` not being stripped in some circumstances -- by :user:`arshsmith1`.

--- a/aiohttp/multipart.py
+++ b/aiohttp/multipart.py
@@ -136,7 +136,7 @@ def parse_content_disposition(
 
         elif is_continuous_param(key):
             if is_quoted(value):
-                value = unescape(value[1:-1].lstrip("\\/"))
+                value = unescape(value[1:-1])
             elif not is_token(value):
                 warnings.warn(BadContentDispositionParam(item))
                 continue
@@ -221,7 +221,7 @@ def content_disposition_filename(
                 # (shadowed in this module by payload.LookupError) and
                 # undecodable bytes raise UnicodeDecodeError.
                 return None
-        return value
+        return value.lstrip("\\/")
 
 
 class MultipartResponseWrapper:

--- a/aiohttp/multipart.py
+++ b/aiohttp/multipart.py
@@ -136,7 +136,7 @@ def parse_content_disposition(
 
         elif is_continuous_param(key):
             if is_quoted(value):
-                value = unescape(value[1:-1])
+                value = unescape(value[1:-1].lstrip("\\/"))
             elif not is_token(value):
                 warnings.warn(BadContentDispositionParam(item))
                 continue
@@ -150,7 +150,7 @@ def parse_content_disposition(
                 continue
 
             try:
-                value = unquote(value, encoding, "strict")
+                value = unquote(value, encoding, "strict").lstrip("\\/")
             except (builtins.LookupError, UnicodeDecodeError):
                 # The charset is attacker-controlled here; an unknown name
                 # raises the builtin LookupError (the bare name is shadowed in
@@ -214,7 +214,7 @@ def content_disposition_filename(
             encoding, _, value = value.split("'", 2)
             encoding = encoding or "utf-8"
             try:
-                return unquote(value, encoding, "strict")
+                return unquote(value, encoding, "strict").lstrip("\\/")
             except (builtins.LookupError, UnicodeDecodeError):
                 # Both the charset name and the octets are attacker-controlled
                 # here; an unknown encoding raises the builtin LookupError

--- a/tests/test_multipart_helpers.py
+++ b/tests/test_multipart_helpers.py
@@ -573,11 +573,13 @@ class TestParseContentDisposition:
         assert {"filename*": "foo.html"} == params
 
     def test_attfncontabspath(self) -> None:
+        # The continuation parts are normalised once they are joined, so the
+        # separator survives parsing.
         disptype, params = parse_content_disposition(
             'attachment; filename*0="/foo."; filename*1="html"'
         )
         assert "attachment" == disptype
-        assert {"filename*0": "foo.", "filename*1": "html"} == params
+        assert {"filename*0": "/foo.", "filename*1": "html"} == params
 
     def test_attfncont(self) -> None:
         disptype, params = parse_content_disposition(
@@ -734,6 +736,18 @@ class TestContentDispositionFilename:
     def test_attfncont(self) -> None:
         params = {"filename*0": "foo.", "filename*1": "html"}
         assert "foo.html" == content_disposition_filename(params)
+
+    def test_attfncontabspath(self) -> None:
+        _, params = parse_content_disposition(
+            'attachment; filename*0="/foo."; filename*1="html"'
+        )
+        assert "foo.html" == content_disposition_filename(params)
+
+    def test_attfncontinnerpath(self) -> None:
+        _, params = parse_content_disposition(
+            'attachment; filename*0="dir"; filename*1="/foo.html"'
+        )
+        assert "dir/foo.html" == content_disposition_filename(params)
 
     def test_attfncontqs(self) -> None:
         params = {"filename*0": "foo", "filename*1": "bar.html"}

--- a/tests/test_multipart_helpers.py
+++ b/tests/test_multipart_helpers.py
@@ -563,7 +563,21 @@ class TestParseContentDisposition:
             "attachment; filename*=UTF-8''%5cfoo.html"
         )
         assert "attachment" == disptype
-        assert {"filename*": "\\foo.html"} == params
+        assert {"filename*": "foo.html"} == params
+
+    def test_attwithfn2231abspath(self) -> None:
+        disptype, params = parse_content_disposition(
+            "attachment; filename*=UTF-8''%2Ffoo.html"
+        )
+        assert "attachment" == disptype
+        assert {"filename*": "foo.html"} == params
+
+    def test_attfncontabspath(self) -> None:
+        disptype, params = parse_content_disposition(
+            'attachment; filename*0="/foo."; filename*1="html"'
+        )
+        assert "attachment" == disptype
+        assert {"filename*0": "foo.", "filename*1": "html"} == params
 
     def test_attfncont(self) -> None:
         disptype, params = parse_content_disposition(
@@ -711,6 +725,12 @@ class TestContentDispositionFilename:
         params = {"filename*": "файл.html"}
         assert "файл.html" == content_disposition_filename(params)
 
+    def test_filename_ext_abspath(self) -> None:
+        _, params = parse_content_disposition(
+            'form-data; name="f"; filename="/etc/evil"; filename*=UTF-8\'\'%2Fetc%2Fevil'
+        )
+        assert "etc/evil" == content_disposition_filename(params)
+
     def test_attfncont(self) -> None:
         params = {"filename*0": "foo.", "filename*1": "html"}
         assert "foo.html" == content_disposition_filename(params)
@@ -721,6 +741,16 @@ class TestContentDispositionFilename:
 
     def test_attfncontenc(self) -> None:
         params = {"filename*0*": "UTF-8''foo-%c3%a4", "filename*1": ".html"}
+        assert "foo-ä.html" == content_disposition_filename(params)
+
+    @pytest.mark.parametrize(
+        "params",
+        (
+            {"filename*0*": "UTF-8''%2Ffoo-%c3%a4", "filename*1": ".html"},
+            {"filename*0*": "UTF-8''%5cfoo-%c3%a4", "filename*1": ".html"},
+        ),
+    )
+    def test_attfncontencabspath(self, params: dict[str, str]) -> None:
         assert "foo-ä.html" == content_disposition_filename(params)
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
## What do these changes do?

`parse_content_disposition` strips leading path separators when the filename arrives as a quoted-string, but the RFC 5987 `filename*` and the RFC 2231 `filename*0` / `filename*0*` continuation forms skip that step, so the sender picks whether the normalisation runs at all: `filename*=UTF-8''%2Fetc%2Fcron.d%2Fevil` comes back as `/etc/cron.d/evil` where `filename="/etc/cron.d/evil"` comes back as `etc/cron.d/evil`. `content_disposition_filename` also prefers `filename*` over `filename` and reassembles continuation parts on its own, so the unnormalised spelling is the one `BodyPartReader.filename` and `FileField.filename` hand to applications. The same `lstrip` now runs in the continuation and extended-parameter branches and on the reassembled continuation value, so every spelling of the header lands the same way.

The divergence is already visible in the test file: `test_attabspath` / `test_attabspathwin` assert the strip on the quoted form, while `test_attwithfn2231abspathdisguised` asserted the raw `\foo.html` for the 2231 form of the same greenbytes case. That expectation is updated here, and the other three forms get coverage alongside it.

## Are there changes in behavior for the user?

A leading `/` or `\` is now removed from `filename*` and from `filename*N` continuation values, matching what a quoted `filename` has always done. Nothing else about the value changes.

## Is it a substantial burden for the maintainers to support this?

No. It reuses the existing `lstrip("\\/")` at three more spots in the same two functions; no new helpers or API.

## Related issue number

None.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes — N/A, no documented behaviour changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt` — already listed
- [x] Add a new news fragment into the `CHANGES/` folder

<details>
<summary>Local run</summary>

```
$ PYTHONPATH=. AIOHTTP_NO_EXTENSIONS=1 pytest tests/ -q -k "not benchmark"
4390 passed, 92 skipped, 107 deselected, 14 xfailed in 260.01s

# the six new/updated assertions on the unpatched tree
FAILED tests/test_multipart_helpers.py::TestParseContentDisposition::test_attwithfn2231abspathdisguised
FAILED tests/test_multipart_helpers.py::TestParseContentDisposition::test_attwithfn2231abspath
FAILED tests/test_multipart_helpers.py::TestParseContentDisposition::test_attfncontabspath
FAILED tests/test_multipart_helpers.py::TestContentDispositionFilename::test_filename_ext_abspath
FAILED tests/test_multipart_helpers.py::TestContentDispositionFilename::test_attfncontencabspath[params0]
FAILED tests/test_multipart_helpers.py::TestContentDispositionFilename::test_attfncontencabspath[params1]
```

</details>
