### PR TITLE
[PR #13176/6fa8f394 backport][3.15] Expose the request timeout to client middlewares

### DIFF
--- a/CHANGES/13176.feature.rst
+++ b/CHANGES/13176.feature.rst
@@ -1,0 +1,3 @@
+Exposed the request's timeout configuration to client middlewares as the
+read-only :attr:`ClientRequest.timeout <aiohttp.ClientRequest.timeout>`
+property -- by :user:`rodrigobnogueira`.

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -805,6 +805,7 @@ class ClientSession:
                         proxy=proxy_,
                         proxy_auth=proxy_auth,
                         timer=timer,
+                        timeout=real_timeout,
                         session=self,
                         ssl=ssl if ssl is not None else True,
                         server_hostname=server_hostname,

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -81,7 +81,7 @@ __all__ = ("ClientRequest", "ClientResponse", "RequestInfo", "Fingerprint")
 
 
 if TYPE_CHECKING:
-    from .client import ClientSession
+    from .client import ClientSession, ClientTimeout
     from .connector import Connection
     from .tracing import Trace
 
@@ -871,6 +871,7 @@ class ClientRequest:
         proxy: URL | None = None,
         proxy_auth: BasicAuth | None = None,
         timer: BaseTimerContext | None = None,
+        timeout: Optional["ClientTimeout"] = None,
         session: Optional["ClientSession"] = None,
         ssl: SSLContext | bool | Fingerprint = True,
         proxy_headers: LooseHeaders | None = None,
@@ -889,11 +890,13 @@ class ClientRequest:
         assert type(url) is URL, url
         if proxy is not None:
             assert type(proxy) is URL, proxy
-        # FIXME: session is None in tests only, need to fix tests
+        # FIXME: session and timeout are None in tests only, need to fix tests
         # assert session is not None
         if TYPE_CHECKING:
             assert session is not None
+            assert timeout is not None
         self._session = session
+        self._timeout = timeout
         if params:
             url = url.extend_query(params)
         self.original_url = url
@@ -950,6 +953,11 @@ class ClientRequest:
     @property
     def skip_auto_headers(self) -> CIMultiDict[None]:
         return self._skip_auto_headers or CIMultiDict()
+
+    @property
+    def timeout(self) -> "ClientTimeout":
+        """The timeout configuration this request runs under (read-only)."""
+        return self._timeout
 
     @property
     def _writer(self) -> Optional["asyncio.Task[None]"]:

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -2145,6 +2145,16 @@ ClientRequest
       - :class:`ssl.SSLContext`: Custom SSL context
       - :class:`Fingerprint`: Verify specific certificate fingerprint
 
+   .. attribute:: timeout
+      :type: ClientTimeout
+
+      The timeout configuration this request runs under (read-only): the
+      per-request timeout when one was passed to the request method, the
+      session's default otherwise. Useful in middleware to bound waits or
+      retries by the caller's time budget.
+
+      .. versionadded:: 3.15
+
    .. attribute:: url
       :type: yarl.URL
 

--- a/tests/test_client_request.py
+++ b/tests/test_client_request.py
@@ -15,7 +15,7 @@ from multidict import CIMultiDict, CIMultiDictProxy, istr
 from yarl import URL
 
 import aiohttp
-from aiohttp import BaseConnector, hdrs, payload
+from aiohttp import BaseConnector, ClientTimeout, hdrs, payload
 from aiohttp.abc import AbstractStreamWriter
 from aiohttp.client_exceptions import ClientConnectionError
 from aiohttp.client_reqrep import (
@@ -125,6 +125,12 @@ def test_version_1_0(make_request) -> None:
 def test_version_default(make_request) -> None:
     req = make_request("get", "http://python.org/")
     assert req.version == (1, 1)
+
+
+def test_timeout_property(make_request: _RequestMaker) -> None:
+    timeout = ClientTimeout(total=42)
+    req = make_request("get", "http://python.org/", timeout=timeout)
+    assert req.timeout is timeout
 
 
 def test_request_info(make_request) -> None:


### PR DESCRIPTION
Manual backport of #13176 (squash commit 6fa8f394544550124df0b3304b37988e17ede1a7) to 3.15 — patchback hit conflicts (https://github.com/aio-libs/aiohttp/pull/13176#issuecomment-5024191625).

The conflicts exist because on master `ClientRequest` already receives and stores the timeout (`self._timeout`), so the original PR only had to add the property. On 3.15 the request object never sees the timeout — `_request()` hands `real_timeout` straight to the connector — so the property needed its plumbing backported with it:

1. **`ClientRequest.__init__` gains `timeout: Optional[ClientTimeout] = None`** (keyword-only, placed between `timer` and `session` to mirror master's parameter order) and stores it as `self._timeout`. The `None` default keeps direct construction (tests, subclasses) working; the `if TYPE_CHECKING: assert timeout is not None` narrowing copies the pattern the same function already uses for `session`, so the property's public type matches master's (`ClientTimeout`, not optional).
2. **`client.py` passes `timeout=real_timeout`** at the `self._request_class(...)` construction site. Since `ClientTimeout` lives in `client.py` on this branch (master moved it to `client_reqrep.py`), the import is `TYPE_CHECKING`-only to avoid the cycle.
3. **Test adapted** to 3.15's `make_request` fixture (master's `make_client_request` doesn't exist here); docs hunk and CHANGES fragment applied unchanged.

Verified locally on this branch: `tests/test_client_request.py` passes in full (210 passed), and an end-to-end script confirms a client middleware observes the session default and a per-request override by identity (`request.timeout is real_timeout`).
