### PR TITLE
Limit number of queued WS fragments (#13352)

### DIFF
--- a/CHANGES/13352.bugfix.rst
+++ b/CHANGES/13352.bugfix.rst
@@ -1,0 +1,1 @@
+Capped the number of per-read payload fragments the WebSocket reader retains in memory -- by :user:`Dreamsorcerer`.

--- a/aiohttp/_websocket/reader_c.pxd
+++ b/aiohttp/_websocket/reader_c.pxd
@@ -71,6 +71,7 @@ cdef class WebSocketReader:
     cdef bint _frame_fin
     cdef int _frame_opcode
     cdef list _payload_fragments
+    cdef Py_ssize_t _max_fragments
     cdef Py_ssize_t _frame_payload_len
 
     cdef bytes _tail

--- a/aiohttp/_websocket/reader_py.py
+++ b/aiohttp/_websocket/reader_py.py
@@ -153,6 +153,9 @@ class WebSocketReader:
         self._frame_fin = False
         self._frame_opcode: int = OP_CODE_NOT_SET
         self._payload_fragments: list[bytes] = []
+        # Limit number of fragments, so a large number of tiny fragments
+        # doesn't exceed reasonable memory usage.
+        self._max_fragments = max(1024, max_msg_size // 256) if max_msg_size else 0
         self._frame_payload_len = 0
 
         self._tail: bytes = b""
@@ -484,6 +487,12 @@ class WebSocketReader:
                     # If we don't have a complete frame, we need to save the
                     # data for the next call to feed_data.
                     self._payload_fragments.append(data_cstr[f_start_pos:f_end_pos])
+                    if (
+                        self._max_fragments
+                        and len(self._payload_fragments) > self._max_fragments
+                        and not self.queue._protocol._reading_paused
+                    ):
+                        self.queue._protocol.pause_reading()
                     break
 
                 payload: bytes | bytearray

--- a/tests/test_websocket_parser.py
+++ b/tests/test_websocket_parser.py
@@ -815,3 +815,47 @@ def test_flow_control_multi_byte_text(
         large_payload_size,
     )
     assert protocol._reading_paused is True
+
+
+async def test_incomplete_frame_pauses_when_fragment_limit_exceeded(
+    protocol: BaseProtocol,
+) -> None:
+    max_msg_size = 64 * 1024
+    loop = asyncio.get_running_loop()
+    out = WebSocketDataQueue(protocol, 2**16, loop=loop)
+    parser = WebSocketReader(out, max_msg_size, compress=False, decode_text=False)
+
+    payload_len = 32 * 1024
+    parser.feed_data(PACK_LEN2(0x80 | WSMsgType.BINARY, 126, payload_len))
+    assert protocol._reading_paused is False
+
+    # Feed the payload two bytes per read so the pause is
+    # driven purely by the fragment count, not the total byte count.
+    paused_after = None
+    for i in range(payload_len // 2 - 1):  # pragma: no branch
+        parser.feed_data(b"xx")
+        if protocol._reading_paused:
+            paused_after = i + 1  # type: ignore[unreachable]
+            break
+
+    assert paused_after is not None
+    # Paused long before the frame could complete (16384 two-byte reads).
+    assert paused_after < payload_len // 2  # type: ignore[unreachable]
+
+
+async def test_incomplete_frame_not_paused_for_normal_reads(
+    protocol: BaseProtocol,
+) -> None:
+    max_msg_size = 64 * 1024
+    loop = asyncio.get_running_loop()
+    out = WebSocketDataQueue(protocol, 2**16, loop=loop)
+    parser = WebSocketReader(out, max_msg_size, compress=False, decode_text=False)
+
+    # Normal traffic (a frame delivered in a handful of reasonably sized reads)
+    # must never trip the fragment-limit backpressure.
+    payload_len = 32 * 1024
+    parser.feed_data(PACK_LEN2(0x80 | WSMsgType.BINARY, 126, payload_len))
+    # 32 KiB in 4 KiB reads -> 8 fragments, far below the cap.
+    for _ in range(payload_len // 4096):
+        parser.feed_data(b"x" * 4096)
+    assert protocol._reading_paused is False


### PR DESCRIPTION
(cherry picked from commit 288cf469ba800a071fcddca61434d6ab9dcf689d)