### PR TITLE
reject legacy hex IPv4 literals in connector host resolution

### DIFF
--- a/CHANGES/13436.bugfix.rst
+++ b/CHANGES/13436.bugfix.rst
@@ -1,0 +1,1 @@
+Rejected legacy hexadecimal IPv4 literals such as ``0x7f000001`` in :class:`~aiohttp.TCPConnector` host resolution, matching the existing rejection of the decimal and octal forms so they cannot be resolved past a connector-level host policy -- by :user:`arshsmith1`.

--- a/aiohttp/connector.py
+++ b/aiohttp/connector.py
@@ -47,6 +47,7 @@ from .helpers import (
     ceil_timeout,
     is_canonical_ipv4_address,
     is_ip_address,
+    is_ipv4_literal,
     sentinel,
     set_exception,
     set_result,
@@ -1123,10 +1124,11 @@ class TCPConnector(BaseConnector):
         self, host: str, port: int, traces: Sequence["Trace"] | None = None
     ) -> list[ResolveResult]:
         """Resolve host and return list of addresses."""
-        if is_ip_address(host):
-            # Reject legacy numeric IPv4 forms (e.g. 2130706433, 127.1) that
-            # socket would map onto an address, slipping past a connector-level
-            # policy that only sees the raw host.
+        if is_ip_address(host) or is_ipv4_literal(host):
+            # Reject legacy numeric IPv4 forms (e.g. 2130706433, 0x7f000001,
+            # 127.1) that socket would map onto an address, slipping past a
+            # connector-level policy that only sees the raw host. is_ip_address
+            # does not recognise the hex forms, so is_ipv4_literal catches them.
             if ":" not in host and not is_canonical_ipv4_address(host):
                 raise InvalidUrlClientError(host, "is not a canonical IPv4 address")
             return [

--- a/aiohttp/helpers.py
+++ b/aiohttp/helpers.py
@@ -12,6 +12,7 @@ import netrc
 import os
 import platform
 import re
+import socket
 import sys
 import time
 import warnings
@@ -511,6 +512,22 @@ def is_canonical_ipv4_address(host: str) -> bool:
             return False
         if int(part) > 255:
             return False
+    return True
+
+
+def is_ipv4_literal(host: str) -> bool:
+    """Check if host is an IPv4 address literal in any form ``socket`` accepts.
+
+    Unlike :func:`is_canonical_ipv4_address`, this also returns ``True`` for the
+    legacy hex (``0x7f000001``), octal (``0177.0.0.1``) and short (``127.1``)
+    forms that ``inet_aton`` maps onto an address. Those never reach DNS since
+    the resolver parses them numerically, so a caller that wants to reject
+    non-canonical literals has to recognise them here first.
+    """
+    try:
+        socket.inet_aton(host)
+    except (OSError, ValueError):
+        return False
     return True
 
 

--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -1339,7 +1339,7 @@ async def test_tcp_connector_rejects_non_canonical_ipv4_alias() -> None:
             """Close the resolver."""
 
     conn = aiohttp.TCPConnector(resolver=_RecordingResolver())
-    for alias in ("2130706433", "017700000001", "127.1"):
+    for alias in ("2130706433", "017700000001", "127.1", "0x7f000001", "0x7f.0.0.1"):
         with pytest.raises(InvalidUrlClientError, match="canonical IPv4"):
             await conn._resolve_host(alias, 8080)
 

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -297,6 +297,40 @@ def test_is_canonical_ipv4_address_rejects_non_canonical(host: str) -> None:
     assert not helpers.is_canonical_ipv4_address(host)
 
 
+# ------------------------------- is_ipv4_literal() -------------------------
+
+
+@pytest.mark.parametrize(
+    "host",
+    [
+        "127.0.0.1",  # canonical dotted-quad
+        "2130706433",  # decimal integer form
+        "017700000001",  # octal form
+        "127.1",  # short-hand form
+        "0177.0.0.1",  # octal leading-zero octet
+        "0x7f000001",  # hex form
+        "0X7F000001",  # upper-case hex form
+        "0x7f.0.0.1",  # dotted hex octet
+    ],
+)
+def test_is_ipv4_literal_accepts_numeric_forms(host: str) -> None:
+    assert helpers.is_ipv4_literal(host)
+
+
+@pytest.mark.parametrize(
+    "host",
+    [
+        "example.com",
+        "0xcafe.example.com",
+        "localhost",
+        "::1",
+        "",
+    ],
+)
+def test_is_ipv4_literal_rejects_names(host: str) -> None:
+    assert not helpers.is_ipv4_literal(host)
+
+
 def _ipaddress_accepts_ipv4(host: str) -> bool:
     """Oracle: does the stdlib accept ``host`` as a canonical IPv4 address?"""
     try:


### PR DESCRIPTION
## What do these changes do?

`TCPConnector._resolve_host` already rejects legacy numeric IPv4 aliases (`2130706433`, `017700000001`, `127.1`) so they cannot be resolved past a connector-level host policy that only inspects the raw host string. That rejection is gated on `is_ip_address(host)`, whose heuristic is `":" in host or host.replace(".", "").isdigit()`, so it only recognises the decimal-dotted forms. Hexadecimal literals like `0x7f000001` and `0x7f.0.0.1` are not seen as IPs at all, so they skip the `is_canonical_ipv4_address` guard and go straight to the resolver, where `getaddrinfo`/`inet_aton` maps them onto `127.0.0.1`.

This adds a small `is_ipv4_literal` helper (backed by `socket.inet_aton`, so it recognises every form the resolver accepts) and widens the connector guard to use it, closing the hex gap while leaving canonical addresses and real hostnames untouched.

## Are there changes in behavior for the user?

Only for the bypass case. Canonical dotted-quad IPs still short-circuit the resolver as before, and real hostnames still resolve normally. A hex/legacy numeric literal that is not canonical now raises `InvalidUrlClientError`, matching what already happens for the decimal and octal forms.

## Is it a substantial burden for the maintainers to support this?

No. It reuses the existing guard and helper next to `is_canonical_ipv4_address`, and the regression sits in the test that already covers the decimal/octal/short aliases.

## Related issue number

None.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes -- N/A, the helper is internal and there is no public API change
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt` -- already listed
- [x] Add a new news fragment into the `CHANGES/` folder
