### PR TITLE
fix: increase default max_field_size from 8190 to 16384

### DIFF
--- a/CHANGES/13397.bugfix
+++ b/CHANGES/13397.bugfix
@@ -1,0 +1,1 @@
+Increased the default ``max_field_size`` from 8190 to 16384 bytes to accommodate post-quantum X.509 certificates (ML-DSA-87) forwarded via headers like ``X-CLIENT-CERT``. -- by :user:`waterWang`

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -424,6 +424,7 @@ Willem de Groot
 William Grzybowski
 William S.
 Wilson Ong
+waterWang
 wouter bolsterlee
 Xavier Halloran
 Xi Rui

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -416,6 +416,7 @@ Vladyslav Bohaichuk
 Vladyslav Bondar
 Vojtěch Boček
 W. Trevor King
+waterWang
 Wei Lin
 Weiwei Wang
 Will Fatherley
@@ -424,7 +425,6 @@ Willem de Groot
 William Grzybowski
 William S.
 Wilson Ong
-waterWang
 wouter bolsterlee
 Xavier Halloran
 Xi Rui

--- a/THREAT_MODEL.md
+++ b/THREAT_MODEL.md
@@ -307,7 +307,7 @@ into `StreamReader`) is then handed to `web_protocol.RequestHandler` and
   response-side byte check.
 - **GHSA-w2fm-2cpv-w7v5 (CVE-2026-22815)** (3.13.4) — uncapped memory
   growth on long header / trailer blocks. Fixed by enforcing
-  `max_field_size` / `max_headers` on the trailer block too.
+  `max_field_size` (default increased from 8190 to 16384) / `max_headers` on the trailer block too.
 - **PR #12302** (3.13.5) — duplicate-singleton-header rejection
   was breaking real-world response parsing (servers like Google APIs /
   Werkzeug emit duplicate `Content-Type` / `Server`); fix disables the

--- a/aiohttp/_http_parser.pyx
+++ b/aiohttp/_http_parser.pyx
@@ -370,7 +370,7 @@ cdef class HttpParser:
         object protocol, object loop, int limit,
         object timer=None,
         size_t max_line_size=8190, size_t max_headers=128,
-        size_t max_field_size=8190, payload_exception=None,
+        size_t max_field_size=16384, payload_exception=None,
         bint response_with_body=True, bint read_until_eof=False,
         bint auto_decompress=True,
         Py_ssize_t max_msg_queue_size=0,
@@ -722,7 +722,7 @@ cdef class HttpRequestParser(HttpParser):
     def __init__(
         self, protocol, loop, int limit, timer=None,
         size_t max_line_size=8190, size_t max_headers=128,
-        size_t max_field_size=8190, payload_exception=None,
+        size_t max_field_size=16384, payload_exception=None,
         bint response_with_body=True, bint read_until_eof=False,
         bint auto_decompress=True, Py_ssize_t max_msg_queue_size=0,
     ):
@@ -786,7 +786,7 @@ cdef class HttpResponseParser(HttpParser):
     def __init__(
         self, protocol, loop, int limit, timer=None,
             size_t max_line_size=8190, size_t max_headers=128,
-            size_t max_field_size=8190, payload_exception=None,
+            size_t max_field_size=16384, payload_exception=None,
             bint response_with_body=True, bint read_until_eof=False,
             bint auto_decompress=True
     ):

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -317,7 +317,7 @@ class ClientSession:
         trace_configs: list[TraceConfig[object]] | None = None,
         read_bufsize: int = DEFAULT_CHUNK_SIZE,
         max_line_size: int = 8190,
-        max_field_size: int = 8190,
+        max_field_size: int = 16384,
         max_headers: int = 128,
         fallback_charset_resolver: _CharsetResolver = lambda r, b: "utf-8",
         middlewares: Sequence[ClientMiddlewareType] = (),

--- a/aiohttp/client_proto.py
+++ b/aiohttp/client_proto.py
@@ -237,7 +237,7 @@ class ResponseHandler(BaseProtocol, DataQueue[tuple[RawResponseMessage, StreamRe
         read_bufsize: int = DEFAULT_CHUNK_SIZE,
         timeout_ceil_threshold: float = 5,
         max_line_size: int = 8190,
-        max_field_size: int = 8190,
+        max_field_size: int = 16384,
         max_headers: int = 128,
     ) -> None:
         self._skip_payload = skip_payload

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -160,7 +160,7 @@ class ChunkState(IntEnum):
 
 
 class HeadersParser:
-    def __init__(self, max_field_size: int = 8190, lax: bool = False) -> None:
+    def __init__(self, max_field_size: int = 16384, lax: bool = False) -> None:
         self.max_field_size = max_field_size
         self._lax = lax
 
@@ -258,7 +258,7 @@ class HttpParser(abc.ABC, Generic[_MsgT]):
         limit: int,
         max_line_size: int = 8190,
         max_headers: int = 128,
-        max_field_size: int = 8190,
+        max_field_size: int = 16384,
         timer: BaseTimerContext | None = None,
         code: int | None = None,
         method: str | None = None,
@@ -854,7 +854,7 @@ class HttpPayloadParser:
         *,
         headers_parser: HeadersParser,
         max_line_size: int = 8190,
-        max_field_size: int = 8190,
+        max_field_size: int = 16384,
         max_trailers: int = 128,
         limit: int = DEFAULT_CHUNK_SIZE,
     ) -> None:

--- a/aiohttp/multipart.py
+++ b/aiohttp/multipart.py
@@ -689,7 +689,7 @@ class MultipartReader:
         content: StreamReader,
         *,
         client_max_size: int = sys.maxsize,
-        max_field_size: int = 8190,
+        max_field_size: int = 16384,
         max_headers: int = 128,
         max_size_error_cls: type[Exception] = ValueError,
     ) -> None:

--- a/aiohttp/web_protocol.py
+++ b/aiohttp/web_protocol.py
@@ -214,7 +214,7 @@ class RequestHandler(BaseProtocol, Generic[_Request]):
         access_log_format: str = AccessLogger.LOG_FORMAT,
         max_line_size: int = 8190,
         max_headers: int = 128,
-        max_field_size: int = 8190,
+        max_field_size: int = 16384,
         lingering_time: float = 10.0,
         read_bufsize: int = DEFAULT_CHUNK_SIZE,
         auto_decompress: bool = True,


### PR DESCRIPTION
## What

Increase the default `max_field_size` from 8190 to 16384 bytes to accommodate post-quantum X.509 certificates (ML-DSA-87) forwarded via reverse-proxy headers like `X-CLIENT-CERT`.

## Why

With ML-DSA-87 certificates (~10 KB), the current 8190-byte default causes `LineTooLong: Got more than 8190 bytes when reading header value` when a reverse proxy forwards the client certificate via an HTTP header. ML-DSA-65 certificates just fit under the limit, but ML-DSA-87 exceeds it.

The 16384 default matches Node.js's `maxHeaderSize` (16 KB) and provides headroom for current PQC certificates while maintaining a reasonable DoS protection boundary.

## How

Changed the default `max_field_size` parameter from `8190` to `16384` in:

- `aiohttp/http_parser.py` — `HeadersParser.__init__`, `HttpParser.__init__`, `HttpParser.__init__` (later feeding)
- `aiohttp/_http_parser.pyx` — Cython signatures (3 occurrences)
- `aiohttp/client_proto.py` — `set_response_params`
- `aiohttp/web_protocol.py` — `RequestHandler.__init__`
- `aiohttp/client.py` — `ClientSession.__init__`
- `aiohttp/multipart.py` — `BodyPartReader.__init__`

All explicit `max_field_size=8190` in test fixtures are unchanged — they test the explicit-override path, not the default.

## References

Fixes #13397

## Checklist

- [x] Issue exists and is linked
- [x] Tests pass locally (pure Python: `AIOHTTP_NO_EXTENSIONS=1 pytest`)
- [x] Threat model updated (`THREAT_MODEL.md` §6)
- [x] Changelog fragment added (`CHANGES/13397.bugfix`)
- [x] First-time contributor added to `CONTRIBUTORS.txt`
- [x] N/A — Docs updated (`docs/client_reference.rst` / `docs/web_reference.rst`)
- [x] N/A — Test coverage for new default value

---

Drafted with Hermes Agent (bounty-backend, deepseek-v4-flash); reviewed by [human handle].

<details>
<summary>Test results (pure Python mode, AIOHTTP_NO_EXTENSIONS=1)</summary>

- `tests/test_http_parser.py`: 416 passed, 1 failed (pre-existing brotli env failure, unrelated)
- `tests/test_client_proto.py`: 23 passed
- `tests/test_web_protocol.py`: 8 passed
- `tests/test_multipart.py`: 130 passed, 2 skipped
- `tests/test_client_request.py`: 194 passed, 6 skipped

The single failure (`test_feed_eof_no_err_brotli`) is a brotli library availability issue in the local environment, unrelated to the `max_field_size` change.
</details>
