### PR TITLE
Add a reference Dockerfile for building aiohttp from a git clone

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,79 @@
+# =============================================================================
+# .dockerignore for the aiohttp build context
+#
+# DELIBERATELY DOES NOT IGNORE .git
+#
+# The usual advice is to exclude .git from the build context. Do not do it
+# here. Two things in this repo depend on it:
+#
+#   1. `git submodule update --init --recursive` needs .git/modules and the
+#      recorded gitlink for vendor/llhttp. Without it the submodule cannot be
+#      materialised at all.
+#
+#   2. setup.py branches on `IS_GIT_REPO = (HERE / ".git").exists()`. Dropping
+#      .git silently disables the "Install submodules when building from git
+#      clone" guard, so the build gets *further* and then fails later and far
+#      less legibly, inside gcc, on missing llhttp sources.
+#
+# .git is ~39 MB here, which is an acceptable cost for a correct build.
+# =============================================================================
+
+# Build/test artefacts that must never leak into the image
+.mypy_cache/
+.pytest_cache/
+.hypothesis/
+.tox/
+.nox/
+htmlcov/
+.coverage
+.coverage.*
+coverage.xml
+*.cover
+build/
+dist/
+*.egg-info/
+.eggs/
+
+# Compiled + Cython-generated output: regenerated inside the image, and stale
+# host copies (wrong libc, wrong arch) would poison the build.
+*.so
+*.pyd
+*.o
+*.obj
+*.a
+*.lib
+__pycache__/
+*.py[cod]
+aiohttp/*.c
+aiohttp/_websocket/*.c
+aiohttp/_find_header.c
+aiohttp/_headers.pyi
+.hash/
+
+# Makefile stamp files - if these are copied in, make thinks work is already
+# done and skips cythonize.
+.install-cython
+.install-deps
+.develop
+.llhttp-gen
+
+# Local virtualenvs and node output from the host
+.venv/
+venv/
+node_modules/
+
+# Editor / OS noise
+.idea/
+.vscode/
+*.swp
+*~
+.DS_Store
+
+# Docs and CI config are not needed to build or test the package
+docs/_build/
+.readthedocs.yml
+.github/
+
+# The Dockerfiles themselves
+*.Dockerfile
+Dockerfile

--- a/fixed.Dockerfile
+++ b/fixed.Dockerfile
@@ -4,7 +4,9 @@
 #
 # Corrected build for aio-libs/aiohttp @ PR #11290 (4.0.0a2.dev0).
 #
-# Three changes relative to original-reconstructed.Dockerfile:
+# Four changes relative to original-reconstructed.Dockerfile. Only FIX 1 and
+# FIX 2 address the recorded failure; FIX 3 is a robustness improvement and
+# FIX 4 only compensates for damage in the supplied repository.zip.
 #
 #   FIX 1 - Ordering. `git submodule update --init --recursive` now runs BEFORE
 #           `pip install -e .`. This is the actual reported bug: setup.py exits

--- a/fixed.Dockerfile
+++ b/fixed.Dockerfile
@@ -1,0 +1,199 @@
+# syntax=docker/dockerfile:1
+# =============================================================================
+# fixed.Dockerfile
+#
+# Corrected build for aio-libs/aiohttp @ PR #11290 (4.0.0a2.dev0).
+#
+# Three changes relative to original-reconstructed.Dockerfile:
+#
+#   FIX 1 - Ordering. `git submodule update --init --recursive` now runs BEFORE
+#           `pip install -e .`. This is the actual reported bug: setup.py exits
+#           with code 2 ("Install submodules when building from git clone")
+#           when vendor/llhttp/README.md is missing.
+#
+#   FIX 2 - Generated sources. setup.py lists aiohttp/_websocket/mask.c,
+#           aiohttp/_http_parser.c, aiohttp/_http_writer.c and
+#           aiohttp/_websocket/reader_c.c as Extension sources, but the repo
+#           only ships the .pyx originals ("NOTE: makefile cythonizes all
+#           Cython modules"). They must be generated with Cython, and
+#           vendor/llhttp/build/c/llhttp.c must be generated with the llhttp
+#           Node toolchain, before the compiler runs. Skipping this is what
+#           produced the second failure in the log:
+#             cc1: fatal error: aiohttp/_websocket/mask.c: No such file or directory
+#
+#   FIX 3 - Dependencies. Install the project's own pinned lockfile
+#           requirements/test.txt instead of hand-listing packages. The
+#           original spec guessed at them and still missed isal, zlib_ng,
+#           blockbuster, freezegun and pytest-mock, which the log rediscovered
+#           one failure at a time across attempts 3, 4 and 5.
+#
+#   FIX 4 - Working-tree hygiene. The supplied repository.zip came from a
+#           Windows checkout: CRLF line endings, stripped exec bits, and
+#           symlinks flattened into text files. `git reset --hard HEAD` with
+#           the core.* overrides rebuilds the tree from the objects in .git.
+#           Not needed for a real git clone.
+#
+# The Node.js/npm toolchain is confined to a builder stage so it never reaches
+# the final image.
+# =============================================================================
+
+# -----------------------------------------------------------------------------
+# Stage 1 - generate the vendored llhttp C sources.
+# `make -C vendor/llhttp generate` needs Node; the final image must not.
+# -----------------------------------------------------------------------------
+FROM node:20-bookworm-slim AS llhttp-builder
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends git make ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /src
+COPY . /src
+
+# FIX 1 applied here: the submodule is materialised before anything consumes it.
+RUN git submodule update --init --recursive vendor/llhttp
+
+# FIX 2 (part a): produces vendor/llhttp/build/c/llhttp.c and build/llhttp.h,
+# which setup.py references via llhttp_sources / include_dirs.
+WORKDIR /src/vendor/llhttp
+RUN npm ci && make generate
+
+
+# -----------------------------------------------------------------------------
+# Stage 2 - the testbed image.
+# Base layout kept identical to the reconstruction (/testbed + the miniconda
+# "testbed" env on Python 3.11) so the SWE-bench harness keeps working.
+# -----------------------------------------------------------------------------
+FROM ubuntu:22.04 AS testbed
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    PIP_DISABLE_PIP_VERSION_CHECK=1 \
+    PYTHONDONTWRITEBYTECODE=1
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        build-essential gcc git libffi-dev libssl-dev pkg-config python3-dev \
+        wget bzip2 ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# Miniforge rather than Miniconda: repo.anaconda.com now refuses
+# non-interactive installs until its Terms of Service are accepted. Same conda,
+# conda-forge defaults, identical /opt/miniconda3 + "testbed" layout.
+RUN wget -qO /tmp/miniforge.sh \
+        "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-$(uname -m).sh" \
+    && bash /tmp/miniforge.sh -b -p /opt/miniconda3 \
+    && rm -f /tmp/miniforge.sh
+
+ENV PATH=/opt/miniconda3/bin:$PATH
+RUN conda create -y -n testbed python=3.11 && conda clean -afy
+ENV PATH=/opt/miniconda3/envs/testbed/bin:/opt/miniconda3/condabin:$PATH \
+    CONDA_DEFAULT_ENV=testbed \
+    CONDA_PREFIX=/opt/miniconda3/envs/testbed
+
+WORKDIR /testbed
+COPY . /testbed
+
+# FIX 4 - normalise the working tree against the commit it claims to be.
+# The supplied repository.zip was produced from a Windows checkout: its
+# .git/config carries `filemode = false`, `symlinks = false`, `ignorecase =
+# true`. Three separate kinds of damage follow, and all three break the build:
+#
+#   a) CRLF everywhere - 395 of 400 tracked files differ from HEAD (117942
+#      insertions / 117942 deletions of pure line-ending churn). tools/gen.py's
+#      shebang becomes `#!/usr/bin/env python\r`:
+#        /usr/bin/env: 'python\r': No such file or directory
+#   b) exec bits stripped - tools/gen.py arrives 644:
+#        ./tools/gen.py: Permission denied
+#        make: *** [Makefile:57: aiohttp/_find_header.c] Error 127
+#   c) symlinks flattened - aiohttp/_websocket/reader_c.py is recorded in git
+#      as mode 120000 -> reader_py.py, but arrives as a 12-byte text file
+#      containing the string "reader_py.py". Cython then compiles an empty
+#      module against reader_c.pxd and fails:
+#        reader_c.pxd:57:29: C method '_release_waiter' is declared but not
+#        defined
+#
+# Overriding the three core.* settings and resetting to HEAD rebuilds the tree
+# correctly from the objects already present in .git. No-op for a real clone.
+RUN git -c core.autocrlf=false -c core.eol=lf \
+        -c core.fileMode=true -c core.symlinks=true \
+        reset --hard HEAD
+
+# FIX 1 - submodule first. Kept even though stage 1 also ran it: this populates
+# the rest of the tree and makes vendor/llhttp/README.md exist, which is the
+# exact file setup.py's guard checks.
+RUN git submodule update --init --recursive
+
+# FIX 2 (part a, continued) - take the generated llhttp artefacts from stage 1
+# rather than dragging Node into this image.
+COPY --from=llhttp-builder /src/vendor/llhttp/build /testbed/vendor/llhttp/build
+
+RUN pip install --upgrade pip setuptools wheel
+
+# FIX 3 - the project's own pinned lockfile, which already covers isal,
+# zlib_ng, blockbuster, freezegun, pytest-mock, pytest-xdist, trustme, etc.
+RUN pip install --no-cache-dir -r requirements/cython.txt \
+    && pip install --no-cache-dir -r requirements/test.txt
+
+# FIX 2 (part b) - .pyx -> .c, plus tools/gen.py for aiohttp/_find_header.c.
+# `cythonize-nodeps` is the project's own target; it skips the pip bootstrap
+# that `cythonize` would redo.
+RUN make cythonize-nodeps
+
+# Now the editable install has everything it needs and builds the accelerated
+# (C extension) variant, exactly as upstream CI does.
+RUN pip install --no-cache-dir -e . -c requirements/runtime-deps.txt
+
+# Basic functionality check for `docker run --rm assessment-fix`: proves the
+# package imports, that the C extensions really were built (not the pure-Python
+# fallback), and that a real request/response round-trip works.
+COPY <<-'PY' /usr/local/bin/smoke-test.py
+	import asyncio
+	import aiohttp
+	from aiohttp import web
+
+
+	def extension_state() -> str:
+	    from aiohttp._websocket import mask
+	    from aiohttp import http_parser
+	    # A compiled module reports a .so path; the pure-Python fallback a .py one.
+	    accel = mask.__file__.endswith(".so")
+	    # Resolves to aiohttp._http_parser when the C parser was built,
+	    # aiohttp.http_parser when it fell back to pure Python.
+	    parser = http_parser.HttpRequestParser.__module__
+	    assert accel, "C extensions did not build - this is the pure-Python fallback"
+	    return f"c_extensions=yes mask={mask.__file__.rsplit('/', 1)[-1]} parser={parser}"
+
+
+	async def round_trip() -> None:
+	    async def handler(request: web.Request) -> web.Response:
+	        return web.json_response({"pong": request.query.get("ping")})
+
+	    app = web.Application()
+	    app.router.add_get("/", handler)
+	    runner = web.AppRunner(app)
+	    await runner.setup()
+	    site = web.TCPSite(runner, "127.0.0.1", 8080)
+	    await site.start()
+	    try:
+	        async with aiohttp.ClientSession() as session:
+	            async with session.get("http://127.0.0.1:8080/?ping=hello") as resp:
+	                body = await resp.json()
+	                print(f"round-trip     : HTTP {resp.status} {body}")
+	                assert resp.status == 200 and body == {"pong": "hello"}
+	    finally:
+	        await runner.cleanup()
+
+
+	print(f"aiohttp version: {aiohttp.__version__}")
+	print(f"build          : {extension_state()}")
+	asyncio.run(round_trip())
+	print("SMOKE TEST PASSED")
+PY
+
+# Drop privileges for the default run. The harness overrides the entrypoint
+# when it needs root, so this does not interfere with evaluation.
+RUN useradd --create-home --uid 1000 testrunner \
+    && chown -R testrunner:testrunner /testbed
+USER testrunner
+
+CMD ["python", "/usr/local/bin/smoke-test.py"]

--- a/original-reconstructed.Dockerfile
+++ b/original-reconstructed.Dockerfile
@@ -1,0 +1,92 @@
+# =============================================================================
+# original-reconstructed.Dockerfile
+#
+# Reverse-engineered from docker-build-failed.logs.
+# Target image : sweb.eval.x86_64.aio-libs__aiohttp-11290:latest
+# Repository   : aio-libs/aiohttp @ PR #11290  (4.0.0a2.dev0, HEAD 9b0153c14)
+#
+# THIS IS THE BROKEN BUILD - it is meant to fail, and it reproduces the
+# recorded failure exactly:
+#
+#   + pip install --no-cache-dir -e .
+#   Obtaining file:///testbed
+#   Getting requirements to build editable: finished with status 'error'
+#   x Getting requirements to build editable did not run successfully.
+#   | exit code: 2
+#   +-> Install submodules when building from git clone
+#       Hint:
+#         git submodule update --init
+#
+# Every instruction below is annotated with the log line that justifies it.
+# =============================================================================
+
+# Log: apt sources are all "jammy" (22.04); packages resolved as "amd64".
+FROM ubuntu:22.04
+
+# Log: "+ export DEBIAN_FRONTEND=noninteractive"
+ENV DEBIAN_FRONTEND=noninteractive
+
+# ---------------------------------------------------------------------------
+# Environment supplied by the SWE-bench base layer (sweb.base.py.x86_64).
+# Log: "Current environment: testbed"
+# Log: "/opt/miniconda3/envs/testbed/lib/python3.11/site-packages"
+# Log: "++ export CONDA_PREFIX=/opt/miniconda3/envs/testbed"
+# Reconstructed explicitly here so this Dockerfile stands alone.
+# ---------------------------------------------------------------------------
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends wget bzip2 ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# NOTE: the SWE-bench base layer ships Miniconda. Miniforge is substituted here
+# because repo.anaconda.com now refuses non-interactive installs until its
+# Terms of Service are accepted (CondaToSNonInteractiveError). Miniforge is the
+# same conda, defaulting to conda-forge, and keeps the /opt/miniconda3 layout
+# and the "testbed" env name identical to the log.
+RUN wget -qO /tmp/miniforge.sh \
+        "https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-$(uname -m).sh" \
+    && bash /tmp/miniforge.sh -b -p /opt/miniconda3 \
+    && rm -f /tmp/miniforge.sh
+
+ENV PATH=/opt/miniconda3/bin:$PATH
+RUN conda create -y -n testbed python=3.11 && conda clean -afy
+ENV PATH=/opt/miniconda3/envs/testbed/bin:/opt/miniconda3/condabin:$PATH \
+    CONDA_DEFAULT_ENV=testbed \
+    CONDA_PREFIX=/opt/miniconda3/envs/testbed
+
+# Log: "Obtaining file:///testbed"  ->  the checkout lives at /testbed
+WORKDIR /testbed
+COPY . /testbed
+
+# ---------------------------------------------------------------------------
+# pre_install block, reproduced in the EXACT order recorded by `set -x`
+# in /root/setup_repo.sh.
+# ---------------------------------------------------------------------------
+
+# Log: "+ apt-get update"
+# Log: "+ apt-get install -y build-essential gcc git libffi-dev libssl-dev python3-dev"
+RUN apt-get update \
+    && apt-get install -y build-essential gcc git libffi-dev libssl-dev python3-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Log: "+ pip install --upgrade pip setuptools wheel Cython"
+RUN pip install --upgrade pip setuptools wheel Cython
+
+# Log: "+ pip install --no-cache-dir attrs charset-normalizer multidict yarl
+#       async-timeout frozenlist aiosignal pytest pytest-asyncio pytest-aiohttp trustme"
+RUN pip install --no-cache-dir attrs charset-normalizer multidict yarl \
+        async-timeout frozenlist aiosignal pytest pytest-asyncio pytest-aiohttp trustme
+
+# Log: "+ pip install --no-cache-dir -e ."
+# >>>>>>>>>>>>>>>>>>>>>>>> THE BUILD DIES ON THIS LINE <<<<<<<<<<<<<<<<<<<<<<<<
+# setup.py aborts with exit code 2 because vendor/llhttp/README.md is absent:
+# the submodule has not been initialised yet.
+RUN pip install --no-cache-dir -e .
+
+# Log: this command IS in the spec, but it is ordered AFTER the install that
+# depends on it, so `set -e` in setup_repo.sh means it is never reached.
+# THIS ORDERING IS THE BUG.
+RUN git submodule update --init --recursive
+
+# Log: "test_cmd": "python -m pytest -v -rA tests/test_client_functional.py tests/test_payload.py"
+CMD ["python", "-m", "pytest", "-v", "-rA", \
+     "tests/test_client_functional.py", "tests/test_payload.py"]


### PR DESCRIPTION
Name: Ritwik Ritu Parn
Email: 

## What it adds

- `fixed.Dockerfile` — builds the repo from a clone with the C extensions enabled, and runs a smoke test that asserts the accelerated build actually loaded.
- `original-reconstructed.Dockerfile` — the same build with the steps in the wrong order, kept as executable documentation of the failure mode.
- `.dockerignore` — notably does **not** exclude `.git`, for reasons below.

## Why it might be worth having

Building from a clone inside a container has three ordering constraints that aren't obvious from `CONTRIBUTING.rst`, and each one fails with an error that points somewhere unhelpful:

1. **Submodules before install.** `pip install -e .` before `git submodule update --init` gives `exit code: 2 / Install submodules when building from git clone` from the guard at `setup.py:24-31`. Clear enough, but easy to get the ordering wrong in a Dockerfile where each `RUN` looks independent.

2. **Cython codegen before compile.** `setup.py` lists `aiohttp/_websocket/mask.c`, `_http_parser.c`, `_http_writer.c` and `_websocket/reader_c.c` as `Extension` sources, but only the `.pyx` originals are tracked — the note at `setup.py:34` says the makefile handles it. Miss `make cythonize` and you get `cc1: fatal error: aiohttp/_websocket/mask.c: No such file or directory`, which reads like a missing compiler dep rather than a missing build step.

3. **llhttp needs Node.** `vendor/llhttp/build/c/llhttp.c` comes from `npm ci && make generate` in the submodule. Here that runs in a `node:20` builder stage so npm never reaches the final image.

The `.dockerignore` keeps `.git` deliberately: `setup.py` branches on `IS_GIT_REPO = (HERE / ".git").exists()`, so dropping it silently disables the submodule guard and the build fails later and less legibly, inside gcc.

Installing `requirements/test.txt` rather than hand-listing packages also avoids rediscovering `isal`, `zlib_ng`, `blockbuster`, `freezegun` and `pytest-mock` one import error at a time.

## Verified

```
$ docker run --rm assessment-fix
aiohttp version: 4.0.0a2.dev0
build          : c_extensions=yes mask=mask.cpython-311-aarch64-linux-gnu.so parser=aiohttp._http_parser
round-trip     : HTTP 200 {'pong': 'hello'}
SMOKE TEST PASSED
```

```
tests/test_payload.py             63 passed
tests/test_client_functional.py  278 passed, 1 skipped, 1 xfailed
```

`parser=aiohttp._http_parser` is the part that matters — that's the compiled parser, not the pure-Python fallback you get from `AIOHTTP_NO_EXTENSIONS=1`.

Built and tested on arm64 against 9b0153c14. No changelog entry since nothing user-facing changes; happy to add one, adjust the layout, or drop `original-reconstructed.Dockerfile` if only the working one is of interest.
