### PR TITLE
[PR #13226/76bb64eb backport][3.14] Shard release publishing and signing across a gated matrix

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -703,7 +703,7 @@ jobs:
         path: ./wheelhouse/*.whl
 
   deploy:
-    name: Deploy
+    name: Deploy (${{ matrix.group }})
     needs:
     - build-tarball
     - build-wheels
@@ -716,12 +716,54 @@ jobs:
       contents: write  # IMPORTANT: mandatory for making GitHub Releases
       id-token: write  # IMPORTANT: mandatory for trusted publishing & sigstore
 
+    # TAG is shared by the two release-existence steps. GITHUB_TOKEN stays scoped
+    # to the steps that need it rather than job-wide, so third-party actions in
+    # this job never see it in their environment.
+    env:
+      TAG: ${{ github.ref_name }}
+
+    # The required-reviewer pypi environment gates this job, so a human must
+    # approve before anything is created or published. Release creation and
+    # publishing all live in this one gated matrix, so a release needs a single
+    # approval: the groups are pending together and a reviewer approves them in
+    # one review (see the strategy comment below).
     environment:
       name: pypi
       url: https://pypi.org/p/aiohttp
 
+    strategy:
+      # The PyPI publish and the Sigstore signing each mint one short-lived OIDC
+      # identity per job and reuse it for every file, so signing the whole dist
+      # set in a single job can outlast the token and fail partway through
+      # (pypa/gh-action-pypi-publish#307). Splitting the work across groups, each
+      # its own job with a fresh identity signing only its share, keeps every
+      # signing loop well under the token lifetime.
+      #
+      # The groups run in parallel and all target the pypi environment, so they
+      # are pending for approval at the same time and a reviewer approves them in
+      # a single review rather than one prompt per group. The first group
+      # (job-index 0) creates the GitHub Release and the others wait for it; each
+      # group only ever touches its own disjoint share of dists, so the
+      # concurrent Release asset uploads never collide. fail-fast is off and
+      # every step is idempotent, so a single failed group can be re-run on its
+      # own.
+      #
+      # Each label "N of M" self-encodes its own position and total, which is the
+      # only source of truth for the split. Keep `group` the sole matrix axis: an
+      # include/exclude entry would renumber strategy.job-index / job-total, but
+      # the label-derived split below stays correct as long as job-index 0 is the
+      # first label.
+      fail-fast: false
+      matrix:
+        group:
+        - 1 of 2
+        - 2 of 2
+
     steps:
     - name: Checkout
+      # Only the release-creating group needs the repo (create-release reads
+      # CHANGES.rst and aiohttp/__init__.py); the others only touch dist/.
+      if: ${{ strategy.job-index == 0 }}
       uses: actions/checkout@v6
       with:
         submodules: true
@@ -734,32 +776,64 @@ jobs:
         path: dist
         pattern: dist-*
         merge-multiple: true
-    - name: Collected dists
+    - name: Select this group's distributions
+      # Keep only this group's share of the dists so the job signs a bounded set.
+      # index and count come from the "N of M" label, the single source of truth
+      # for the split; to add a group, extend the matrix list above (e.g.
+      # "1 of 3" .. "3 of 3").
+      #
+      # The split is fully deterministic: the same built dists always sort the
+      # same way (LC_ALL=C, byte order, independent of runner locale) and land in
+      # the same group, so re-running a single failed group reprocesses exactly
+      # its own share and never touches another group's dists.
+      id: group
+      shell: bash
+      env:
+        GROUP: ${{ matrix.group }}
       run: |
-        tree dist
+        set -euo pipefail
+        index=$(( ${GROUP%% of *} - 1 ))
+        count=${GROUP##* of }
+        shopt -s nullglob
+        mapfile -t all < <(printf '%s\n' dist/*.whl dist/*.tar.gz | LC_ALL=C sort)
+        i=0
+        inputs=()
+        for f in "${all[@]}"; do
+          if [ "$(( i % count ))" -eq "${index}" ]; then
+            inputs+=("${f}")
+          else
+            rm -f -- "${f}"
+          fi
+          i=$(( i + 1 ))
+        done
+        echo "Group ${GROUP} keeps ${#inputs[@]} of ${#all[@]} dist(s):"
+        printf '  %s\n' "${inputs[@]}"
+        echo "sigstore-inputs=${inputs[*]}" >> "${GITHUB_OUTPUT}"
     - name: Check whether the GitHub Release already exists
-      # Allows re-running the deploy job after a partial failure (e.g. PyPI
-      # upload error) without the Make Release step failing with HTTP 422
-      # because the tag/release was created on a prior attempt. Treat
-      # only the literal `release not found` reply as "does not exist";
-      # other failures (auth, rate-limit, network) re-raise so the job
-      # fails loudly instead of falling through to Make Release.
+      # The first group owns Release creation. Skipping Make Release when the
+      # release already exists lets the job be re-run after a partial failure
+      # without hitting HTTP 422. Query the API and branch on the HTTP status,
+      # not on prose: a 404 means "create it", any other failure (auth,
+      # rate-limit, network) re-raises so the job fails loudly.
+      if: ${{ strategy.job-index == 0 }}
       id: gh-release
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        TAG: ${{ github.ref_name }}
       run: |
-        if gh release view "${TAG}" --repo "${GITHUB_REPOSITORY}" \
-            >/dev/null 2>err; then
+        set -euo pipefail
+        if gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${TAG}" \
+            --silent 2>err; then
           echo 'exists=true' >> "${GITHUB_OUTPUT}"
-        elif grep -qx 'release not found' err; then
+        elif grep -q 'HTTP 404' err; then
           echo 'exists=false' >> "${GITHUB_OUTPUT}"
         else
           cat err >&2
           exit 1
         fi
     - name: Make Release
-      if: steps.gh-release.outputs.exists != 'true'
+      # The first group creates the Release and uploads its share of the
+      # packages; the other groups add their packages and signatures below.
+      if: ${{ strategy.job-index == 0 && steps.gh-release.outputs.exists != 'true' }}
       uses: aio-libs/create-release@v1.6.6
       with:
         changes_file: CHANGES.rst
@@ -771,28 +845,52 @@ jobs:
           :issue:`(\d+)`
         fix_issue_repl: >-
           #\1
-
-    - name: >-
-        Publish 🐍📦 to PyPI
+    - name: Wait for the GitHub Release
+      # The other groups do not create the Release; they wait for the first
+      # group to create it before they publish or upload anything, so a failure
+      # to create the Release blocks the irreversible PyPI upload too. Only a
+      # 404 counts as "not yet"; any other API failure re-raises immediately
+      # instead of silently retrying for the whole timeout.
+      if: ${{ strategy.job-index != 0 }}
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        set -euo pipefail
+        for _ in $(seq 1 150); do
+          if gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${TAG}" \
+              --silent 2>err; then
+            exit 0
+          fi
+          if ! grep -q 'HTTP 404' err; then
+            cat err >&2
+            exit 1
+          fi
+          sleep 2
+        done
+        echo "GitHub Release ${TAG} did not appear in time" >&2
+        exit 1
+    - name: Publish 🐍📦 to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
-        # Allow re-running the deploy job after a partial PyPI upload
-        # without failing on dists that were already published.
+        # Allow re-running after a partial PyPI upload without failing on
+        # dists that a prior attempt already published.
         skip-existing: true
-
     - name: Sign the dists with Sigstore
       uses: sigstore/gh-action-sigstore-python@v3.3.0
       with:
-        inputs: >-
-          ./dist/*.tar.gz
-          ./dist/*.whl
-
+        inputs: ${{ steps.group.outputs.sigstore-inputs }}
     - name: Upload artifact signatures to GitHub Release
       # Confusingly, this action also supports updating releases, not
-      # just creating them. This is what we want here, since we've manually
+      # just creating them. This is what we want here, since the first group
       # created the release above.
+      #
+      # The groups run this concurrently against the same release, which is safe:
+      # each group's files are a disjoint share, so asset names never collide, and
+      # with no body/name inputs the action preserves the existing release
+      # metadata (it writes back what it reads) rather than clearing it, so the
+      # concurrent metadata updates are identical no-ops. The Wait step above
+      # guarantees the release (with its notes) already exists first.
       uses: softprops/action-gh-release@v3
       with:
-        # dist/ contains the built packages, which smoketest-artifacts/
-        # contains the signatures and certificates.
+        # dist/ holds this group's packages plus their Sigstore signatures.
         files: dist/**

--- a/CHANGES/13226.contrib.rst
+++ b/CHANGES/13226.contrib.rst
@@ -1,0 +1,1 @@
+Split release publishing and signing across multiple jobs so each stays within the short-lived signing token lifetime, fixing intermittent release upload failures -- by :user:`bdraco`.


### PR DESCRIPTION
**This is a backport of PR #13226 as merged into master (76bb64eb27fec484fa8a176d9d1c41c027c4d2ad).**

## What do these changes do?

The release signed every dist in a single `deploy` job: the PyPI publish step signs a PEP 740 attestation for each dist, and the standalone Sigstore step signs them again for the GitHub Release. Both mint one short lived OIDC identity per job and reuse it for the whole set. With the current wheel matrix that loop takes about five minutes, right at the OIDC token lifetime, so it now fails partway through with `sigstore.oidc.ExpiredIdentity` (pypa/gh-action-pypi-publish#307). The v3.14.3 release hit this on several attempts.

This turns the `deploy` job into a matrix of groups. Each group is its own job, so it mints a fresh OIDC identity and signs only its share of the dists, comfortably under the token lifetime. The groups run in parallel; the first one creates the GitHub Release and the others wait for it, then each group publishes and signs its own disjoint share.

Both the GitHub Release and the PyPI upload are install vectors, so both stay behind the required-reviewer `pypi` environment. Because every group targets that environment and they are pending at the same time, a reviewer approves them in a single review, so a release still needs exactly one approval and it now gates both Release creation and the PyPI upload. If a reviewer declines, nothing is created or published.

The split is deterministic and every step is idempotent, so a flaky run can be re-run and still complete:

- each group's share is chosen by position in a locale independent (`LC_ALL=C`) sort, so a given dist always lands in the same group, and re-running one failed group reprocesses exactly its own share without touching another group's dists;
- the first group creates the Release and the others poll for it, so no group publishes to PyPI before the Release exists;
- PyPI publish uses `skip-existing: true`, so already uploaded dists are skipped on a retry;
- `softprops/action-gh-release` overwrites signature assets by default, so re-uploads are clean;
- `Make Release` is guarded by an existence check that branches on the HTTP 404 status rather than on gh's wording.

## Are there changes in behavior for the user?

No end user impact. This only changes how the release workflow publishes and signs dists.

## Is it a substantial burden for the maintainers to support this?

No, it splits one job into a small gated matrix. Worth a look during review:

- the number of groups and each group's identity come from the `N of M` matrix label, which is the single source of truth; to add a group, extend the matrix list (e.g. `1 of 3` .. `3 of 3`) and re-check that a group's share still signs under the token lifetime as the wheel matrix grows. Keep `group` the only matrix axis, since the label-derived split assumes the first label is job-index 0;
- the workflow filename and `pypi` environment are unchanged, so the PyPI trusted publisher identity still matches.

## Related issue number

Refs pypa/gh-action-pypi-publish#307.

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist; N/A, release workflow change
- [ ] Documentation reflects the changes; N/A
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt` (already present)
- [x] Add a new news fragment into the `CHANGES/` folder

<details>
<summary>Validation</summary>

Cannot be exercised without a real tagged release (trusted publishing plus OIDC), so it was validated statically:

```
$ actionlint .github/workflows/ci-cd.yml
# only pre-existing findings (lines 49, 234, 699); the deploy matrix is clean
```

The dist partition was checked in bash 5: for 16 dists, two groups keep 8 and 8 with no overlap and full coverage; a three group split keeps 6, 5, 5.

</details>

Drafted with Claude Code (Fable 5); reviewed by @bdraco.

