### PR TITLE
Fix a flaky test

### DIFF
--- a/tests/test_web_functional.py
+++ b/tests/test_web_functional.py
@@ -2529,7 +2529,7 @@ async def test_bad_method_for_c_http_parser_not_hangs(
     aiohttp_client: AiohttpClient,
 ) -> None:
     app = web.Application()
-    timeout = aiohttp.ClientTimeout(sock_read=0.2)
+    timeout = aiohttp.ClientTimeout(sock_read=3)
     client = await aiohttp_client(app, timeout=timeout)
     resp = await client.request("GET1", "/")
     assert 400 == resp.status


### PR DESCRIPTION
This test is meant to verify the parser doesn't hang. The timeout doesn't need to be that short, which can fail occasionally on some machines. A failure would still occur if it hung, as there'd be no response.