### PR TITLE
Stop handing back pipelined requests the parser buffered

### DIFF
--- a/CHANGES/13356.bugfix.rst
+++ b/CHANGES/13356.bugfix.rst
@@ -1,4 +1,4 @@
 Fixed requests pipelined behind a request whose upgrade the handler declined
-being served more than once, and requests past the per-connection queue limit
-on that path being left unanswered. Only the pure-Python parser was affected
--- by :user:`rodrigobnogueira`.
+going unanswered once there were more of them than the per-connection queue
+holds. With the pure-Python parser the same requests were also served more
+than once -- by :user:`rodrigobnogueira`.

--- a/CHANGES/13356.bugfix.rst
+++ b/CHANGES/13356.bugfix.rst
@@ -1,0 +1,4 @@
+Fixed requests pipelined behind a request whose upgrade the handler declined
+being served more than once, and requests past the per-connection queue limit
+on that path being left unanswered. Only the pure-Python parser was affected
+-- by :user:`rodrigobnogueira`.

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -358,6 +358,11 @@ class HttpParser(abc.ABC, Generic[_MsgT]):
                     # any preceding body is consumed before the next request
                     # line. Resumes via feed_data(b"") when the queue drains.
                     self._tail = data[start_pos:]
+                    # The remainder now lives in self._tail only. Returning it
+                    # as well hands the caller a second copy of the same bytes,
+                    # which comes back in a later feed_data() and is parsed
+                    # twice.
+                    data = EMPTY
                     break
                 pos = data.find(SEP, start_pos)
                 # consume \r\n

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -358,10 +358,7 @@ class HttpParser(abc.ABC, Generic[_MsgT]):
                     # any preceding body is consumed before the next request
                     # line. Resumes via feed_data(b"") when the queue drains.
                     self._tail = data[start_pos:]
-                    # The remainder now lives in self._tail only. Returning it
-                    # as well hands the caller a second copy of the same bytes,
-                    # which comes back in a later feed_data() and is parsed
-                    # twice.
+                    # The remainder now lives in self._tail only. Don't return it.
                     data = EMPTY
                     break
                 pos = data.find(SEP, start_pos)

--- a/aiohttp/web_protocol.py
+++ b/aiohttp/web_protocol.py
@@ -816,6 +816,15 @@ class RequestHandler(BaseProtocol, Generic[_Request]):
                 for msg, payload in messages:
                     self._request_count += 1
                     self._messages.append((msg, payload))
+                # The parser stops at the queue limit and keeps the rest, so
+                # mark the queue paused the way data_received() does. start()
+                # resumes as it drains, which is what feeds the parser the
+                # remainder; without this the requests it held are never read.
+                if (
+                    not self._msg_queue_paused
+                    and len(self._messages) >= self._max_msg_queue_size
+                ):
+                    self._pause_msg_queue_reading()
                 # This shouldn't be possible. If a future refactor results in this
                 # failing, then the code may need to be updated to set the waiter.
                 assert self._waiter is None

--- a/aiohttp/web_protocol.py
+++ b/aiohttp/web_protocol.py
@@ -816,10 +816,7 @@ class RequestHandler(BaseProtocol, Generic[_Request]):
                 for msg, payload in messages:
                     self._request_count += 1
                     self._messages.append((msg, payload))
-                # The parser stops at the queue limit and keeps the rest, so
-                # mark the queue paused the way data_received() does. start()
-                # resumes as it drains, which is what feeds the parser the
-                # remainder; without this the requests it held are never read.
+                # Pause the transport, like in data_received().
                 if (
                     not self._msg_queue_paused
                     and len(self._messages) >= self._max_msg_queue_size

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -184,6 +184,24 @@ def test_max_msg_queue_size_caps_emitted_messages(
     assert not upgraded
 
 
+def test_max_msg_queue_size_keeps_tail_to_itself(
+    request_cls: type[HttpRequestParser],
+    protocol: BaseProtocol,
+    event_loop: asyncio.AbstractEventLoop,
+) -> None:
+    """The remainder is buffered for the next feed, so it must not be returned.
+
+    Handing it back as well gives the caller a second copy of bytes the parser
+    is already holding, and both copies get parsed.
+    """
+    parser = _build_request_parser(request_cls, protocol, event_loop, 4)
+
+    messages, _upgraded, tail = parser.feed_data(_PIPELINED_GET * 10)
+
+    assert len(messages) == 4
+    assert tail == b""
+
+
 def test_max_msg_queue_size_resumes_after_consume(
     request_cls: type[HttpRequestParser],
     protocol: BaseProtocol,

--- a/tests/test_web_functional.py
+++ b/tests/test_web_functional.py
@@ -1847,6 +1847,57 @@ async def test_http1_pipelined_queue_resumes_after_drain(
     assert len(handled) == pipelined_requests + 1
 
 
+async def test_http1_pipelined_behind_declined_upgrade_served_once(
+    aiohttp_server: AiohttpServer,
+) -> None:
+    """Requests pipelined behind a declined upgrade are each served once.
+
+    The bytes following an upgrade request are buffered whole, then re-fed once
+    the handler answers it normally. More of them than the queue holds must
+    still be served, and none of them twice.
+    """
+    pipelined_requests = MAX_MSG_QUEUE_SIZE + 8
+    handled: list[str] = []
+    all_handled = asyncio.Event()
+
+    async def handler(request: web.Request) -> web.Response:
+        handled.append(request.path)
+        if len(handled) == pipelined_requests + 1:
+            all_handled.set()
+        return web.Response()
+
+    app = web.Application()
+    app.router.add_get("/{tail:.*}", handler)
+    server = await aiohttp_server(app)
+
+    def raw_get(path: str) -> bytes:
+        return (
+            f"GET {path} HTTP/1.1\r\nHost: localhost\r\n"
+            "Connection: keep-alive\r\n\r\n"
+        ).encode("ascii")
+
+    # An upgrade the handler answers normally, then the pipeline, in one write.
+    upgrade = (
+        "GET /upgrade HTTP/1.1\r\nHost: localhost\r\n"
+        "Connection: Upgrade\r\nUpgrade: websocket\r\n\r\n"
+    ).encode("ascii")
+
+    reader, writer = await asyncio.open_connection(server.host, server.port)
+    try:
+        writer.write(
+            upgrade + b"".join(raw_get(f"/r{i}") for i in range(pipelined_requests))
+        )
+        await writer.drain()
+        await asyncio.wait_for(all_handled.wait(), 10)
+    finally:
+        writer.close()
+        with suppress(ConnectionResetError, BrokenPipeError):
+            await writer.wait_closed()
+
+    assert len(handled) == pipelined_requests + 1
+    assert len(set(handled)) == len(handled)
+
+
 async def test_declined_websocket_upgrade_reads_body(
     aiohttp_server: AiohttpServer,
 ) -> None:

--- a/tests/test_web_functional.py
+++ b/tests/test_web_functional.py
@@ -1878,9 +1878,9 @@ async def test_http1_pipelined_behind_declined_upgrade_served_once(
 
     # An upgrade the handler answers normally, then the pipeline, in one write.
     upgrade = (
-        "GET /upgrade HTTP/1.1\r\nHost: localhost\r\n"
-        "Connection: Upgrade\r\nUpgrade: websocket\r\n\r\n"
-    ).encode("ascii")
+        b"GET /upgrade HTTP/1.1\r\nHost: localhost\r\n"
+        b"Connection: Upgrade\r\nUpgrade: websocket\r\n\r\n"
+    )
 
     reader, writer = await asyncio.open_connection(server.host, server.port)
     try:


### PR DESCRIPTION
## What do these changes do?

When the pipelined message queue fills, the pure-Python parser buffers the unparsed remainder in `self._tail` **and** returns it (`http_parser.py`, queue-full break). The caller therefore holds a second copy of bytes the parser is already keeping, and the next `feed_data()` prepends the retained copy onto the returned one.

`data_received()` discards the returned tail unless the request upgraded, so ordinary pipelining never notices. `finish_response()` stores it unconditionally, and that is the path taken when a handler answers an `Upgrade:` request with a normal response. Pipelining more requests than the queue holds behind such a request then makes the server either serve them repeatedly or grow the buffer by a copy of itself per handled request.

Measured on this branch's parent, pure-Python parser, one upgrade request followed by 40 pipelined GETs in a single write:

| | before | after |
|---|---|---|
| responses | connection never settles; handlers re-run indefinitely | 41 |
| distinct paths served | — | 41 |
| repeat dispatches | unbounded | 0 |

The fix clears the returned buffer, which is exactly what the incomplete-request-line branch a few lines below already does. The C parser never returned the tail, so the *duplication* is pure-Python only, and the added parser test passes on the C backend before and after.

The second defect is not parser-specific. `finish_response()` appends to the message queue without the pause bookkeeping `data_received()` performs, so `_msg_queue_paused` stays `False`, `start()` never calls `_resume_msg_queue_reading()`, and nothing ever feeds the parser the remainder it kept. The requests past the queue limit simply go unanswered (33 of 41 above). **This half affects the C parser too** — arguably more cleanly, since before the fix the pure-Python duplicate kept `_message_tail` non-empty and so kept pumping. Reverting both source files and running the new functional test under the C extensions fails on its 10s timeout. Pausing in `finish_response()` lets the existing drain resume them.

## Are there changes in behavior for the user?

Requests pipelined behind a declined upgrade past the queue limit are answered instead of being left buffered — that applies to both parsers. With the pure-Python parser they are additionally handled exactly once rather than repeatedly. No API change.

## Is it a substantial burden for the maintainers to support this?

No. Five lines of parser change plus the queue-pause call that the neighbouring code path already makes, and both new tests fail without them.

## Related issue number

None.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes — N/A, no user-facing API change
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt` — already listed
- [x] Add a new news fragment into the `CHANGES/` folder

<details>
<summary>Test run</summary>

Both parser backends, C extensions built (`make cythonize` + editable install):

```
$ pytest tests/test_http_parser.py tests/test_web_protocol.py \
         tests/test_web_functional.py tests/test_web_server.py
1015 passed, 6 deselected, 3 xfailed          # C extensions
599 passed, 35 skipped, 4 deselected          # AIOHTTP_NO_EXTENSIONS=1
```

Revert check, with the source changes reverted and the tests kept:

```
# pure-Python parser
FAILED tests/test_http_parser.py::test_max_msg_queue_size_keeps_tail_to_itself[py-parser]
# C extensions - the stalled-request half
FAILED tests/test_web_functional.py::test_http1_pipelined_behind_declined_upgrade_served_once
       (1 failed in 10.06s - the wait_for timeout, requests stranded)
```

Under `AIOHTTP_NO_EXTENSIONS=1` that functional test does not fail cleanly when reverted: the repeated dispatch keeps the loop busy and the test's own timeout never fires. With the C extensions there is no repeated dispatch, so it fails on the timeout as shown above. It passes in well under a second either way with the change applied.

</details>
