### PR TITLE
Replace broken upload attributes with new ones

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -472,8 +472,7 @@ Features
 
 
 
-- Added :attr:`~aiohttp.ClientResponse.output_size` and
-  :attr:`~aiohttp.ClientResponse.upload_complete` -- by :user:`Dreamsorcerer`.
+- Added ``ClientResponse.output_size`` and ``ClientResponse.upload_complete`` -- by :user:`Dreamsorcerer`.
 
 
   *Related issues and pull requests on GitHub:*

--- a/CHANGES/13427.deprecation.rst
+++ b/CHANGES/13427.deprecation.rst
@@ -1,0 +1,4 @@
+Deprecated ``ClientResponse.output_size`` and ``ClientResponse.upload_complete``;
+use :attr:`Payload.bytes_written <aiohttp.Payload.bytes_written>` and
+:attr:`Payload.upload_complete <aiohttp.Payload.upload_complete>` instead
+-- by :user:`Dreamsorcerer`.

--- a/CHANGES/13427.deprecation.rst
+++ b/CHANGES/13427.deprecation.rst
@@ -1,4 +1,3 @@
 Deprecated ``ClientResponse.output_size`` and ``ClientResponse.upload_complete``;
-use :attr:`Payload.bytes_written <aiohttp.Payload.bytes_written>` and
-:attr:`Payload.upload_complete <aiohttp.Payload.upload_complete>` instead
+use ``Payload.bytes_written`` and ``Payload.upload_complete`` instead
 -- by :user:`Dreamsorcerer`.

--- a/CHANGES/13427.feature.rst
+++ b/CHANGES/13427.feature.rst
@@ -1,4 +1,3 @@
-Added :attr:`Payload.bytes_written <aiohttp.Payload.bytes_written>` and
-:attr:`Payload.upload_complete <aiohttp.Payload.upload_complete>` for tracking
+Added ``Payload.bytes_written`` and ``Payload.upload_complete`` for tracking
 upload progress of a request body
 -- by :user:`Dreamsorcerer`.

--- a/CHANGES/13427.feature.rst
+++ b/CHANGES/13427.feature.rst
@@ -1,0 +1,4 @@
+Added :attr:`Payload.bytes_written <aiohttp.Payload.bytes_written>` and
+:attr:`Payload.upload_complete <aiohttp.Payload.upload_complete>` for tracking
+upload progress of a request body
+-- by :user:`Dreamsorcerer`.

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -528,83 +528,92 @@ class ClientSession:
             # the request are reported through upload_complete as well.
             data._reset_upload()
 
-        redirects = 0
-        history: list[ClientResponse] = []
-        version = self._version
-        params = params or {}
-
-        # Merge with default headers and transform to CIMultiDict
-        headers = self._prepare_headers(headers)
-
         try:
-            url = self._build_url(str_or_url)
-        except ValueError as e:
-            raise InvalidUrlClientError(str_or_url) from e
+            redirects = 0
+            history: list[ClientResponse] = []
+            version = self._version
+            params = params or {}
 
-        assert self._connector is not None
-        if url.scheme not in self._connector.allowed_protocol_schema_set:
-            raise NonHttpUrlClientError(url)
+            # Merge with default headers and transform to CIMultiDict
+            headers = self._prepare_headers(headers)
 
-        skip_headers: Iterable[istr] | None
-        if skip_auto_headers is not None:
-            skip_headers = {
-                istr(i) for i in skip_auto_headers
-            } | self._skip_auto_headers
-        elif self._skip_auto_headers:
-            skip_headers = self._skip_auto_headers
-        else:
-            skip_headers = None
-
-        if proxy is None:
-            proxy = self._default_proxy
-
-        resolved_proxy_headers: CIMultiDict[str] | None
-        if proxy is None:
-            resolved_proxy_headers = None
-        else:
-            resolved_proxy_headers = self._prepare_headers(proxy_headers)
             try:
-                proxy = URL(proxy)
+                url = self._build_url(str_or_url)
             except ValueError as e:
-                raise InvalidURL(proxy) from e
+                raise InvalidUrlClientError(str_or_url) from e
 
-        if timeout is sentinel or timeout is None:
-            real_timeout: ClientTimeout = self._timeout
-        else:
-            real_timeout = timeout
-        # timeout is cumulative for all request operations
-        # (request, redirects, responses, data consuming)
-        tm = TimeoutHandle(
-            self._loop, real_timeout.total, ceil_threshold=real_timeout.ceil_threshold
-        )
-        handle = tm.start()
+            assert self._connector is not None
+            if url.scheme not in self._connector.allowed_protocol_schema_set:
+                raise NonHttpUrlClientError(url)
 
-        if read_bufsize is None:
-            read_bufsize = self._read_bufsize
+            skip_headers: Iterable[istr] | None
+            if skip_auto_headers is not None:
+                skip_headers = {
+                    istr(i) for i in skip_auto_headers
+                } | self._skip_auto_headers
+            elif self._skip_auto_headers:
+                skip_headers = self._skip_auto_headers
+            else:
+                skip_headers = None
 
-        if auto_decompress is None:
-            auto_decompress = self._auto_decompress
+            if proxy is None:
+                proxy = self._default_proxy
 
-        if max_line_size is None:
-            max_line_size = self._max_line_size
+            resolved_proxy_headers: CIMultiDict[str] | None
+            if proxy is None:
+                resolved_proxy_headers = None
+            else:
+                resolved_proxy_headers = self._prepare_headers(proxy_headers)
+                try:
+                    proxy = URL(proxy)
+                except ValueError as e:
+                    raise InvalidURL(proxy) from e
 
-        if max_field_size is None:
-            max_field_size = self._max_field_size
-
-        if max_headers is None:
-            max_headers = self._max_headers
-
-        traces = [
-            Trace(
-                self,
-                trace_config,
-                trace_config.trace_config_ctx(trace_request_ctx=trace_request_ctx),
+            if timeout is sentinel or timeout is None:
+                real_timeout: ClientTimeout = self._timeout
+            else:
+                real_timeout = timeout
+            # timeout is cumulative for all request operations
+            # (request, redirects, responses, data consuming)
+            tm = TimeoutHandle(
+                self._loop,
+                real_timeout.total,
+                ceil_threshold=real_timeout.ceil_threshold,
             )
-            for trace_config in self._trace_configs
-        ]
+            handle = tm.start()
 
-        for trace in traces:
-            await trace.send_request_start(method, url.update_query(params), headers)
+            if read_bufsize is None:
+                read_bufsize = self._read_bufsize
+
+            if auto_decompress is None:
+                auto_decompress = self._auto_decompress
+
+            if max_line_size is None:
+                max_line_size = self._max_line_size
+
+            if max_field_size is None:
+                max_field_size = self._max_field_size
+
+            if max_headers is None:
+                max_headers = self._max_headers
+
+            traces = [
+                Trace(
+                    self,
+                    trace_config,
+                    trace_config.trace_config_ctx(trace_request_ctx=trace_request_ctx),
+                )
+                for trace_config in self._trace_configs
+            ]
+
+            for trace in traces:
+                await trace.send_request_start(
+                    method, url.update_query(params), headers
+                )
+        except BaseException as e:
+            if isinstance(data, payload.Payload):
+                data._abort_upload(e)
+            raise
 
         timer = tm.timer()
         req: ClientRequest | None = None

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -882,6 +882,13 @@ class ClientSession:
 
             if req._body is not None:
                 await req._body.close()
+                # Abort upload if a middleware returns a response without sending
+                # the request (e.g. a cache hit).
+                if (
+                    req._body is not ClientRequest._EMPTY_BODY
+                    and not req._body._upload_active
+                ):
+                    req._body._abort_upload()
             # check response status
             if raise_for_status is None:
                 raise_for_status = self._raise_for_status

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -522,6 +522,12 @@ class ClientSession:
             else:
                 data = payload.JsonPayload(json, dumps=self._json_serialize)
 
+        if isinstance(data, payload.Payload):
+            # Reused payloads carry a previous attempt's upload state; drop
+            # it before this attempt so failures raised prior to building
+            # the request are reported through upload_complete as well.
+            data._reset_upload()
+
         redirects = 0
         history: list[ClientResponse] = []
         version = self._version

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -611,8 +611,10 @@ class ClientSession:
                     method, url.update_query(params), headers
                 )
         except BaseException as e:
-            if isinstance(data, payload.Payload) and not data._upload_active:
-                data._abort_upload(e)
+            if isinstance(data, payload.Payload):
+                if not data._upload_active:
+                    data._abort_upload(e)
+                data._mark_upload_error_propagated()
             raise
 
         timer = tm.timer()
@@ -915,8 +917,10 @@ class ClientSession:
                 body = None if req._body is req._EMPTY_BODY else req._body
             else:
                 body = data if isinstance(data, payload.Payload) else None
-            if body is not None and not body._upload_active:
-                body._abort_upload(e)
+            if body is not None:
+                if not body._upload_active:
+                    body._abort_upload(e)
+                body._mark_upload_error_propagated()
 
             for trace in traces:
                 await trace.send_request_exception(

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -901,7 +901,7 @@ class ClientSession:
             else:
                 body = data if isinstance(data, payload.Payload) else None
             if body is not None and not body._upload_active:
-                body._abort_upload()
+                body._abort_upload(e)
 
             for trace in traces:
                 await trace.send_request_exception(

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -528,6 +528,18 @@ class ClientSession:
             # the request are reported through upload_complete as well.
             data._reset_upload()
 
+        real_timeout = (
+            self._timeout if timeout is sentinel or timeout is None else timeout
+        )
+        # timeout is cumulative for all request operations
+        # (request, redirects, responses, data consuming)
+        tm = TimeoutHandle(
+            self._loop,
+            real_timeout.total,
+            ceil_threshold=real_timeout.ceil_threshold,
+        )
+        handle: asyncio.TimerHandle | None = None
+
         try:
             redirects = 0
             history: list[ClientResponse] = []
@@ -569,17 +581,6 @@ class ClientSession:
                 except ValueError as e:
                     raise InvalidURL(proxy) from e
 
-            if timeout is sentinel or timeout is None:
-                real_timeout: ClientTimeout = self._timeout
-            else:
-                real_timeout = timeout
-            # timeout is cumulative for all request operations
-            # (request, redirects, responses, data consuming)
-            tm = TimeoutHandle(
-                self._loop,
-                real_timeout.total,
-                ceil_threshold=real_timeout.ceil_threshold,
-            )
             handle = tm.start()
 
             if read_bufsize is None:
@@ -611,6 +612,10 @@ class ClientSession:
                     method, url.update_query(params), headers
                 )
         except BaseException as e:
+            tm.close()
+            if handle is not None:
+                handle.cancel()
+                handle = None
             if isinstance(data, payload.Payload):
                 if not data._upload_active:
                     data._abort_upload(e)

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -616,9 +616,8 @@ class ClientSession:
             if handle is not None:
                 handle.cancel()
                 handle = None
-            if isinstance(data, payload.Payload):
-                if not data._upload_active:
-                    data._abort_upload(e)
+            if isinstance(data, payload.Payload) and not data._upload_active:
+                data._abort_upload(e)
                 data._mark_upload_error_propagated()
             raise
 
@@ -919,12 +918,12 @@ class ClientSession:
 
             # Ensure we abort when the write never started.
             if req is not None:
-                body = None if req._body is req._EMPTY_BODY else req._body
+                # Use class (not instance) attribute to protect against test autospecs.
+                body = None if req._body is ClientRequest._EMPTY_BODY else req._body
             else:
                 body = data if isinstance(data, payload.Payload) else None
-            if body is not None:
-                if not body._upload_active:
-                    body._abort_upload(e)
+            if body is not None and not body._upload_active:
+                body._abort_upload(e)
                 body._mark_upload_error_propagated()
 
             for trace in traces:

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -618,7 +618,7 @@ class ClientSession:
                 handle = None
             if isinstance(data, payload.Payload) and not data._upload_active:
                 data._abort_upload(e)
-                data._mark_upload_error_propagated()
+                data._mark_upload_error_propagated(e)
             raise
 
         timer = tm.timer()
@@ -931,7 +931,7 @@ class ClientSession:
                 body = data if isinstance(data, payload.Payload) else None
             if body is not None and not body._upload_active:
                 body._abort_upload(e)
-                body._mark_upload_error_propagated()
+                body._mark_upload_error_propagated(e)
 
             for trace in traces:
                 await trace.send_request_exception(

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -895,6 +895,14 @@ class ClientSession:
             if req is not None and req._body is not None:
                 await req._body.close()
 
+            # Ensure we abort when the write never started.
+            if req is not None:
+                body = None if req._body is req._EMPTY_BODY else req._body
+            else:
+                body = data if isinstance(data, payload.Payload) else None
+            if body is not None and not body._upload_active:
+                body._abort_upload()
+
             for trace in traces:
                 await trace.send_request_exception(
                     method, url.update_query(params), headers, e

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -876,6 +876,9 @@ class ClientSession:
                         url = parsed_redirect_url
                         params = {}
                         resp.release()
+                        # Wait for the previous hop's writer to finish to ensure
+                        # payload upload tracking is complete before we start again.
+                        await req._close()
                         continue
 
                     break

--- a/aiohttp/client.py
+++ b/aiohttp/client.py
@@ -611,7 +611,7 @@ class ClientSession:
                     method, url.update_query(params), headers
                 )
         except BaseException as e:
-            if isinstance(data, payload.Payload):
+            if isinstance(data, payload.Payload) and not data._upload_active:
                 data._abort_upload(e)
             raise
 

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -1562,11 +1562,16 @@ class ClientRequest(ClientRequestBase):
                 if track_progress:
                     body._finish_upload()
                 protocol.start_timeout()
+        except BaseException as underlying_exc:
+            # Failures escaping the inner handlers (100-continue preamble,
+            # write_eof) must still complete upload_complete with the error;
+            # _abort_upload treats CancelledError as cancellation.
+            abort_exc = underlying_exc
+            raise
         finally:
             if track_progress:
-                # No-op when the upload finished; reports the write error
-                # otherwise, or cancels upload_complete when there is none
-                # (cancellation or a failure that bypassed the handlers).
+                # No-op when the upload finished; reports the failure or,
+                # on cancellation, cancels upload_complete.
                 body._abort_upload(abort_exc)
 
     async def _close(self) -> None:

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -1518,6 +1518,7 @@ class ClientRequest(ClientRequestBase):
         track_progress = body is not self._EMPTY_BODY and body._start_upload()
         if track_progress:
             writer = payload._ProgressWriter(writer, body)
+        abort_exc: BaseException | None = None
         try:
             # 100 response
             if self._continue is not None:
@@ -1544,20 +1545,17 @@ class ClientRequest(ClientRequestBase):
                     )
 
                 set_exception(protocol, reraised_exc, underlying_exc)
-                if track_progress:
-                    body._abort_upload(reraised_exc)
+                abort_exc = reraised_exc
             except asyncio.CancelledError:
                 # Body hasn't been fully sent, so connection can't be reused
                 conn.close()
                 raise
             except Exception as underlying_exc:
-                conn_exc = ClientConnectionError(
+                abort_exc = ClientConnectionError(
                     "Failed to send bytes into the underlying connection "
                     f"{conn !s}: {underlying_exc!r}",
                 )
-                set_exception(protocol, conn_exc, underlying_exc)
-                if track_progress:
-                    body._abort_upload(conn_exc)
+                set_exception(protocol, abort_exc, underlying_exc)
             else:
                 # Successfully wrote the body, signal EOF and start response timeout
                 await writer.write_eof()
@@ -1566,9 +1564,10 @@ class ClientRequest(ClientRequestBase):
                 protocol.start_timeout()
         finally:
             if track_progress:
-                # No-op when already finished or failed; cancels
-                # upload_complete on cancellation and any bypassed failure.
-                body._abort_upload()
+                # No-op when the upload finished; reports the write error
+                # otherwise, or cancels upload_complete when there is none
+                # (cancellation or a failure that bypassed the handlers).
+                body._abort_upload(abort_exc)
 
     async def _close(self) -> None:
         if self._writer_task is not None:

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -1470,7 +1470,8 @@ class ClientRequest(ClientRequestBase):
         )
 
     def _mark_body_sent(self) -> None:
-        if (body := self._body) is not self._EMPTY_BODY:
+        body = self._body
+        if body is not self._EMPTY_BODY and body._start_upload():
             body._finish_upload()
 
     async def _write_bytes(

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -1540,19 +1540,20 @@ class ClientRequest(ClientRequestBase):
                     )
 
                 set_exception(protocol, reraised_exc, underlying_exc)
+                if track_progress:
+                    body._abort_upload(reraised_exc)
             except asyncio.CancelledError:
                 # Body hasn't been fully sent, so connection can't be reused
                 conn.close()
                 raise
             except Exception as underlying_exc:
-                set_exception(
-                    protocol,
-                    ClientConnectionError(
-                        "Failed to send bytes into the underlying connection "
-                        f"{conn !s}: {underlying_exc!r}",
-                    ),
-                    underlying_exc,
+                conn_exc = ClientConnectionError(
+                    "Failed to send bytes into the underlying connection "
+                    f"{conn !s}: {underlying_exc!r}",
                 )
+                set_exception(protocol, conn_exc, underlying_exc)
+                if track_progress:
+                    body._abort_upload(conn_exc)
             else:
                 # Successfully wrote the body, signal EOF and start response timeout
                 await writer.write_eof()
@@ -1561,7 +1562,8 @@ class ClientRequest(ClientRequestBase):
                 protocol.start_timeout()
         finally:
             if track_progress:
-                # No-op when the upload finished; cancels upload_complete otherwise.
+                # No-op when already finished or failed; cancels
+                # upload_complete on cancellation and any bypassed failure.
                 body._abort_upload()
 
     async def _close(self) -> None:

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -361,7 +361,17 @@ class ClientResponse(HeadersMixin):
 
     @property
     def output_size(self) -> int:
-        """Number of bytes sent for this request."""
+        """Number of bytes sent for this request.
+
+        .. deprecated:: 3.14.4
+           Use :attr:`Payload.bytes_written` instead.
+        """
+        warnings.warn(
+            "ClientResponse.output_size is deprecated, "
+            "use Payload.bytes_written instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         if self._stream_writer is not None:
             return self._stream_writer.output_size
         return self._output_size
@@ -370,8 +380,15 @@ class ClientResponse(HeadersMixin):
     def upload_complete(self) -> "asyncio.Future[None]":
         """Future set when the request body has been fully sent.
 
-        Already done when the request had no body or was written eagerly.
+        .. deprecated:: 3.14.4
+           Use :attr:`Payload.upload_complete` instead.
         """
+        warnings.warn(
+            "ClientResponse.upload_complete is deprecated, "
+            "use Payload.upload_complete instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         if self._upload_complete is None:
             self._upload_complete = self._loop.create_future()
             if self._stream_writer is None:  # upload already finished
@@ -1001,6 +1018,7 @@ class ClientRequestBase:
             protocol.start_timeout()
             writer.set_eof()
             task = None
+            self._mark_body_sent()
         self._response = self._create_response(task, stream_writer=writer)
         return self._response
 
@@ -1012,6 +1030,10 @@ class ClientRequestBase:
     ) -> None:
         # Base class never has a body, this will never be run.
         assert False
+
+    def _mark_body_sent(self) -> None:
+        """Hook invoked when the request is sent without a body to write."""
+        # Base class requests (CONNECT) never carry a body payload.
 
 
 class ClientRequestArgs(TypedDict, total=False):
@@ -1447,6 +1469,10 @@ class ClientRequest(ClientRequestBase):
             self.body.size != 0 or self._continue is not None or protocol.writing_paused
         )
 
+    def _mark_body_sent(self) -> None:
+        if (body := self._body) is not self._EMPTY_BODY:
+            body._finish_upload()
+
     async def _write_bytes(
         self,
         writer: AbstractStreamWriter,
@@ -1472,6 +1498,8 @@ class ClientRequest(ClientRequestBase):
         - Content length constraints for chunked encoding
         - Error handling for network issues, cancellation, and other exceptions
         - Signaling EOF and timeout management
+        - Upload progress bookkeeping on the payload
+          (:attr:`Payload.bytes_written` / :attr:`Payload.upload_complete`)
 
         Raises:
             ClientOSError: When there's an OS-level error writing the body
@@ -1479,48 +1507,59 @@ class ClientRequest(ClientRequestBase):
             asyncio.CancelledError: When the operation is cancelled
 
         """
-        # 100 response
-        if self._continue is not None:
-            # Force headers to be sent before waiting for 100-continue
-            writer.send_headers()
-            await writer.drain()
-            await self._continue
-
-        protocol = conn.protocol
-        assert protocol is not None
+        body = self._body
+        track_progress = body is not self._EMPTY_BODY
+        if track_progress:
+            body._start_upload()
+            writer = payload._ProgressWriter(writer, body)
         try:
-            await self._body.write_with_length(writer, content_length)
-        except OSError as underlying_exc:
-            reraised_exc = underlying_exc
+            # 100 response
+            if self._continue is not None:
+                # Force headers to be sent before waiting for 100-continue
+                writer.send_headers()
+                await writer.drain()
+                await self._continue
 
-            # Distinguish between timeout and other OS errors for better error reporting
-            exc_is_not_timeout = underlying_exc.errno is not None or not isinstance(
-                underlying_exc, asyncio.TimeoutError
-            )
-            if exc_is_not_timeout:
-                reraised_exc = ClientOSError(
-                    underlying_exc.errno,
-                    f"Can not write request body for {self.url !s}",
+            protocol = conn.protocol
+            assert protocol is not None
+            try:
+                await body.write_with_length(writer, content_length)
+            except OSError as underlying_exc:
+                reraised_exc = underlying_exc
+
+                # Distinguish between timeout and other OS errors for better error reporting
+                exc_is_not_timeout = underlying_exc.errno is not None or not isinstance(
+                    underlying_exc, asyncio.TimeoutError
                 )
+                if exc_is_not_timeout:
+                    reraised_exc = ClientOSError(
+                        underlying_exc.errno,
+                        f"Can not write request body for {self.url !s}",
+                    )
 
-            set_exception(protocol, reraised_exc, underlying_exc)
-        except asyncio.CancelledError:
-            # Body hasn't been fully sent, so connection can't be reused
-            conn.close()
-            raise
-        except Exception as underlying_exc:
-            set_exception(
-                protocol,
-                ClientConnectionError(
-                    "Failed to send bytes into the underlying connection "
-                    f"{conn !s}: {underlying_exc!r}",
-                ),
-                underlying_exc,
-            )
-        else:
-            # Successfully wrote the body, signal EOF and start response timeout
-            await writer.write_eof()
-            protocol.start_timeout()
+                set_exception(protocol, reraised_exc, underlying_exc)
+            except asyncio.CancelledError:
+                # Body hasn't been fully sent, so connection can't be reused
+                conn.close()
+                raise
+            except Exception as underlying_exc:
+                set_exception(
+                    protocol,
+                    ClientConnectionError(
+                        "Failed to send bytes into the underlying connection "
+                        f"{conn !s}: {underlying_exc!r}",
+                    ),
+                    underlying_exc,
+                )
+            else:
+                # Successfully wrote the body, signal EOF and start response timeout
+                await writer.write_eof()
+                body._finish_upload()
+                protocol.start_timeout()
+        finally:
+            if track_progress:
+                # No-op when the upload finished; cancels upload_complete otherwise.
+                body._abort_upload()
 
     async def _close(self) -> None:
         if self._writer_task is not None:

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -1508,9 +1508,10 @@ class ClientRequest(ClientRequestBase):
 
         """
         body = self._body
-        track_progress = body is not self._EMPTY_BODY
+        # Progress tracking is exclusive per payload; when overlapping
+        # requests share one instance, later uploads run untracked.
+        track_progress = body is not self._EMPTY_BODY and body._start_upload()
         if track_progress:
-            body._start_upload()
             writer = payload._ProgressWriter(writer, body)
         try:
             # 100 response
@@ -1554,7 +1555,8 @@ class ClientRequest(ClientRequestBase):
             else:
                 # Successfully wrote the body, signal EOF and start response timeout
                 await writer.write_eof()
-                body._finish_upload()
+                if track_progress:
+                    body._finish_upload()
                 protocol.start_timeout()
         finally:
             if track_progress:

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -1553,10 +1553,6 @@ class ClientRequest(ClientRequestBase):
 
                 set_exception(protocol, reraised_exc, underlying_exc)
                 abort_exc = reraised_exc
-            except asyncio.CancelledError:
-                # Body hasn't been fully sent, so connection can't be reused
-                conn.close()
-                raise
             except Exception as underlying_exc:
                 abort_exc = ClientConnectionError(
                     "Failed to send bytes into the underlying connection "
@@ -1569,10 +1565,13 @@ class ClientRequest(ClientRequestBase):
                 if track_progress:
                     body._finish_upload()
                 protocol.start_timeout()
+        except asyncio.CancelledError:
+            # Body hasn't been fully sent, so the connection can't be reused.
+            conn.close()
+            raise
         except BaseException as underlying_exc:
             # Failures escaping the inner handlers (100-continue preamble,
-            # write_eof) must still complete upload_complete with the error;
-            # _abort_upload treats CancelledError as cancellation.
+            # write_eof) must still complete upload_complete with the error.
             abort_exc = underlying_exc
             raise
         finally:

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -1288,6 +1288,10 @@ class ClientRequest(ClientRequestBase):
                 body = FormData(body, boundary=boundary)()
 
         self._body = body
+        # A payload may be reused from an earlier request (redirects,
+        # retries, or explicit reuse): drop that attempt's upload state so
+        # a failure of this request cannot be masked by a stale outcome.
+        body._reset_upload()
 
         # enable chunked encoding if needed
         if not self.chunked and hdrs.CONTENT_LENGTH not in self.headers:

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -1386,6 +1386,13 @@ class ClientRequest(ClientRequestBase):
         # Close existing payload if it exists and needs closing
         if self._body is not None:
             await self._body.close()
+            # Abort upload progress on the original body.
+            if (
+                self._body is not body
+                and self._body is not self._EMPTY_BODY
+                and not self._body._upload_active
+            ):
+                self._body._abort_upload()
         self._update_body(body)
 
     def _update_expect_continue(self, expect: bool = False) -> None:

--- a/aiohttp/payload.py
+++ b/aiohttp/payload.py
@@ -292,8 +292,16 @@ class Payload(ABC):
                 # the future is the only holder and the log must stay armed.
                 fut.exception()
 
-    def _mark_upload_error_propagated(self) -> None:
-        """Record that the request raised the upload failure to its caller."""
+    def _mark_upload_error_propagated(self, exc: BaseException) -> None:
+        """Record that the caller received the stored upload failure.
+
+        Only when the exception the request raised is the stored one is
+        the future's copy a duplicate; a different error (e.g. a preamble
+        failure superseded by a timeout) must keep the never-retrieved
+        log armed, or the stored error would vanish entirely.
+        """
+        if exc is not self._upload_abort_exc:
+            return
         self._upload_error_propagated = True
         fut = self._upload_future
         if fut is not None and fut.done() and not fut.cancelled():

--- a/aiohttp/payload.py
+++ b/aiohttp/payload.py
@@ -151,6 +151,7 @@ class Payload(ABC):
     _upload_active: bool = False
     _upload_finished: bool = False
     _upload_aborted: bool = False
+    _upload_abort_exc: "BaseException | None" = None
 
     def __init__(
         self,
@@ -257,21 +258,31 @@ class Payload(ABC):
         """Future resolved when a request finishes uploading this payload.
 
         The future completes with ``None`` once the request body has been
-        fully written, or is cancelled if the upload is interrupted (e.g.
-        connection error or request cancellation). If the payload is sent
-        again (e.g. a redirected request resends the body), a new future
-        is returned for the new upload. When overlapping requests share a
-        payload, the future tracks the first upload only.
+        fully written. If the upload fails, it completes with the same
+        error the request raises; if the request is cancelled, the future
+        is cancelled. If the payload is sent again (e.g. a redirected
+        request resends the body), a new future is returned for the new
+        upload. When overlapping requests share a payload, the future
+        tracks the first upload only.
 
         Must be accessed from within the event loop.
         """
         if self._upload_future is None:
             self._upload_future = asyncio.get_running_loop().create_future()
             if self._upload_aborted:
-                self._upload_future.cancel()
+                self._resolve_aborted(self._upload_future)
             elif self._upload_finished:
                 self._upload_future.set_result(None)
         return self._upload_future
+
+    def _resolve_aborted(self, fut: "asyncio.Future[None]") -> None:
+        if self._upload_abort_exc is None:
+            fut.cancel()
+        else:
+            fut.set_exception(self._upload_abort_exc)
+            # Consume the exception: the request raises it as well, so an
+            # unawaited future must not log it at garbage collection.
+            fut.exception()
 
     def _start_upload(self) -> bool:
         """Try to begin tracking a new upload of this payload.
@@ -285,6 +296,7 @@ class Payload(ABC):
         self._bytes_written = 0
         self._upload_finished = False
         self._upload_aborted = False
+        self._upload_abort_exc = None
         fut = self._upload_future
         if fut is not None and fut.done():
             # A previous upload of this payload already completed (e.g. the
@@ -301,15 +313,21 @@ class Payload(ABC):
         if fut is not None and not fut.done():
             fut.set_result(None)
 
-    def _abort_upload(self) -> None:
-        """Mark an unfinished upload as aborted, cancelling upload_complete."""
-        if self._upload_finished:
+    def _abort_upload(self, exc: BaseException | None = None) -> None:
+        """Mark an unfinished upload as failed or cancelled.
+
+        With an exception, upload_complete reports the upload error;
+        without one (or on cancellation), the future is cancelled.
+        """
+        if self._upload_finished or self._upload_aborted:
             return
         self._upload_active = False
         self._upload_aborted = True
+        if exc is not None and not isinstance(exc, asyncio.CancelledError):
+            self._upload_abort_exc = exc
         fut = self._upload_future
         if fut is not None and not fut.done():
-            fut.cancel()
+            self._resolve_aborted(fut)
 
     def set_content_disposition(
         self,

--- a/aiohttp/payload.py
+++ b/aiohttp/payload.py
@@ -142,6 +142,11 @@ class Payload(ABC):
     _size: int | None = None
     _consumed: bool = False  # Default: payload has not been consumed yet
     _autoclose: bool = False  # Default: assume resource needs explicit closing
+    # Upload progress bookkeeping (client requests); see bytes_written.
+    _bytes_written: int = 0
+    _upload_future: "asyncio.Future[None] | None" = None
+    _upload_finished: bool = False
+    _upload_aborted: bool = False
 
     def __init__(
         self,
@@ -229,6 +234,65 @@ class Payload(ABC):
         explicit closing. If False, callers must await close() to release resources.
         """
         return self._autoclose
+
+    @property
+    def bytes_written(self) -> int:
+        """Number of bytes of this payload written to the connection so far.
+
+        Counts the bytes handed to the transport while a client request
+        is uploading this payload, before any transport-level transformation
+        (compression, chunked framing). Reset when a new upload of the same
+        payload starts, e.g. when a redirect causes the body to be resent.
+        """
+        return self._bytes_written
+
+    @property
+    def upload_complete(self) -> "asyncio.Future[None]":
+        """Future resolved when a request finishes uploading this payload.
+
+        The future completes with ``None`` once the request body has been
+        fully written, or is cancelled if the upload is interrupted (e.g.
+        connection error or request cancellation). If the payload is sent
+        again (e.g. a redirected request resends the body), a new future
+        is returned for the new upload.
+
+        Must be accessed from within the event loop.
+        """
+        if self._upload_future is None:
+            self._upload_future = asyncio.get_running_loop().create_future()
+            if self._upload_aborted:
+                self._upload_future.cancel()
+            elif self._upload_finished:
+                self._upload_future.set_result(None)
+        return self._upload_future
+
+    def _start_upload(self) -> None:
+        """Reset upload progress state before the payload is written."""
+        self._bytes_written = 0
+        self._upload_finished = False
+        self._upload_aborted = False
+        fut = self._upload_future
+        if fut is not None and fut.done():
+            # A previous upload of this payload already completed (e.g. the
+            # request is resent after a redirect); track the new upload with
+            # a fresh future created lazily on the next upload_complete access.
+            self._upload_future = None
+
+    def _finish_upload(self) -> None:
+        """Mark the payload as fully written to the connection."""
+        self._upload_finished = True
+        fut = self._upload_future
+        if fut is not None and not fut.done():
+            fut.set_result(None)
+
+    def _abort_upload(self) -> None:
+        """Mark an unfinished upload as aborted, cancelling upload_complete."""
+        if self._upload_finished:
+            return
+        self._upload_aborted = True
+        fut = self._upload_future
+        if fut is not None and not fut.done():
+            fut.cancel()
 
     def set_content_disposition(
         self,
@@ -335,6 +399,79 @@ class Payload(ABC):
         In the future, this will be the only close method supported.
         """
         self._close()
+
+
+class _ProgressWriter(AbstractStreamWriter):
+    """Proxy for AbstractStreamWriter to count written bytes on a Payload.
+
+    Used by the client request machinery so that Payload.bytes_written
+    reflects how much of the payload has been handed to the transport.
+    """
+
+    def __init__(self, writer: AbstractStreamWriter, payload: "Payload") -> None:
+        self._writer = writer
+        self._payload = payload
+
+    def __getattr__(self, name: str) -> Any:
+        # Forward non-interface attributes of the wrapped writer
+        # (e.g. StreamWriter.transport) for duck-typing compatibility.
+        return getattr(self._writer, name)
+
+    @property
+    def buffer_size(self) -> int:
+        return self._writer.buffer_size
+
+    @buffer_size.setter
+    def buffer_size(self, value: int) -> None:
+        self._writer.buffer_size = value
+
+    @property
+    def output_size(self) -> int:
+        return self._writer.output_size
+
+    @output_size.setter
+    def output_size(self, value: int) -> None:
+        self._writer.output_size = value
+
+    @property
+    def length(self) -> int | None:
+        return self._writer.length
+
+    @length.setter
+    def length(self, value: int | None) -> None:
+        self._writer.length = value
+
+    async def write(
+        self, chunk: "bytes | bytearray | memoryview[int] | memoryview[bytes]"
+    ) -> None:
+        await self._writer.write(chunk)
+        self._payload._bytes_written += (
+            chunk.nbytes if isinstance(chunk, memoryview) else len(chunk)
+        )
+
+    async def write_eof(self, chunk: bytes = b"") -> None:
+        await self._writer.write_eof(chunk)
+        if chunk:
+            self._payload._bytes_written += len(chunk)
+
+    async def drain(self) -> None:
+        await self._writer.drain()
+
+    def enable_compression(
+        self, encoding: str = "deflate", strategy: int | None = None
+    ) -> None:
+        self._writer.enable_compression(encoding, strategy)
+
+    def enable_chunking(self) -> None:
+        self._writer.enable_chunking()
+
+    async def write_headers(
+        self, status_line: str, headers: "CIMultiDict[str]"
+    ) -> None:
+        await self._writer.write_headers(status_line, headers)
+
+    def send_headers(self) -> None:
+        self._writer.send_headers()
 
 
 class BytesPayload(Payload):

--- a/aiohttp/payload.py
+++ b/aiohttp/payload.py
@@ -152,6 +152,7 @@ class Payload(ABC):
     _upload_finished: bool = False
     _upload_aborted: bool = False
     _upload_abort_exc: "BaseException | None" = None
+    _upload_error_propagated: bool = False
 
     def __init__(
         self,
@@ -258,11 +259,13 @@ class Payload(ABC):
         """Future resolved when a request finishes uploading this payload.
 
         The future completes with ``None`` once the request body has been
-        fully written. If the upload fails, it completes with the same
-        error the request raises; if the request is cancelled, the future
-        is cancelled. If the payload is sent again (e.g. a redirected
-        request resends the body), a new future is returned for the new
-        upload. When overlapping requests share a payload, the future
+        fully written. If the upload fails, it completes with the upload
+        error (normally also raised by the request; a request can still
+        succeed if the server responded before reading the whole body).
+        If the request is cancelled, the future is cancelled. If the
+        payload is sent again (e.g. a redirected request resends the
+        body), a new future is returned for the new upload. When
+        overlapping requests share a payload, the future
         tracks the first upload only.
 
         Must be accessed from within the event loop.
@@ -280,8 +283,19 @@ class Payload(ABC):
             fut.cancel()
         else:
             fut.set_exception(self._upload_abort_exc)
-            # Consume the exception: the request raises it as well, so an
-            # unawaited future must not log it at garbage collection.
+            if self._upload_error_propagated:
+                # The request raised this failure to its caller, so the
+                # future's copy is supplementary: consume it to avoid a
+                # duplicate never-retrieved log at garbage collection.
+                # When the request succeeded despite the failed upload,
+                # the future is the only holder and the log must stay armed.
+                fut.exception()
+
+    def _mark_upload_error_propagated(self) -> None:
+        """Record that the request raised the upload failure to its caller."""
+        self._upload_error_propagated = True
+        fut = self._upload_future
+        if fut is not None and fut.done() and not fut.cancelled():
             fut.exception()
 
     def _reset_upload(self) -> None:
@@ -298,6 +312,7 @@ class Payload(ABC):
         self._upload_finished = False
         self._upload_aborted = False
         self._upload_abort_exc = None
+        self._upload_error_propagated = False
         fut = self._upload_future
         if fut is not None and fut.done():
             # A previous upload of this payload already completed (e.g. the

--- a/aiohttp/payload.py
+++ b/aiohttp/payload.py
@@ -284,15 +284,16 @@ class Payload(ABC):
             # unawaited future must not log it at garbage collection.
             fut.exception()
 
-    def _start_upload(self) -> bool:
-        """Try to begin tracking a new upload of this payload.
+    def _reset_upload(self) -> None:
+        """
+        Forget a previous attempt's upload state.
 
-        Returns False when another upload is already being tracked; the
-        caller must then write the payload without progress tracking.
+        Called when the payload is attached to a new request, so state
+        left by an earlier attempt cannot be mistaken for the outcome of
+        the new one. Does nothing while another upload is in progress.
         """
         if self._upload_active:
-            return False
-        self._upload_active = True
+            return
         self._bytes_written = 0
         self._upload_finished = False
         self._upload_aborted = False
@@ -303,6 +304,17 @@ class Payload(ABC):
             # request is resent after a redirect); track the new upload with
             # a fresh future created lazily on the next upload_complete access.
             self._upload_future = None
+
+    def _start_upload(self) -> bool:
+        """Try to begin tracking a new upload of this payload.
+
+        Returns False when another upload is already being tracked; the
+        caller must then write the payload without progress tracking.
+        """
+        if self._upload_active:
+            return False
+        self._reset_upload()
+        self._upload_active = True
         return True
 
     def _finish_upload(self) -> None:

--- a/aiohttp/payload.py
+++ b/aiohttp/payload.py
@@ -504,9 +504,14 @@ class _ProgressWriter(AbstractStreamWriter):
         self._writer.length = value
 
     async def write(
-        self, chunk: "bytes | bytearray | memoryview[int] | memoryview[bytes]"
+        self,
+        chunk: "bytes | bytearray | memoryview[int] | memoryview[bytes]",
+        **kwargs: Any,
     ) -> None:
-        await self._writer.write(chunk)
+        # Keyword arguments are forwarded untouched so payloads written
+        # against a concrete writer's extended signature keep working
+        # (e.g. StreamWriter's write(chunk, drain=False)).
+        await self._writer.write(chunk, **kwargs)
         self._payload._bytes_written += (
             chunk.nbytes if isinstance(chunk, memoryview) else len(chunk)
         )

--- a/aiohttp/payload.py
+++ b/aiohttp/payload.py
@@ -143,8 +143,12 @@ class Payload(ABC):
     _consumed: bool = False  # Default: payload has not been consumed yet
     _autoclose: bool = False  # Default: assume resource needs explicit closing
     # Upload progress bookkeeping (client requests); see bytes_written.
+    # Tracking is exclusive: only one upload of a payload is tracked at a
+    # time, so overlapping requests sharing an instance cannot corrupt the
+    # owner's counter or complete its future (they run untracked instead).
     _bytes_written: int = 0
     _upload_future: "asyncio.Future[None] | None" = None
+    _upload_active: bool = False
     _upload_finished: bool = False
     _upload_aborted: bool = False
 
@@ -243,6 +247,8 @@ class Payload(ABC):
         is uploading this payload, before any transport-level transformation
         (compression, chunked framing). Reset when a new upload of the same
         payload starts, e.g. when a redirect causes the body to be resent.
+        Only one upload of a payload is tracked at a time: when overlapping
+        requests share an instance, later uploads are not counted.
         """
         return self._bytes_written
 
@@ -254,7 +260,8 @@ class Payload(ABC):
         fully written, or is cancelled if the upload is interrupted (e.g.
         connection error or request cancellation). If the payload is sent
         again (e.g. a redirected request resends the body), a new future
-        is returned for the new upload.
+        is returned for the new upload. When overlapping requests share a
+        payload, the future tracks the first upload only.
 
         Must be accessed from within the event loop.
         """
@@ -266,8 +273,15 @@ class Payload(ABC):
                 self._upload_future.set_result(None)
         return self._upload_future
 
-    def _start_upload(self) -> None:
-        """Reset upload progress state before the payload is written."""
+    def _start_upload(self) -> bool:
+        """Try to begin tracking a new upload of this payload.
+
+        Returns False when another upload is already being tracked; the
+        caller must then write the payload without progress tracking.
+        """
+        if self._upload_active:
+            return False
+        self._upload_active = True
         self._bytes_written = 0
         self._upload_finished = False
         self._upload_aborted = False
@@ -277,9 +291,11 @@ class Payload(ABC):
             # request is resent after a redirect); track the new upload with
             # a fresh future created lazily on the next upload_complete access.
             self._upload_future = None
+        return True
 
     def _finish_upload(self) -> None:
         """Mark the payload as fully written to the connection."""
+        self._upload_active = False
         self._upload_finished = True
         fut = self._upload_future
         if fut is not None and not fut.done():
@@ -289,6 +305,7 @@ class Payload(ABC):
         """Mark an unfinished upload as aborted, cancelling upload_complete."""
         if self._upload_finished:
             return
+        self._upload_active = False
         self._upload_aborted = True
         fut = self._upload_future
         if fut is not None and not fut.done():

--- a/aiohttp/payload.py
+++ b/aiohttp/payload.py
@@ -262,7 +262,8 @@ class Payload(ABC):
         fully written. If the upload fails, it completes with the upload
         error (normally also raised by the request; a request can still
         succeed if the server responded before reading the whole body).
-        If the request is cancelled, the future is cancelled. If the
+        If the body is never fully sent (e.g. the request is cancelled or
+        answered without sending it), the future is cancelled. If the
         payload is sent again (e.g. a redirected request resends the
         body), a new future is returned for the new upload. When
         overlapping requests share a payload, the future

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -2674,9 +2674,9 @@ Payload
 The ``data`` argument of :meth:`ClientSession.request` accepts a
 :class:`Payload`, which streams the request body to the server. Other
 supported ``data`` types are wrapped in an appropriate payload
-automatically; ``aiohttp.get_payload(data)`` performs the same conversion
-explicitly. :class:`MultipartWriter` and the payload returned by calling
-a :class:`FormData` instance are payloads as well.
+automatically; ``aiohttp.get_payload(data, disposition=None)`` performs
+the same conversion explicitly. :class:`MultipartWriter` and the payload
+returned by calling a :class:`FormData` instance are payloads as well.
 
 Creating the payload explicitly gives access to the state of the upload.
 For example, to track upload progress, start a task watching the payload

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -1565,30 +1565,6 @@ Response object
 
       .. versionadded:: 3.2
 
-   .. attribute:: output_size
-
-      Number of bytes sent for this request.
-
-      Pair with :attr:`upload_complete` to display upload progress::
-
-          async with session.post(url, data=mpwriter) as resp:
-              while not resp.upload_complete.done():
-                  print(f"uploaded {resp.output_size} bytes")
-                  await asyncio.sleep(0.5)
-              print(f"upload complete: {resp.output_size} bytes")
-
-      .. versionadded:: 3.14
-
-   .. attribute:: upload_complete
-
-      An :class:`asyncio.Future` set when the request body has been fully sent.
-
-      Use ``await resp.upload_complete`` to block until the upload finishes, or
-      ``resp.upload_complete.done()`` to poll from a progress-sampling loop
-      (see :attr:`output_size`).
-
-      .. versionadded:: 3.14
-
    .. attribute:: content_type
 
       Read-only property with *content* part of *Content-Type* header.
@@ -2691,6 +2667,121 @@ on being called.
                      - :class:`io.IOBase`, e.g. a file-like object
                      - :class:`multidict.MultiDict` or :class:`multidict.MultiDictProxy`
                      - :class:`tuple` or :class:`list` of length two, containing a name-value pair
+
+Payload
+^^^^^^^
+
+The ``data`` argument of :meth:`ClientSession.request` accepts a
+:class:`Payload`, which streams the request body to the server. Other
+supported ``data`` types are wrapped in an appropriate payload
+automatically; ``aiohttp.get_payload(data)`` performs the same conversion
+explicitly. :class:`MultipartWriter` and the payload returned by calling
+a :class:`FormData` instance are payloads as well.
+
+Creating the payload explicitly gives access to the state of the upload.
+For example, to track upload progress, start a task watching the payload
+while the request runs::
+
+    async def report(p: aiohttp.Payload) -> None:
+        while not p.upload_complete.done():
+            print(f"uploaded {p.bytes_written} bytes")
+            await asyncio.sleep(1)
+        print(f"upload complete: {p.bytes_written} bytes")
+
+    data = aiohttp.BytesPayload(b"some large body")
+    progress = asyncio.create_task(report(data))
+    async with session.post(url, data=data) as resp:
+        print(await resp.text())
+    await progress
+
+To upload a file object, build the payload with ``aiohttp.get_payload()``
+(``disposition=None`` avoids adding a ``Content-Disposition`` header)::
+
+    with open("massive-body", "rb") as f:
+        file_payload = aiohttp.get_payload(f, disposition=None)
+        progress = asyncio.create_task(report(file_payload))
+        async with session.post(url, data=file_payload) as resp:
+            print(await resp.text())
+        await progress
+
+A :class:`MultipartWriter` can be tracked directly. Progress is tracked
+on the payload passed as ``data``, not on the individual parts::
+
+    with aiohttp.MultipartWriter("form-data") as mpwriter:
+        mpwriter.append(open("report.xls", "rb"))
+
+    progress = asyncio.create_task(report(mpwriter))
+    async with session.post(url, data=mpwriter) as resp:
+        print(await resp.text())
+    await progress
+
+Similarly, :class:`FormData` can be converted to a trackable payload by
+calling it: ``data = form()``.
+
+If the upload is interrupted, :attr:`Payload.upload_complete` is
+cancelled rather than resolved, and the error is raised by the request
+itself.
+
+The body may be sent more than once during a single request, e.g. when a
+307 or 308 redirect is followed or the request is retried on a new
+connection. Each send restarts the tracking: :attr:`Payload.bytes_written`
+returns to ``0`` and :attr:`Payload.upload_complete` is replaced by a
+future for the new attempt, so a reporter waiting on
+:attr:`Payload.upload_complete` finishes with the first attempt. To keep
+reporting across resends, run the reporter for the lifetime of the
+request and cancel it when the request completes::
+
+    async def report(p: aiohttp.Payload) -> None:
+        while True:
+            print(f"uploaded {p.bytes_written} bytes")
+            await asyncio.sleep(1)
+
+    progress = asyncio.create_task(report(data))
+    try:
+        async with session.post(url, data=data) as resp:
+            print(await resp.text())
+    finally:
+        progress.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await progress
+
+.. class:: Payload
+   :canonical: aiohttp.payload.Payload
+
+   Base class for request body payloads.
+
+   .. attribute:: size
+
+      Size of the payload body in bytes, or ``None`` if the size is
+      unknown (the request body is then sent using chunked transfer
+      encoding).
+
+   .. attribute:: bytes_written
+
+      Number of bytes of this payload written to the connection so far.
+
+      The payload's bytes are counted as they are handed to the
+      transport, before transport-level transformations such as
+      compression or chunked framing, so a finished upload satisfies
+      ``payload.bytes_written == payload.size`` when :attr:`size` is
+      known. Restarts from ``0`` if the body is sent again, e.g. when a
+      redirected request resends the body.
+
+      .. versionadded:: 3.14.4
+
+   .. attribute:: upload_complete
+
+      An :class:`asyncio.Future` completed when the request body has been
+      fully sent. The future resolves to ``None`` once the upload
+      finishes, and is cancelled instead if the upload is interrupted by
+      a connection error or cancellation (the error itself is raised by
+      the request). If the body is sent again, e.g. when a redirected
+      request resends it, the attribute is a new future tracking the new
+      upload.
+
+      Must be accessed from within the event loop.
+
+      .. versionadded:: 3.14.4
 
 Client exceptions
 -----------------

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -2718,9 +2718,9 @@ on the payload passed as ``data``, not on the individual parts::
 Similarly, :class:`FormData` can be converted to a trackable payload by
 calling it: ``data = form()``.
 
-If the upload is interrupted, :attr:`Payload.upload_complete` is
-cancelled rather than resolved, and the error is raised by the request
-itself.
+If the upload fails, :attr:`Payload.upload_complete` completes with the
+same error the request raises; if the request is cancelled, the future is
+cancelled too.
 
 The body may be sent more than once during a single request, e.g. when a
 307 or 308 redirect is followed or the request is retried on a new
@@ -2777,9 +2777,9 @@ first upload; the others are sent without tracking.
 
       An :class:`asyncio.Future` completed when the request body has been
       fully sent. The future resolves to ``None`` once the upload
-      finishes, and is cancelled instead if the upload is interrupted by
-      a connection error or cancellation (the error itself is raised by
-      the request). If the body is sent again, e.g. when a redirected
+      finishes. If the upload fails, it completes with the same error the
+      request raises; if the request is cancelled, the future is
+      cancelled. If the body is sent again, e.g. when a redirected
       request resends it, the attribute is a new future tracking the new
       upload.
 

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -2721,7 +2721,9 @@ calling it: ``data = form()``.
 If the upload fails, :attr:`Payload.upload_complete` completes with the
 upload error — normally the same error the request raises, though a
 request can still succeed if the server responded before reading the
-whole body. If the request is cancelled, the future is cancelled too.
+whole body. If the body is never fully sent — e.g. the request is
+cancelled, or a middleware answers it without sending — the future is
+cancelled too.
 
 The body may be sent more than once during a single request, e.g. when a
 307 or 308 redirect is followed or the request is retried on a new
@@ -2781,7 +2783,8 @@ first upload; the others are sent without tracking.
       finishes. If the upload fails, it completes with the upload error
       (normally also raised by the request; a request can still succeed
       if the server responded before reading the whole body); if the
-      request is cancelled, the future is cancelled. If the body is sent
+      body is never fully sent (e.g. the request is cancelled or answered
+      without sending it), the future is cancelled. If the body is sent
       again, e.g. when a redirected request resends it, the attribute is
       a new future tracking the new upload.
 

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -2719,8 +2719,9 @@ Similarly, :class:`FormData` can be converted to a trackable payload by
 calling it: ``data = form()``.
 
 If the upload fails, :attr:`Payload.upload_complete` completes with the
-same error the request raises; if the request is cancelled, the future is
-cancelled too.
+upload error — normally the same error the request raises, though a
+request can still succeed if the server responded before reading the
+whole body. If the request is cancelled, the future is cancelled too.
 
 The body may be sent more than once during a single request, e.g. when a
 307 or 308 redirect is followed or the request is retried on a new
@@ -2777,11 +2778,12 @@ first upload; the others are sent without tracking.
 
       An :class:`asyncio.Future` completed when the request body has been
       fully sent. The future resolves to ``None`` once the upload
-      finishes. If the upload fails, it completes with the same error the
-      request raises; if the request is cancelled, the future is
-      cancelled. If the body is sent again, e.g. when a redirected
-      request resends it, the attribute is a new future tracking the new
-      upload.
+      finishes. If the upload fails, it completes with the upload error
+      (normally also raised by the request; a request can still succeed
+      if the server responded before reading the whole body); if the
+      request is cancelled, the future is cancelled. If the body is sent
+      again, e.g. when a redirected request resends it, the attribute is
+      a new future tracking the new upload.
 
       Must be accessed from within the event loop.
 

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -2745,6 +2745,10 @@ request and cancel it when the request completes::
         with contextlib.suppress(asyncio.CancelledError):
             await progress
 
+A payload tracks a single upload at a time. If the same payload instance
+is shared between overlapping requests, progress is reported only for the
+first upload; the others are sent without tracking.
+
 .. class:: Payload
    :canonical: aiohttp.payload.Payload
 

--- a/docs/spelling_wordlist.txt
+++ b/docs/spelling_wordlist.txt
@@ -311,6 +311,7 @@ request’s
 Request’s
 requote
 requoting
+resends
 resolvehost
 resolvers
 reusage

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -17,6 +17,7 @@ import zipfile
 import zlib
 from collections.abc import AsyncIterator, Awaitable, Callable
 from contextlib import suppress
+from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any, NoReturn
 from unittest import mock
 
@@ -6257,6 +6258,81 @@ async def test_payload_reused_after_success_reports_new_failure(
                 await session.post(f"http://127.0.0.1:{port}/", data=p)
 
     # The payload reports the new attempt's failure, not the stale success.
+    assert p.upload_complete.exception() is excinfo.value
+    assert p.bytes_written == 0
+
+
+@pytest.mark.parametrize(
+    ("url", "proxy", "expected"),
+    (
+        ("ftp://example.com/", None, aiohttp.NonHttpUrlClientError),
+        ("http://example.com/", "http://[::1", aiohttp.InvalidURL),
+    ),
+    ids=("bad-scheme", "bad-proxy"),
+)
+async def test_payload_upload_aborted_before_request_built(
+    url: str, proxy: str | None, expected: type[Exception]
+) -> None:
+    """A failure before the request is even built resolves upload_complete.
+
+    These raise between the payload being adopted and the request loop, so
+    nothing else can report the outcome to a caller awaiting the future.
+    """
+    p = aiohttp.BytesPayload(b"x" * 1024)
+    async with aiohttp.ClientSession() as session:
+        with pytest.raises(expected) as excinfo:
+            await session.post(url, data=p, proxy=proxy)
+
+    assert p.upload_complete.exception() is excinfo.value
+    assert p.bytes_written == 0
+
+
+async def test_payload_upload_aborted_by_request_start_trace() -> None:
+    """A trace callback raising before the request runs resolves the future."""
+    error = RuntimeError("trace failed")
+
+    async def on_request_start(
+        session: aiohttp.ClientSession,
+        context: SimpleNamespace,
+        params: aiohttp.TraceRequestStartParams,
+    ) -> NoReturn:
+        raise error
+
+    trace_config = aiohttp.TraceConfig()
+    trace_config.on_request_start.append(on_request_start)
+
+    p = aiohttp.BytesPayload(b"x" * 1024)
+    async with aiohttp.ClientSession(trace_configs=[trace_config]) as session:
+        with pytest.raises(RuntimeError) as excinfo:
+            await session.post("http://example.com/", data=p)
+
+    assert excinfo.value is error
+    assert p.upload_complete.exception() is error
+
+
+async def test_payload_reused_aborted_before_request_built(
+    aiohttp_client: AiohttpClient,
+) -> None:
+    """Resetting a reused payload must not strand its future when preflight fails."""
+
+    async def handler(request: web.Request) -> web.Response:
+        await request.read()
+        return web.Response()
+
+    app = web.Application()
+    app.router.add_post("/", handler)
+    client = await aiohttp_client(app)
+
+    p = aiohttp.BytesPayload(b"x" * 1024)
+    async with client.post("/", data=p) as resp:
+        assert resp.status == 200
+    assert p.upload_complete.done()
+
+    async with aiohttp.ClientSession() as session:
+        with pytest.raises(aiohttp.NonHttpUrlClientError) as excinfo:
+            await session.post("ftp://example.com/", data=p)
+
+    # The stale success was dropped by the reset, so this must replace it.
     assert p.upload_complete.exception() is excinfo.value
     assert p.bytes_written == 0
 

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -6189,7 +6189,7 @@ async def test_empty_body_shared_payload_not_mutated(
 
 
 async def test_payload_upload_aborted(aiohttp_client: AiohttpClient) -> None:
-    """An interrupted upload cancels upload_complete instead of resolving it."""
+    """A failed upload completes upload_complete with the request's error."""
 
     async def handler(request: web.Request) -> web.Response:
         await request.read()
@@ -6207,11 +6207,13 @@ async def test_payload_upload_aborted(aiohttp_client: AiohttpClient) -> None:
     with pytest.raises(aiohttp.ClientError):
         async with client.post("/", data=p):
             pass
-    assert p.upload_complete.cancelled()
+    assert p.upload_complete.done()
+    assert not p.upload_complete.cancelled()
+    assert isinstance(p.upload_complete.exception(), aiohttp.ClientConnectionError)
 
 
 async def test_payload_upload_aborted_before_write() -> None:
-    """A request failing before the body write starts cancels upload_complete."""
+    """A request failing before the body write starts reports the error."""
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
         # Bound but not listening: connecting is refused, and the port
         # cannot be taken by another test in the meantime.
@@ -6220,10 +6222,11 @@ async def test_payload_upload_aborted_before_write() -> None:
         p = aiohttp.BytesPayload(b"x" * 1024)
         fut = p.upload_complete
         async with aiohttp.ClientSession() as session:
-            with pytest.raises(aiohttp.ClientConnectorError):
+            with pytest.raises(aiohttp.ClientConnectorError) as excinfo:
                 await session.post(f"http://127.0.0.1:{port}/", data=p)
-        assert fut.cancelled()
-        assert p.upload_complete.cancelled()
+        # The future holds the same error the request raised.
+        assert fut.exception() is excinfo.value
+        assert p.upload_complete.exception() is excinfo.value
 
 
 async def test_payload_reused_after_redirect(aiohttp_client: AiohttpClient) -> None:
@@ -6379,6 +6382,64 @@ async def test_empty_payload_overlap_keeps_tracking_ownership(
     # Interrupting the parked upload still cancels its future.
     await asyncio.wait([fut], timeout=5)
     assert fut.cancelled()
+
+
+async def test_empty_payload_reused_after_aborted_upload(
+    aiohttp_client: AiohttpClient,
+) -> None:
+    """A successful resend after an aborted attempt gets a fresh resolved future.
+
+    The no-write fast path must clear the aborted state left by a previous
+    attempt, otherwise upload_complete stays cancelled despite the success.
+    """
+    release = asyncio.Event()
+    parked = asyncio.Event()
+
+    async def expect_handler(request: web.Request) -> None:
+        parked.set()
+        await release.wait()
+        await request.writer.write(b"HTTP/1.1 100 Continue\r\n\r\n")
+
+    async def handler(request: web.Request) -> web.Response:
+        await request.read()
+        return web.Response()
+
+    app = web.Application()
+    app.router.add_post("/", handler, expect_handler=expect_handler)
+    app.router.add_post("/plain", handler)
+    client = await aiohttp_client(app)
+
+    p = aiohttp.BytesPayload(b"")
+    first = p.upload_complete
+
+    async def slow_post() -> None:
+        async with client.post("/", data=p, expect100=True) as resp:
+            assert resp.status == 200
+
+    slow_task = asyncio.create_task(slow_post())
+    try:
+        waiter = asyncio.create_task(parked.wait())
+        await asyncio.wait({waiter, slow_task}, return_when=asyncio.FIRST_COMPLETED)
+        if not waiter.done():
+            waiter.cancel()
+            await slow_task  # raises the underlying error
+            pytest.fail("slow request completed before parking")
+    finally:
+        slow_task.cancel()
+        with suppress(asyncio.CancelledError):
+            await slow_task
+        release.set()
+
+    await asyncio.wait([first], timeout=5)
+    assert first.cancelled()  # the first attempt was aborted
+
+    # Reusing the payload on the no-write fast path succeeds and yields a
+    # fresh resolved future in place of the cancelled one.
+    async with client.post("/plain", data=p) as resp:
+        assert resp.status == 200
+    assert p.upload_complete is not first
+    assert p.upload_complete.done()
+    assert not p.upload_complete.cancelled()
 
 
 async def test_output_size_deprecated(aiohttp_client: AiohttpClient) -> None:

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -6470,6 +6470,63 @@ async def test_empty_payload_reused_after_aborted_upload(
     assert not p.upload_complete.cancelled()
 
 
+@pytest.mark.parametrize("exc_type", [OSError, RuntimeError])
+async def test_untracked_upload_failure_leaves_owner_state(
+    aiohttp_client: AiohttpClient, exc_type: type[Exception]
+) -> None:
+    """A failing untracked write must not settle the tracking owner's future."""
+    release = asyncio.Event()
+    parked = asyncio.Event()
+
+    async def expect_handler(request: web.Request) -> None:
+        parked.set()
+        await release.wait()
+        await request.writer.write(b"HTTP/1.1 100 Continue\r\n\r\n")
+
+    async def handler(request: web.Request) -> web.Response:
+        await request.read()
+        return web.Response()
+
+    app = web.Application()
+    app.router.add_post("/", handler, expect_handler=expect_handler)
+    app.router.add_post("/fail", handler)
+    client = await aiohttp_client(app)
+
+    async def failing_body() -> AsyncIterator[bytes]:
+        yield b"z" * 16
+        raise exc_type("body source failed")
+
+    p = aiohttp.AsyncIterablePayload(failing_body())
+    fut = p.upload_complete
+
+    async def slow_post() -> None:
+        async with client.post("/", data=p, expect100=True) as resp:
+            assert resp.status == 200
+
+    slow_task = asyncio.create_task(slow_post())
+    try:
+        # The slow request's writer acquires the tracking before parking.
+        waiter = asyncio.create_task(parked.wait())
+        await asyncio.wait({waiter, slow_task}, return_when=asyncio.FIRST_COMPLETED)
+        assert waiter.done(), "slow request finished before parking"
+
+        # The second request runs untracked and its write fails.
+        with pytest.raises(aiohttp.ClientError):
+            async with client.post("/fail", data=p):
+                pass
+        assert not fut.done()
+    finally:
+        waiter.cancel()
+        slow_task.cancel()
+        with suppress(asyncio.CancelledError):
+            await slow_task
+        release.set()
+
+    # The owner's outcome is its own cancellation, not the loser's error.
+    await asyncio.wait([fut], timeout=5)
+    assert fut.cancelled()
+
+
 async def test_output_size_deprecated(aiohttp_client: AiohttpClient) -> None:
     async def handler(request: web.Request) -> web.Response:
         await request.read()

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -6313,6 +6313,61 @@ async def test_payload_shared_by_overlapping_requests(
     assert p.upload_complete.done()
 
 
+async def test_empty_payload_overlap_keeps_tracking_ownership(
+    aiohttp_client: AiohttpClient,
+) -> None:
+    """A bodyless fast-path request must not steal another upload's tracking.
+
+    A zero-length payload can be owned by an expect100 request whose writer
+    is parked waiting for 100 Continue while a second bodyless request using
+    the same payload completes via the no-write path.
+    """
+    release = asyncio.Event()
+    parked = asyncio.Event()
+
+    async def expect_handler(request: web.Request) -> None:
+        parked.set()
+        await release.wait()
+        await request.writer.write(b"HTTP/1.1 100 Continue\r\n\r\n")
+
+    async def handler(request: web.Request) -> web.Response:
+        await request.read()
+        return web.Response()
+
+    app = web.Application()
+    app.router.add_post("/", handler, expect_handler=expect_handler)
+    app.router.add_post("/fast", handler)
+    client = await aiohttp_client(app)
+
+    p = aiohttp.BytesPayload(b"")
+    fut = p.upload_complete
+
+    async def slow_post() -> None:
+        async with client.post("/", data=p, expect100=True) as resp:
+            assert resp.status == 200
+
+    slow_task = asyncio.create_task(slow_post())
+    try:
+        # The slow request's writer owns the tracking, parked at 100-continue.
+        await parked.wait()
+
+        # A fast bodyless request sharing the payload completes meanwhile.
+        async with client.post("/fast", data=p) as resp:
+            assert resp.status == 200
+
+        # It must not have resolved the parked upload's future.
+        assert not fut.done()
+    finally:
+        slow_task.cancel()
+        with suppress(asyncio.CancelledError):
+            await slow_task
+        release.set()
+
+    # Interrupting the parked upload still cancels its future.
+    await asyncio.wait([fut], timeout=5)
+    assert fut.cancelled()
+
+
 async def test_output_size_deprecated(aiohttp_client: AiohttpClient) -> None:
     async def handler(request: web.Request) -> web.Response:
         await request.read()

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -6023,7 +6023,7 @@ async def test_payload_bytes_written_bytes(aiohttp_client: AiohttpClient) -> Non
         assert resp.status == 200
         assert p.upload_complete.done()
         assert p.bytes_written == len(body)
-    assert await p.upload_complete is None
+    await p.upload_complete
 
 
 async def test_payload_bytes_written_file(

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -6434,6 +6434,45 @@ async def test_payload_reused_after_redirect(aiohttp_client: AiohttpClient) -> N
     assert p.upload_complete.done()
 
 
+async def test_payload_redirect_while_writer_parked(
+    aiohttp_client: AiohttpClient,
+) -> None:
+    """A redirect arriving before the body write starts hands tracking over.
+
+    The first hop's writer is parked at the 100-continue wait when the
+    server answers with a redirect; the resent body on the second hop must
+    be tracked, not clobbered by the first writer's late cancellation.
+    """
+    received: list[int] = []
+
+    async def redirect_expect_handler(request: web.Request) -> None:
+        raise web.HTTPTemporaryRedirect("/final")
+
+    async def redirecting(request: web.Request) -> NoReturn:
+        assert False, "handler must not run; the expect handler redirects"
+
+    async def final(request: web.Request) -> web.Response:
+        received.append(len(await request.read()))
+        return web.Response()
+
+    app = web.Application()
+    app.router.add_post("/", redirecting, expect_handler=redirect_expect_handler)
+    app.router.add_post("/final", final)
+    client = await aiohttp_client(app)
+
+    body = b"x" * 2048
+    p = aiohttp.BytesPayload(body)
+    async with client.post("/", data=p, expect100=True) as resp:
+        assert resp.status == 200
+    assert received == [len(body)]
+
+    # The second hop owns the tracking: resolved future, full byte count.
+    assert p.upload_complete.done()
+    assert not p.upload_complete.cancelled()
+    assert p.upload_complete.result() is None
+    assert p.bytes_written == len(body)
+
+
 async def test_payload_reuse_two_requests(aiohttp_client: AiohttpClient) -> None:
     """Sequential requests with the same payload each track their own upload."""
 

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -6105,14 +6105,21 @@ async def test_payload_upload_progress(aiohttp_client: AiohttpClient) -> None:
 
     post_task = asyncio.create_task(do_post())
     samples: list[int] = []
-    for _ in range(num_chunks):
-        await next_chunk.wait()
-        next_chunk.clear()
-        samples.append(p.bytes_written)
-        assert not p.upload_complete.done()
-        sample_taken.set()
-    await p.upload_complete
-    await post_task
+    try:
+        for _ in range(num_chunks):
+            await next_chunk.wait()
+            next_chunk.clear()
+            samples.append(p.bytes_written)
+            assert not p.upload_complete.done()
+            sample_taken.set()
+        # Awaited first so an upload failure surfaces as the underlying
+        # ClientError rather than the cancellation of upload_complete.
+        await post_task
+        await p.upload_complete
+    finally:
+        post_task.cancel()
+        with suppress(asyncio.CancelledError):
+            await post_task
 
     # Each sample reflects exactly one more chunk of the payload, with no
     # transport framing overhead included.

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -6711,6 +6711,10 @@ async def test_untracked_preflight_failure_leaves_owner_state(
                 await session.post("ftp://example.com/", data=p)
 
         assert p._upload_active
+        # The sharer's failure must not mark the owner's error as
+        # propagated, or a later unpropagated owner failure would have its
+        # never-retrieved log wrongly disarmed.
+        assert not p._upload_error_propagated
         assert not fut.done()
     finally:
         waiter.cancel()
@@ -6720,6 +6724,63 @@ async def test_untracked_preflight_failure_leaves_owner_state(
         release.set()
 
     # The owner's outcome is its own cancellation, not the preflight error.
+    await asyncio.wait([fut], timeout=5)
+    assert fut.cancelled()
+
+
+async def test_untracked_request_failure_does_not_mark_owner(
+    aiohttp_client: AiohttpClient,
+) -> None:
+    """A built request's failure must not mark an overlapping owner's payload."""
+    release = asyncio.Event()
+    parked = asyncio.Event()
+
+    async def expect_handler(request: web.Request) -> None:
+        parked.set()
+        await release.wait()
+        await request.writer.write(b"HTTP/1.1 100 Continue\r\n\r\n")
+
+    async def handler(request: web.Request) -> NoReturn:
+        assert False
+
+    app = web.Application()
+    app.router.add_post("/", handler, expect_handler=expect_handler)
+    client = await aiohttp_client(app)
+
+    p = aiohttp.BytesPayload(b"z" * 16)
+    fut = p.upload_complete
+
+    async def slow_post() -> None:
+        async with client.post("/", data=p, expect100=True):
+            assert False
+
+    slow_task = asyncio.create_task(slow_post())
+    try:
+        waiter = asyncio.create_task(parked.wait())
+        await asyncio.wait({waiter, slow_task}, return_when=asyncio.FIRST_COMPLETED)
+        assert waiter.done(), "slow request finished before parking"
+        assert p._upload_active
+
+        # The overlapping request fails after being built: connecting to a
+        # bound but not listening port is refused.
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.bind(("127.0.0.1", 0))
+            port = s.getsockname()[1]
+            async with aiohttp.ClientSession() as session:
+                with pytest.raises(aiohttp.ClientConnectorError):
+                    await session.post(f"http://127.0.0.1:{port}/", data=p)
+
+        assert p._upload_active
+        assert not p._upload_error_propagated
+        assert not fut.done()
+    finally:
+        waiter.cancel()
+        slow_task.cancel()
+        with suppress(asyncio.CancelledError):
+            await slow_task
+        release.set()
+
+    # The owner's outcome is its own cancellation, not the sharer's error.
     await asyncio.wait([fut], timeout=5)
     assert fut.cancelled()
 

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -6105,16 +6105,20 @@ async def test_payload_upload_progress(aiohttp_client: AiohttpClient) -> None:
             assert resp.status == 200
 
     post_task = asyncio.create_task(do_post())
-    waiter: asyncio.Task[bool] | None = None
     samples: list[int] = []
     try:
         for _ in range(num_chunks):
             waiter = asyncio.create_task(next_chunk.wait())
-            # Race the event against the request so a failed upload fails
-            # the test immediately instead of blocking on an event that
-            # will never be set; the finally surfaces the actual error.
-            await asyncio.wait({waiter, post_task}, return_when=asyncio.FIRST_COMPLETED)
-            assert waiter.done(), "request finished before sampling"
+            try:
+                # Race the event against the request so a failed upload fails
+                # the test immediately instead of blocking on an event that
+                # will never be set; the finally surfaces the actual error.
+                await asyncio.wait(
+                    {waiter, post_task}, return_when=asyncio.FIRST_COMPLETED
+                )
+                assert waiter.done(), "request finished before sampling"
+            finally:
+                waiter.cancel()
             next_chunk.clear()
             samples.append(p.bytes_written)
             assert not p.upload_complete.done()
@@ -6124,8 +6128,6 @@ async def test_payload_upload_progress(aiohttp_client: AiohttpClient) -> None:
         await post_task
         await p.upload_complete
     finally:
-        if waiter is not None:
-            waiter.cancel()
         post_task.cancel()
         with suppress(asyncio.CancelledError):
             await post_task
@@ -6683,3 +6685,50 @@ async def test_upload_complete_deprecated(aiohttp_client: AiohttpClient) -> None
         with pytest.warns(DeprecationWarning, match="upload_complete"):
             fut = resp.upload_complete
         assert fut.done()
+
+
+async def test_deprecated_progress_attrs_while_uploading(
+    aiohttp_client: AiohttpClient,
+) -> None:
+    """The deprecated attributes still track an upload that is still running."""
+
+    async def handler(request: web.Request) -> web.StreamResponse:
+        response = web.StreamResponse()
+        await response.prepare(request)
+        # Flush headers so the client has a response while it is still
+        # uploading, which is the only way to observe a live writer.
+        await response.write(b"x")
+        await request.read()
+        return response
+
+    app = web.Application()
+    app.router.add_post("/", handler)
+    client = await aiohttp_client(app)
+
+    chunk_sent = asyncio.Event()
+    sampled = asyncio.Event()
+
+    async def gated_body() -> AsyncIterator[bytes]:
+        yield b"z" * 4096
+        chunk_sent.set()
+        await sampled.wait()
+        yield b"z" * 4096
+
+    async with client.post("/", data=gated_body()) as resp:
+        await chunk_sent.wait()
+        with pytest.warns(DeprecationWarning, match="output_size"):
+            mid = resp.output_size
+        assert mid >= 4096
+
+        with pytest.warns(DeprecationWarning, match="upload_complete"):
+            fut = resp.upload_complete
+        assert not fut.done()
+        with pytest.warns(DeprecationWarning, match="upload_complete"):
+            assert resp.upload_complete is fut
+
+        sampled.set()
+        await fut
+
+        with pytest.warns(DeprecationWarning, match="output_size"):
+            assert resp.output_size > mid
+        await resp.read()

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -6107,7 +6107,15 @@ async def test_payload_upload_progress(aiohttp_client: AiohttpClient) -> None:
     samples: list[int] = []
     try:
         for _ in range(num_chunks):
-            await next_chunk.wait()
+            waiter = asyncio.create_task(next_chunk.wait())
+            # Race the event against the request so a failed upload fails
+            # the test immediately instead of blocking on an event that
+            # will never be set.
+            await asyncio.wait({waiter, post_task}, return_when=asyncio.FIRST_COMPLETED)
+            if not waiter.done():
+                waiter.cancel()
+                await post_task  # raises the underlying error
+                pytest.fail("request completed before sampling finished")
             next_chunk.clear()
             samples.append(p.bytes_written)
             assert not p.upload_complete.done()
@@ -6349,7 +6357,12 @@ async def test_empty_payload_overlap_keeps_tracking_ownership(
     slow_task = asyncio.create_task(slow_post())
     try:
         # The slow request's writer owns the tracking, parked at 100-continue.
-        await parked.wait()
+        waiter = asyncio.create_task(parked.wait())
+        await asyncio.wait({waiter, slow_task}, return_when=asyncio.FIRST_COMPLETED)
+        if not waiter.done():
+            waiter.cancel()
+            await slow_task  # raises the underlying error
+            pytest.fail("slow request completed before parking")
 
         # A fast bodyless request sharing the payload completes meanwhile.
         async with client.post("/fast", data=p) as resp:

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -6104,18 +6104,16 @@ async def test_payload_upload_progress(aiohttp_client: AiohttpClient) -> None:
             assert resp.status == 200
 
     post_task = asyncio.create_task(do_post())
+    waiter: asyncio.Task[bool] | None = None
     samples: list[int] = []
     try:
         for _ in range(num_chunks):
             waiter = asyncio.create_task(next_chunk.wait())
             # Race the event against the request so a failed upload fails
             # the test immediately instead of blocking on an event that
-            # will never be set.
+            # will never be set; the finally surfaces the actual error.
             await asyncio.wait({waiter, post_task}, return_when=asyncio.FIRST_COMPLETED)
-            if not waiter.done():
-                waiter.cancel()
-                await post_task  # raises the underlying error
-                pytest.fail("request completed before sampling finished")
+            assert waiter.done(), "request finished before sampling"
             next_chunk.clear()
             samples.append(p.bytes_written)
             assert not p.upload_complete.done()
@@ -6125,6 +6123,8 @@ async def test_payload_upload_progress(aiohttp_client: AiohttpClient) -> None:
         await post_task
         await p.upload_complete
     finally:
+        if waiter is not None:
+            waiter.cancel()
         post_task.cancel()
         with suppress(asyncio.CancelledError):
             await post_task
@@ -6362,10 +6362,7 @@ async def test_empty_payload_overlap_keeps_tracking_ownership(
         # The slow request's writer owns the tracking, parked at 100-continue.
         waiter = asyncio.create_task(parked.wait())
         await asyncio.wait({waiter, slow_task}, return_when=asyncio.FIRST_COMPLETED)
-        if not waiter.done():
-            waiter.cancel()
-            await slow_task  # raises the underlying error
-            pytest.fail("slow request completed before parking")
+        assert waiter.done(), "slow request finished before parking"
 
         # A fast bodyless request sharing the payload completes meanwhile.
         async with client.post("/fast", data=p) as resp:
@@ -6374,6 +6371,7 @@ async def test_empty_payload_overlap_keeps_tracking_ownership(
         # It must not have resolved the parked upload's future.
         assert not fut.done()
     finally:
+        waiter.cancel()
         slow_task.cancel()
         with suppress(asyncio.CancelledError):
             await slow_task
@@ -6420,11 +6418,9 @@ async def test_empty_payload_reused_after_aborted_upload(
     try:
         waiter = asyncio.create_task(parked.wait())
         await asyncio.wait({waiter, slow_task}, return_when=asyncio.FIRST_COMPLETED)
-        if not waiter.done():
-            waiter.cancel()
-            await slow_task  # raises the underlying error
-            pytest.fail("slow request completed before parking")
+        assert waiter.done(), "slow request finished before parking"
     finally:
+        waiter.cancel()
         slow_task.cancel()
         with suppress(asyncio.CancelledError):
             await slow_task

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -6168,6 +6168,22 @@ async def test_payload_upload_aborted(aiohttp_client: AiohttpClient) -> None:
     assert p.upload_complete.cancelled()
 
 
+async def test_payload_upload_aborted_before_write() -> None:
+    """A request failing before the body write starts cancels upload_complete."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        # Bound but not listening: connecting is refused, and the port
+        # cannot be taken by another test in the meantime.
+        s.bind(("127.0.0.1", 0))
+        port = s.getsockname()[1]
+        p = aiohttp.BytesPayload(b"x" * 1024)
+        fut = p.upload_complete
+        async with aiohttp.ClientSession() as session:
+            with pytest.raises(aiohttp.ClientConnectorError):
+                await session.post(f"http://127.0.0.1:{port}/", data=p)
+        assert fut.cancelled()
+        assert p.upload_complete.cancelled()
+
+
 async def test_payload_reused_after_redirect(aiohttp_client: AiohttpClient) -> None:
     """A body resent after a redirect restarts the progress tracking."""
     received: list[int] = []

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -6386,7 +6386,7 @@ async def test_empty_payload_overlap_keeps_tracking_ownership(
     fut = p.upload_complete
 
     async def slow_post() -> None:
-        async with client.post("/", data=p, expect100=True) as resp:
+        async with client.post("/", data=p, expect100=True):
             assert False
 
     slow_task = asyncio.create_task(slow_post())
@@ -6443,7 +6443,7 @@ async def test_empty_payload_reused_after_aborted_upload(
     first = p.upload_complete
 
     async def slow_post() -> None:
-        async with client.post("/", data=p, expect100=True) as resp:
+        async with client.post("/", data=p, expect100=True):
             assert False
 
     slow_task = asyncio.create_task(slow_post())

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -6212,7 +6212,46 @@ async def test_payload_upload_aborted(aiohttp_client: AiohttpClient) -> None:
             assert False
     assert p.upload_complete.done()
     assert not p.upload_complete.cancelled()
+    # The request raised the failure, so the future's copy is consumed and
+    # will not log a never-retrieved warning at garbage collection.
+    assert not p.upload_complete._log_traceback
     assert isinstance(p.upload_complete.exception(), aiohttp.ClientConnectionError)
+
+
+async def test_upload_error_after_completed_response(
+    aiohttp_client: AiohttpClient,
+) -> None:
+    """A request can succeed while its upload fails; the error stays on the future."""
+
+    async def handler(request: web.Request) -> web.Response:
+        # Respond without ever reading the request body.
+        return web.Response()
+
+    app = web.Application()
+    app.router.add_post("/", handler)
+    client = await aiohttp_client(app)
+
+    response_received = asyncio.Event()
+
+    async def failing_body() -> AsyncIterator[bytes]:
+        yield b"z" * 16
+        await response_received.wait()
+        raise RuntimeError("body source failed")
+
+    p = aiohttp.AsyncIterablePayload(failing_body())
+    async with client.post("/", data=p) as resp:
+        assert resp.status == 200
+        await resp.read()
+        response_received.set()
+        await asyncio.wait([p.upload_complete], timeout=5)
+
+    fut = p.upload_complete
+    assert fut.done()
+    # Depending on connection teardown timing the unfinished upload is
+    # either failed by its own body source or cancelled with the writer
+    # task; it must never report success.
+    if not fut.cancelled():
+        assert isinstance(fut.exception(), aiohttp.ClientConnectionError)
 
 
 async def test_payload_upload_aborted_before_write() -> None:
@@ -6227,7 +6266,9 @@ async def test_payload_upload_aborted_before_write() -> None:
         async with aiohttp.ClientSession() as session:
             with pytest.raises(aiohttp.ClientConnectorError) as excinfo:
                 await session.post(f"http://127.0.0.1:{port}/", data=p)
-        # The future holds the same error the request raised.
+        # The future holds the same error the request raised; the raise
+        # consumed the future's copy, so it will not log at collection.
+        assert not fut._log_traceback
         assert fut.exception() is excinfo.value
         assert p.upload_complete.exception() is excinfo.value
 

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -6220,6 +6220,49 @@ async def test_payload_reuse_two_requests(aiohttp_client: AiohttpClient) -> None
     assert p.upload_complete.done()
 
 
+async def test_payload_shared_by_overlapping_requests(
+    aiohttp_client: AiohttpClient,
+) -> None:
+    """Overlapping requests sharing a payload track only one upload."""
+    release = asyncio.Event()
+    waiting = 0
+    received: list[int] = []
+
+    async def expect_handler(request: web.Request) -> None:
+        # Hold both uploads at the 100-continue wait, after progress
+        # tracking has started, to guarantee the uploads overlap.
+        nonlocal waiting
+        waiting += 1
+        if waiting == 2:
+            release.set()
+        await release.wait()
+        await request.writer.write(b"HTTP/1.1 100 Continue\r\n\r\n")
+
+    async def handler(request: web.Request) -> web.Response:
+        received.append(len(await request.read()))
+        return web.Response()
+
+    app = web.Application()
+    app.router.add_post("/", handler, expect_handler=expect_handler)
+    client = await aiohttp_client(app)
+
+    body = b"x" * 1024
+    p = aiohttp.BytesPayload(body)
+    resp1, resp2 = await asyncio.gather(
+        client.post("/", data=p, expect100=True),
+        client.post("/", data=p, expect100=True),
+    )
+    assert resp1.status == 200
+    assert resp2.status == 200
+    resp1.release()
+    resp2.release()
+
+    assert received == [len(body), len(body)]
+    # The counter reflects exactly the tracked upload, not a mix of both.
+    assert p.bytes_written == len(body)
+    assert p.upload_complete.done()
+
+
 async def test_output_size_deprecated(aiohttp_client: AiohttpClient) -> None:
     async def handler(request: web.Request) -> web.Response:
         await request.read()

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -6229,6 +6229,38 @@ async def test_payload_upload_aborted_before_write() -> None:
         assert p.upload_complete.exception() is excinfo.value
 
 
+async def test_payload_reused_after_success_reports_new_failure(
+    aiohttp_client: AiohttpClient,
+) -> None:
+    """A pre-write failure on a reused payload replaces the stale success state."""
+
+    async def handler(request: web.Request) -> web.Response:
+        await request.read()
+        return web.Response()
+
+    app = web.Application()
+    app.router.add_post("/", handler)
+    client = await aiohttp_client(app)
+
+    p = aiohttp.BytesPayload(b"x" * 1024)
+    async with client.post("/", data=p) as resp:
+        assert resp.status == 200
+    assert p.upload_complete.done()
+    assert p.bytes_written == len(p._value)
+
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        # Bound but not listening: connecting is refused.
+        s.bind(("127.0.0.1", 0))
+        port = s.getsockname()[1]
+        async with aiohttp.ClientSession() as session:
+            with pytest.raises(aiohttp.ClientConnectorError) as excinfo:
+                await session.post(f"http://127.0.0.1:{port}/", data=p)
+
+    # The payload reports the new attempt's failure, not the stale success.
+    assert p.upload_complete.exception() is excinfo.value
+    assert p.bytes_written == 0
+
+
 async def test_payload_reused_after_redirect(aiohttp_client: AiohttpClient) -> None:
     """A body resent after a redirect restarts the progress tracking."""
     received: list[int] = []

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -6006,7 +6006,7 @@ async def test_stream_reader_total_raw_bytes(aiohttp_client: AiohttpClient) -> N
         assert resp.content.total_raw_bytes == int(resp.headers["Content-Length"])
 
 
-async def test_output_size_bytes(aiohttp_client: AiohttpClient) -> None:
+async def test_payload_bytes_written_bytes(aiohttp_client: AiohttpClient) -> None:
     async def handler(request: web.Request) -> web.Response:
         await request.read()
         return web.Response()
@@ -6016,11 +6016,21 @@ async def test_output_size_bytes(aiohttp_client: AiohttpClient) -> None:
     client = await aiohttp_client(app)
 
     body = b"x" * 1024
-    async with client.post("/", data=body) as resp:
-        assert resp.output_size >= len(body)
+    p = aiohttp.BytesPayload(body)
+    assert p.bytes_written == 0
+    assert not p.upload_complete.done()
+    async with client.post("/", data=p) as resp:
+        assert resp.status == 200
+        assert p.upload_complete.done()
+        assert p.bytes_written == len(body)
+    assert await p.upload_complete is None
 
 
-async def test_output_size_multipart(aiohttp_client: AiohttpClient) -> None:
+async def test_payload_bytes_written_file(
+    aiohttp_client: AiohttpClient, tmp_path: pathlib.Path
+) -> None:
+    """A file payload counts the bytes streamed from the file."""
+
     async def handler(request: web.Request) -> web.Response:
         await request.read()
         return web.Response()
@@ -6029,55 +6039,44 @@ async def test_output_size_multipart(aiohttp_client: AiohttpClient) -> None:
     app.router.add_post("/", handler)
     client = await aiohttp_client(app)
 
-    mpwriter = aiohttp.MultipartWriter("form-data")
-    mpwriter.append(b"x" * 4096)
-    mpwriter.append(b"y" * 2048)
-    expected_body_size = mpwriter.size
-    assert expected_body_size is not None
+    file_path = tmp_path / "body.bin"
+    file_path.write_bytes(b"y" * 70000)
 
-    async with client.post("/", data=mpwriter) as resp:
-        assert resp.output_size >= expected_body_size
+    with file_path.open("rb") as f:
+        p = aiohttp.get_payload(f, disposition=None)
+        async with client.post("/", data=p) as resp:
+            assert resp.status == 200
+        assert p.upload_complete.done()
+        assert p.bytes_written == 70000
 
 
-async def test_output_size_keepalive_isolated(
-    aiohttp_client: AiohttpClient,
-) -> None:
-    """Each request on a keep-alive connection has its own counter."""
-    transports: set[object] = set()
+async def test_payload_bytes_written_multipart(aiohttp_client: AiohttpClient) -> None:
+    """The multipart payload counts boundaries and part headers too."""
 
     async def handler(request: web.Request) -> web.Response:
-        transports.add(request.transport)
         await request.read()
         return web.Response()
 
     app = web.Application()
     app.router.add_post("/", handler)
-    connector = aiohttp.TCPConnector(limit=1, force_close=False)
-    client = await aiohttp_client(app, connector=connector)
-    body = b"x" * 65536
+    client = await aiohttp_client(app)
 
-    async with client.post("/", data=body) as resp1:
-        size1 = resp1.output_size
+    with aiohttp.MultipartWriter("form-data") as mpwriter:
+        mpwriter.append(b"x" * 4096)
+        mpwriter.append(b"y" * 2048)
 
-    async with client.post("/", data=body) as resp2:
-        size2 = resp2.output_size
-
-    assert len(transports) == 1  # Check keep-alive worked.
-    assert size1 >= len(body)
-    assert size1 == size2
+    async with client.post("/", data=mpwriter) as resp:
+        assert resp.status == 200
+    assert mpwriter.upload_complete.done()
+    assert mpwriter.bytes_written == mpwriter.size
 
 
-async def test_output_size_progress(aiohttp_client: AiohttpClient) -> None:
-    """output_size advances by exactly one chunk per yield."""
+async def test_payload_upload_progress(aiohttp_client: AiohttpClient) -> None:
+    """bytes_written advances by exactly one chunk per yield."""
 
-    async def handler(request: web.Request) -> web.StreamResponse:
-        response = web.StreamResponse()
-        await response.prepare(request)
-        # Flush headers + a chunk so resp.start() returns on the client
-        # side before we read the body.
-        await response.write(b"x")
+    async def handler(request: web.Request) -> web.Response:
         await request.read()
-        return response
+        return web.Response()
 
     app = web.Application()
     app.router.add_post("/", handler)
@@ -6092,45 +6091,136 @@ async def test_output_size_progress(aiohttp_client: AiohttpClient) -> None:
     async def gated_body() -> AsyncIterator[bytes]:
         for _ in range(num_chunks):
             yield chunk
+            # Resumed when the writer requests the next chunk, i.e. after
+            # the previous one has been fully handed to the transport.
             sample_taken.clear()
             next_chunk.set()
             await sample_taken.wait()
 
-    async with client.post("/", data=gated_body()) as resp:
-        samples: list[int] = []
-        for _ in range(num_chunks):
-            await next_chunk.wait()
-            next_chunk.clear()
-            samples.append(resp.output_size)
-            assert not resp.upload_complete.done()
-            sample_taken.set()
-        await resp.upload_complete
-        assert resp.upload_complete.done()
-        await resp.read()
+    p = aiohttp.AsyncIterablePayload(gated_body())
 
-    # Each sample after the first reflects exactly one more chunk on the wire.
-    chunked_framing = len(f"{chunk_size:x}".encode()) + 4
-    deltas = [samples[i] - samples[i - 1] for i in range(1, len(samples))]
-    assert deltas == [chunk_size + chunked_framing] * (num_chunks - 1)
+    async def do_post() -> None:
+        async with client.post("/", data=p) as resp:
+            assert resp.status == 200
+
+    post_task = asyncio.create_task(do_post())
+    samples: list[int] = []
+    for _ in range(num_chunks):
+        await next_chunk.wait()
+        next_chunk.clear()
+        samples.append(p.bytes_written)
+        assert not p.upload_complete.done()
+        sample_taken.set()
+    await p.upload_complete
+    await post_task
+
+    # Each sample reflects exactly one more chunk of the payload, with no
+    # transport framing overhead included.
+    assert samples == [chunk_size * (i + 1) for i in range(num_chunks)]
 
 
-async def test_output_size_get_request(aiohttp_client: AiohttpClient) -> None:
-    """GET request with no body still reports the request header byte count."""
+async def test_payload_upload_complete_empty_body(
+    aiohttp_client: AiohttpClient,
+) -> None:
+    """An empty payload completes even though nothing is written."""
 
     async def handler(request: web.Request) -> web.Response:
         return web.Response()
 
     app = web.Application()
-    app.router.add_get("/", handler)
+    app.router.add_post("/", handler)
     client = await aiohttp_client(app)
 
-    async with client.get("/") as resp:
-        assert resp.output_size >= 0
+    # Future requested before the request is made.
+    p1 = aiohttp.BytesPayload(b"")
+    fut = p1.upload_complete
+    async with client.post("/", data=p1) as resp:
+        assert resp.status == 200
+    assert fut.done()
+    assert p1.bytes_written == 0
+
+    # Future requested only after the request finished.
+    p2 = aiohttp.BytesPayload(b"")
+    async with client.post("/", data=p2) as resp:
+        assert resp.status == 200
+    assert p2.upload_complete.done()
 
 
-async def test_output_size_writer_released(aiohttp_client: AiohttpClient) -> None:
-    """Writer is dropped once body upload completes; output_size survives."""
+async def test_payload_upload_aborted(aiohttp_client: AiohttpClient) -> None:
+    """An interrupted upload cancels upload_complete instead of resolving it."""
 
+    async def handler(request: web.Request) -> web.Response:
+        await request.read()
+        return web.Response()
+
+    app = web.Application()
+    app.router.add_post("/", handler)
+    client = await aiohttp_client(app)
+
+    async def failing_body() -> AsyncIterator[bytes]:
+        yield b"z" * 16
+        raise RuntimeError("body source failed")
+
+    p = aiohttp.AsyncIterablePayload(failing_body())
+    with pytest.raises(aiohttp.ClientError):
+        async with client.post("/", data=p):
+            pass
+    assert p.upload_complete.cancelled()
+
+
+async def test_payload_reused_after_redirect(aiohttp_client: AiohttpClient) -> None:
+    """A body resent after a redirect restarts the progress tracking."""
+    received: list[int] = []
+
+    async def redirecting(request: web.Request) -> NoReturn:
+        raise web.HTTPTemporaryRedirect("/final")
+
+    async def final(request: web.Request) -> web.Response:
+        received.append(len(await request.read()))
+        return web.Response()
+
+    app = web.Application()
+    app.router.add_post("/", redirecting)
+    app.router.add_post("/final", final)
+    client = await aiohttp_client(app)
+
+    body = b"x" * 2048
+    p = aiohttp.BytesPayload(body)
+    first_upload = p.upload_complete
+    async with client.post("/", data=p) as resp:
+        assert resp.status == 200
+    assert received == [len(body)]
+    # The counter was reset for the second hop rather than accumulating.
+    assert p.bytes_written == len(body)
+    assert first_upload.done()
+    assert p.upload_complete.done()
+
+
+async def test_payload_reuse_two_requests(aiohttp_client: AiohttpClient) -> None:
+    """Sequential requests with the same payload each track their own upload."""
+
+    async def handler(request: web.Request) -> web.Response:
+        await request.read()
+        return web.Response()
+
+    app = web.Application()
+    app.router.add_post("/", handler)
+    client = await aiohttp_client(app)
+
+    body = b"x" * 65536
+    p = aiohttp.BytesPayload(body)
+
+    async with client.post("/", data=p) as resp1:
+        assert resp1.status == 200
+    assert p.bytes_written == len(body)
+
+    async with client.post("/", data=p) as resp2:
+        assert resp2.status == 200
+    assert p.bytes_written == len(body)
+    assert p.upload_complete.done()
+
+
+async def test_output_size_deprecated(aiohttp_client: AiohttpClient) -> None:
     async def handler(request: web.Request) -> web.Response:
         await request.read()
         return web.Response()
@@ -6141,12 +6231,12 @@ async def test_output_size_writer_released(aiohttp_client: AiohttpClient) -> Non
 
     body = b"x" * 1024
     async with client.post("/", data=body) as resp:
-        await resp.read()
-        assert resp._stream_writer is None
-    assert resp.output_size >= len(body)
+        with pytest.warns(DeprecationWarning, match="output_size"):
+            size = resp.output_size
+    assert size >= len(body)
 
 
-async def test_upload_complete_no_body(aiohttp_client: AiohttpClient) -> None:
+async def test_upload_complete_deprecated(aiohttp_client: AiohttpClient) -> None:
     async def handler(request: web.Request) -> web.Response:
         return web.Response()
 
@@ -6155,22 +6245,6 @@ async def test_upload_complete_no_body(aiohttp_client: AiohttpClient) -> None:
     client = await aiohttp_client(app)
 
     async with client.get("/") as resp:
-        assert resp.upload_complete.done()
-
-
-async def test_upload_complete_late_access(aiohttp_client: AiohttpClient) -> None:
-    """Accessing upload_complete after the upload finished returns a done future."""
-
-    async def handler(request: web.Request) -> web.Response:
-        await request.read()
-        return web.Response()
-
-    app = web.Application()
-    app.router.add_post("/", handler)
-    client = await aiohttp_client(app)
-
-    async with client.post("/", data=b"x" * 1024) as resp:
-        await resp.read()
-        # Writer task is done; future is created lazily on this first access.
-        assert resp._upload_complete is None
-        assert resp.upload_complete.done()
+        with pytest.warns(DeprecationWarning, match="upload_complete"):
+            fut = resp.upload_complete
+        assert fut.done()

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -57,7 +57,7 @@ from aiohttp.client_exceptions import (
     TooManyRedirects,
 )
 from aiohttp.client_reqrep import ClientRequest
-from aiohttp.helpers import DEFAULT_CHUNK_SIZE
+from aiohttp.helpers import DEFAULT_CHUNK_SIZE, TimeoutHandle
 from aiohttp.payload import (
     AsyncIterablePayload,
     BufferedReaderPayload,
@@ -6351,6 +6351,32 @@ async def test_payload_upload_aborted_by_request_start_trace() -> None:
 
     assert excinfo.value is error
     assert p.upload_complete.exception() is error
+
+
+async def test_preflight_failure_disarms_timeout(mocker: MockerFixture) -> None:
+    """A preflight failure closes the timeout handle and cancels its timer."""
+    close_spy = mocker.spy(TimeoutHandle, "close")
+    start_spy = mocker.spy(TimeoutHandle, "start")
+
+    async def on_request_start(
+        session: aiohttp.ClientSession,
+        context: SimpleNamespace,
+        params: aiohttp.TraceRequestStartParams,
+    ) -> NoReturn:
+        raise RuntimeError("trace failed")
+
+    trace_config = aiohttp.TraceConfig()
+    trace_config.on_request_start.append(on_request_start)
+
+    async with aiohttp.ClientSession(trace_configs=[trace_config]) as session:
+        with pytest.raises(RuntimeError):
+            await session.post("http://example.com/", data=b"x")
+
+    # The armed loop timer is cancelled, not left running until expiry.
+    close_spy.assert_called_once()
+    timer = start_spy.spy_return
+    assert timer is not None
+    assert timer.cancelled()
 
 
 async def test_payload_reused_aborted_before_request_built(

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -6146,6 +6146,33 @@ async def test_payload_upload_complete_empty_body(
     assert p2.upload_complete.done()
 
 
+async def test_empty_body_shared_payload_not_mutated(
+    aiohttp_client: AiohttpClient,
+) -> None:
+    """Bodyless requests never touch the shared empty-payload singleton.
+
+    With expect100 the writer task runs even for an empty body, so the
+    write path must skip progress tracking for the class-level payload.
+    """
+
+    async def handler(request: web.Request) -> web.Response:
+        return web.Response()
+
+    app = web.Application()
+    app.router.add_post("/", handler)
+    client = await aiohttp_client(app)
+
+    async with client.post("/", expect100=True) as resp:
+        assert resp.status == 200
+
+    empty = aiohttp.ClientRequest._EMPTY_BODY
+    assert empty._upload_active is False
+    assert empty._upload_finished is False
+    assert empty._upload_aborted is False
+    assert empty._bytes_written == 0
+    assert empty._upload_future is None
+
+
 async def test_payload_upload_aborted(aiohttp_client: AiohttpClient) -> None:
     """An interrupted upload cancels upload_complete instead of resolving it."""
 

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -6603,6 +6603,58 @@ async def test_untracked_upload_failure_leaves_owner_state(
     assert fut.cancelled()
 
 
+async def test_untracked_preflight_failure_leaves_owner_state(
+    aiohttp_client: AiohttpClient,
+) -> None:
+    """A preflight failure must not settle an overlapping request's future."""
+    release = asyncio.Event()
+    parked = asyncio.Event()
+
+    async def expect_handler(request: web.Request) -> None:
+        parked.set()
+        await release.wait()
+        await request.writer.write(b"HTTP/1.1 100 Continue\r\n\r\n")
+
+    async def handler(request: web.Request) -> NoReturn:
+        assert False
+
+    app = web.Application()
+    app.router.add_post("/", handler, expect_handler=expect_handler)
+    client = await aiohttp_client(app)
+
+    p = aiohttp.BytesPayload(b"z" * 16)
+    fut = p.upload_complete
+
+    async def slow_post() -> None:
+        async with client.post("/", data=p, expect100=True):
+            assert False
+
+    slow_task = asyncio.create_task(slow_post())
+    try:
+        waiter = asyncio.create_task(parked.wait())
+        await asyncio.wait({waiter, slow_task}, return_when=asyncio.FIRST_COMPLETED)
+        assert waiter.done(), "slow request finished before parking"
+        assert p._upload_active
+
+        # The overlapping request fails before its request is even built.
+        async with aiohttp.ClientSession() as session:
+            with pytest.raises(aiohttp.NonHttpUrlClientError):
+                await session.post("ftp://example.com/", data=p)
+
+        assert p._upload_active
+        assert not fut.done()
+    finally:
+        waiter.cancel()
+        slow_task.cancel()
+        with suppress(asyncio.CancelledError):
+            await slow_task
+        release.set()
+
+    # The owner's outcome is its own cancellation, not the preflight error.
+    await asyncio.wait([fut], timeout=5)
+    assert fut.cancelled()
+
+
 async def test_output_size_deprecated(aiohttp_client: AiohttpClient) -> None:
     async def handler(request: web.Request) -> web.Response:
         await request.read()

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -6193,7 +6193,7 @@ async def test_payload_upload_aborted(aiohttp_client: AiohttpClient) -> None:
 
     async def handler(request: web.Request) -> web.Response:
         await request.read()
-        return web.Response()
+        assert False
 
     app = web.Application()
     app.router.add_post("/", handler)
@@ -6206,7 +6206,7 @@ async def test_payload_upload_aborted(aiohttp_client: AiohttpClient) -> None:
     p = aiohttp.AsyncIterablePayload(failing_body())
     with pytest.raises(aiohttp.ClientError):
         async with client.post("/", data=p):
-            pass
+            assert False
     assert p.upload_complete.done()
     assert not p.upload_complete.cancelled()
     assert isinstance(p.upload_complete.exception(), aiohttp.ClientConnectionError)
@@ -6387,7 +6387,7 @@ async def test_empty_payload_overlap_keeps_tracking_ownership(
 
     async def slow_post() -> None:
         async with client.post("/", data=p, expect100=True) as resp:
-            assert resp.status == 200
+            assert False
 
     slow_task = asyncio.create_task(slow_post())
     try:
@@ -6444,7 +6444,7 @@ async def test_empty_payload_reused_after_aborted_upload(
 
     async def slow_post() -> None:
         async with client.post("/", data=p, expect100=True) as resp:
-            assert resp.status == 200
+            assert False
 
     slow_task = asyncio.create_task(slow_post())
     try:

--- a/tests/test_client_functional.py
+++ b/tests/test_client_functional.py
@@ -6559,9 +6559,9 @@ async def test_untracked_upload_failure_leaves_owner_state(
         await release.wait()
         await request.writer.write(b"HTTP/1.1 100 Continue\r\n\r\n")
 
-    async def handler(request: web.Request) -> web.Response:
+    async def handler(request: web.Request) -> NoReturn:
         await request.read()
-        return web.Response()
+        assert False
 
     app = web.Application()
     app.router.add_post("/", handler, expect_handler=expect_handler)
@@ -6576,8 +6576,8 @@ async def test_untracked_upload_failure_leaves_owner_state(
     fut = p.upload_complete
 
     async def slow_post() -> None:
-        async with client.post("/", data=p, expect100=True) as resp:
-            assert resp.status == 200
+        async with client.post("/", data=p, expect100=True):
+            assert False
 
     slow_task = asyncio.create_task(slow_post())
     try:
@@ -6589,7 +6589,7 @@ async def test_untracked_upload_failure_leaves_owner_state(
         # The second request runs untracked and its write fails.
         with pytest.raises(aiohttp.ClientError):
             async with client.post("/fail", data=p):
-                pass
+                assert False
         assert not fut.done()
     finally:
         waiter.cancel()

--- a/tests/test_client_middleware.py
+++ b/tests/test_client_middleware.py
@@ -1383,3 +1383,35 @@ async def test_middleware_short_circuit_settles_payload(
         # The body was never sent, so the upload is aborted, not resolved.
         assert p2.upload_complete.cancelled()
         assert p2.bytes_written == 0
+
+
+async def test_middleware_update_body_settles_replaced_payload(
+    aiohttp_server: AiohttpServer,
+) -> None:
+    """Replacing the body via update_body aborts the replaced payload.
+
+    The caller may hold upload_complete of the payload passed as data;
+    once a middleware swaps it out, that body will never be sent.
+    """
+
+    async def handler(request: web.Request) -> web.Response:
+        return web.Response(body=await request.read())
+
+    app = web.Application()
+    app.router.add_post("/", handler)
+    server = await aiohttp_server(app)
+
+    async def replace_middleware(
+        request: ClientRequest, handler: ClientHandlerType
+    ) -> ClientResponse:
+        await request.update_body(b"replacement")
+        return await handler(request)
+
+    async with ClientSession(middlewares=(replace_middleware,)) as session:
+        original = payload.BytesPayload(b"original")
+        fut = original.upload_complete
+        async with session.post(server.make_url("/"), data=original) as resp:
+            assert resp.status == 200
+            assert await resp.read() == b"replacement"
+        assert fut.cancelled()
+        assert original.bytes_written == 0

--- a/tests/test_client_middleware.py
+++ b/tests/test_client_middleware.py
@@ -15,6 +15,7 @@ from aiohttp import (
     ClientSession,
     ClientTimeout,
     TCPConnector,
+    payload,
     web,
 )
 from aiohttp.abc import ResolveResult
@@ -1337,3 +1338,48 @@ async def test_client_middleware_switch_types(
             assert resp.status == 200
             text = await resp.text()
             assert text == "now a string"
+
+
+async def test_middleware_short_circuit_settles_payload(
+    aiohttp_server: AiohttpServer,
+) -> None:
+    """A middleware answering from cache settles the unsent payload.
+
+    When the handler is never awaited, no writer ever runs, so the success
+    path must resolve upload_complete instead of leaving it pending forever.
+    """
+
+    async def handler(request: web.Request) -> web.Response:
+        await request.read()
+        return web.Response()
+
+    app = web.Application()
+    app.router.add_post("/", handler)
+    server = await aiohttp_server(app)
+
+    cached: list[ClientResponse] = []
+
+    async def cache_middleware(
+        request: ClientRequest, handler: ClientHandlerType
+    ) -> ClientResponse:
+        if cached:
+            return cached[0]
+        response = await handler(request)
+        cached.append(response)
+        return response
+
+    async with ClientSession(middlewares=(cache_middleware,)) as session:
+        p1 = payload.BytesPayload(b"x" * 64)
+        async with session.post(server.make_url("/"), data=p1) as resp:
+            assert resp.status == 200
+        assert p1.upload_complete.done()
+        assert p1.bytes_written == 64
+
+        # Served from cache: the request is never sent.
+        p2 = payload.BytesPayload(b"y" * 64)
+        resp2 = await session.post(server.make_url("/"), data=p2)
+        assert resp2.status == 200
+        assert p2.upload_complete.done()
+        # The body was never sent, so the upload is aborted, not resolved.
+        assert p2.upload_complete.cancelled()
+        assert p2.bytes_written == 0

--- a/tests/test_client_request.py
+++ b/tests/test_client_request.py
@@ -1251,6 +1251,44 @@ async def test_expect_100_continue_header(
     resp.close()
 
 
+async def test_expect100_preamble_failure_reports_upload_error(
+    conn: mock.Mock,
+    protocol: mock.Mock,
+    make_client_request: _RequestMaker,
+) -> None:
+    """A failure before the body write completes upload_complete with the error.
+
+    The 100-continue preamble runs outside the body-write exception
+    handlers; its errors must still reach the payload's future instead of
+    reporting an indistinguishable cancellation.
+    """
+    loop = asyncio.get_running_loop()
+    # Park the writer task at the preamble's drain(), then fail the flush.
+    drain_fut: asyncio.Future[None] = loop.create_future()
+    protocol._paused = True
+    protocol._drain_helper.return_value = drain_fut
+
+    p = payload.BytesPayload(b"x" * 1024)
+    req = make_client_request(
+        "post", URL("http://python.org/"), data=p, expect100=True, loop=loop
+    )
+    resp = await req._send(conn)
+    error = OSError("flush failed")
+    drain_fut.set_exception(error)
+
+    assert req._writer is not None
+    with pytest.raises(OSError) as excinfo:
+        await req._writer
+    assert excinfo.value is error
+
+    fut = p.upload_complete
+    assert fut.done()
+    assert not fut.cancelled()
+    assert fut.exception() is error
+    req._terminate()
+    resp.close()
+
+
 async def test_data_stream(
     buf: bytearray, conn: mock.Mock, make_client_request: _RequestMaker
 ) -> None:

--- a/tests/test_payload.py
+++ b/tests/test_payload.py
@@ -1442,3 +1442,45 @@ async def test_empty_bytes_payload_is_reusable() -> None:
         assert empty_payload.size == 0, f"size changed on write {i+1}"
 
     assert empty_payload.headers == CIMultiDict(initial_headers)
+
+
+async def test_upload_error_unpropagated_keeps_gc_log_armed() -> None:
+    """Without request propagation the future must keep the GC log armed.
+
+    When the request succeeds despite the failed upload (server responded
+    without reading the body), the future is the only holder of the error.
+    """
+    p = payload.BytesPayload(b"x")
+    assert p._start_upload()
+    err = RuntimeError("upload failed")
+    p._abort_upload(err)
+    fut = p.upload_complete
+    assert fut._log_traceback
+    assert fut.exception() is err
+    assert not fut._log_traceback  # retrieved by this test
+
+
+async def test_upload_error_propagated_is_consumed() -> None:
+    """A request raising the failure consumes the future's duplicate copy."""
+    p = payload.BytesPayload(b"x")
+    assert p._start_upload()
+    err = RuntimeError("upload failed")
+    p._abort_upload(err)
+    p._mark_upload_error_propagated()
+    fut = p.upload_complete
+    assert not fut._log_traceback
+    assert fut.exception() is err
+
+
+async def test_upload_error_propagation_consumes_existing_future() -> None:
+    """Propagation marking consumes a future created before the failure."""
+    p = payload.BytesPayload(b"x")
+    fut = p.upload_complete
+    assert p._start_upload()
+    err = RuntimeError("upload failed")
+    p._abort_upload(err)
+    armed = fut._log_traceback
+    assert armed
+    p._mark_upload_error_propagated()
+    assert not fut._log_traceback
+    assert fut.exception() is err

--- a/tests/test_payload.py
+++ b/tests/test_payload.py
@@ -1466,7 +1466,7 @@ async def test_upload_error_propagated_is_consumed() -> None:
     assert p._start_upload()
     err = RuntimeError("upload failed")
     p._abort_upload(err)
-    p._mark_upload_error_propagated()
+    p._mark_upload_error_propagated(err)
     fut = p.upload_complete
     assert not fut._log_traceback
     assert fut.exception() is err
@@ -1481,6 +1481,25 @@ async def test_upload_error_propagation_consumes_existing_future() -> None:
     p._abort_upload(err)
     armed = fut._log_traceback
     assert armed
-    p._mark_upload_error_propagated()
+    p._mark_upload_error_propagated(err)
     assert not fut._log_traceback
+    assert fut.exception() is err
+
+
+async def test_upload_error_propagation_requires_identity() -> None:
+    """Marking with a different exception must not consume the stored one.
+
+    A preamble failure can be superseded by an unrelated request error
+    (e.g. a timeout); the stored error is then the future's only holder
+    and its never-retrieved log must stay armed.
+    """
+    p = payload.BytesPayload(b"x")
+    fut = p.upload_complete
+    assert p._start_upload()
+    err = RuntimeError("preamble failed")
+    p._abort_upload(err)
+    p._mark_upload_error_propagated(RuntimeError("request timeout"))
+    assert not p._upload_error_propagated
+    armed = fut._log_traceback
+    assert armed
     assert fut.exception() is err


### PR DESCRIPTION
The upload progress attributes added recently fundamentally can't work as most servers won't send the headers in response to a request until they've read the entire body.

This replaces it with a new API.