### PR TITLE
fix: decode multiple Content-Encoding codings in reverse order (RFC 9110)

### DIFF
--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -617,9 +617,18 @@ class HttpParser(abc.ABC, Generic[_MsgT]):
                 upgrade = True
 
         # encoding
+        # RFC 9110 §8.4: Content-Encoding can be a comma-separated list.
+        # If multiple codings are present, the client must decode them
+        # in reverse order. We store them as a comma-separated normalized
+        # string so the payload parser can chain decompressors.
         enc = headers.get(hdrs.CONTENT_ENCODING, "")
-        if enc.isascii() and enc.lower() in {"gzip", "deflate", "br", "zstd"}:
-            encoding = enc
+        if enc.isascii():
+            encodings = [e.strip() for e in enc.lower().split(",")]
+            encodings = [e for e in encodings if e]  # Remove empty entries
+            if encodings and all(
+                e in {"gzip", "deflate", "br", "zstd"} for e in encodings
+            ):
+                encoding = ",".join(encodings)
 
         # chunking
         te = headers.get(hdrs.TRANSFER_ENCODING)
@@ -874,10 +883,15 @@ class HttpPayloadParser:
         self._eof_pending = False
 
         # payload decompression wrapper
+        # RFC 9110 §8.4: Content-Encoding can be a comma-separated list.
+        # Decode in reverse order (last applied first).
         if response_with_body and compression and self._auto_decompress:
-            real_payload: StreamReader | DeflateBuffer = DeflateBuffer(
-                payload, compression, max_decompress_size=limit
-            )
+            encodings = [e.strip() for e in compression.split(",")]
+            real_payload: StreamReader | DeflateBuffer = payload
+            for enc in reversed(encodings):
+                real_payload = DeflateBuffer(  # type: ignore[arg-type]
+                    real_payload, enc, max_decompress_size=limit
+                )
         else:
             real_payload = payload
 
@@ -1131,6 +1145,9 @@ class DeflateBuffer:
         out.total_compressed_bytes = self.size
         self.encoding = encoding
         self._started_decoding = False
+        # Forward _low_water from the wrapped stream so DeflateBuffer
+        # can be safely chained (RFC 9110 §8.4 multi-coding).
+        self._low_water = getattr(out, "_low_water", 0)
 
         self.decompressor: BrotliDecompressor | ZLibDecompressor | ZSTDDecompressor
         if encoding == "br":


### PR DESCRIPTION
## Summary

RFC 9110 §8.4 allows `Content-Encoding` to list multiple codings. The client must decode them in reverse order. When a server sends a body compressed twice with `Content-Encoding: gzip,gzip`, aiohttp currently does not decode the body because the header value `"gzip,gzip"` does not match the single-coding set `{"gzip", "deflate", "br", "zstd"}`.

## Changes

1. **`HttpParser.parse_headers()`** — Parse `Content-Encoding` as a comma-separated list. Validate each coding individually and store the normalized list as a comma-separated string (e.g., `"gzip,gzip"`).

2. **`HttpPayloadParser.__init__()`** — Chain multiple `DeflateBuffer` instances in reverse order so each coding is decoded in the correct sequence (last applied first).

3. **`DeflateBuffer.__init__()`** — Forward `_low_water` from the wrapped stream to support safe chaining of `DeflateBuffer` instances.

## Testing

Expected: `{"hello": "world"}` when the endpoint sends `Content-Encoding: gzip,gzip` with a doubly-gzipped JSON body.

Fixes #13364