### PR TITLE
guard non-ascii transfer-encoding in response _is_chunked_te

### DIFF
--- a/CHANGES/13284.bugfix.rst
+++ b/CHANGES/13284.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed the pure-Python HTTP response parser treating a ``Transfer-Encoding`` whose final coding lower-cases to ``chunked`` only because it contains a non-ASCII character (e.g. ``chunKed`` with U+212A KELVIN SIGN) as chunked, so it now guards with ``isascii()`` before the case-insensitive comparison the same way the request parser does -- by :user:`arshsmith1`.

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -834,7 +834,9 @@ class HttpResponseParser(HttpParser[RawResponseMessage]):
 
     def _is_chunked_te(self, te: str) -> bool:
         # https://www.rfc-editor.org/rfc/rfc9112#section-6.3-2.4.2
-        return te.rsplit(",", maxsplit=1)[-1].strip(" \t").lower() == "chunked"
+        last = te.rsplit(",", maxsplit=1)[-1].strip(" \t")
+        # .lower() transforms some non-ascii chars, so must check first.
+        return last.isascii() and last.lower() == "chunked"
 
 
 class HttpPayloadParser:

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -929,6 +929,17 @@ def test_upgrade_header_non_ascii(parser: HttpRequestParser) -> None:
     assert not upgrade
 
 
+def test_response_te_header_non_ascii(response: HttpResponseParser) -> None:
+    # K = Kelvin sign, not valid ascii; str.lower() folds it to "chunked".
+    # The response parser must guard with isascii() before lower()-comparing,
+    # like the request parser does, so it does not frame the body as chunked
+    # when a peer reading the same bytes would treat it as an unknown coding.
+    text = "HTTP/1.1 200 OK\r\nTransfer-Encoding: chunKed\r\n\r\n"
+    messages, upgrade, tail = response.feed_data(text.encode())
+    msg = messages[0][0]
+    assert not msg.chunked
+
+
 @pytest.mark.parametrize(
     ("connection", "expected"),
     [


### PR DESCRIPTION
## What do these changes do?

`HttpResponseParser._is_chunked_te` lower-cases the last `Transfer-Encoding` coding and compares it to `chunked` without first checking the value is ASCII. `str.lower()` folds a few non-ASCII characters onto ASCII letters, so `Transfer-Encoding: chunKed` (the `K` is U+212A KELVIN SIGN, and `"chunKed".lower() == "chunked"`) makes the client frame the response body as chunked, while a spec-conforming proxy or cache reading the same bytes sees an unknown transfer-coding and frames it differently. On a keep-alive connection that disagreement is a response desync primitive. Lax mode is the production default for responses, and its header check only rejects raw CR/LF/NUL, so the Kelvin sign survives to reach this comparison.

The request parser already guards exactly this with `isascii()` and documents why; this puts the same guard on the response side.

## Are there changes in behavior for the user?

Only for the crafted case. A normal `chunked` response (including `gzip, chunked`) is unaffected; a value that merely folds to `chunked` under Unicode case mapping is no longer treated as chunked.

## Is it a substantial burden for the maintainers to support this?

No. It is two lines mirroring the existing request-parser guard, plus one regression test placed beside the request-parser sibling.

## Related issue number

None.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes — N/A, no public API change
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
- [x] Add a new news fragment into the `CHANGES/` folder