### PR TITLE
Skip symlink tests when the host cannot create symlinks

### DIFF
--- a/CHANGES/13286.contrib.rst
+++ b/CHANGES/13286.contrib.rst
@@ -1,0 +1,3 @@
+Made the test suite skip the symlink tests when the host does not permit creating
+symlinks, rather than failing with ``OSError: [WinError 1314]`` on Windows without
+``SeCreateSymbolicLinkPrivilege`` -- by :user:`Zuhef`.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -446,6 +446,7 @@ Yuvi Panda
 Zainab Lawal
 Zeal Wierslee
 Zlatan Sičanica
+Zuhef Ahmed
 Łukasz Setla
 Марк Коренберг
 Семён Марьясин

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -207,6 +207,25 @@ async def loop_debug_mode() -> AsyncIterator[None]:
 
 
 @pytest.fixture
+def symlinks_supported() -> None:
+    # Skip tests that need to create symlinks when the host does not allow it.
+
+    # On Windows, os.symlink() needs SeCreateSymbolicLinkPrivilege, which is only
+    # held by an elevated process or when Developer Mode is enabled. CI runs with
+    # that privilege, so the symlink tests still execute there; without this check
+    # an unprivileged local checkout errors out with
+    # `OSError: [WinError 1314] A required privilege is not held by the client`
+    # instead of skipping.
+    with TemporaryDirectory() as tmp_dir:
+        target = Path(tmp_dir) / "symlink-target"
+        target.touch()
+        try:
+            (Path(tmp_dir) / "symlink").symlink_to(target)
+        except OSError as exc:
+            pytest.skip(f"requires privilege to create symlinks: {exc}")
+
+
+@pytest.fixture
 def unix_sockname(
     tmp_path: Path, tmp_path_factory: pytest.TempPathFactory
 ) -> Iterator[str]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -221,7 +221,7 @@ def symlinks_supported() -> None:
         target.touch()
         try:
             (Path(tmp_dir) / "symlink").symlink_to(target)
-        except OSError as exc:
+        except OSError as exc:  # pragma: no cover
             pytest.skip(f"requires privilege to create symlinks: {exc}")
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -206,16 +206,9 @@ async def loop_debug_mode() -> AsyncIterator[None]:
         loop.set_debug(False)
 
 
-@pytest.fixture
+@pytest.fixture(scope="session")
 def symlinks_supported() -> None:
-    # Skip tests that need to create symlinks when the host does not allow it.
-
-    # On Windows, os.symlink() needs SeCreateSymbolicLinkPrivilege, which is only
-    # held by an elevated process or when Developer Mode is enabled. CI runs with
-    # that privilege, so the symlink tests still execute there; without this check
-    # an unprivileged local checkout errors out with
-    # `OSError: [WinError 1314] A required privilege is not held by the client`
-    # instead of skipping.
+    """Skip tests if symlinks not support (e.g. Windows permission problem)."""
     with TemporaryDirectory() as tmp_dir:
         target = Path(tmp_dir) / "symlink-target"
         target.touch()

--- a/tests/test_urldispatch.py
+++ b/tests/test_urldispatch.py
@@ -464,7 +464,9 @@ def test_add_static_append_version_non_exists_file_without_slash(
 
 
 def test_add_static_append_version_follow_symlink(
-    router: web.UrlDispatcher, tmp_path: pathlib.Path
+    router: web.UrlDispatcher,
+    tmp_path: pathlib.Path,
+    symlinks_supported: None,
 ) -> None:
     # Tests the access to a symlink, in static folder with apeend_version
     symlink_path = tmp_path / "append_version_symlink"
@@ -486,7 +488,9 @@ def test_add_static_append_version_follow_symlink(
 
 
 def test_add_static_append_version_not_follow_symlink(
-    router: web.UrlDispatcher, tmp_path: pathlib.Path
+    router: web.UrlDispatcher,
+    tmp_path: pathlib.Path,
+    symlinks_supported: None,
 ) -> None:
     # Tests the access to a symlink, in static folder with apeend_version
 

--- a/tests/test_web_urldispatcher.py
+++ b/tests/test_web_urldispatcher.py
@@ -199,7 +199,9 @@ async def test_access_root_of_static_handler_xss(
 
 
 async def test_follow_symlink(
-    tmp_path: pathlib.Path, aiohttp_client: AiohttpClient
+    tmp_path: pathlib.Path,
+    aiohttp_client: AiohttpClient,
+    symlinks_supported: None,
 ) -> None:
     # Tests the access to a symlink, in static folder
     data = "hello world"
@@ -257,7 +259,9 @@ async def test_follow_symlink_directory_traversal(
 
 
 async def test_follow_symlink_directory_traversal_after_normalization(
-    tmp_path: pathlib.Path, aiohttp_client: AiohttpClient
+    tmp_path: pathlib.Path,
+    aiohttp_client: AiohttpClient,
+    symlinks_supported: None,
 ) -> None:
     # Tests that break_symlink_sandbox does not allow directory transversal
     # after normalization
@@ -518,7 +522,9 @@ async def test_static_file_with_mock_permission_error(
 
 
 async def test_access_symlink_loop(
-    tmp_path: pathlib.Path, aiohttp_client: AiohttpClient
+    tmp_path: pathlib.Path,
+    aiohttp_client: AiohttpClient,
+    symlinks_supported: None,
 ) -> None:
     # Tests the access to a looped symlink, which could not be resolved.
     my_dir_path = tmp_path / "my_symlink"
@@ -536,7 +542,9 @@ async def test_access_symlink_loop(
 
 
 async def test_access_compressed_file_as_symlink(
-    tmp_path: pathlib.Path, aiohttp_client: AiohttpClient
+    tmp_path: pathlib.Path,
+    aiohttp_client: AiohttpClient,
+    symlinks_supported: None,
 ) -> None:
     """Test that compressed file variants as symlinks are ignored."""
     private_file = tmp_path / "private.txt"


### PR DESCRIPTION
## What do these changes do?

Six tests create symlinks unconditionally. On Windows `os.symlink()` requires
`SeCreateSymbolicLinkPrivilege`, which is only held by an elevated process or when
Developer Mode is enabled, so on an unprivileged local checkout these tests fail with
`OSError: [WinError 1314] A required privilege is not held by the client` rather than
skipping.

This adds a `symlinks_supported` fixture to `tests/conftest.py` that probes the
capability once in a throwaway temporary directory and skips only when the privilege is
genuinely missing, then requests it from the six affected tests. It follows the existing
`unix_sockname` pattern, which already skips with `pytest.skip("requires UNIX sockets")`.

The probe deliberately tests the capability instead of the platform. A plain
`skipif(sys.platform == "win32")` would also disable these tests on CI, where the
privilege *is* held — that would silently drop coverage, which is worse than the
problem being fixed.

## Are there changes in behavior for the user?

No. Test-only change; no library code is touched.

## Is it a substantial burden for the maintainers to support this?

No — it is one small fixture plus six signature changes, and it removes a
platform-specific failure mode rather than adding a configuration surface. The fixture
has no dependencies beyond `tempfile`/`pathlib`, both already imported in `conftest.py`.
The one judgement call worth reviewing is capability-probing vs. platform-gating; I chose
probing specifically so CI coverage is preserved.

## Related issue number

None — found while running the suite on Windows. I did not open a separate issue to avoid
adding tracker noise for a test-only fix; happy to file one if you would prefer that.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
  * N/A in the strict sense — this *is* a test-infrastructure change. Both branches of
    the new fixture were verified explicitly (see the log block below).
- [ ] Documentation reflects the changes
  * N/A — no user-facing behaviour changed.
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
- [x] Add a new news fragment into the `CHANGES/` folder

<details>
<summary>Verification log (Windows 11, Python 3.13, <code>AIOHTTP_NO_EXTENSIONS=1</code>)</summary>

Before, full suite — six symlink tests error out:

```
FAILED tests/test_urldispatch.py::test_add_static_append_version_follow_symlink - OSError: [WinError 1314] ...
FAILED tests/test_urldispatch.py::test_add_static_append_version_not_follow_symlink - OSError: [WinError 1314] ...
FAILED tests/test_web_urldispatcher.py::test_access_symlink_loop - OSError: [WinError 1314] ...
FAILED tests/test_web_urldispatcher.py::test_access_compressed_file_as_symlink - OSError: [WinError 1314] ...
FAILED tests/test_web_urldispatcher.py::test_follow_symlink - OSError: [WinError 1314] ...
FAILED tests/test_web_urldispatcher.py::test_follow_symlink_directory_traversal_after_normalization - OSError: [WinError 1314] ...
7 failed, 4470 passed, 80 skipped, 14 xfailed in 110.66s
```

After — they skip with a reason, and the suite is otherwise unchanged:

```
SKIPPED [1] tests/test_web_urldispatcher.py:201: requires privilege to create symlinks: [WinError 1314] ...
SKIPPED [1] tests/test_web_urldispatcher.py:261: requires privilege to create symlinks: [WinError 1314] ...
SKIPPED [1] tests/test_web_urldispatcher.py:524: requires privilege to create symlinks: [WinError 1314] ...
SKIPPED [1] tests/test_web_urldispatcher.py:544: requires privilege to create symlinks: [WinError 1314] ...
SKIPPED [1] tests/test_urldispatch.py:466: requires privilege to create symlinks: [WinError 1314] ...
SKIPPED [1] tests/test_urldispatch.py:490: requires privilege to create symlinks: [WinError 1314] ...
1 failed, 4470 passed, 86 skipped, 14 xfailed in 106.17s
```

`test_follow_symlink_directory_traversal` still runs — it does not create a symlink, so
the fixture was deliberately not added to it.

Both fixture branches were checked, since this host cannot exercise the privileged path:

```
[branch: real host    ] SKIPPED -> Skipped
[branch: capable host ] did NOT skip -> tests RUN (CI coverage preserved)
PASS: skips only when the privilege is genuinely absent
```

The capable-host branch was exercised by making the probe succeed, which is what happens
on POSIX and on your Windows CI runners.

Lint and types:

```
pre-commit run --files tests/conftest.py tests/test_urldispatch.py \
                       tests/test_web_urldispatcher.py CONTRIBUTORS.txt
  isort / black / pyupgrade / flake8 / codespell / file contents sorter ... Passed
mypy tests/conftest.py tests/test_urldispatch.py tests/test_web_urldispatcher.py
  Found 21 errors in 7 files   # identical to baseline on an unmodified tree
```

Two notes, both outside the scope of this change and left alone:

1. `tests/test_circular_imports.py::test_no_warnings[aiohttp._websocket.reader_c]` is the
   remaining failure above. It fails under `AIOHTTP_NO_EXTENSIONS=1` because the Cython
   module is absent. Say the word and I will open a separate issue.
2. The 21 mypy errors are pre-existing and Windows-specific (`socket.AF_UNIX` missing, an
   unused `type: ignore` on the proactor branch).

</details>

Drafted with Kiro CLI (claude-opus-5); reviewed by @Zuhef.
