### PR TITLE
Shard release publishing and signing across a gated matrix

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -764,11 +764,6 @@ jobs:
 
     permissions:
       contents: write  # IMPORTANT: mandatory for making GitHub Releases
-      id-token: write  # IMPORTANT: mandatory for trusted publishing & sigstore
-
-    environment:
-      name: pypi
-      url: https://pypi.org/p/aiohttp
 
     steps:
     - name: Checkout
@@ -822,27 +817,95 @@ jobs:
         fix_issue_repl: >-
           #\1
 
-    - name: >-
-        Publish 🐍📦 to PyPI
+  publish:
+    name: Publish (shard ${{ matrix.shard }}/2)
+    needs:
+    - deploy
+    - pre-setup  # transitive, for accessing settings
+    runs-on: ubuntu-latest
+    if: >-
+      needs.pre-setup.outputs.upstream-repository-id == github.repository_id
+
+    permissions:
+      contents: write  # IMPORTANT: mandatory for uploading Sigstore signatures
+      id-token: write  # IMPORTANT: mandatory for trusted publishing & sigstore
+
+    environment:
+      name: pypi
+      url: https://pypi.org/p/aiohttp
+
+    strategy:
+      # Run the shards sequentially: each is a separate job that mints its own
+      # fresh OIDC identity, so per-shard signing stays well under the token
+      # lifetime (see pypa/gh-action-pypi-publish#307), and only one job updates
+      # the shared GitHub Release at a time. fail-fast is off so a failed shard
+      # can be re-run on its own; every step is idempotent.
+      fail-fast: false
+      max-parallel: 1
+      matrix:
+        shard:
+        - 0
+        - 1
+
+    steps:
+    - name: Download distributions
+      uses: actions/download-artifact@v8
+      with:
+        path: dist
+        pattern: dist-*
+        merge-multiple: true
+    - name: Select this shard's distributions
+      # gh-action-pypi-publish and the Sigstore signing below each mint a single
+      # short-lived OIDC identity per job and reuse it for every file, so signing
+      # the whole dist set in one job can outlast the token and fail partway
+      # through (pypa/gh-action-pypi-publish#307). Keeping only every Nth dist
+      # here bounds each job's signing loop. Bump the matrix and SHARDS together
+      # if the wheel matrix keeps growing.
+      #
+      # The split is fully deterministic: the same built dists always sort the
+      # same way (LC_ALL=C, byte order, independent of runner locale) and land
+      # in the same shard, so re-running a single failed shard reprocesses
+      # exactly its own half and never touches the other shard's dists.
+      id: shard
+      shell: bash
+      env:
+        SHARD: ${{ matrix.shard }}
+        SHARDS: '2'
+      run: |
+        shopt -s nullglob
+        cd dist
+        mapfile -t all < <(printf '%s\n' ./*.whl ./*.tar.gz | LC_ALL=C sort)
+        i=0
+        inputs=()
+        for f in "${all[@]}"; do
+          [ -n "${f}" ] || continue
+          name=${f#./}
+          if [ "$(( i % SHARDS ))" -eq "${SHARD}" ]; then
+            inputs+=("dist/${name}")
+          else
+            rm -f -- "${name}"
+          fi
+          i=$(( i + 1 ))
+        done
+        cd ..
+        echo "Shard ${SHARD}/${SHARDS} keeps ${#inputs[@]} dist(s):"
+        printf '  %s\n' "${inputs[@]}"
+        echo "sigstore-inputs=${inputs[*]}" >> "${GITHUB_OUTPUT}"
+    - name: Publish 🐍📦 to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
-        # Allow re-running the deploy job after a partial PyPI upload
-        # without failing on dists that were already published.
+        # Allow re-running after a partial PyPI upload without failing on
+        # dists that a prior attempt already published.
         skip-existing: true
-
     - name: Sign the dists with Sigstore
       uses: sigstore/gh-action-sigstore-python@v3.4.0
       with:
-        inputs: >-
-          ./dist/*.tar.gz
-          ./dist/*.whl
-
+        inputs: ${{ steps.shard.outputs.sigstore-inputs }}
     - name: Upload artifact signatures to GitHub Release
       # Confusingly, this action also supports updating releases, not
-      # just creating them. This is what we want here, since we've manually
-      # created the release above.
+      # just creating them. This is what we want here, since the release
+      # was created by the deploy job above.
       uses: softprops/action-gh-release@v3.0.2
       with:
-        # dist/ contains the built packages, which smoketest-artifacts/
-        # contains the signatures and certificates.
+        # dist/ holds this shard's packages plus their Sigstore signatures.
         files: dist/**

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -765,12 +765,10 @@ jobs:
     permissions:
       contents: write  # IMPORTANT: mandatory for making GitHub Releases
 
-    # The pypi environment's required reviewers gate this job, so a human must
-    # approve before the GitHub Release is created; the publish job below is
-    # gated by the same environment before anything reaches PyPI.
-    environment:
-      name: pypi
-      url: https://pypi.org/p/aiohttp
+    # No environment gate here on purpose: creating the GitHub Release is
+    # reversible, so it does not need the required-reviewer prompt. The gate
+    # lives on the publish job below, which performs the irreversible PyPI
+    # upload; keeping it off deploy means a release needs only one approval.
 
     steps:
     - name: Checkout

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -753,7 +753,7 @@ jobs:
         path: ./wheelhouse/*.whl
 
   deploy:
-    name: Deploy (shard ${{ matrix.shard }})
+    name: Deploy (${{ matrix.group }})
     needs:
     - build-tarball
     - build-wheels
@@ -769,7 +769,7 @@ jobs:
     # The required-reviewer pypi environment gates this job, so a human must
     # approve before anything is created or published. Release creation and
     # publishing all live in this one gated matrix, so a release needs a single
-    # approval: the shards are pending together and a reviewer approves them in
+    # approval: the groups are pending together and a reviewer approves them in
     # one review (see the strategy comment below).
     environment:
       name: pypi
@@ -779,22 +779,23 @@ jobs:
       # The PyPI publish and the Sigstore signing each mint one short-lived OIDC
       # identity per job and reuse it for every file, so signing the whole dist
       # set in a single job can outlast the token and fail partway through
-      # (pypa/gh-action-pypi-publish#307). Splitting the work across shards, each
+      # (pypa/gh-action-pypi-publish#307). Splitting the work across groups, each
       # its own job with a fresh identity signing only its share, keeps every
       # signing loop well under the token lifetime.
       #
-      # The shards run in parallel and all target the pypi environment, so they
+      # The groups run in parallel and all target the pypi environment, so they
       # are pending for approval at the same time and a reviewer approves them in
-      # a single review rather than one prompt per shard. Shard 0 creates the
-      # GitHub Release and the others wait for it; each shard only ever touches
-      # its own disjoint share of dists, so the concurrent Release asset uploads
-      # never collide. fail-fast is off and every step is idempotent, so a single
-      # failed shard can be re-run on its own.
+      # a single review rather than one prompt per group. The first group
+      # (job-index 0) creates the GitHub Release and the others wait for it; each
+      # group only ever touches its own disjoint share of dists, so the
+      # concurrent Release asset uploads never collide. fail-fast is off and
+      # every step is idempotent, so a single failed group can be re-run on its
+      # own.
       fail-fast: false
       matrix:
-        shard:
-        - 0
-        - 1
+        group:
+        - 1 of 2
+        - 2 of 2
 
     steps:
     - name: Checkout
@@ -810,66 +811,62 @@ jobs:
         path: dist
         pattern: dist-*
         merge-multiple: true
-    - name: Select this shard's distributions
+    - name: Select this group's distributions
       # Keep only every Nth dist so this job signs a bounded share. To add a
-      # shard, extend the matrix list above; the count comes from
-      # strategy.job-total automatically, so there is no separate shard count to
-      # keep in sync.
+      # group, extend the matrix list above; the count comes from
+      # strategy.job-total automatically, so there is no separate count to keep
+      # in sync.
       #
       # The split is fully deterministic: the same built dists always sort the
       # same way (LC_ALL=C, byte order, independent of runner locale) and land in
-      # the same shard, so re-running a single failed shard reprocesses exactly
-      # its own share and never touches another shard's dists.
-      id: shard
+      # the same group, so re-running a single failed group reprocesses exactly
+      # its own share and never touches another group's dists.
+      id: group
       shell: bash
       env:
-        SHARD: ${{ strategy.job-index }}
-        SHARDS: ${{ strategy.job-total }}
+        GROUP_INDEX: ${{ strategy.job-index }}
+        GROUP_COUNT: ${{ strategy.job-total }}
       run: |
         shopt -s nullglob
-        cd dist
-        mapfile -t all < <(printf '%s\n' ./*.whl ./*.tar.gz | LC_ALL=C sort)
+        mapfile -t all < <(printf '%s\n' dist/*.whl dist/*.tar.gz | LC_ALL=C sort)
         i=0
         inputs=()
         for f in "${all[@]}"; do
           [ -n "${f}" ] || continue
-          name=${f#./}
-          if [ "$(( i % SHARDS ))" -eq "${SHARD}" ]; then
-            inputs+=("dist/${name}")
+          if [ "$(( i % GROUP_COUNT ))" -eq "${GROUP_INDEX}" ]; then
+            inputs+=("${f}")
           else
-            rm -f -- "${name}"
+            rm -f -- "${f}"
           fi
           i=$(( i + 1 ))
         done
-        cd ..
-        echo "Shard ${SHARD}/${SHARDS} keeps ${#inputs[@]} dist(s):"
+        echo "Group $(( GROUP_INDEX + 1 )) of ${GROUP_COUNT} keeps ${#inputs[@]} dist(s):"
         printf '  %s\n' "${inputs[@]}"
         echo "sigstore-inputs=${inputs[*]}" >> "${GITHUB_OUTPUT}"
     - name: Check whether the GitHub Release already exists
-      # Shard 0 owns Release creation. Allows re-running after a partial failure
-      # without the Make Release step failing with HTTP 422 because the
-      # tag/release was created on a prior attempt. Treat only the literal
-      # `release not found` reply as "does not exist"; other failures (auth,
-      # rate-limit, network) re-raise so the job fails loudly instead of falling
-      # through to Make Release.
+      # The first group owns Release creation. Skipping Make Release when the
+      # release already exists lets the job be re-run after a partial failure
+      # without hitting HTTP 422. Query the API and branch on the HTTP status,
+      # not on prose: a 404 means "create it", any other failure (auth,
+      # rate-limit, network) re-raises so the job fails loudly.
       if: ${{ strategy.job-index == 0 }}
       id: gh-release
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         TAG: ${{ github.ref_name }}
       run: |
-        if gh release view "${TAG}" --repo "${GITHUB_REPOSITORY}" \
-            >/dev/null 2>err; then
+        if gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${TAG}" \
+            --silent 2>err; then
           echo 'exists=true' >> "${GITHUB_OUTPUT}"
-        elif grep -qx 'release not found' err; then
+        elif grep -q 'HTTP 404' err; then
           echo 'exists=false' >> "${GITHUB_OUTPUT}"
         else
           cat err >&2
           exit 1
         fi
     - name: Make Release
-      # Shard 0 creates the Release and uploads its share of the packages; the
-      # other shards add their packages and signatures below.
+      # The first group creates the Release and uploads its share of the
+      # packages; the other groups add their packages and signatures below.
       if: ${{ strategy.job-index == 0 && steps.gh-release.outputs.exists != 'true' }}
       uses: aio-libs/create-release@v1.6.6
       with:
@@ -883,18 +880,24 @@ jobs:
         fix_issue_repl: >-
           #\1
     - name: Wait for the GitHub Release
-      # The other shards do not create the Release; they wait for shard 0 to
-      # create it before they publish or upload anything, so a failure to create
-      # the Release blocks the irreversible PyPI upload too.
+      # The other groups do not create the Release; they wait for the first
+      # group to create it before they publish or upload anything, so a failure
+      # to create the Release blocks the irreversible PyPI upload too. Only a
+      # 404 counts as "not yet"; any other API failure re-raises immediately
+      # instead of silently retrying for the whole timeout.
       if: ${{ strategy.job-index != 0 }}
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         TAG: ${{ github.ref_name }}
       run: |
         for _ in $(seq 1 150); do
-          if gh release view "${TAG}" --repo "${GITHUB_REPOSITORY}" \
-              >/dev/null 2>&1; then
+          if gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${TAG}" \
+              --silent 2>err; then
             exit 0
+          fi
+          if ! grep -q 'HTTP 404' err; then
+            cat err >&2
+            exit 1
           fi
           sleep 2
         done
@@ -909,12 +912,12 @@ jobs:
     - name: Sign the dists with Sigstore
       uses: sigstore/gh-action-sigstore-python@v3.4.0
       with:
-        inputs: ${{ steps.shard.outputs.sigstore-inputs }}
+        inputs: ${{ steps.group.outputs.sigstore-inputs }}
     - name: Upload artifact signatures to GitHub Release
       # Confusingly, this action also supports updating releases, not
-      # just creating them. This is what we want here, since shard 0 created
-      # the release above.
+      # just creating them. This is what we want here, since the first group
+      # created the release above.
       uses: softprops/action-gh-release@v3.0.2
       with:
-        # dist/ holds this shard's packages plus their Sigstore signatures.
+        # dist/ holds this group's packages plus their Sigstore signatures.
         files: dist/**

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -753,7 +753,7 @@ jobs:
         path: ./wheelhouse/*.whl
 
   deploy:
-    name: Deploy
+    name: Deploy (shard ${{ matrix.shard }})
     needs:
     - build-tarball
     - build-wheels
@@ -764,11 +764,37 @@ jobs:
 
     permissions:
       contents: write  # IMPORTANT: mandatory for making GitHub Releases
+      id-token: write  # IMPORTANT: mandatory for trusted publishing & sigstore
 
-    # No environment gate here on purpose: creating the GitHub Release is
-    # reversible, so it does not need the required-reviewer prompt. The gate
-    # lives on the publish job below, which performs the irreversible PyPI
-    # upload; keeping it off deploy means a release needs only one approval.
+    # The required-reviewer pypi environment gates this job, so a human must
+    # approve before anything is created or published. Release creation and
+    # publishing all live in this one gated matrix, so a release needs a single
+    # approval: the shards are pending together and a reviewer approves them in
+    # one review (see the strategy comment below).
+    environment:
+      name: pypi
+      url: https://pypi.org/p/aiohttp
+
+    strategy:
+      # The PyPI publish and the Sigstore signing each mint one short-lived OIDC
+      # identity per job and reuse it for every file, so signing the whole dist
+      # set in a single job can outlast the token and fail partway through
+      # (pypa/gh-action-pypi-publish#307). Splitting the work across shards, each
+      # its own job with a fresh identity signing only its share, keeps every
+      # signing loop well under the token lifetime.
+      #
+      # The shards run in parallel and all target the pypi environment, so they
+      # are pending for approval at the same time and a reviewer approves them in
+      # a single review rather than one prompt per shard. Shard 0 creates the
+      # GitHub Release and the others wait for it; each shard only ever touches
+      # its own disjoint share of dists, so the concurrent Release asset uploads
+      # never collide. fail-fast is off and every step is idempotent, so a single
+      # failed shard can be re-run on its own.
+      fail-fast: false
+      matrix:
+        shard:
+        - 0
+        - 1
 
     steps:
     - name: Checkout
@@ -784,97 +810,16 @@ jobs:
         path: dist
         pattern: dist-*
         merge-multiple: true
-    - name: Collected dists
-      run: |
-        tree dist
-    - name: Check whether the GitHub Release already exists
-      # Allows re-running the deploy job after a partial failure (e.g. PyPI
-      # upload error) without the Make Release step failing with HTTP 422
-      # because the tag/release was created on a prior attempt. Treat
-      # only the literal `release not found` reply as "does not exist";
-      # other failures (auth, rate-limit, network) re-raise so the job
-      # fails loudly instead of falling through to Make Release.
-      id: gh-release
-      env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        TAG: ${{ github.ref_name }}
-      run: |
-        if gh release view "${TAG}" --repo "${GITHUB_REPOSITORY}" \
-            >/dev/null 2>err; then
-          echo 'exists=true' >> "${GITHUB_OUTPUT}"
-        elif grep -qx 'release not found' err; then
-          echo 'exists=false' >> "${GITHUB_OUTPUT}"
-        else
-          cat err >&2
-          exit 1
-        fi
-    - name: Make Release
-      if: steps.gh-release.outputs.exists != 'true'
-      uses: aio-libs/create-release@v1.6.6
-      with:
-        changes_file: CHANGES.rst
-        name: aiohttp
-        version_file: aiohttp/__init__.py
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        dist_dir: dist
-        fix_issue_regex: >-
-          :issue:`(\d+)`
-        fix_issue_repl: >-
-          #\1
-
-  publish:
-    name: Publish (shard ${{ matrix.shard }})
-    needs:
-    - deploy
-    - pre-setup  # transitive, for accessing settings
-    runs-on: ubuntu-latest
-    if: >-
-      needs.pre-setup.outputs.upstream-repository-id == github.repository_id
-
-    permissions:
-      contents: write  # IMPORTANT: mandatory for uploading Sigstore signatures
-      id-token: write  # IMPORTANT: mandatory for trusted publishing & sigstore
-
-    environment:
-      name: pypi
-      url: https://pypi.org/p/aiohttp
-
-    strategy:
-      # Both shards run in parallel: each is a separate job that mints its own
-      # fresh OIDC identity, so per-shard signing stays well under the token
-      # lifetime (see pypa/gh-action-pypi-publish#307). Running them together
-      # (rather than sequentially) keeps both environment deployments pending at
-      # the same time, so a required reviewer approves both in a single review
-      # instead of one prompt per shard. Each shard uploads a disjoint set of
-      # dists, so the concurrent GitHub Release asset uploads never collide.
-      # fail-fast is off so a failed shard can be re-run on its own; every step
-      # is idempotent.
-      fail-fast: false
-      matrix:
-        shard:
-        - 0
-        - 1
-
-    steps:
-    - name: Download distributions
-      uses: actions/download-artifact@v8
-      with:
-        path: dist
-        pattern: dist-*
-        merge-multiple: true
     - name: Select this shard's distributions
-      # gh-action-pypi-publish and the Sigstore signing below each mint a single
-      # short-lived OIDC identity per job and reuse it for every file, so signing
-      # the whole dist set in one job can outlast the token and fail partway
-      # through (pypa/gh-action-pypi-publish#307). Keeping only every Nth dist
-      # here bounds each job's signing loop. To add a shard, extend the matrix
-      # list below; the count comes from strategy.job-total automatically, so
-      # there is no separate shard count to keep in sync.
+      # Keep only every Nth dist so this job signs a bounded share. To add a
+      # shard, extend the matrix list above; the count comes from
+      # strategy.job-total automatically, so there is no separate shard count to
+      # keep in sync.
       #
       # The split is fully deterministic: the same built dists always sort the
-      # same way (LC_ALL=C, byte order, independent of runner locale) and land
-      # in the same shard, so re-running a single failed shard reprocesses
-      # exactly its own half and never touches the other shard's dists.
+      # same way (LC_ALL=C, byte order, independent of runner locale) and land in
+      # the same shard, so re-running a single failed shard reprocesses exactly
+      # its own share and never touches another shard's dists.
       id: shard
       shell: bash
       env:
@@ -900,6 +845,61 @@ jobs:
         echo "Shard ${SHARD}/${SHARDS} keeps ${#inputs[@]} dist(s):"
         printf '  %s\n' "${inputs[@]}"
         echo "sigstore-inputs=${inputs[*]}" >> "${GITHUB_OUTPUT}"
+    - name: Check whether the GitHub Release already exists
+      # Shard 0 owns Release creation. Allows re-running after a partial failure
+      # without the Make Release step failing with HTTP 422 because the
+      # tag/release was created on a prior attempt. Treat only the literal
+      # `release not found` reply as "does not exist"; other failures (auth,
+      # rate-limit, network) re-raise so the job fails loudly instead of falling
+      # through to Make Release.
+      if: ${{ strategy.job-index == 0 }}
+      id: gh-release
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        TAG: ${{ github.ref_name }}
+      run: |
+        if gh release view "${TAG}" --repo "${GITHUB_REPOSITORY}" \
+            >/dev/null 2>err; then
+          echo 'exists=true' >> "${GITHUB_OUTPUT}"
+        elif grep -qx 'release not found' err; then
+          echo 'exists=false' >> "${GITHUB_OUTPUT}"
+        else
+          cat err >&2
+          exit 1
+        fi
+    - name: Make Release
+      # Shard 0 creates the Release and uploads its share of the packages; the
+      # other shards add their packages and signatures below.
+      if: ${{ strategy.job-index == 0 && steps.gh-release.outputs.exists != 'true' }}
+      uses: aio-libs/create-release@v1.6.6
+      with:
+        changes_file: CHANGES.rst
+        name: aiohttp
+        version_file: aiohttp/__init__.py
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        dist_dir: dist
+        fix_issue_regex: >-
+          :issue:`(\d+)`
+        fix_issue_repl: >-
+          #\1
+    - name: Wait for the GitHub Release
+      # The other shards do not create the Release; they wait for shard 0 to
+      # create it before they publish or upload anything, so a failure to create
+      # the Release blocks the irreversible PyPI upload too.
+      if: ${{ strategy.job-index != 0 }}
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        TAG: ${{ github.ref_name }}
+      run: |
+        for _ in $(seq 1 150); do
+          if gh release view "${TAG}" --repo "${GITHUB_REPOSITORY}" \
+              >/dev/null 2>&1; then
+            exit 0
+          fi
+          sleep 2
+        done
+        echo "GitHub Release ${TAG} did not appear in time" >&2
+        exit 1
     - name: Publish 🐍📦 to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
@@ -912,8 +912,8 @@ jobs:
         inputs: ${{ steps.shard.outputs.sigstore-inputs }}
     - name: Upload artifact signatures to GitHub Release
       # Confusingly, this action also supports updating releases, not
-      # just creating them. This is what we want here, since the release
-      # was created by the deploy job above.
+      # just creating them. This is what we want here, since shard 0 created
+      # the release above.
       uses: softprops/action-gh-release@v3.0.2
       with:
         # dist/ holds this shard's packages plus their Sigstore signatures.

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -765,6 +765,13 @@ jobs:
     permissions:
       contents: write  # IMPORTANT: mandatory for making GitHub Releases
 
+    # The pypi environment's required reviewers gate this job, so a human must
+    # approve before the GitHub Release is created; the publish job below is
+    # gated by the same environment before anything reaches PyPI.
+    environment:
+      name: pypi
+      url: https://pypi.org/p/aiohttp
+
     steps:
     - name: Checkout
       uses: actions/checkout@v7
@@ -818,7 +825,7 @@ jobs:
           #\1
 
   publish:
-    name: Publish (shard ${{ matrix.shard }}/2)
+    name: Publish (shard ${{ matrix.shard }})
     needs:
     - deploy
     - pre-setup  # transitive, for accessing settings
@@ -862,8 +869,9 @@ jobs:
       # short-lived OIDC identity per job and reuse it for every file, so signing
       # the whole dist set in one job can outlast the token and fail partway
       # through (pypa/gh-action-pypi-publish#307). Keeping only every Nth dist
-      # here bounds each job's signing loop. Bump the matrix and SHARDS together
-      # if the wheel matrix keeps growing.
+      # here bounds each job's signing loop. To add a shard, extend the matrix
+      # list below; the count comes from strategy.job-total automatically, so
+      # there is no separate shard count to keep in sync.
       #
       # The split is fully deterministic: the same built dists always sort the
       # same way (LC_ALL=C, byte order, independent of runner locale) and land
@@ -872,8 +880,8 @@ jobs:
       id: shard
       shell: bash
       env:
-        SHARD: ${{ matrix.shard }}
-        SHARDS: '2'
+        SHARD: ${{ strategy.job-index }}
+        SHARDS: ${{ strategy.job-total }}
       run: |
         shopt -s nullglob
         cd dist

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -933,6 +933,13 @@ jobs:
       # Confusingly, this action also supports updating releases, not
       # just creating them. This is what we want here, since the first group
       # created the release above.
+      #
+      # The groups run this concurrently against the same release, which is safe:
+      # each group's files are a disjoint share, so asset names never collide, and
+      # with no body/name inputs the action preserves the existing release
+      # metadata (it writes back what it reads) rather than clearing it, so the
+      # concurrent metadata updates are identical no-ops. The Wait step above
+      # guarantees the release (with its notes) already exists first.
       uses: softprops/action-gh-release@v3.0.2
       with:
         # dist/ holds this group's packages plus their Sigstore signatures.

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -835,13 +835,16 @@ jobs:
       url: https://pypi.org/p/aiohttp
 
     strategy:
-      # Run the shards sequentially: each is a separate job that mints its own
+      # Both shards run in parallel: each is a separate job that mints its own
       # fresh OIDC identity, so per-shard signing stays well under the token
-      # lifetime (see pypa/gh-action-pypi-publish#307), and only one job updates
-      # the shared GitHub Release at a time. fail-fast is off so a failed shard
-      # can be re-run on its own; every step is idempotent.
+      # lifetime (see pypa/gh-action-pypi-publish#307). Running them together
+      # (rather than sequentially) keeps both environment deployments pending at
+      # the same time, so a required reviewer approves both in a single review
+      # instead of one prompt per shard. Each shard uploads a disjoint set of
+      # dists, so the concurrent GitHub Release asset uploads never collide.
+      # fail-fast is off so a failed shard can be re-run on its own; every step
+      # is idempotent.
       fail-fast: false
-      max-parallel: 1
       matrix:
         shard:
         - 0

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -766,6 +766,12 @@ jobs:
       contents: write  # IMPORTANT: mandatory for making GitHub Releases
       id-token: write  # IMPORTANT: mandatory for trusted publishing & sigstore
 
+    # TAG is shared by the two release-existence steps. GITHUB_TOKEN stays scoped
+    # to the steps that need it rather than job-wide, so third-party actions in
+    # this job never see it in their environment.
+    env:
+      TAG: ${{ github.ref_name }}
+
     # The required-reviewer pypi environment gates this job, so a human must
     # approve before anything is created or published. Release creation and
     # publishing all live in this one gated matrix, so a release needs a single
@@ -791,6 +797,12 @@ jobs:
       # concurrent Release asset uploads never collide. fail-fast is off and
       # every step is idempotent, so a single failed group can be re-run on its
       # own.
+      #
+      # Each label "N of M" self-encodes its own position and total, which is the
+      # only source of truth for the split. Keep `group` the sole matrix axis: an
+      # include/exclude entry would renumber strategy.job-index / job-total, but
+      # the label-derived split below stays correct as long as job-index 0 is the
+      # first label.
       fail-fast: false
       matrix:
         group:
@@ -799,6 +811,9 @@ jobs:
 
     steps:
     - name: Checkout
+      # Only the release-creating group needs the repo (create-release reads
+      # CHANGES.rst and aiohttp/__init__.py); the others only touch dist/.
+      if: ${{ strategy.job-index == 0 }}
       uses: actions/checkout@v7
       with:
         submodules: true
@@ -812,10 +827,10 @@ jobs:
         pattern: dist-*
         merge-multiple: true
     - name: Select this group's distributions
-      # Keep only every Nth dist so this job signs a bounded share. To add a
-      # group, extend the matrix list above; the count comes from
-      # strategy.job-total automatically, so there is no separate count to keep
-      # in sync.
+      # Keep only this group's share of the dists so the job signs a bounded set.
+      # index and count come from the "N of M" label, the single source of truth
+      # for the split; to add a group, extend the matrix list above (e.g.
+      # "1 of 3" .. "3 of 3").
       #
       # The split is fully deterministic: the same built dists always sort the
       # same way (LC_ALL=C, byte order, independent of runner locale) and land in
@@ -824,23 +839,24 @@ jobs:
       id: group
       shell: bash
       env:
-        GROUP_INDEX: ${{ strategy.job-index }}
-        GROUP_COUNT: ${{ strategy.job-total }}
+        GROUP: ${{ matrix.group }}
       run: |
+        set -euo pipefail
+        index=$(( ${GROUP%% of *} - 1 ))
+        count=${GROUP##* of }
         shopt -s nullglob
         mapfile -t all < <(printf '%s\n' dist/*.whl dist/*.tar.gz | LC_ALL=C sort)
         i=0
         inputs=()
         for f in "${all[@]}"; do
-          [ -n "${f}" ] || continue
-          if [ "$(( i % GROUP_COUNT ))" -eq "${GROUP_INDEX}" ]; then
+          if [ "$(( i % count ))" -eq "${index}" ]; then
             inputs+=("${f}")
           else
             rm -f -- "${f}"
           fi
           i=$(( i + 1 ))
         done
-        echo "Group $(( GROUP_INDEX + 1 )) of ${GROUP_COUNT} keeps ${#inputs[@]} dist(s):"
+        echo "Group ${GROUP} keeps ${#inputs[@]} of ${#all[@]} dist(s):"
         printf '  %s\n' "${inputs[@]}"
         echo "sigstore-inputs=${inputs[*]}" >> "${GITHUB_OUTPUT}"
     - name: Check whether the GitHub Release already exists
@@ -853,8 +869,8 @@ jobs:
       id: gh-release
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        TAG: ${{ github.ref_name }}
       run: |
+        set -euo pipefail
         if gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${TAG}" \
             --silent 2>err; then
           echo 'exists=true' >> "${GITHUB_OUTPUT}"
@@ -888,8 +904,8 @@ jobs:
       if: ${{ strategy.job-index != 0 }}
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        TAG: ${{ github.ref_name }}
       run: |
+        set -euo pipefail
         for _ in $(seq 1 150); do
           if gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${TAG}" \
               --silent 2>err; then

--- a/CHANGES/13226.contrib.rst
+++ b/CHANGES/13226.contrib.rst
@@ -1,0 +1,1 @@
+Split release publishing and signing across multiple jobs so each stays within the short-lived signing token lifetime, fixing intermittent release upload failures -- by :user:`bdraco`.


### PR DESCRIPTION
## What do these changes do?

The release signed every dist in a single `deploy` job: the PyPI publish step signs a PEP 740 attestation for each dist, and the standalone Sigstore step signs them again for the GitHub Release. Both mint one short lived OIDC identity per job and reuse it for the whole set. With the current wheel matrix that loop takes about five minutes, right at the OIDC token lifetime, so it now fails partway through with `sigstore.oidc.ExpiredIdentity` (pypa/gh-action-pypi-publish#307). The v3.14.3 release hit this on several attempts.

This turns the `deploy` job into a matrix of groups. Each group is its own job, so it mints a fresh OIDC identity and signs only its share of the dists, comfortably under the token lifetime. The groups run in parallel; the first one creates the GitHub Release and the others wait for it, then each group publishes and signs its own disjoint share.

Both the GitHub Release and the PyPI upload are install vectors, so both stay behind the required-reviewer `pypi` environment. Because every group targets that environment and they are pending at the same time, a reviewer approves them in a single review, so a release still needs exactly one approval and it now gates both Release creation and the PyPI upload. If a reviewer declines, nothing is created or published.

The split is deterministic and every step is idempotent, so a flaky run can be re-run and still complete:

- each group's share is chosen by position in a locale independent (`LC_ALL=C`) sort, so a given dist always lands in the same group, and re-running one failed group reprocesses exactly its own share without touching another group's dists;
- the first group creates the Release and the others poll for it, so no group publishes to PyPI before the Release exists;
- PyPI publish uses `skip-existing: true`, so already uploaded dists are skipped on a retry;
- `softprops/action-gh-release` overwrites signature assets by default, so re-uploads are clean;
- `Make Release` is guarded by an existence check that branches on the HTTP 404 status rather than on gh's wording.

## Are there changes in behavior for the user?

No end user impact. This only changes how the release workflow publishes and signs dists.

## Is it a substantial burden for the maintainers to support this?

No, it splits one job into a small gated matrix. Worth a look during review:

- the number of groups and each group's identity come from the `N of M` matrix label, which is the single source of truth; to add a group, extend the matrix list (e.g. `1 of 3` .. `3 of 3`) and re-check that a group's share still signs under the token lifetime as the wheel matrix grows. Keep `group` the only matrix axis, since the label-derived split assumes the first label is job-index 0;
- the workflow filename and `pypi` environment are unchanged, so the PyPI trusted publisher identity still matches.

## Related issue number

Refs pypa/gh-action-pypi-publish#307.

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist; N/A, release workflow change
- [ ] Documentation reflects the changes; N/A
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt` (already present)
- [x] Add a new news fragment into the `CHANGES/` folder

<details>
<summary>Validation</summary>

Cannot be exercised without a real tagged release (trusted publishing plus OIDC), so it was validated statically:

```
$ actionlint .github/workflows/ci-cd.yml
# only pre-existing findings (lines 49, 234, 699); the deploy matrix is clean
```

The dist partition was checked in bash 5: for 16 dists, two groups keep 8 and 8 with no overlap and full coverage; a three group split keeps 6, 5, 5.

</details>

Drafted with Claude Code (Fable 5); reviewed by @bdraco.
