### PR TITLE
fix(client): avoid cross-loop eager body writers

### DIFF
--- a/CHANGES/13346.bugfix.rst
+++ b/CHANGES/13346.bugfix.rst
@@ -1,0 +1,1 @@
+Avoid eagerly starting the request body writer when a request is sent from a different event loop than the :class:`~aiohttp.ClientSession`.

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -982,7 +982,7 @@ class ClientRequestBase:
         task: asyncio.Task[None] | None
         if self._should_write(protocol):
             coro = self._write_bytes(writer, conn, self._get_content_length())
-            if sys.version_info >= (3, 12):
+            if sys.version_info >= (3, 12) and self.loop is asyncio.get_running_loop():
                 # Optimization for Python 3.12, try to write
                 # bytes immediately to avoid having to schedule
                 # the task on the event loop.

--- a/tests/test_client_request.py
+++ b/tests/test_client_request.py
@@ -1070,6 +1070,29 @@ async def test_chunked_empty_body(
     resp.close()
 
 
+async def test_send_does_not_eager_start_writer_from_another_loop(
+    conn: mock.Mock, make_client_request: _RequestMaker
+) -> None:
+    req = make_client_request(
+        "post",
+        URL("http://python.org/"),
+        data=b"foo",
+        loop=asyncio.get_running_loop(),
+    )
+    other_loop = mock.Mock()
+    with (
+        mock.patch(
+            "aiohttp.client_reqrep.asyncio.get_running_loop", return_value=other_loop
+        ),
+        mock.patch("aiohttp.client_reqrep.asyncio.Task") as eager_task,
+    ):
+        resp = await req._send(conn)
+
+    eager_task.assert_not_called()
+    await req._close()
+    resp.close()
+
+
 async def test_chunked_explicit(
     conn: mock.Mock, make_client_request: _RequestMaker
 ) -> None:


### PR DESCRIPTION
## What do these changes do?

Guard aiohttp's Python 3.12+ eager request-body writer optimization so it is used only when the request is sent from the session's event loop. Cross-loop use now schedules the writer on the session loop instead of eagerly stepping a coroutine from the caller's thread.

## Are there changes in behavior for the user?

Same-loop requests keep the existing eager-write optimization. Cross-loop misuse no longer lets a foreign thread execute a task against the session loop, avoiding the event-loop corruption described in #13346.

## Related issue number

Fixes #13346

## Testing

- Added a regression test asserting that the eager task constructor is not used when the caller loop differs.
- python -m compileall -q aiohttp/client_reqrep.py tests/test_client_request.py passed.
- The focused pytest run was blocked locally because the Windows checkout cannot build aiohttp's generated C extensions; GitHub CI will provide the supported build/test environment.
- Added CHANGES/13346.bugfix.rst.