### PR TITLE
🧪 Run tests from sdist like downstreams

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -107,7 +107,7 @@ jobs:
     - name: Install build tooling and cython
       run: >-
         python -m
-        pip install -U pip wheel setuptools build twine -r requirements/cython.in -c requirements/cython.txt
+        pip install -U build -r requirements/cython.in -c requirements/cython.txt
     - name: Restore llhttp generated files
       uses: actions/download-artifact@v8
       with:
@@ -462,7 +462,7 @@ jobs:
       env:
         DEPENDENCY_GROUP: test${{ endsWith(matrix.pyver, 't') && '-ft' || '' }}
       run: |
-        uv pip install -U pip wheel setuptools build twine -r requirements/${{ env.DEPENDENCY_GROUP }}.in -c requirements/${{ env.DEPENDENCY_GROUP }}.txt
+        uv pip install -r requirements/${{ env.DEPENDENCY_GROUP }}.in -c requirements/${{ env.DEPENDENCY_GROUP }}.txt
     - name: Install self
       env:
         AIOHTTP_NO_EXTENSIONS: ${{ matrix.no-extensions }}
@@ -528,7 +528,7 @@ jobs:
         cache-dependency-path: requirements/*.txt
     - name: Install dependencies
       run: |
-        python -m pip install -U pip wheel setuptools build twine -r requirements/test.in -c requirements/test.txt
+        python -m pip install -r requirements/test.in -c requirements/test.txt
     - name: Self-install from sdist
       run: |
         python -m pip install "${SDIST_PATH}" -c requirements/runtime-deps.txt

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -50,12 +50,11 @@ jobs:
         run: |
           echo "Pre-setup step"
 
-  lint:
+  gen-llhttp:
     permissions:
       contents: read # to fetch code (actions/checkout)
-      pull-requests: read  # to read PR metadata (verify change fragments step)
 
-    name: Linter
+    name: Generate llhttp sources
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -63,6 +62,86 @@ jobs:
       uses: actions/checkout@v7
       with:
         submodules: true
+    - name: Cache llhttp generated files
+      uses: actions/cache@v6.1.0
+      id: cache
+      with:
+        key: llhttp-${{ hashFiles('vendor/llhttp/package*.json', 'vendor/llhttp/src/**/*') }}
+        path:  vendor/llhttp/build
+    - name: Setup NodeJS
+      if: steps.cache.outputs.cache-hit != 'true'
+      uses: actions/setup-node@v7
+      with:
+        node-version: 18
+    - name: Generate llhttp sources
+      if: steps.cache.outputs.cache-hit != 'true'
+      run: |
+        make generate-llhttp
+    - name: Upload llhttp generated files
+      uses: actions/upload-artifact@v7
+      with:
+        name: llhttp
+        path: vendor/llhttp/build
+        if-no-files-found: error
+
+  build-pure-python-dists:
+    permissions:
+      contents: read # to fetch code (actions/checkout)
+
+    name: 📦 Build distribution packages
+    runs-on: ubuntu-latest
+    needs:
+    - gen-llhttp
+    outputs:
+      sdist-filename: >-
+        ${{ steps.dist-filename-detection.outputs.sdist-filename }}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v7
+      with:
+        submodules: true
+    - name: Setup Python
+      uses: actions/setup-python@v7.0.0
+    - name: Install build tooling and cython
+      run: >-
+        python -m
+        pip install -U pip wheel setuptools build twine -r requirements/cython.in -c requirements/cython.txt
+    - name: Restore llhttp generated files
+      uses: actions/download-artifact@v8
+      with:
+        name: llhttp
+        path: vendor/llhttp/build/
+    - name: Cythonize
+      run: |
+        make cythonize
+    - name: Make sdist
+      run: |
+        python -m build --sdist
+    - name: Determine the sdist filename
+      id: dist-filename-detection
+      run: echo "sdist-filename=$(basename dist/*.tar.gz)" >> "$GITHUB_OUTPUT"
+    - name: Upload artifacts
+      uses: actions/upload-artifact@v7
+      with:
+        name: dist-sdist
+        path: dist
+
+  lint-from-git:
+    permissions:
+      contents: read # to fetch code (actions/checkout)
+
+    name: Lint / Git
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v7
+      with:
+        submodules: true
+    - name: Setup Python
+      uses: actions/setup-python@v7.0.0
+      with:
+        python-version: 3.11
     - name: >-
         Verify that `requirements/runtime-deps.in`
         is in sync with `pyproject.toml`
@@ -70,6 +149,40 @@ jobs:
         set -eEuo pipefail
         make sync-direct-runtime-deps
         git diff --exit-code -- requirements/runtime-deps.in
+    - name: Install self
+      run: |  # needed so sphinxcontrib-spelling could allowlist some dep names
+        python -m pip install . -c requirements/runtime-deps.txt
+      env:
+        AIOHTTP_NO_EXTENSIONS: 1
+    - name: Install spell checker
+      run: |
+        pip install -r requirements/doc-spelling.in -c requirements/doc-spelling.txt
+    - name: Run docs spelling
+      run: |
+        # towncrier --yes  # uncomment me after publishing a release
+        make doc-spelling
+
+  lint-from-sdist:
+    permissions:
+      pull-requests: read  # to read PR metadata (verify change fragments step)
+
+    name: Lint / sdist
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    needs:
+    - build-pure-python-dists
+    steps:
+    - name: Retrieve the sdist and unpack it into the workspace
+      uses: re-actors/checkout-python-sdist@release/v3
+      with:
+        source-tarball-name: >-
+          ${{ needs.build-pure-python-dists.outputs.sdist-filename }}
+        workflow-artifact-name: dist-sdist
+    - name: Download the sdist artifact for the twine check
+      uses: actions/download-artifact@v8
+      with:
+        name: dist-sdist
+        path: dist/
     - name: Setup Python
       uses: actions/setup-python@v7.0.0
       with:
@@ -83,11 +196,13 @@ jobs:
             pip-lint-
     - name: Install dependencies
       run: |
-        python -m pip install -U pip wheel setuptools build twine -r requirements/lint.in -c requirements/lint.txt
-    - name: Install self
+        python -m pip install -U pip twine -r requirements/lint.in -c requirements/lint.txt
+    - name: Self-install from sdist
       run: |
-        python -m pip install . -c requirements/runtime-deps.txt
+        python -m pip install "${SDIST_PATH}" -c requirements/runtime-deps.txt
       env:
+        SDIST_PATH: >-
+          dist/${{ needs.build-pure-python-dists.outputs.sdist-filename }}
         AIOHTTP_NO_EXTENSIONS: 1
     - name: Run mypy
       run: |
@@ -126,18 +241,6 @@ jobs:
           failed=1
         done
         exit $failed
-    - name: Install spell checker
-      run: |
-        pip install -r requirements/doc-spelling.in -c requirements/doc-spelling.txt
-    - name: Run docs spelling
-      run: |
-        # towncrier --yes  # uncomment me after publishing a release
-        make doc-spelling
-    - name: Build package
-      run: |
-        python -m build
-      env:
-        AIOHTTP_NO_EXTENSIONS: 1
     - name: Run twine checker
       run: |
         twine check --strict dist/*
@@ -145,46 +248,10 @@ jobs:
       run: |
         LC_ALL=C sort --check --ignore-case CONTRIBUTORS.txt
 
-  gen_llhttp:
-    permissions:
-      contents: read # to fetch code (actions/checkout)
-
-    name: Generate llhttp sources
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v7
-      with:
-        submodules: true
-    - name: Cache llhttp generated files
-      uses: actions/cache@v6.1.0
-      id: cache
-      with:
-        key: llhttp-${{ hashFiles('vendor/llhttp/package*.json', 'vendor/llhttp/src/**/*') }}
-        path:  vendor/llhttp/build
-    - name: Setup NodeJS
-      if: steps.cache.outputs.cache-hit != 'true'
-      uses: actions/setup-node@v7
-      with:
-        node-version: 18
-    - name: Generate llhttp sources
-      if: steps.cache.outputs.cache-hit != 'true'
-      run: |
-        make generate-llhttp
-    - name: Upload llhttp generated files
-      uses: actions/upload-artifact@v7
-      with:
-        name: llhttp
-        path: vendor/llhttp/build
-        if-no-files-found: error
-
   test:
-    permissions:
-      contents: read # to fetch code (actions/checkout)
-
     name: Test
-    needs: gen_llhttp
+    needs:
+    - build-pure-python-dists
     strategy:
       matrix:
         pyver: ['3.10', '3.11', '3.12', '3.13', '3.14']
@@ -210,10 +277,12 @@ jobs:
     continue-on-error: ${{ matrix.experimental }}
     timeout-minutes: 15
     steps:
-    - name: Checkout
-      uses: actions/checkout@v7
+    - name: Retrieve the sdist and unpack it into the workspace
+      uses: re-actors/checkout-python-sdist@release/v3
       with:
-        submodules: true
+        source-tarball-name: >-
+          ${{ needs.build-pure-python-dists.outputs.sdist-filename }}
+        workflow-artifact-name: dist-sdist
     - name: Setup Python ${{ matrix.pyver }}
       id: python-install
       # important: do not use system python
@@ -232,16 +301,6 @@ jobs:
     - name: Set PYTHON_GIL=0 for free-threading builds
       if: ${{ endsWith(matrix.pyver, 't') }}
       run: echo "PYTHON_GIL=0" >> $GITHUB_ENV
-    - name: Restore llhttp generated files
-      if: ${{ matrix.no-extensions == '' }}
-      uses: actions/download-artifact@v8
-      with:
-        name: llhttp
-        path: vendor/llhttp/build/
-    - name: Cythonize
-      if: ${{ matrix.no-extensions == '' }}
-      run: |
-        make cythonize
     - name: Install self
       env:
         AIOHTTP_NO_EXTENSIONS: ${{ matrix.no-extensions }}
@@ -298,12 +357,10 @@ jobs:
         token: ${{ secrets.CODECOV_TOKEN }}
 
   test-mobile:
-    permissions:
-      contents: read # to fetch code (actions/checkout)
-
     name: Test (${{ matrix.config.platform }}, ${{ matrix.pyver }}, ${{ matrix.config.os }})
     runs-on: ${{ matrix.config.os }}
-    needs: gen_llhttp
+    needs:
+    - build-pure-python-dists
     strategy:
       matrix:
         pyver: ["cp313", "cp314"]
@@ -315,10 +372,11 @@ jobs:
             platform: ios
             archs: arm64_iphonesimulator
     steps:
-    - name: Checkout
-      uses: actions/checkout@v7
+    - name: Download the source distribution
+      uses: actions/download-artifact@v8
       with:
-        submodules: true
+        name: dist-sdist
+        path: dist/
     - name: Setup Python ${{ matrix.pyver }}
       id: python-install
       # important: do not use system python
@@ -329,17 +387,6 @@ jobs:
         python-version: ${{ matrix.pyver }}
         activate-environment: true
         enable-cache: true
-    - name: Install build tooling and cython
-      run: |
-        uv pip install -U pip wheel setuptools build twine -r requirements/cython.in -c requirements/cython.txt
-    - name: Restore llhttp generated files
-      uses: actions/download-artifact@v8
-      with:
-        name: llhttp
-        path: vendor/llhttp/build/
-    - name: Cythonize
-      run: |
-        make cythonize
     - name: Free up disk space for Android emulator
       if: ${{ matrix.config.platform == 'android' }}
       uses: BRAINSia/free-disk-space@v2.1.3
@@ -362,7 +409,9 @@ jobs:
       # cibuildwheel normally uses grouping in its outputs for its build/test steps. But the loading time when
       # expanding large groups in GitHub Actions is very high. So by unsetting GITHUB_ACTIONS, cibuildwheel does
       # not know that it is running in a GitHub Action and thus does not use groups.
-      run: env -u GITHUB_ACTIONS cibuildwheel
+      # Additionally, passing a tarball means that cibuildwheel will use that
+      # tarball and not the current working directory as the source.
+      run: env -u GITHUB_ACTIONS cibuildwheel "${SDIST_PATH}"
       env:
         CIBW_BUILD: ${{ matrix.pyver }}-*
         CIBW_PLATFORM: ${{ matrix.config.platform }}
@@ -371,13 +420,13 @@ jobs:
         CIBW_TEST_SOURCES: setup.cfg README.rst tests
         # Currently only Android supports colored output. See https://github.com/python/cpython/issues/150932 for iOS.
         CIBW_TEST_COMMAND: python -m pytest ${{ matrix.config.platform == 'android' && '--color=yes' || '' }}
+        SDIST_PATH: >-
+          dist/${{ needs.build-pure-python-dists.outputs.sdist-filename }}
 
   autobahn:
-    permissions:
-      contents: read # to fetch code (actions/checkout)
-
     name: Autobahn testsuite
-    needs: gen_llhttp
+    needs:
+    - build-pure-python-dists
     strategy:
       matrix:
         pyver: ['3.14']
@@ -387,10 +436,12 @@ jobs:
     runs-on: ${{ matrix.os }}-latest
     timeout-minutes: 15
     steps:
-    - name: Checkout
-      uses: actions/checkout@v7
+    - name: Retrieve the sdist and unpack it into the workspace
+      uses: re-actors/checkout-python-sdist@release/v3
       with:
-        submodules: true
+        source-tarball-name: >-
+          ${{ needs.build-pure-python-dists.outputs.sdist-filename }}
+        workflow-artifact-name: dist-sdist
     - name: Setup Python ${{ matrix.pyver }}
       id: python-install
       # important: do not use system python
@@ -406,16 +457,6 @@ jobs:
         DEPENDENCY_GROUP: test${{ endsWith(matrix.pyver, 't') && '-ft' || '' }}
       run: |
         uv pip install -U pip wheel setuptools build twine -r requirements/${{ env.DEPENDENCY_GROUP }}.in -c requirements/${{ env.DEPENDENCY_GROUP }}.txt
-    - name: Restore llhttp generated files
-      if: ${{ matrix.no-extensions == '' }}
-      uses: actions/download-artifact@v8
-      with:
-        name: llhttp
-        path: vendor/llhttp/build/
-    - name: Cythonize
-      if: ${{ matrix.no-extensions == '' }}
-      run: |
-        make cythonize
     - name: Install self
       env:
         AIOHTTP_NO_EXTENSIONS: ${{ matrix.no-extensions }}
@@ -452,7 +493,7 @@ jobs:
   benchmark:
     name: Benchmark
     needs:
-    - gen_llhttp
+    - build-pure-python-dists
     - pre-setup  # transitive, for accessing settings
     if: >-
       needs.pre-setup.outputs.upstream-repository-id == github.repository_id
@@ -460,9 +501,18 @@ jobs:
     timeout-minutes: 15
     steps:
     - name: Checkout project
-      uses: actions/checkout@v7
+      uses: actions/checkout@v7  # despite sdist, codspeed needs Git
+    - name: Retrieve the sdist and unpack it into the workspace
+      uses: re-actors/checkout-python-sdist@release/v3
       with:
-        submodules: true
+        source-tarball-name: >-
+          ${{ needs.build-pure-python-dists.outputs.sdist-filename }}
+        workflow-artifact-name: dist-sdist
+    - name: Download the source distribution
+      uses: actions/download-artifact@v8
+      with:
+        name: dist-sdist
+        path: dist/
     - name: Setup Python 3.13.2
       id: python-install
       uses: actions/setup-python@v7.0.0
@@ -473,16 +523,12 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install -U pip wheel setuptools build twine -r requirements/test.in -c requirements/test.txt
-    - name: Restore llhttp generated files
-      uses: actions/download-artifact@v8
-      with:
-        name: llhttp
-        path: vendor/llhttp/build/
-    - name: Cythonize
+    - name: Self-install from sdist
       run: |
-        make cythonize
-    - name: Install self
-      run: python -m pip install -e .
+        python -m pip install "${SDIST_PATH}" -c requirements/runtime-deps.txt
+      env:
+        SDIST_PATH: >-
+          dist/${{ needs.build-pure-python-dists.outputs.sdist-filename }}
     - name: Load kernel TLS module
       if: runner.os == 'Linux'
       run: sudo modprobe tls
@@ -504,7 +550,8 @@ jobs:
       contents: read # to fetch code (actions/checkout)
 
     name: Cython coverage
-    needs: gen_llhttp
+    needs:
+    - gen-llhttp
     strategy:
       matrix:
         os: [ubuntu, windows]
@@ -562,7 +609,8 @@ jobs:
     if: always()
 
     needs:
-    - lint
+    - lint-from-sdist
+    - lint-from-git
     - test
     - test-mobile
     - autobahn
@@ -593,48 +641,12 @@ jobs:
         run: |
             echo "Predeploy step"
 
-  build-tarball:
-    permissions:
-      contents: read # to fetch code (actions/checkout)
-
-    name: Tarball
-    runs-on: ubuntu-latest
-    needs: pre-deploy
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v7
-      with:
-        submodules: true
-    - name: Setup Python
-      uses: actions/setup-python@v7.0.0
-    - name: Install build tooling and cython
-      run: >-
-        python -m
-        pip install -U pip wheel setuptools build twine -r requirements/cython.in -c requirements/cython.txt
-    - name: Restore llhttp generated files
-      uses: actions/download-artifact@v8
-      with:
-        name: llhttp
-        path: vendor/llhttp/build/
-    - name: Cythonize
-      run: |
-        make cythonize
-    - name: Make sdist
-      run: |
-        python -m build --sdist
-    - name: Upload artifacts
-      uses: actions/upload-artifact@v7
-      with:
-        name: dist-sdist
-        path: dist
-
   build-wheels:
-    permissions:
-      contents: read # to fetch code (actions/checkout)
-
     name: Build wheels on ${{ matrix.os }} ${{ matrix.qemu }} ${{ matrix.musl }} ${{ matrix.platform }}
     runs-on: ${{ matrix.os }}
-    needs: pre-deploy
+    needs:
+    - build-pure-python-dists
+    - pre-deploy
     strategy:
       matrix:
         os: ["ubuntu-latest", "windows-latest", "windows-11-arm", "macos-latest", "ubuntu-24.04-arm"]
@@ -681,10 +693,11 @@ jobs:
         - os: macos-14
           platform: ios
     steps:
-    - name: Checkout
-      uses: actions/checkout@v7
+    - name: Download the source distribution
+      uses: actions/download-artifact@v8
       with:
-        submodules: true
+        name: dist-sdist
+        path: dist/
     - name: Set up QEMU
       if: ${{ matrix.qemu }}
       uses: docker/setup-qemu-action@v4
@@ -706,25 +719,11 @@ jobs:
           echo "CIBW_BUILD_FRONTEND=build" >> $GITHUB_ENV
         fi
       shell: bash
-    - name: Setup Python
-      uses: actions/setup-python@v7.0.0
-      with:
-        python-version: 3.x
-    - name: Install build tooling and cython
-      run: >-
-        python -m
-        pip install -U pip wheel setuptools build twine -r requirements/cython.in -c requirements/cython.txt
-    - name: Restore llhttp generated files
-      uses: actions/download-artifact@v8
-      with:
-        name: llhttp
-        path: vendor/llhttp/build/
-    - name: Cythonize
-      run: |
-        make cythonize
     - name: Build wheels
       uses: pypa/cibuildwheel@v4.2.0
       with:
+        package-dir: >-  # not necessarily a dir, we pass an acceptable sdist
+          dist/${{ needs.build-pure-python-dists.outputs.sdist-filename }}
         # `build-frontend = "build[uv]"` (pyproject.toml) requires uv to be
         # available on the runner for Windows and macOS. Installing
         # cibuildwheel with the `uv` extra bundles uv with it; the
@@ -755,7 +754,6 @@ jobs:
   deploy:
     name: Deploy
     needs:
-    - build-tarball
     - build-wheels
     - pre-setup  # transitive, for accessing settings
     runs-on: ubuntu-latest

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -95,6 +95,8 @@ jobs:
     outputs:
       sdist-filename: >-
         ${{ steps.dist-filename-detection.outputs.sdist-filename }}
+      wheel-filename: >-
+        ${{ steps.dist-filename-detection.outputs.wheel-filename }}
     steps:
     - name: Checkout
       uses: actions/checkout@v7
@@ -114,16 +116,20 @@ jobs:
     - name: Cythonize
       run: |
         make cythonize
-    - name: Make sdist
+    - name: Build sdists and pure-python wheel
       run: |
-        python -m build --sdist
-    - name: Determine the sdist filename
+        python -m build
+      env:
+        AIOHTTP_NO_EXTENSIONS: 1
+    - name: Determine the sdist and wheel filenames
       id: dist-filename-detection
-      run: echo "sdist-filename=$(basename dist/*.tar.gz)" >> "$GITHUB_OUTPUT"
+      run: |
+        echo "sdist-filename=$(basename dist/*.tar.gz)" >> "$GITHUB_OUTPUT"
+        echo "wheel-filename=$(basename dist/*.whl)" >> "$GITHUB_OUTPUT"
     - name: Upload artifacts
       uses: actions/upload-artifact@v7
       with:
-        name: dist-sdist
+        name: dist-pure
         path: dist
 
   lint-from-git:
@@ -177,11 +183,11 @@ jobs:
       with:
         source-tarball-name: >-
           ${{ needs.build-pure-python-dists.outputs.sdist-filename }}
-        workflow-artifact-name: dist-sdist
+        workflow-artifact-name: dist-pure
     - name: Download the sdist artifact for the twine check
       uses: actions/download-artifact@v8
       with:
-        name: dist-sdist
+        name: dist-pure
         path: dist/
     - name: Setup Python
       uses: actions/setup-python@v7.0.0
@@ -282,7 +288,7 @@ jobs:
       with:
         source-tarball-name: >-
           ${{ needs.build-pure-python-dists.outputs.sdist-filename }}
-        workflow-artifact-name: dist-sdist
+        workflow-artifact-name: dist-pure
     - name: Setup Python ${{ matrix.pyver }}
       id: python-install
       # important: do not use system python
@@ -375,7 +381,7 @@ jobs:
     - name: Download the source distribution
       uses: actions/download-artifact@v8
       with:
-        name: dist-sdist
+        name: dist-pure
         path: dist/
     - name: Setup Python ${{ matrix.pyver }}
       id: python-install
@@ -441,7 +447,7 @@ jobs:
       with:
         source-tarball-name: >-
           ${{ needs.build-pure-python-dists.outputs.sdist-filename }}
-        workflow-artifact-name: dist-sdist
+        workflow-artifact-name: dist-pure
     - name: Setup Python ${{ matrix.pyver }}
       id: python-install
       # important: do not use system python
@@ -507,11 +513,11 @@ jobs:
       with:
         source-tarball-name: >-
           ${{ needs.build-pure-python-dists.outputs.sdist-filename }}
-        workflow-artifact-name: dist-sdist
+        workflow-artifact-name: dist-pure
     - name: Download the source distribution
       uses: actions/download-artifact@v8
       with:
-        name: dist-sdist
+        name: dist-pure
         path: dist/
     - name: Setup Python 3.13.2
       id: python-install
@@ -696,7 +702,7 @@ jobs:
     - name: Download the source distribution
       uses: actions/download-artifact@v8
       with:
-        name: dist-sdist
+        name: dist-pure
         path: dist/
     - name: Set up QEMU
       if: ${{ matrix.qemu }}

--- a/CHANGES/13363.contrib.rst
+++ b/CHANGES/13363.contrib.rst
@@ -1,0 +1,13 @@
+CI now builds the ``sdist`` (and a pure-Python wheel) once, in a new
+``build-pure-python-dists`` job, and shares that build across ``test``,
+``autobahn``, ``benchmark``, ``build-wheels``, ``test-mobile`` and the
+``sdist``-based half of linting, instead of every one of those jobs
+checking out the repository and running ``make cythonize`` on its own
+-- by :user:`webknjaz`.
+
+Linting is also now split into ``lint-from-git`` (the
+:file:`requirements/runtime-deps.in` sync check and docs spell-checking,
+which need real Git history) and ``lint-from-sdist`` (``mypy``,
+``slotscheck``, the changelog fragment check, and ``twine check``, which
+build from the shared artifact instead), since an ``sdist`` tarball never
+contains :file:`.git`.

--- a/CHANGES/13388.contrib.rst
+++ b/CHANGES/13388.contrib.rst
@@ -1,0 +1,1 @@
+13363.contrib.rst

--- a/CHANGES/13388.packaging.rst
+++ b/CHANGES/13388.packaging.rst
@@ -1,0 +1,1 @@
+7632.packaging.rst

--- a/CHANGES/7632.packaging.rst
+++ b/CHANGES/7632.packaging.rst
@@ -1,0 +1,6 @@
+Started publishing an additional pure-Python wheel alongside the existing
+per-platform binary wheels and the ``sdist`` -- by :user:`webknjaz`.
+
+This gives users on platforms without a working C compiler, or without a
+matching pre-built wheel, an installable fallback that does not require
+compilation.

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,6 +3,9 @@ include CHANGES.rst
 include README.rst
 include CONTRIBUTORS.txt
 include Makefile
+include .mypy.ini
+include .coveragerc.toml
+include .coveragerc-cython.toml
 graft aiohttp
 graft docs
 graft examples

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -171,6 +171,12 @@ test-command = ""
 # don't build PyPy wheels, install from source instead
 skip = "pp*"
 
+[tool.cibuildwheel.environment]
+PIP_BUILD_CONSTRAINT = "requirements/cython.txt"
+PIP_CONSTRAINT = "requirements/cython.txt"
+UV_BUILD_CONSTRAINT = "requirements/cython.txt"
+UV_CONSTRAINT = "requirements/cython.txt"
+
 [tool.cibuildwheel.ios]
 # iOS currently does not support build[uv]
 build-frontend = "build"


### PR DESCRIPTION
## What do these changes do?

This allows us make sure everything they need is shipped through PyPI. And brings us closer to how `pip install` would build wheels in the wild. We now also run tests in CI from sdist.

## Are there changes in behavior for the user?

A quality-of-life change — once released, the users' installers will be able to get new aiohttp versions in their pure-python form by default, even if there's no pre-built wheel for their runtime (like if they get back to a certain version in the future with an interpreter released years later).

## Is it a substantial burden for the maintainers to support this?

It's actually bringing the infra closer to the rest of the repos. So it's a win.

## Related issue number

And this should help us out getting CI/CD to:
* closes #7632
* closes #13363
* #13353

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES/` folder
  * name it `<issue_or_pr_num>.<type>.rst` (e.g. `588.bugfix.rst`)
  * if you don't have an issue number, change it to the pull request
    number after creating the PR
    * `.bugfix`: A bug fix for something the maintainers deemed an
      improper undesired behavior that got corrected to match
      pre-agreed expectations.
    * `.feature`: A new behavior, public APIs. That sort of stuff.
    * `.deprecation`: A declaration of future API removals and breaking
      changes in behavior.
    * `.breaking`: When something public is removed in a breaking way.
      Could be deprecated in an earlier release.
    * `.doc`: Notable updates to the documentation structure or build
      process.
    * `.packaging`: Notes for downstreams about unobvious side effects
      and tooling. Changes in the test invocation considerations and
      runtime assumptions.
    * `.contrib`: Stuff that affects the contributor experience. e.g.
      Running tests, building the docs, setting up the development
      environment.
    * `.misc`: Changes that are hard to assign to any of the above
      categories.
  * Make sure to use full sentences with correct case and punctuation,
    for example:
    ```rst
    Fixed issue with non-ascii contents in doctest text files
    -- by :user:`contributor-gh-handle`.
    ```

    Use the past tense or the present tense a non-imperative mood,
    referring to what's changed compared to the last released version
    of this project.
