### PR TITLE
Retain the chunk-received trace task in read_nowait

### DIFF
--- a/CHANGES/13300.bugfix.rst
+++ b/CHANGES/13300.bugfix.rst
@@ -1,0 +1,3 @@
+Retained the chunk-received trace task scheduled by
+:py:meth:`~aiohttp.StreamReader.read_nowait`, so the tracing hook can no
+longer be garbage collected before it fires -- by :user:`noron12234`.

--- a/aiohttp/streams.py
+++ b/aiohttp/streams.py
@@ -102,6 +102,7 @@ class StreamReader:
         "_eof_callbacks",
         "_eof_counter",
         "_on_chunk_received",
+        "_chunk_received_tasks",
         "total_bytes",
         "total_compressed_bytes",
     )
@@ -138,6 +139,7 @@ class StreamReader:
         self._on_chunk_received: (
             Callable[[bytes], Coroutine[None, None, None]] | None
         ) = None
+        self._chunk_received_tasks: set[asyncio.Task[None]] = set()
         self.total_bytes = 0
         self.total_compressed_bytes: int | None = None
 
@@ -536,9 +538,14 @@ class StreamReader:
         chunk = self._read_nowait(n)
         if chunk and (cb := self._on_chunk_received) is not None:
             # read_nowait is sync but the hook is async; schedule it so the
-            # observability event still fires.
-            # TODO: Save and await this task.
-            asyncio.create_task(cb(chunk))  # type: ignore[unused-awaitable]
+            # observability event still fires. The loop only holds a weak
+            # reference to a task, so keep one here until it completes —
+            # otherwise the trace event can be collected before it fires.
+            # TODO: this still bypasses the `self._timer` bound that
+            # _fire_chunk_received applies; awaiting it needs a sync/async split.
+            task = asyncio.create_task(cb(chunk))
+            self._chunk_received_tasks.add(task)
+            task.add_done_callback(self._chunk_received_tasks.discard)
         return chunk
 
     def _read_nowait_chunk(self, n: int) -> bytes:

--- a/aiohttp/streams.py
+++ b/aiohttp/streams.py
@@ -139,7 +139,10 @@ class StreamReader:
         self._on_chunk_received: (
             Callable[[bytes], Coroutine[None, None, None]] | None
         ) = None
-        self._chunk_received_tasks: set[asyncio.Task[None]] = set()
+        # Allocated lazily: a StreamReader is built per response, but the
+        # chunk-received hook is only set when tracing is enabled, so an
+        # eager set() would cost every response for a rarely-used feature.
+        self._chunk_received_tasks: set[asyncio.Task[None]] | None = None
         self.total_bytes = 0
         self.total_compressed_bytes: int | None = None
 
@@ -544,8 +547,10 @@ class StreamReader:
             # TODO: this still bypasses the `self._timer` bound that
             # _fire_chunk_received applies; awaiting it needs a sync/async split.
             task = asyncio.create_task(cb(chunk))
-            self._chunk_received_tasks.add(task)
-            task.add_done_callback(self._chunk_received_tasks.discard)
+            if (tasks := self._chunk_received_tasks) is None:
+                tasks = self._chunk_received_tasks = set()
+            tasks.add(task)
+            task.add_done_callback(tasks.discard)
         return chunk
 
     def _read_nowait_chunk(self, n: int) -> bytes:

--- a/tests/test_streams.py
+++ b/tests/test_streams.py
@@ -1296,6 +1296,36 @@ class TestStreamReaderChunkHook:
         await asyncio.sleep(0)
         assert seen == [b"abc"]
 
+    async def test_read_nowait_holds_the_task_then_releases_it(self) -> None:
+        # The loop keeps only a weak reference to a task, so the scheduled
+        # hook needs a strong referent of its own until it completes. This
+        # asserts the reference exists while pending and is dropped after,
+        # so holding it cannot turn into a leak.
+        stream, seen = self._make_one()
+        stream.feed_data(b"abc")
+
+        assert stream.read_nowait() == b"abc"
+        assert stream._chunk_received_tasks is not None
+        assert len(stream._chunk_received_tasks) == 1
+
+        await asyncio.sleep(0)
+        assert seen == [b"abc"]
+
+        # add_done_callback is delivered via call_soon, so the discard lands
+        # on the tick after the task finishes rather than synchronously.
+        await asyncio.sleep(0)
+        assert not stream._chunk_received_tasks
+
+    async def test_no_hook_does_not_allocate_the_task_set(self) -> None:
+        # A StreamReader is built per response but the hook is only set when
+        # tracing is enabled, so the set stays unallocated in the common case.
+        stream, _ = self._make_one()
+        stream._on_chunk_received = None
+        stream.feed_data(b"abc")
+
+        assert stream.read_nowait() == b"abc"
+        assert stream._chunk_received_tasks is None
+
     async def test_hook_exception_propagates(self) -> None:
         async def cb(chunk: bytes) -> None:
             raise RuntimeError("boom")


### PR DESCRIPTION
## What

`read_nowait` schedules the chunk-received trace hook and drops the task, which the `TODO` on that line already flags:

```python
chunk = self._read_nowait(n)
if chunk and (cb := self._on_chunk_received) is not None:
    # read_nowait is sync but the hook is async; schedule it so the
    # observability event still fires.
    # TODO: Save and await this task.
    asyncio.create_task(cb(chunk))  # type: ignore[unused-awaitable]
```

The loop only keeps a weak reference, so the task can be garbage collected before the hook runs. Chunk tracing then loses events with no error and no log line — the failure is a missing datapoint, which is the hardest kind to notice, and it gets more likely exactly when the loop is busiest.

## What this PR does — and does not — do

This is **only the "save" half** of that TODO.

The async paths already handle this properly through `_fire_chunk_received`, which also bounds a hung handler with the per-stream timer:

```python
async def _fire_chunk_received(self, chunk: bytes) -> None:
    cb = self._on_chunk_received
    assert cb is not None
    # Run under the same per-stream timer that _wait() uses, so a hung
    # trace handler is bounded by sock_read just like a hung socket read would be.
    with self._timer:
        await cb(chunk)
```

`read_nowait` cannot use it because it is synchronous. Awaiting the hook there would need a sync/async split of `read_nowait`, and the fire-and-forget task also bypasses the `self._timer` bound the async paths get. Both are design calls for the maintainers, not something to decide in a drive-by PR — so the TODO is **narrowed rather than removed**, and now names the remaining piece:

```python
# TODO: this still bypasses the `self._timer` bound that
# _fire_chunk_received applies; awaiting it needs a sync/async split.
task = asyncio.create_task(cb(chunk))
self._chunk_received_tasks.add(task)
task.add_done_callback(self._chunk_received_tasks.discard)
```

`_chunk_received_tasks` is added to `__slots__` and initialised next to `_on_chunk_received`. `discard` rather than `remove` so a double callback cannot raise; the set stays bounded by the number of in-flight hooks.

The `# type: ignore[unused-awaitable]` is gone, since the result is bound now.

## Verification

```console
$ black --check aiohttp/streams.py     # black 26.5.1, pinned in .pre-commit-config.yaml
1 file would be left unchanged.
$ isort --check-only aiohttp/streams.py
$ python -m py_compile aiohttp/streams.py
```

No test: the failure is a garbage-collection race, so a test would have to force a GC at a chosen moment and assert a task did *not* vanish — flaky by construction. Happy to add one if you have a shape in mind.

Found with an AST scan for `create_task` / `ensure_future` results discarded as bare expression statements (excluding `TaskGroup.create_task`, which does hold strong references). This was the only hit in the package.
