### PR TITLE
🧪 Sync coveragepy setup w/ other projects

### DIFF
--- a/.coveragerc-cython.toml
+++ b/.coveragerc-cython.toml
@@ -17,7 +17,7 @@ exclude_also = [
   ': \.\.\.(\s*#.*)?$',
   '^ +\.\.\.$',
   'pytest.fail\(',
-  '^\s*@pytest\.mark\.xfail',
+  # '^\s*@pytest\.mark\.xfail',  # important for Dreamsorcerer
 ]
 # fail_under = 100
 partial_also = [

--- a/.coveragerc-cython.toml
+++ b/.coveragerc-cython.toml
@@ -62,9 +62,13 @@ omit = [
 # NOTE: tests/autobahn/test_autobahn.py::test_{client,server}
 # NOTE: pass `-a|--append` to `coverage run` wich conflicts
 # NOTE: with `-p|--parallel-mode`. We cannot override it on
-# NOTE: the CLI level, which is why it's unset here.
-# Ref: https://discord.com/channels/267624335836053506/1253355750684753950/1537906072474488973
-# parallel = true
+# NOTE: the CLI level, but instead define an environment
+# NOTE: variable to implement this.
+#
+# Refs:
+# * https://discord.com/channels/267624335836053506/1253355750684753950/1537906072474488973
+# * https://discord.com/channels/267624335836053506/1253355750684753950/1537914331629486130
+parallel = '${COVERAGE_PARALLEL_MODE-true}'
 plugins = [
   'Cython.Coverage',
 ]

--- a/.coveragerc-cython.toml
+++ b/.coveragerc-cython.toml
@@ -1,20 +1,69 @@
-[run]
-branch = true
-plugins = [
-  'Cython.Coverage',
-]
-omit = [
-  'site-packages',
+[html]
+show_contexts = true
+skip_covered = false
+
+[paths]
+_site-packages-to-src-mapping = [
+  '.',
+  '*/lib/pypy*/site-packages',
+  '*/lib/python*/site-packages',
+  '*\Lib\site-packages',
 ]
 
 [report]
-partial_also = [
-  'if not TYPE_CHECKING',
-]
 exclude_also = [
   'if TYPE_CHECKING',
   'assert False',
   ': \.\.\.(\s*#.*)?$',
   '^ +\.\.\.$',
-  'pytest.fail\('
+  'pytest.fail\(',
+  '^\s*@pytest\.mark\.xfail',
+]
+# fail_under = 100
+partial_also = [
+  'if not TYPE_CHECKING',
+]
+show_missing = true
+skip_covered = true
+skip_empty = true
+
+[run]
+branch = true
+# NOTE: `ctrace` tracing method is needed because the `sysmon` tracer
+# NOTE: which is default on Python 3.14, causes unprecedented slow-down
+# NOTE: of the test runs. Also, Cython the `Cython.Coverage` plugin does
+# NOTE: not support `sysmon`.
+# Ref: https://github.com/coveragepy/coveragepy/issues/2099
+core = 'ctrace'
+cover_pylib = false
+# NOTE: `disable_warnings` is needed when `pytest-cov` runs in tandem
+# NOTE: with `pytest-xdist`. These warnings are false negative in this
+# NOTE: context.
+#
+# NOTE: It's `coveragepy` that emits the warnings and previously they
+# NOTE: wouldn't get on the radar of `pytest`'s `filterwarnings`
+# NOTE: mechanism. This changed, however, with `pytest >= 8.4`. And
+# NOTE: since we set `filterwarnings = error`, those warnings are being
+# NOTE: raised as exceptions, cascading into `pytest`'s internals and
+# NOTE: causing tracebacks and crashes of the test sessions.
+#
+# Ref:
+# * https://github.com/pytest-dev/pytest-cov/issues/693
+# * https://github.com/pytest-dev/pytest-cov/pull/695
+# * https://github.com/pytest-dev/pytest-cov/pull/696
+disable_warnings = [
+  'module-not-measured',
+]
+# https://coverage.rtfd.io/en/latest/contexts.html#dynamic-contexts
+# dynamic_context = 'test_function'  # conflicts with `pytest-cov` if set here
+parallel = true
+plugins = [
+  'Cython.Coverage',
+]
+relative_files = true
+source = [
+  '.',
+]
+source_pkgs = [
+  'aiohttp',
 ]

--- a/.coveragerc-cython.toml
+++ b/.coveragerc-cython.toml
@@ -56,7 +56,12 @@ disable_warnings = [
 ]
 # https://coverage.rtfd.io/en/latest/contexts.html#dynamic-contexts
 # dynamic_context = 'test_function'  # conflicts with `pytest-cov` if set here
-parallel = true
+# NOTE: tests/autobahn/test_autobahn.py::test_{client,server}
+# NOTE: pass `-a|--append` to `coverage run` wich conflicts
+# NOTE: with `-p|--parallel-mode`. We cannot override it on
+# NOTE: the CLI level, which is why it's unset here.
+# Ref: https://discord.com/channels/267624335836053506/1253355750684753950/1537906072474488973
+# parallel = true
 plugins = [
   'Cython.Coverage',
 ]

--- a/.coveragerc-cython.toml
+++ b/.coveragerc-cython.toml
@@ -56,6 +56,9 @@ disable_warnings = [
 ]
 # https://coverage.rtfd.io/en/latest/contexts.html#dynamic-contexts
 # dynamic_context = 'test_function'  # conflicts with `pytest-cov` if set here
+omit = [
+  'setup.py',
+]
 # NOTE: tests/autobahn/test_autobahn.py::test_{client,server}
 # NOTE: pass `-a|--append` to `coverage run` wich conflicts
 # NOTE: with `-p|--parallel-mode`. We cannot override it on

--- a/.coveragerc.toml
+++ b/.coveragerc.toml
@@ -17,7 +17,7 @@ exclude_also = [
   ': \.\.\.(\s*#.*)?$',
   '^ +\.\.\.$',
   'pytest.fail\(',
-  '^\s*@pytest\.mark\.xfail',
+  # '^\s*@pytest\.mark\.xfail',  # important for Dreamsorcerer
 ]
 # fail_under = 100
 partial_also = [

--- a/.coveragerc.toml
+++ b/.coveragerc.toml
@@ -62,9 +62,13 @@ omit = [
 # NOTE: tests/autobahn/test_autobahn.py::test_{client,server}
 # NOTE: pass `-a|--append` to `coverage run` wich conflicts
 # NOTE: with `-p|--parallel-mode`. We cannot override it on
-# NOTE: the CLI level, which is why it's unset here.
-# Ref: https://discord.com/channels/267624335836053506/1253355750684753950/1537906072474488973
-# parallel = true
+# NOTE: the CLI level, but instead define an environment
+# NOTE: variable to implement this.
+#
+# Refs:
+# * https://discord.com/channels/267624335836053506/1253355750684753950/1537906072474488973
+# * https://discord.com/channels/267624335836053506/1253355750684753950/1537914331629486130
+parallel = '${COVERAGE_PARALLEL_MODE-true}'
 # plugins = [
 #   'covdefaults',
 # ]

--- a/.coveragerc.toml
+++ b/.coveragerc.toml
@@ -56,7 +56,12 @@ disable_warnings = [
 ]
 # https://coverage.rtfd.io/en/latest/contexts.html#dynamic-contexts
 # dynamic_context = 'test_function'  # conflicts with `pytest-cov` if set here
-parallel = true
+# NOTE: tests/autobahn/test_autobahn.py::test_{client,server}
+# NOTE: pass `-a|--append` to `coverage run` wich conflicts
+# NOTE: with `-p|--parallel-mode`. We cannot override it on
+# NOTE: the CLI level, which is why it's unset here.
+# Ref: https://discord.com/channels/267624335836053506/1253355750684753950/1537906072474488973
+# parallel = true
 # plugins = [
 #   'covdefaults',
 # ]

--- a/.coveragerc.toml
+++ b/.coveragerc.toml
@@ -1,26 +1,69 @@
-[run]
-branch = true
-# NOTE: `ctrace` tracing method is needed because the `sysmon` tracer
-# NOTE: which is default on Python 3.14, causes unprecedented slow-down
-# NOTE: of the test runs.
-# Ref: https://github.com/coveragepy/coveragepy/issues/2099
-core = 'ctrace'
-source = [
-  'aiohttp',
-  'tests',
-]
-omit = [
-  'site-packages',
+[html]
+show_contexts = true
+skip_covered = false
+
+[paths]
+_site-packages-to-src-mapping = [
+  '.',
+  '*/lib/pypy*/site-packages',
+  '*/lib/python*/site-packages',
+  '*\Lib\site-packages',
 ]
 
 [report]
-partial_also = [
-  'if not TYPE_CHECKING',
-]
 exclude_also = [
   'if TYPE_CHECKING',
   'assert False',
   ': \.\.\.(\s*#.*)?$',
   '^ +\.\.\.$',
-  'pytest.fail\('
+  'pytest.fail\(',
+  '^\s*@pytest\.mark\.xfail',
+]
+# fail_under = 100
+partial_also = [
+  'if not TYPE_CHECKING',
+]
+show_missing = true
+skip_covered = true
+skip_empty = true
+
+[run]
+branch = true
+# NOTE: `ctrace` tracing method is needed because the `sysmon` tracer
+# NOTE: which is default on Python 3.14, causes unprecedented slow-down
+# NOTE: of the test runs. Also, Cython the `Cython.Coverage` plugin does
+# NOTE: not support `sysmon`.
+# Ref: https://github.com/coveragepy/coveragepy/issues/2099
+core = 'ctrace'
+cover_pylib = false
+# NOTE: `disable_warnings` is needed when `pytest-cov` runs in tandem
+# NOTE: with `pytest-xdist`. These warnings are false negative in this
+# NOTE: context.
+#
+# NOTE: It's `coveragepy` that emits the warnings and previously they
+# NOTE: wouldn't get on the radar of `pytest`'s `filterwarnings`
+# NOTE: mechanism. This changed, however, with `pytest >= 8.4`. And
+# NOTE: since we set `filterwarnings = error`, those warnings are being
+# NOTE: raised as exceptions, cascading into `pytest`'s internals and
+# NOTE: causing tracebacks and crashes of the test sessions.
+#
+# Ref:
+# * https://github.com/pytest-dev/pytest-cov/issues/693
+# * https://github.com/pytest-dev/pytest-cov/pull/695
+# * https://github.com/pytest-dev/pytest-cov/pull/696
+disable_warnings = [
+  'module-not-measured',
+]
+# https://coverage.rtfd.io/en/latest/contexts.html#dynamic-contexts
+# dynamic_context = 'test_function'  # conflicts with `pytest-cov` if set here
+parallel = true
+# plugins = [
+#   'covdefaults',
+# ]
+relative_files = true
+source = [
+  '.',
+]
+source_pkgs = [
+  'aiohttp',
 ]

--- a/.coveragerc.toml
+++ b/.coveragerc.toml
@@ -56,6 +56,9 @@ disable_warnings = [
 ]
 # https://coverage.rtfd.io/en/latest/contexts.html#dynamic-contexts
 # dynamic_context = 'test_function'  # conflicts with `pytest-cov` if set here
+omit = [
+  'setup.py',
+]
 # NOTE: tests/autobahn/test_autobahn.py::test_{client,server}
 # NOTE: pass `-a|--append` to `coverage run` wich conflicts
 # NOTE: with `-p|--parallel-mode`. We cannot override it on

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -601,11 +601,11 @@ jobs:
       shell: bash
     - name: Turn coverage into xml
       run: |
-        python -m coverage xml -o cython-coverage.xml --rcfile=.coveragerc-cython.toml
+        python -m coverage xml --rcfile=.coveragerc-cython.toml
     - name: Upload coverage
       uses: codecov/codecov-action@v7
       with:
-        files: ./cython-coverage.xml
+        files: ./coverage.xml
         disable_search: true
         flags: cython-coverage
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -317,7 +317,7 @@ jobs:
         AIOHTTP_NO_EXTENSIONS: ${{ matrix.no-extensions }}
         PIP_USER: 1
       run: >-
-        pytest --junitxml=junit.xml --numprocesses=auto --cov=aiohttp/ --cov=tests/ -m 'not dev_mode and not autobahn'
+        pytest --junitxml=junit.xml --numprocesses=auto --cov -m 'not dev_mode and not autobahn'
       shell: bash
     - name: Re-run the failing tests with maximum verbosity
       if: failure()
@@ -333,7 +333,7 @@ jobs:
         AIOHTTP_NO_EXTENSIONS: ${{ matrix.no-extensions }}
         PIP_USER: 1
         PYTHONDEVMODE: 1
-      run: pytest -m dev_mode --cov=aiohttp/ --cov=tests/ --cov-append
+      run: pytest -m dev_mode --cov --cov-append
       shell: bash
     - name: Turn coverage into xml
       env:
@@ -474,7 +474,7 @@ jobs:
         PIP_USER: 1
       run: >-
         PATH="${HOME}/Library/Python/3.11/bin:${HOME}/.local/bin:${PATH}"
-        pytest --junitxml=junit.xml --cov=aiohttp/ --cov=tests/ --timeout=0 -m autobahn
+        pytest --junitxml=junit.xml --cov --timeout=0 -m autobahn
       shell: bash
     - name: Turn coverage into xml
       env:
@@ -596,7 +596,7 @@ jobs:
         PIP_USER: 1
       run: >-
         pytest tests/test_client_functional.py tests/test_http_parser.py tests/test_http_writer.py tests/test_web_functional.py tests/test_web_response.py tests/test_websocket_parser.py
-        --cov-config=.coveragerc-cython.toml --cov=aiohttp/ --cov=tests/ --numprocesses=auto
+        --cov-config=.coveragerc-cython.toml --cov --numprocesses=auto
         -m 'not dev_mode and not autobahn'
       shell: bash
     - name: Turn coverage into xml

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -333,14 +333,8 @@ jobs:
         AIOHTTP_NO_EXTENSIONS: ${{ matrix.no-extensions }}
         PIP_USER: 1
         PYTHONDEVMODE: 1
-      run: pytest -m dev_mode --cov --cov-append
+      run: pytest -m dev_mode --cov --cov-append --cov-report=xml
       shell: bash
-    - name: Turn coverage into xml
-      env:
-        COLOR: 'yes'
-        PIP_USER: 1
-      run: |
-        python -m coverage xml
     - name: Upload coverage
       uses: codecov/codecov-action@v7
       with:
@@ -474,14 +468,9 @@ jobs:
         PIP_USER: 1
       run: >-
         PATH="${HOME}/Library/Python/3.11/bin:${HOME}/.local/bin:${PATH}"
-        pytest --junitxml=junit.xml --cov --timeout=0 -m autobahn
+        pytest --junitxml=junit.xml --cov --cov-report=xml
+        --timeout=0 -m autobahn
       shell: bash
-    - name: Turn coverage into xml
-      env:
-        COLOR: 'yes'
-        PIP_USER: 1
-      run: |
-        python -m coverage xml
     - name: Upload coverage
       uses: codecov/codecov-action@v7
       with:
@@ -596,12 +585,10 @@ jobs:
         PIP_USER: 1
       run: >-
         pytest tests/test_client_functional.py tests/test_http_parser.py tests/test_http_writer.py tests/test_web_functional.py tests/test_web_response.py tests/test_websocket_parser.py
-        --cov-config=.coveragerc-cython.toml --cov --numprocesses=auto
+        --cov-config=.coveragerc-cython.toml --cov --cov-report=xml
+        --numprocesses=auto
         -m 'not dev_mode and not autobahn'
       shell: bash
-    - name: Turn coverage into xml
-      run: |
-        python -m coverage xml --rcfile=.coveragerc-cython.toml
     - name: Upload coverage
       uses: codecov/codecov-action@v7
       with:

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -585,14 +585,15 @@ jobs:
         PIP_USER: 1
       run: >-
         pytest tests/test_client_functional.py tests/test_http_parser.py tests/test_http_writer.py tests/test_web_functional.py tests/test_web_response.py tests/test_websocket_parser.py
-        --cov-config=.coveragerc-cython.toml --cov --cov-report=xml
+        --cov-config=.coveragerc-cython.toml --cov
+        --cov-report=xml:cython-coverage.xml
         --numprocesses=auto
         -m 'not dev_mode and not autobahn'
       shell: bash
     - name: Upload coverage
       uses: codecov/codecov-action@v7
       with:
-        files: ./coverage.xml
+        files: ./cython-coverage.xml
         disable_search: true
         flags: cython-coverage
         token: ${{ secrets.CODECOV_TOKEN }}

--- a/CHANGES/13422.contrib.rst
+++ b/CHANGES/13422.contrib.rst
@@ -1,0 +1,17 @@
+Synchronized the ``coverage.py`` configuration (:file:`.coveragerc.toml` and
+:file:`.coveragerc-cython.toml`) with the pattern already established in
+:external+yarl:doc:`yarl <index>`, :external+multidict:doc:`multidict
+<index>`, ``frozenlist`` and other sibling projects
+-- by :user:`webknjaz`.
+
+Both files now anchor package discovery through ``source_pkgs`` instead of
+relying on a same-named directory happening to exist relative to the
+working directory, and add a ``[paths]`` mapping so coverage recorded
+against an installed copy of ``aiohttp`` still combines correctly with
+coverage recorded from the Git checkout. CI now lets ``pytest-cov`` write
+``coverage.xml`` directly via ``--cov-report=xml`` instead of a separate
+``coverage xml`` step, and the Autobahn testsuite's subprocess-based
+coverage collection (which uses ``coverage run --append``, incompatible
+with parallel mode) now opts out per-invocation via a
+``COVERAGE_PARALLEL_MODE`` environment variable instead of trying to
+override it on the command line.

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,11 +34,6 @@ combine_as_imports=True
 known_third_party=jinja2,pytest,multidict,yarl,gunicorn,freezegun
 known_first_party=aiohttp,aiohttp_jinja2,aiopg
 
-[report]
-exclude_lines =
-    @abc.abstractmethod
-    @abstractmethod
-
 [tool:pytest]
 addopts =
     # show 10 slowest invocations:

--- a/tests/autobahn/test_autobahn.py
+++ b/tests/autobahn/test_autobahn.py
@@ -103,7 +103,17 @@ def test_client(report_dir: Path, request: pytest.FixtureRequest) -> None:
     )
     try:
         wait_for_port(9001)
-        subprocess.run(("coverage", "run", "-a", "tests/autobahn/client/client.py"))
+        subprocess.run(
+            (
+                "coverage",
+                "run",
+                "--append",
+                "tests/autobahn/client/client.py",
+            ),
+            env={
+                "COVERAGE_PARALLEL_MODE": "false",
+            },
+        )
     finally:
         autobahn_container.stop()
 
@@ -141,7 +151,15 @@ def test_client(report_dir: Path, request: pytest.FixtureRequest) -> None:
 @pytest.mark.autobahn
 def test_server(report_dir: Path, request: pytest.FixtureRequest) -> None:
     server = subprocess.Popen(
-        ("coverage", "run", "-a", "tests/autobahn/server/server.py")
+        (
+            "coverage",
+            "run",
+            "--append",
+            "tests/autobahn/server/server.py",
+        ),
+        env={
+            "COVERAGE_PARALLEL_MODE": "false",
+        },
     )
     try:
         wait_for_port(9001)

--- a/tests/autobahn/test_autobahn.py
+++ b/tests/autobahn/test_autobahn.py
@@ -1,7 +1,9 @@
 import json
+import os
 import pprint
 import socket
 import subprocess
+import sys
 import time
 from collections.abc import Iterator
 from pathlib import Path
@@ -105,6 +107,8 @@ def test_client(report_dir: Path, request: pytest.FixtureRequest) -> None:
         wait_for_port(9001)
         subprocess.run(
             (
+                sys.executable,
+                "-m",
                 "coverage",
                 "run",
                 "--append",
@@ -112,6 +116,7 @@ def test_client(report_dir: Path, request: pytest.FixtureRequest) -> None:
             ),
             env={
                 "COVERAGE_PARALLEL_MODE": "false",
+                **os.environ.copy(),
             },
         )
     finally:
@@ -152,6 +157,8 @@ def test_client(report_dir: Path, request: pytest.FixtureRequest) -> None:
 def test_server(report_dir: Path, request: pytest.FixtureRequest) -> None:
     server = subprocess.Popen(
         (
+            sys.executable,
+            "-m",
             "coverage",
             "run",
             "--append",
@@ -159,6 +166,7 @@ def test_server(report_dir: Path, request: pytest.FixtureRequest) -> None:
         ),
         env={
             "COVERAGE_PARALLEL_MODE": "false",
+            **os.environ.copy(),
         },
     )
     try:


### PR DESCRIPTION
## What do these changes do?

Specifically, this change configures the top-level project dir as the global source, put the Python package into `source_pkgs` by name, and set up the path mapping across the Git checkout and installed site-packages location. This is a follow-up to #13388 that revealed a slight misconfiguration in coveragepy's ability to properly collect coverage from the installed project copy.

## Are there changes in behavior for the user?

Nope.

## Is it a substantial burden for the maintainers to support this?

No.

## Related issue number

#13388. Sorta.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES/` folder
  * name it `<issue_or_pr_num>.<type>.rst` (e.g. `588.bugfix.rst`)
  * if you don't have an issue number, change it to the pull request
    number after creating the PR
    * `.bugfix`: A bug fix for something the maintainers deemed an
      improper undesired behavior that got corrected to match
      pre-agreed expectations.
    * `.feature`: A new behavior, public APIs. That sort of stuff.
    * `.deprecation`: A declaration of future API removals and breaking
      changes in behavior.
    * `.breaking`: When something public is removed in a breaking way.
      Could be deprecated in an earlier release.
    * `.doc`: Notable updates to the documentation structure or build
      process.
    * `.packaging`: Notes for downstreams about unobvious side effects
      and tooling. Changes in the test invocation considerations and
      runtime assumptions.
    * `.contrib`: Stuff that affects the contributor experience. e.g.
      Running tests, building the docs, setting up the development
      environment.
    * `.misc`: Changes that are hard to assign to any of the above
      categories.
  * Make sure to use full sentences with correct case and punctuation,
    for example:
    ```rst
    Fixed issue with non-ascii contents in doctest text files
    -- by :user:`contributor-gh-handle`.
    ```

    Use the past tense or the present tense a non-imperative mood,
    referring to what's changed compared to the last released version
    of this project.
