### PR TITLE
Strip trailing OWS from header values in the C parser

### DIFF
--- a/CHANGES/13246.bugfix.rst
+++ b/CHANGES/13246.bugfix.rst
@@ -1,0 +1,3 @@
+Stripped the trailing whitespace from header values in the C HTTP parser,
+so that it matches the pure-Python parser and :rfc:`9110#section-5.5`
+-- by :user:`LuShadowX`.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -253,6 +253,7 @@ Lubomir Gelo
 Ludovic Gasc
 Luis Pedrosa
 Lukasz Marcin Dobrzanski
+Lukshya Supyal
 Lénárd Szolnoki
 Makc Belousow
 Manuel Miranda

--- a/aiohttp/_http_parser.pyx
+++ b/aiohttp/_http_parser.pyx
@@ -430,16 +430,21 @@ cdef class HttpParser:
 
     cdef _process_header(self):
         cdef str value
+        cdef bytes raw_value
         if self._raw_name != b"":
             name = find_header(self._raw_name)
-            value = self._raw_value.decode('utf-8', 'surrogateescape')
+            # llhttp strips the OWS before the field value but not the one
+            # after it, so drop that here.
+            # ref: RFC 9110 section 5.5
+            raw_value = self._raw_value.strip(b" \t")
+            value = raw_value.decode('utf-8', 'surrogateescape')
 
             # reject null bytes in header values - matches the Python parser
             # check at http_parser.py. llhttp in lenient mode doesn't reject
             # these itself, so we need to catch them here.
             # ref: RFC 9110 section 5.5 (CTL chars forbidden in field values)
             if "\x00" in value:
-                raise InvalidHeader(self._raw_value)
+                raise InvalidHeader(raw_value)
 
             if not self._lax and name in SINGLETON_HEADERS:
                 if name in self._seen_singletons:
@@ -454,7 +459,7 @@ cdef class HttpParser:
 
             self._has_value = False
             self._header_name_size = 0
-            self._raw_headers.append((self._raw_name, self._raw_value))
+            self._raw_headers.append((self._raw_name, raw_value))
             self._raw_name = b""
             self._raw_value = b""
 

--- a/aiohttp/_http_parser.pyx
+++ b/aiohttp/_http_parser.pyx
@@ -433,10 +433,9 @@ cdef class HttpParser:
         cdef bytes raw_value
         if self._raw_name != b"":
             name = find_header(self._raw_name)
-            # llhttp strips the OWS before the field value but not the one
-            # after it, so drop that here.
-            # ref: RFC 9110 section 5.5
-            raw_value = self._raw_value.strip(b" \t")
+            # llhttp strips the OWS before the field value but not after.
+            # https://www.rfc-editor.org/info/rfc9110/#section-5.5-3
+            raw_value = self._raw_value.rstrip(b" \t")
             value = raw_value.decode('utf-8', 'surrogateescape')
 
             # reject null bytes in header values - matches the Python parser

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -645,6 +645,15 @@ def test_whitespace_before_header(parser: HttpRequestParser) -> None:
         parser.feed_data(text)
 
 
+def test_whitespace_around_header_value(parser: HttpRequestParser) -> None:
+    text = b"GET / HTTP/1.1\r\nHost: a\r\ntest: \t value \t \r\n\r\n"
+    messages, upgrade, tail = parser.feed_data(text)
+    msg = messages[0][0]
+
+    assert msg.headers["test"] == "value"
+    assert msg.raw_headers == ((b"Host", b"a"), (b"test", b"value"))
+
+
 @pytest.fixture
 def xfail_c_parser_status(request: pytest.FixtureRequest) -> None:
     if isinstance(request.getfixturevalue("parser"), HttpRequestParserPy):


### PR DESCRIPTION
## What do these changes do?

llhttp strips the OWS before a header value but leaves the OWS after it, and `_process_header()` decodes the raw bytes as-is. So the C parser keeps trailing spaces and tabs where the Python parser strips them:

```pycon
>>> feed(b"GET / HTTP/1.1\r\nHost: a\r\ntest: \t value \t \r\n\r\n").headers["test"]
'value'        # HttpRequestParserPy
'value \t '    # HttpRequestParserC
```

RFC 9110 section 5.5 says the OWS on both sides is excluded from the field value, and `HeadersParser.parse_headers()` already does `bvalue.strip(b" \t")` for both `headers` and `raw_headers` (there is a comment there saying raw does not mean the OWS is kept). This does the same in the C parser.

`test_http_request_parser_utf8_request_line` covers this for the Python parser, but it is xfailed for the C parser over an unrelated URL difference, so the gap was not visible.

## Are there changes in behavior for the user?

Header values read through the C parser no longer carry trailing spaces or tabs, so both parsers now return the same thing. `raw_headers` changes the same way.

## Is it a substantial burden for the maintainers to support this?

No, it is three lines in `_process_header()` and removes a difference between the two parsers.

## Related issue number

None.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes — N/A, no API change
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
- [x] Add a new news fragment into the `CHANGES/` folder

<details>
<summary>Test run</summary>

Built with the Cython extensions (`make generate-llhttp`, `make cythonize`, `pip install -e .`).

New test, both parsers:

```
$ PYTHONPATH='.' pytest tests/test_http_parser.py -k whitespace_around_header_value -v
tests/test_http_parser.py::test_whitespace_around_header_value[py-parser] PASSED
tests/test_http_parser.py::test_whitespace_around_header_value[c-parser] PASSED
```

Same test against master, to check it catches the bug:

```
E       AssertionError: assert 'value \t ' == 'value'
FAILED tests/test_http_parser.py::test_whitespace_around_header_value[c-parser]
1 failed, 1 passed
```

Parser suite and full suite:

```
$ PYTHONPATH='.' pytest tests/test_http_parser.py
837 passed, 6 deselected, 3 xfailed

$ PYTHONPATH='.' pytest --numprocesses=auto
15 failed, 4932 passed, 23 skipped, 17 xfailed
```

The 15 failures are all `tests/test_run_app.py`, `OSError: [Errno 48] address already in use` on port 8080 on this machine. They fail the same way on master (4930 passed there, the +2 here is the new test).

</details>

Drafted with Claude Opus 5 (Claude Code); reviewed by @LuShadowX.

