### PR TITLE
fix quadratic backtracking in Forwarded and Link header parsing

### DIFF
--- a/CHANGES/13285.bugfix.rst
+++ b/CHANGES/13285.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed quadratic worst-case backtracking (ReDoS) when parsing the ``Forwarded`` request header and the ``Link`` response header. A single header value carrying a long run of whitespace ahead of a non-space character could stall the event loop for seconds -- by :user:`arshsmith1`.

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -497,10 +497,14 @@ class ClientResponse(HeadersMixin):
             link: MultiDict[str | URL] = MultiDict()
 
             for param in params:
-                match = re.match(r"^\s*(\S*)\s*=\s*(['\"]?)(.*?)(\2)\s*$", param, re.M)
+                match = re.match(r"\s*(\S*)\s*=\s*(.*)", param)
                 if match is None:  # Malformed param
                     continue
-                key, _, value, _ = match.groups()
+                key, value = match.groups()
+                value = value.strip()
+                if len(value) >= 2 and value[0] in "\"'" and value[-1] == value[0]:
+                    # strip a matching pair of surrounding quotes
+                    value = value[1:-1]
 
                 link.add(key, value)
 

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -84,7 +84,8 @@ _LIST_ELEMENT_RE = re.compile(
             (?<=[^\s]=) {_QUOTED_STRING}  # parameter quoted value
             | (?<=\s) \( {_ESCAPED_COMMENT} \)  # comment
             | [^,]  # any non-comma character
-          )+?
+          )+  # greedy: a lazy quantifier here backtracks quadratically when
+              # an element carries a long run of whitespace (ReDoS)
         )
     )
     [ \t]* (?:,|\Z)

--- a/tests/test_client_response.py
+++ b/tests/test_client_response.py
@@ -3,6 +3,7 @@
 import asyncio
 import gc
 import sys
+import time
 from http.cookies import SimpleCookie
 from json import JSONDecodeError
 from unittest import mock
@@ -1595,6 +1596,68 @@ def test_response_links_empty(
     )
     response._headers = HeadersDictProxy(CIMultiDict())
     assert response.links == {}
+
+
+def test_response_links_unquoted_whitespace(
+    event_loop: asyncio.AbstractEventLoop, session: ClientSession
+) -> None:
+    url = URL("http://def-cl-resp.org/")
+    response = ClientResponse(
+        "get",
+        url,
+        writer=WriterMock(),
+        continue100=None,
+        timer=TimerNoop(),
+        traces=[],
+        loop=event_loop,
+        session=session,
+        request_headers=CIMultiDict[str](),
+        original_url=url,
+        stream_writer=mock.create_autospec(
+            AbstractStreamWriter, spec_set=True, instance=True
+        ),
+    )
+    h = (("Link", "<http://example.com/>;  rel =  next  ; title = a b "),)
+    response._headers = HeadersDictProxy(CIMultiDict(h))
+    assert response.links == {
+        "next": {"url": URL("http://example.com/"), "rel": "next", "title": "a b"}
+    }
+
+
+def test_response_links_redos(
+    event_loop: asyncio.AbstractEventLoop, session: ClientSession
+) -> None:
+    # A malicious server can make the per-parameter regex backtrack
+    # quadratically with an unquoted value that carries a long run of
+    # whitespace ahead of a non-space character.
+    url = URL("http://def-cl-resp.org/")
+    response = ClientResponse(
+        "get",
+        url,
+        writer=WriterMock(),
+        continue100=None,
+        timer=TimerNoop(),
+        traces=[],
+        loop=event_loop,
+        session=session,
+        request_headers=CIMultiDict[str](),
+        original_url=url,
+        stream_writer=mock.create_autospec(
+            AbstractStreamWriter, spec_set=True, instance=True
+        ),
+    )
+    payload = "<http://example.com/>; rel=a" + " " * 15000 + "b"
+    response._headers = HeadersDictProxy(CIMultiDict((("Link", payload),)))
+
+    start = time.perf_counter()
+    links = response.links
+    elapsed = time.perf_counter() - start
+
+    assert elapsed < 0.5, (
+        f"Parsing took {elapsed * 1000:.1f}ms - potential ReDoS in the Link "
+        "header parser"
+    )
+    assert links["a" + " " * 15000 + "b"]["rel"] == "a" + " " * 15000 + "b"
 
 
 def test_response_not_closed_after_get_ok(mocker: MockerFixture) -> None:

--- a/tests/test_web_request.py
+++ b/tests/test_web_request.py
@@ -702,6 +702,25 @@ def test_forwarded_re_performance() -> None:
     assert match is None
 
 
+def test_forwarded_getall_performance() -> None:
+    # HeadersDictProxy.getall() splits the header into comma-separated
+    # elements before forwarded parses them. An unquoted element carrying a
+    # long whitespace run ahead of a non-space character made that split
+    # regex backtrack quadratically, so a single request header could stall
+    # the worker for seconds.
+    header = "for=a" + " " * 30000 + "b"
+    req = make_mocked_request("GET", "/", headers=CIMultiDict({"Forwarded": header}))
+
+    start = time.perf_counter()
+    req.forwarded
+    elapsed = time.perf_counter() - start
+
+    assert elapsed < 0.5, (
+        f"Parsing took {elapsed * 1000:.1f}ms - potential ReDoS in the "
+        "Forwarded header split"
+    )
+
+
 @pytest.mark.parametrize(
     "forward_for_in, forward_for_out",
     [


### PR DESCRIPTION
## What do these changes do?

`HeadersDictProxy.getall` splits a comma-separated header into elements with `_LIST_ELEMENT_RE`, whose unquoted-element group used a lazy quantifier ahead of a trailing `[ \t]*(?:,|\Z)`. When an element carries a long run of whitespace before a non-space character (e.g. `for=a` followed by many spaces then `b`), the engine backtracks quadratically. That regex sits on two attacker-reachable paths: `request.forwarded` (a request header, server side) and `response.links` (a response header, client side), so a single ~8 KB header value burns hundreds of ms of CPU per access.

`response.links` also parsed each `Link` parameter with `(.*?)(\2)\s*$`, which backtracks the same way on an unquoted value that ends in trailing whitespace. Making the split-regex group greedy fixes the first case with no change in output (the captured group is stripped afterwards anyway), and the `Link` parameter is now captured greedily with the surrounding quotes and whitespace stripped in Python. Both go from O(n^2) to O(n).

## Are there changes in behavior for the user?

No. Parsed results are identical for every input; only the worst-case timing changes. I ran a differential fuzz of the old and new `getall` regex over a few hundred thousand generated inputs with zero divergence, and the same for the `Link` parameter parsing.

## Is it a substantial burden for the maintainers to support this?

No. It is a one-character change to the split regex plus a small rewrite of the `Link` parameter parse, each covered by a regression test that fails on the unpatched tree.

## Related issue number

N/A

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes — N/A, no public API change
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
- [x] Add a new news fragment into the `CHANGES/` folder

<details>
<summary>Before/after timing (pure-Python parser)</summary>

```
request.forwarded, header = "for=a" + " "*N + "b"
  N= 8000   before: 306 ms    after: 0.7 ms
  N=16000   before: ~1.2 s    after: 1.6 ms

response.links, Link = "<http://example.com/>; rel=a" + " "*15000 + "b"
  before: ~1.5 s    after: 1.2 ms
```
</details>
