### PR TITLE
Skip lingering close when response declines keep-alive

### DIFF
--- a/CHANGES/1800.bugfix.rst
+++ b/CHANGES/1800.bugfix.rst
@@ -1,0 +1,2 @@
+Fixed ``response.force_close()`` not preventing the lingering close timer
+from waiting to drain an unread request body -- by :user:`Ranjeeth11`.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -328,6 +328,7 @@ Puneet Dixit
 Qiao Han
 Rafael Viotti
 Rahul Nahata
+Ranjeeth Narayanasamy
 Raphael Bialon
 Raúl Cumplido
 Required Field

--- a/aiohttp/web_protocol.py
+++ b/aiohttp/web_protocol.py
@@ -735,7 +735,7 @@ class RequestHandler(BaseProtocol, Generic[_Request]):
                 if not payload.is_eof():
                     lingering_time = self._lingering_time
                     # Could be force closed while awaiting above tasks.
-                    if not self._force_close and lingering_time:  # type: ignore[redundant-expr]
+                    if not self._force_close and self._keepalive and lingering_time:  # type: ignore[redundant-expr]
                         self.log_debug(
                             "Start lingering close timer for %s sec.", lingering_time
                         )

--- a/tests/test_web_functional.py
+++ b/tests/test_web_functional.py
@@ -29,7 +29,7 @@ from aiohttp import (
 from aiohttp.abc import AbstractResolver, ResolveResult
 from aiohttp.compression_utils import ZLibBackend, ZLibCompressObjProtocol
 from aiohttp.hdrs import CONTENT_LENGTH, CONTENT_TYPE, TRANSFER_ENCODING
-from aiohttp.helpers import DEFAULT_CHUNK_SIZE, HeadersDictProxy
+from aiohttp.helpers import DEFAULT_CHUNK_SIZE, HeadersDictProxy, ceil_timeout
 from aiohttp.streams import StreamReader
 from aiohttp.typedefs import Handler, Middleware
 from aiohttp.web_protocol import MAX_MSG_QUEUE_SIZE, RequestHandler
@@ -810,11 +810,19 @@ async def test_force_close_response_skips_lingering_close(
     app = web.Application()
     app.router.add_post("/", handler)
 
-    with mock.patch.object(StreamReader, "readany", spy_readany):
+    with (
+        mock.patch.object(StreamReader, "readany", spy_readany),
+        mock.patch(
+            "aiohttp.web_protocol.ceil_timeout", wraps=ceil_timeout
+        ) as mock_ceil_timeout,
+    ):
         client = await aiohttp_client(app)
         async with client.post("/", data=b"x" * (2**20)) as resp:
             assert resp.status == 200
 
+    # The lingering-close branch itself must never be entered...
+    assert not mock_ceil_timeout.called
+    # ...and the unread request body must never be drained.
     assert drained is False
 
 

--- a/tests/test_web_functional.py
+++ b/tests/test_web_functional.py
@@ -782,6 +782,42 @@ async def test_http10_keep_alive_with_headers(aiohttp_client: AiohttpClient) -> 
     resp.release()
 
 
+async def test_force_close_response_skips_lingering_close(
+    aiohttp_client: AiohttpClient,
+) -> None:
+    """Calling resp.force_close() must close the connection promptly instead
+    of waiting to drain an unread request body (see issue #1800)."""
+    request_payload: StreamReader | None = None
+    drained = False
+    orig_readany = StreamReader.readany
+
+    async def spy_readany(self: StreamReader) -> bytes:
+        nonlocal drained
+        if self is request_payload:
+            drained = True
+        return await orig_readany(self)
+
+    async def handler(request: web.Request) -> web.StreamResponse:
+        nonlocal request_payload
+        request_payload = request.content
+        resp = web.StreamResponse()
+        resp.force_close()
+        await resp.prepare(request)
+        await resp.write_eof()
+        # Deliberately do not read request.content, leaving the body unread.
+        return resp
+
+    app = web.Application()
+    app.router.add_post("/", handler)
+
+    with mock.patch.object(StreamReader, "readany", spy_readany):
+        client = await aiohttp_client(app)
+        async with client.post("/", data=b"x" * (2**20)) as resp:
+            assert resp.status == 200
+
+    assert drained is False
+
+
 async def test_upload_file(aiohttp_client: AiohttpClient) -> None:
     here = pathlib.Path(__file__).parent
     fname = here / "aiohttp.png"


### PR DESCRIPTION
**What changed**
`RequestHandler`'s lingering-close gate in the request-handling loop now also checks `self._keepalive` before starting the wait to drain an unread request body. Previously it only checked `self._force_close`.

**Why**
`self._keepalive` is already set from the response's `keep_alive` value earlier in the same loop iteration, but wasn't consulted here — unlike two other nearby checks in the same file (`_process_keepalive`, and the keep-alive-timer-arming condition) that already treat "keep-alive declined" and "force closed" as equivalent grounds to skip further keep-alive-related work. A handler calling `resp.force_close()` still triggered the full lingering wait despite declining keep-alive.

**User-visible behavior**
Any response for which keep-alive is declined (`resp.force_close()`, `Connection: close`, or HTTP/1.0 without keep-alive) now skips the lingering-drain wait instead of waiting up to `lingering_time` seconds. Responses that keep the connection alive are unaffected.

**Tests**
Added `test_force_close_response_skips_lingering_close` in `tests/test_web_functional.py`, which spies on `StreamReader.readany` (identity-filtered to the request's own payload) to confirm the unread body is never drained when `resp.force_close()` is called. Verified it fails on unfixed code and passes with the fix.

Fixes #1800
