### PR TITLE
parse cookie expires date as ascii-only

### DIFF
--- a/CHANGES/13278.bugfix.rst
+++ b/CHANGES/13278.bugfix.rst
@@ -1,1 +1,1 @@
-Restricted cookie ``Expires`` date parsing to ASCII digits, so a ``Set-Cookie`` date built from non-ASCII digits (Arabic-Indic, fullwidth and the like) no longer parses to a valid expiry as it would in a spec-compliant client per :rfc:`6265#section-5.1.1` -- by :user:`dxbjavid`.
+Restricted cookie ``Expires`` date parsing to ASCII digits -- by :user:`dxbjavid`.

--- a/CHANGES/13278.bugfix.rst
+++ b/CHANGES/13278.bugfix.rst
@@ -1,0 +1,1 @@
+Restricted cookie ``Expires`` date parsing to ASCII digits, so a ``Set-Cookie`` date built from non-ASCII digits (Arabic-Indic, fullwidth and the like) no longer parses to a valid expiry as it would in a spec-compliant client per :rfc:`6265#section-5.1.1` -- by :user:`dxbjavid`.

--- a/aiohttp/cookiejar.py
+++ b/aiohttp/cookiejar.py
@@ -44,11 +44,7 @@ _RELATIVE_EXPIRY_ATTRS = frozenset(("max-age", "expires"))
 class CookieJar(AbstractCookieJar):
     """Implements cookie storage adhering to RFC 6265."""
 
-    # RFC 6265 5.1.1 defines cookie-date digits as %x30-39 (ASCII only), so the
-    # date regexes are compiled with re.ASCII. Without it \d also matches
-    # unicode decimal digits (Arabic-Indic, fullwidth, ...) which int() then
-    # happily converts, so a server could smuggle a valid expiry through a date
-    # string a spec-compliant client would reject.
+    # https://datatracker.ietf.org/doc/html/rfc6265#section-5.1.1
     DATE_TOKENS_RE = re.compile(
         r"[\x09\x20-\x2F\x3B-\x40\x5B-\x60\x7B-\x7E]*"
         r"(?P<token>[\x00-\x08\x0A-\x1F\d:a-zA-Z\x7F-\xFF]+)",

--- a/aiohttp/cookiejar.py
+++ b/aiohttp/cookiejar.py
@@ -44,21 +44,27 @@ _RELATIVE_EXPIRY_ATTRS = frozenset(("max-age", "expires"))
 class CookieJar(AbstractCookieJar):
     """Implements cookie storage adhering to RFC 6265."""
 
+    # RFC 6265 5.1.1 defines cookie-date digits as %x30-39 (ASCII only), so the
+    # date regexes are compiled with re.ASCII. Without it \d also matches
+    # unicode decimal digits (Arabic-Indic, fullwidth, ...) which int() then
+    # happily converts, so a server could smuggle a valid expiry through a date
+    # string a spec-compliant client would reject.
     DATE_TOKENS_RE = re.compile(
         r"[\x09\x20-\x2F\x3B-\x40\x5B-\x60\x7B-\x7E]*"
-        r"(?P<token>[\x00-\x08\x0A-\x1F\d:a-zA-Z\x7F-\xFF]+)"
+        r"(?P<token>[\x00-\x08\x0A-\x1F\d:a-zA-Z\x7F-\xFF]+)",
+        re.ASCII,
     )
 
-    DATE_HMS_TIME_RE = re.compile(r"(\d{1,2}):(\d{1,2}):(\d{1,2})")
+    DATE_HMS_TIME_RE = re.compile(r"(\d{1,2}):(\d{1,2}):(\d{1,2})", re.ASCII)
 
-    DATE_DAY_OF_MONTH_RE = re.compile(r"(\d{1,2})")
+    DATE_DAY_OF_MONTH_RE = re.compile(r"(\d{1,2})", re.ASCII)
 
     DATE_MONTH_RE = re.compile(
         "(jan)|(feb)|(mar)|(apr)|(may)|(jun)|(jul)|(aug)|(sep)|(oct)|(nov)|(dec)",
-        re.I,
+        re.I | re.ASCII,
     )
 
-    DATE_YEAR_RE = re.compile(r"(\d{2,4})")
+    DATE_YEAR_RE = re.compile(r"(\d{2,4})", re.ASCII)
 
     # calendar.timegm() fails for timestamps after datetime.datetime.max
     # Minus one as a loss of precision occurs when timestamp() is called.

--- a/tests/test_cookiejar.py
+++ b/tests/test_cookiejar.py
@@ -141,9 +141,8 @@ def test_date_parsing() -> None:
     # Invalid time
     assert parse_func("Tue, 1 Jan 1970 77:88:99 GMT") is None
 
-    # Non-ASCII digits are not cookie-date digits (RFC 6265 5.1.1), so a date
-    # built from Arabic-Indic or fullwidth digits must not parse even though
-    # int() would otherwise accept them.
+    # Invalid digits
+    # https://datatracker.ietf.org/doc/html/rfc6265#section-5.1.1
     assert parse_func("Tue, ١ Jan ١٩٧٠ ٠٠:٠٠:٠٠ GMT") is None
     assert parse_func("Tue, １ Jan １９７０ ００:００:００ GMT") is None
     assert parse_func("Tue, 1 Jan 1970 ٠٠:٠٠:٠٠ GMT") is None

--- a/tests/test_cookiejar.py
+++ b/tests/test_cookiejar.py
@@ -141,6 +141,13 @@ def test_date_parsing() -> None:
     # Invalid time
     assert parse_func("Tue, 1 Jan 1970 77:88:99 GMT") is None
 
+    # Non-ASCII digits are not cookie-date digits (RFC 6265 5.1.1), so a date
+    # built from Arabic-Indic or fullwidth digits must not parse even though
+    # int() would otherwise accept them.
+    assert parse_func("Tue, ١ Jan ١٩٧٠ ٠٠:٠٠:٠٠ GMT") is None
+    assert parse_func("Tue, １ Jan １９７０ ００:００:００ GMT") is None
+    assert parse_func("Tue, 1 Jan 1970 ٠٠:٠٠:٠٠ GMT") is None
+
 
 def test_domain_matching() -> None:
     test_func = CookieJar._is_domain_match


### PR DESCRIPTION
## What do these changes do?

cookie `Expires` values are parsed in `CookieJar._parse_date` with regexes whose `\d` classes were compiled without `re.ASCII`, so `\d` also matches unicode decimal digits (Arabic-Indic, fullwidth and the like). response header values reach the jar decoded as utf-8, so a server can send an `Expires` built from non-ascii digits and `int()` converts them just fine, giving a valid expiry identical to the plain-ascii date.

RFC 6265 5.1.1 defines cookie-date digits as ascii only, and browsers reject such a date and keep the cookie as a session cookie, so today aiohttp can be handed a longer-lived cookie than a compliant client would retain. compiling the date regexes with `re.ASCII` restricts them to ascii digits, in line with the spec and with how the rest of the parser already treats digits.

## Are there changes in behavior for the user?

`Expires` values that rely on non-ascii digits now fail to parse and clear the attribute, so the cookie becomes a session cookie, the same as any other unparseable date. plain-ascii dates are unchanged.

## Is it a substantial burden for the maintainers to support this?

no, it is a flag on the existing date regexes plus a regression test.

## Related issue number

N/A

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes — N/A, internal parsing only
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt` — already present
- [x] Add a new news fragment into the `CHANGES/` folder