### PR TITLE
Handle the replayed tail the way data_received does

### DIFF
--- a/CHANGES/13356.bugfix.rst
+++ b/CHANGES/13356.bugfix.rst
@@ -1,4 +1,4 @@
 Fixed requests pipelined behind a request whose upgrade the handler declined
-being served more than once, and requests past the per-connection queue limit
-on that path being left unanswered. Only the pure-Python parser was affected
--- by :user:`rodrigobnogueira`.
+going unanswered once there were more of them than the per-connection queue
+holds. With the pure-Python parser the same requests were also served more
+than once -- by :user:`rodrigobnogueira`.

--- a/CHANGES/13356.bugfix.rst
+++ b/CHANGES/13356.bugfix.rst
@@ -1,0 +1,4 @@
+Fixed requests pipelined behind a request whose upgrade the handler declined
+being served more than once, and requests past the per-connection queue limit
+on that path being left unanswered. Only the pure-Python parser was affected
+-- by :user:`rodrigobnogueira`.

--- a/CHANGES/13358.bugfix.rst
+++ b/CHANGES/13358.bugfix.rst
@@ -1,0 +1,4 @@
+Fixed a malformed request pipelined behind a declined upgrade discarding the
+response to that upgrade and closing the connection, instead of being answered
+with ``400``. Requests buffered behind a second declined upgrade on the same
+connection are no longer dropped -- by :user:`rodrigobnogueira`.

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -358,6 +358,11 @@ class HttpParser(abc.ABC, Generic[_MsgT]):
                     # any preceding body is consumed before the next request
                     # line. Resumes via feed_data(b"") when the queue drains.
                     self._tail = data[start_pos:]
+                    # The remainder now lives in self._tail only. Returning it
+                    # as well hands the caller a second copy of the same bytes,
+                    # which comes back in a later feed_data() and is parsed
+                    # twice.
+                    data = EMPTY
                     break
                 pos = data.find(SEP, start_pos)
                 # consume \r\n

--- a/aiohttp/web_protocol.py
+++ b/aiohttp/web_protocol.py
@@ -816,6 +816,15 @@ class RequestHandler(BaseProtocol, Generic[_Request]):
                 for msg, payload in messages:
                     self._request_count += 1
                     self._messages.append((msg, payload))
+                # The parser stops at the queue limit and keeps the rest, so
+                # mark the queue paused the way data_received() does. start()
+                # resumes as it drains, which is what feeds the parser the
+                # remainder; without this the requests it held are never read.
+                if (
+                    not self._msg_queue_paused
+                    and len(self._messages) >= self._max_msg_queue_size
+                ):
+                    self._pause_msg_queue_reading()
                 # This shouldn't be possible. If a future refactor results in this
                 # failing, then the code may need to be updated to set the waiter.
                 assert self._waiter is None

--- a/aiohttp/web_protocol.py
+++ b/aiohttp/web_protocol.py
@@ -811,8 +811,31 @@ class RequestHandler(BaseProtocol, Generic[_Request]):
             self._parser.set_upgraded(False)
             self._upgraded = False
             if self._message_tail:
-                messages, _upgraded, tail = self._parser.feed_data(self._message_tail)
+                try:
+                    messages, upgraded, tail = self._parser.feed_data(
+                        self._message_tail
+                    )
+                except HttpProcessingError as parse_exc:
+                    # Answer it like data_received() does. Letting this escape
+                    # loses the response already built for the request being
+                    # finished, and closes the connection on a client error.
+                    messages = [
+                        (
+                            _ErrInfo(
+                                status=400,
+                                exc=parse_exc,
+                                message=parse_exc.message,
+                            ),
+                            EMPTY_PAYLOAD,
+                        )
+                    ]
+                    upgraded = False
+                    tail = b""
                 self._message_tail = tail
+                # A second upgrade in the tail leaves the parser upgraded while
+                # this stayed False, and the next data_received() would replace
+                # the buffered bytes instead of appending to them.
+                self._upgraded = upgraded
                 for msg, payload in messages:
                     self._request_count += 1
                     self._messages.append((msg, payload))

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -184,6 +184,24 @@ def test_max_msg_queue_size_caps_emitted_messages(
     assert not upgraded
 
 
+def test_max_msg_queue_size_keeps_tail_to_itself(
+    request_cls: type[HttpRequestParser],
+    protocol: BaseProtocol,
+    event_loop: asyncio.AbstractEventLoop,
+) -> None:
+    """The remainder is buffered for the next feed, so it must not be returned.
+
+    Handing it back as well gives the caller a second copy of bytes the parser
+    is already holding, and both copies get parsed.
+    """
+    parser = _build_request_parser(request_cls, protocol, event_loop, 4)
+
+    messages, _upgraded, tail = parser.feed_data(_PIPELINED_GET * 10)
+
+    assert len(messages) == 4
+    assert tail == b""
+
+
 def test_max_msg_queue_size_resumes_after_consume(
     request_cls: type[HttpRequestParser],
     protocol: BaseProtocol,

--- a/tests/test_web_functional.py
+++ b/tests/test_web_functional.py
@@ -1847,6 +1847,57 @@ async def test_http1_pipelined_queue_resumes_after_drain(
     assert len(handled) == pipelined_requests + 1
 
 
+async def test_http1_pipelined_behind_declined_upgrade_served_once(
+    aiohttp_server: AiohttpServer,
+) -> None:
+    """Requests pipelined behind a declined upgrade are each served once.
+
+    The bytes following an upgrade request are buffered whole, then re-fed once
+    the handler answers it normally. More of them than the queue holds must
+    still be served, and none of them twice.
+    """
+    pipelined_requests = MAX_MSG_QUEUE_SIZE + 8
+    handled: list[str] = []
+    all_handled = asyncio.Event()
+
+    async def handler(request: web.Request) -> web.Response:
+        handled.append(request.path)
+        if len(handled) == pipelined_requests + 1:
+            all_handled.set()
+        return web.Response()
+
+    app = web.Application()
+    app.router.add_get("/{tail:.*}", handler)
+    server = await aiohttp_server(app)
+
+    def raw_get(path: str) -> bytes:
+        return (
+            f"GET {path} HTTP/1.1\r\nHost: localhost\r\n"
+            "Connection: keep-alive\r\n\r\n"
+        ).encode("ascii")
+
+    # An upgrade the handler answers normally, then the pipeline, in one write.
+    upgrade = (
+        "GET /upgrade HTTP/1.1\r\nHost: localhost\r\n"
+        "Connection: Upgrade\r\nUpgrade: websocket\r\n\r\n"
+    ).encode("ascii")
+
+    reader, writer = await asyncio.open_connection(server.host, server.port)
+    try:
+        writer.write(
+            upgrade + b"".join(raw_get(f"/r{i}") for i in range(pipelined_requests))
+        )
+        await writer.drain()
+        await asyncio.wait_for(all_handled.wait(), 10)
+    finally:
+        writer.close()
+        with suppress(ConnectionResetError, BrokenPipeError):
+            await writer.wait_closed()
+
+    assert len(handled) == pipelined_requests + 1
+    assert len(set(handled)) == len(handled)
+
+
 async def test_declined_websocket_upgrade_reads_body(
     aiohttp_server: AiohttpServer,
 ) -> None:

--- a/tests/test_web_functional.py
+++ b/tests/test_web_functional.py
@@ -1878,9 +1878,9 @@ async def test_http1_pipelined_behind_declined_upgrade_served_once(
 
     # An upgrade the handler answers normally, then the pipeline, in one write.
     upgrade = (
-        "GET /upgrade HTTP/1.1\r\nHost: localhost\r\n"
-        "Connection: Upgrade\r\nUpgrade: websocket\r\n\r\n"
-    ).encode("ascii")
+        b"GET /upgrade HTTP/1.1\r\nHost: localhost\r\n"
+        b"Connection: Upgrade\r\nUpgrade: websocket\r\n\r\n"
+    )
 
     reader, writer = await asyncio.open_connection(server.host, server.port)
     try:

--- a/tests/test_web_websocket_functional.py
+++ b/tests/test_web_websocket_functional.py
@@ -162,7 +162,13 @@ async def test_bad_pipelined_request_after_failed_websocket_upgrade(
         )
         await writer.drain()
 
-        data = await asyncio.wait_for(reader.read(65536), timeout=5)
+        # The two responses need not arrive in the same segment.
+        data = b""
+        while b"400" not in data:
+            chunk = await asyncio.wait_for(reader.read(65536), timeout=5)
+            if not chunk:
+                break
+            data += chunk
     finally:
         writer.close()
         with contextlib.suppress(ConnectionResetError):

--- a/tests/test_web_websocket_functional.py
+++ b/tests/test_web_websocket_functional.py
@@ -162,13 +162,9 @@ async def test_bad_pipelined_request_after_failed_websocket_upgrade(
         )
         await writer.drain()
 
-        # The two responses need not arrive in the same segment.
-        data = b""
-        while b"400" not in data:
-            chunk = await asyncio.wait_for(reader.read(65536), timeout=5)
-            if not chunk:
-                break
-            data += chunk
+        # The two responses need not arrive in the same segment, and the 400
+        # closes the connection, so read to EOF rather than once.
+        data = await asyncio.wait_for(reader.read(), timeout=5)
     finally:
         writer.close()
         with contextlib.suppress(ConnectionResetError):

--- a/tests/test_web_websocket_functional.py
+++ b/tests/test_web_websocket_functional.py
@@ -127,6 +127,117 @@ async def test_partial_pipelined_request_after_failed_websocket_upgrade(
         await writer.wait_closed()
 
 
+async def test_bad_pipelined_request_after_failed_websocket_upgrade(
+    aiohttp_server: AiohttpServer,
+) -> None:
+    """A malformed pipelined request still gets a 400, like any other.
+
+    ``finish_response()`` replays the tail before the declined upgrade's own
+    response is written, so letting the parse error escape loses that response
+    and closes the connection on what is only a client error.
+    """
+
+    async def upgrade_handler(request: web.Request) -> NoReturn:
+        raise web.HTTPUpgradeRequired()
+
+    app = web.Application()
+    app.router.add_route("GET", "/", upgrade_handler)
+    server = await aiohttp_server(app)
+
+    reader, writer = await asyncio.open_connection(server.host, server.port)
+    try:
+        writer.write(
+            b"GET / HTTP/1.1\r\n"
+            b"Host: localhost\r\n"
+            b"Upgrade: websocket\r\n"
+            b"Connection: Upgrade\r\n"
+            b"Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n"
+            b"Sec-WebSocket-Version: 13\r\n"
+            b"\r\n"
+            b"POST /bad HTTP/1.1\r\n"
+            b"Host: localhost\r\n"
+            b"Transfer-Encoding: chunked\r\n"
+            b"Content-Length: 5\r\n"
+            b"\r\n"
+        )
+        await writer.drain()
+
+        data = await asyncio.wait_for(reader.read(65536), timeout=5)
+    finally:
+        writer.close()
+        with contextlib.suppress(ConnectionResetError):
+            await writer.wait_closed()
+
+    # The declined upgrade is answered, and the malformed request gets a 400.
+    assert b"426" in data
+    assert b"400" in data
+
+
+async def test_second_upgrade_pipelined_after_failed_websocket_upgrade(
+    aiohttp_server: AiohttpServer,
+) -> None:
+    """Bytes arriving after a replayed upgrade are appended, not replaced.
+
+    The replayed tail can itself contain an upgrade request. If that leaves the
+    parser upgraded while the protocol believes otherwise, the next
+    ``data_received()`` overwrites the buffered pipelined bytes instead of
+    appending to them, and the requests behind it are never dispatched.
+    """
+    handled: list[str] = []
+    second_started = asyncio.Event()
+    release_second = asyncio.Event()
+
+    async def upgrade_handler(request: web.Request) -> NoReturn:
+        handled.append(request.path)
+        if request.path == "/upgrade2":
+            second_started.set()
+            await release_second.wait()
+        raise web.HTTPUpgradeRequired()
+
+    async def plain_handler(request: web.Request) -> web.Response:
+        handled.append(request.path)
+        return web.Response(text=f"ok{request.path}")
+
+    app = web.Application()
+    app.router.add_route("GET", "/upgrade1", upgrade_handler)
+    app.router.add_route("GET", "/upgrade2", upgrade_handler)
+    app.router.add_route("GET", "/{tail:.*}", plain_handler)
+    server = await aiohttp_server(app)
+
+    def upgrade(path: str) -> bytes:
+        return (
+            f"GET {path} HTTP/1.1\r\nHost: localhost\r\n"
+            "Upgrade: websocket\r\nConnection: Upgrade\r\n"
+            "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n"
+            "Sec-WebSocket-Version: 13\r\n\r\n"
+        ).encode()
+
+    reader, writer = await asyncio.open_connection(server.host, server.port)
+    try:
+        writer.write(
+            upgrade("/upgrade1")
+            + upgrade("/upgrade2")
+            + b"GET /pipelined HTTP/1.1\r\nHost: localhost\r\n\r\n"
+        )
+        await writer.drain()
+        await asyncio.wait_for(second_started.wait(), timeout=5)
+
+        # Arrives while the second upgrade is still being handled.
+        writer.write(b"GET /later HTTP/1.1\r\nHost: localhost\r\n\r\n")
+        await writer.drain()
+        await asyncio.sleep(0.1)
+        release_second.set()
+
+        await asyncio.wait_for(reader.readuntil(b"ok/later"), timeout=5)
+    finally:
+        writer.close()
+        with contextlib.suppress(ConnectionResetError):
+            await writer.wait_closed()
+
+    assert "/pipelined" in handled
+    assert "/later" in handled
+
+
 async def test_handshake_connection_header_substring_not_a_token(
     aiohttp_client: AiohttpClient,
 ) -> None:


### PR DESCRIPTION
> Stacked on #13356, which touches the same block in `finish_response()`. Review that one first; this branch contains its two commits. Happy to rebase onto master if #13356 lands or is dropped.

## What do these changes do?

`finish_response()` replays the bytes buffered behind an upgrade request the handler declined (#12796). It feeds them to the parser without the two things `data_received()` does around the same call, and both are reachable from the network.

**A parse error escapes.** `data_received()` wraps `feed_data()` and turns `HttpProcessingError` into a queued 400. `finish_response()` does not, and it replays *before* `resp.prepare()` runs — so a malformed request pipelined behind the declined upgrade discards the response already built for the upgrade, force-closes the connection, and logs a routine client error as an unhandled server exception:

```
GET /upgrade  (Upgrade: websocket, handler declines)
POST /bad     (Transfer-Encoding: chunked + Content-Length: 5)

before:  response bytes b''            connection closed, "Unhandled exception" logged
after:   HTTP/1.1 200 ... then 400     both answered, connection intact
```

The identical malformed request on the ordinary path already gets a clean 400.

**The upgraded flag is discarded.** When the replayed bytes contain a second upgrade, the parser switches to upgraded while `self._upgraded` stays `False`. The next `data_received()` therefore takes the parser branch and *assigns* `_message_tail` instead of appending to it, dropping whatever was buffered there:

| pipelined behind two declined upgrades | before | after |
|---|---|---|
| pure-Python parser | `/pipelined` dropped, silently | served |
| C parser | `/pipelined` dropped **and** the next request corrupted | both served |

The C parser's corruption is worth spelling out, because it is the sharper symptom. `nb` is declared at `_http_parser.pyx:631` and assigned only inside the `HPE_PAUSED_UPGRADE` branch at `:675`, but it is read at `:711`:

```cython
if self._upgraded:
    return messages, True, data[nb:]
```

Entering `feed_data()` already upgraded, without llhttp returning `HPE_PAUSED_UPGRADE` on that call, therefore slices `data` with an uninitialised `size_t`. In the reproducer it lands on 1, and the next request line arrives as `b"ET /later HTTP/1.1"` — the leading `G` eaten. Keeping the flag stops the protocol from ever handing the parser that state, so this is a hardening of an invariant the C parser already assumes rather than only a bookkeeping fix.

## Are there changes in behavior for the user?

A malformed request pipelined behind a declined upgrade is answered with 400 instead of killing the connection and losing the preceding response. Requests buffered behind a second declined upgrade are dispatched instead of dropped. No API change.

## Is it a substantial burden for the maintainers to support this?

No. It makes the replay path mirror `data_received()`, which is where the same three concerns are already handled.

## Related issue number

None. Both defects predate #13356 — verified by running each reproducer against `288cf469b` and against this branch's parent and getting identical results — and both are on the path added in #12796.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes — N/A, no user-facing API change
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt` — already listed
- [x] Add a new news fragment into the `CHANGES/` folder

<details>
<summary>Test run</summary>

Both parser backends, C extensions built:

```
$ pytest tests/test_web_websocket_functional.py tests/test_web_protocol.py \
         tests/test_web_functional.py tests/test_http_parser.py tests/test_web_server.py
1072 passed, 6 deselected, 3 xfailed        # C extensions
656 passed, 35 skipped, 4 deselected        # AIOHTTP_NO_EXTENSIONS=1
```

Both new tests fail with only `web_protocol.py` reverted, on both backends:

```
FAILED tests/test_web_websocket_functional.py::test_bad_pipelined_request_after_failed_websocket_upgrade
FAILED tests/test_web_websocket_functional.py::test_second_upgrade_pipelined_after_failed_websocket_upgrade
```

`mypy aiohttp/web_protocol.py` reports the same count as the parent commit, with no errors in the file itself.

</details>
