### PR TITLE
fix(client): strip IPv6 link-local zone id from Host header

### DIFF
--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -902,8 +902,14 @@ class ClientRequestBase:
         """Update request headers."""
         self.headers: CIMultiDict[str] = CIMultiDict()
 
-        # Build the host header
-        host = self.url.host_port_subcomponent
+        # Build the host header. Per RFC 6874 §4, the zone id of an IPv6
+        # link-local address only has local significance at the sending
+        # host and must be stripped from the outgoing Host header.
+        url = self.url
+        raw_host = url.raw_host
+        if raw_host is not None and "%" in raw_host:
+            url = url.with_host(raw_host.split("%", 1)[0])
+        host = url.host_port_subcomponent
 
         # host_port_subcomponent is None when the URL is a relative URL.
         # but we know we do not have a relative URL here.
@@ -942,7 +948,12 @@ class ClientRequestBase:
         # - not CONNECT proxy must send absolute form URI
         # - most common is origin form URI
         if self.method == hdrs.METH_CONNECT:
-            connect_host = self.url.host_subcomponent
+            url = self.url
+            raw_host = url.raw_host
+            if raw_host is not None and "%" in raw_host:
+                # RFC 6874 §4: strip the zone id from the authority.
+                url = url.with_host(raw_host.split("%", 1)[0])
+            connect_host = url.host_subcomponent
             assert connect_host is not None
             path = f"{connect_host}:{self.url.port}"
         elif self.proxy and not self.is_ssl():

--- a/tests/test_client_request.py
+++ b/tests/test_client_request.py
@@ -333,6 +333,22 @@ async def test_host_header_ipv6_with_port(make_client_request: _RequestMaker) ->
     assert req.headers["HOST"] == "[::2]:99"
 
 
+async def test_host_header_ipv6_link_local_zone_id_stripped(
+    make_client_request: _RequestMaker,
+) -> None:
+    # RFC 6874 §4: the zone id has only local significance at the
+    # sending host and must be stripped from the outgoing Host header.
+    req = make_client_request("get", URL("http://[fe80::1%eth0]/"))
+    assert req.headers["HOST"] == "[fe80::1]"
+
+
+async def test_host_header_ipv6_link_local_zone_id_with_port(
+    make_client_request: _RequestMaker,
+) -> None:
+    req = make_client_request("get", URL("http://[fe80::1%eth0]:99/"))
+    assert req.headers["HOST"] == "[fe80::1]:99"
+
+
 @pytest.mark.parametrize(
     ("url", "headers", "expected"),
     (


### PR DESCRIPTION
## Problem

When a request is made to a URL containing an IPv6 link-local address with a zone id (e.g. `http://[fe80::1%eth0]/`), aiohttp sends the zone id verbatim as part of the Host header: `Host: [fe80::1%eth0]`.

Per [RFC 6874 §4](https://datatracker.ietf.org/doc/html/rfc6874#section-4), the zone id only has local significance to the sending host and must be removed by the client:

> an HTTP client, proxy, or other intermediary MUST remove any ZoneID attached to an outgoing URI, as it has only local significance at the sending host.

Servers that validate the Host header strictly against RFC 3986 — for example nginx from 1.29.4 onward — now reject such requests with `400 Bad Request`.

## Root cause

`_update_headers` builds the Host header from `self.url.host_port_subcomponent`, which yarl returns including the zone id. The same applies to the CONNECT authority form URI built in `_send`.

## Fix

Strip the zone id before building the Host header in `_update_headers`, and before building the CONNECT authority form URI in `_send`. Both use `url.with_host(raw_host.split("%", 1)[0])` when the raw host contains `%`.

`raw_host` is used (rather than `host`) so the check operates on the un-decoded form, matching yarl's own IPv6 handling.

## Testing

Added two regression tests to `tests/test_client_request.py`:

- `test_host_header_ipv6_link_local_zone_id_stripped` — verifies `Host: [fe80::1]` (zone id removed, no port)
- `test_host_header_ipv6_link_local_zone_id_with_port` — verifies `Host: [fe80::1]:99` (zone id removed, port preserved)

Existing tests for plain IPv6, IPv4, domains, and explicit Host headers continue to pass, confirming the fix only affects the zone-id case.

Fixes aio-libs/yarl#1862