### PR TITLE
[PR #13301/58bae08b backport][3.15] Add METH_QUERY and treat QUERY as an idempotent method

### DIFF
--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -249,7 +249,10 @@ class ClientTimeout:
 DEFAULT_TIMEOUT: Final[ClientTimeout] = ClientTimeout(total=5 * 60, sock_connect=30)
 
 # https://www.rfc-editor.org/rfc/rfc9110#section-9.2.2
-IDEMPOTENT_METHODS = frozenset({"GET", "HEAD", "OPTIONS", "TRACE", "PUT", "DELETE"})
+# https://www.rfc-editor.org/info/rfc10008/#section-1-12
+IDEMPOTENT_METHODS = frozenset(
+    {"GET", "HEAD", "OPTIONS", "TRACE", "PUT", "DELETE", "QUERY"}
+)
 
 _RetType_co = TypeVar(
     "_RetType_co",

--- a/aiohttp/hdrs.py
+++ b/aiohttp/hdrs.py
@@ -16,6 +16,7 @@ METH_OPTIONS: Final[str] = "OPTIONS"
 METH_PATCH: Final[str] = "PATCH"
 METH_POST: Final[str] = "POST"
 METH_PUT: Final[str] = "PUT"
+METH_QUERY: Final[str] = "QUERY"
 METH_TRACE: Final[str] = "TRACE"
 
 METH_ALL: Final[set[str]] = {

--- a/tests/test_test_utils.py
+++ b/tests/test_test_utils.py
@@ -11,7 +11,7 @@ from multidict import CIMultiDict, CIMultiDictProxy
 from yarl import URL
 
 import aiohttp
-from aiohttp import web
+from aiohttp import hdrs, web
 from aiohttp.pytest_plugin import AiohttpClient
 from aiohttp.test_utils import (
     AioHTTPTestCase,
@@ -375,6 +375,29 @@ async def test_retry_persistent_connection_lowercase_method(
     client = await aiohttp_client(app)
     client.session._retry_connection = True
     async with client.request("get", "/") as resp:
+        assert resp.status == 200
+
+    assert num_requests == 2
+
+
+async def test_retry_persistent_connection_query_method(
+    aiohttp_client: AiohttpClient,
+) -> None:
+    """QUERY is safe and idempotent, so it must trigger retry."""
+    num_requests = 0
+
+    async def handler(request: web.Request) -> web.Response:
+        nonlocal num_requests
+        num_requests += 1
+        if num_requests == 1:
+            request.protocol.force_close()
+        return web.Response()
+
+    app = web.Application()
+    app.router.add_route(hdrs.METH_QUERY, "/", handler)
+    client = await aiohttp_client(app)
+    client.session._retry_connection = True
+    async with client.request(hdrs.METH_QUERY, "/") as resp:
         assert resp.status == 200
 
     assert num_requests == 2


### PR DESCRIPTION
**This is a backport of PR #13301 as merged into master (58bae08b7e4831c6c184fe22233bfc19941c700b).**

## What do these changes do?

Follow-up to #13160, as requested in https://github.com/aio-libs/aiohttp/issues/13160#issuecomment-5038250224.

#13174 fixed the parser half of that issue, so `QUERY` now arrives intact instead of `<unknown>`. The two remaining pieces (originally part of the closed #13167) never landed:

1. `aiohttp/hdrs.py` gains `METH_QUERY`, alongside the other `METH_*` constants.
2. `aiohttp/client.py` adds `"QUERY"` to `IDEMPOTENT_METHODS`, so a `QUERY` request is replayed when the server closes a keep-alive connection underneath it, the same as `GET` or `PUT`. RFC 10008 defines the method as both safe and idempotent (https://www.rfc-editor.org/info/rfc10008/#section-1-12), which is exactly the property that set encodes.

`METH_QUERY` is deliberately **not** added to `METH_ALL`. `RouteDef.register()` dispatches every `METH_ALL` member through `getattr(router, "add_" + method.lower())`, and `UrlDispatcher` has no `add_query()`, so adding it there would turn `web.route("QUERY", ...)` passed to `add_routes()` into an `AttributeError`. (`METH_CONNECT` and `METH_TRACE` are already in `METH_ALL` without matching `add_*` methods, so that path is broken for them today — out of scope here.)

## Are there changes in behavior for the user?

Yes, one: a `QUERY` request that hits a keep-alive connection the server has just closed is now retried once instead of raising `ServerDisconnectedError`. That is the documented behavior for safe, idempotent methods, and `QUERY` qualifies. Everything else is additive — a new public constant.

## Is it a substantial burden for the maintainers to support this?

No. It is one constant and one set member, with no new code paths; the retry logic itself is untouched.

## Related issue number

Follows up #13160 (fixed for the parser by #13174). Reuses the `hdrs.py`/`client.py` hunks from the closed #13167, with the RFC URL amended to the form suggested in review there.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes — N/A, `hdrs` constants are not individually documented and the retry behavior is described generically
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt` — N/A, already listed
- [x] Add a new news fragment into the `CHANGES/` folder

<details>
<summary>Test evidence</summary>

New test `test_retry_persistent_connection_query_method` sits alongside the existing `test_retry_persistent_connection_lowercase_method`, and follows the same shape: the handler force-closes the connection on the first request, and the test asserts the request is retried.

Passes with **both** parsers:

```
$ AIOHTTP_NO_EXTENSIONS=1 pytest tests/test_test_utils.py -k retry_persistent -v
tests/test_test_utils.py::test_disable_retry_persistent_connection PASSED
tests/test_test_utils.py::test_retry_persistent_connection_lowercase_method PASSED
tests/test_test_utils.py::test_retry_persistent_connection_query_method PASSED

$ pytest tests/test_test_utils.py -k retry_persistent -v   # C extensions built
tests/test_test_utils.py::test_disable_retry_persistent_connection PASSED
tests/test_test_utils.py::test_retry_persistent_connection_lowercase_method PASSED
tests/test_test_utils.py::test_retry_persistent_connection_query_method PASSED
```

Confirmed the test fails without the production change (reverting `IDEMPOTENT_METHODS` to its previous value makes it error with the connection dropped, no retry), so it is not vacuous.

Wider run, no regressions:

```
$ pytest tests/test_test_utils.py tests/test_client_session.py
148 passed, 1 skipped, 1 xfailed
```

`black`, `isort` and `mypy` are clean on the touched files.
</details>

