### PR TITLE
🧪 Fix the circular import branch directory skip

### DIFF
--- a/tests/test_circular_imports.py
+++ b/tests/test_circular_imports.py
@@ -71,8 +71,13 @@ def _discover_path_importables(
         if pkg_dir_path.parts[-1] == "__pycache__":
             continue
 
-        if all(Path(_).suffix != ".py" for _ in file_names):
-            continue
+        if all(Path(_).suffix != ".py" for _ in file_names):  # pragma: no branch
+            # NOTE: This is only possible when testing editable installs where
+            # NOTE: the directory lookup encounters the `aiohttp/.hash/` cache
+            # NOTE: directory with files like `_http_parser.pyx.hash` in it that
+            # NOTE: never get included into source distributions or wheels and so
+            # NOTE: the module discovery mechanism never hits this code branch.
+            continue  # pragma: no cover
 
         rel_pt = pkg_dir_path.relative_to(pkg_pth)
         pkg_pref = ".".join((pkg_name,) + rel_pt.parts)


### PR DESCRIPTION
## What do these changes do?

PR #13388 introduced partial branch coverage in a directory scan skip logic in `tests/test_circular_imports.py::test_no_warnings`. This patch is attempting to address is by bringing the coverage on the test module back to 100% metric.

## Are there changes in behavior for the user?

Nah.

## Is it a substantial burden for the maintainers to support this?

Nope.

## Related issue number

This is just a follow-up for PR #13388.

## Checklist

- [ ] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES/` folder
  * name it `<issue_or_pr_num>.<type>.rst` (e.g. `588.bugfix.rst`)
  * if you don't have an issue number, change it to the pull request
    number after creating the PR
    * `.bugfix`: A bug fix for something the maintainers deemed an
      improper undesired behavior that got corrected to match
      pre-agreed expectations.
    * `.feature`: A new behavior, public APIs. That sort of stuff.
    * `.deprecation`: A declaration of future API removals and breaking
      changes in behavior.
    * `.breaking`: When something public is removed in a breaking way.
      Could be deprecated in an earlier release.
    * `.doc`: Notable updates to the documentation structure or build
      process.
    * `.packaging`: Notes for downstreams about unobvious side effects
      and tooling. Changes in the test invocation considerations and
      runtime assumptions.
    * `.contrib`: Stuff that affects the contributor experience. e.g.
      Running tests, building the docs, setting up the development
      environment.
    * `.misc`: Changes that are hard to assign to any of the above
      categories.
  * Make sure to use full sentences with correct case and punctuation,
    for example:
    ```rst
    Fixed issue with non-ascii contents in doctest text files
    -- by :user:`contributor-gh-handle`.
    ```

    Use the past tense or the present tense a non-imperative mood,
    referring to what's changed compared to the last released version
    of this project.
