### PR TITLE
Build the websocket reader_c extension without the reader_c.py symlink

### DIFF
--- a/CHANGES/13457.packaging.rst
+++ b/CHANGES/13457.packaging.rst
@@ -1,0 +1,1 @@
+Removed the ``aiohttp/_websocket/reader_c.py`` symlink from the source tree; the ``aiohttp._websocket.reader_c`` extension is now compiled directly from ``reader_py.py`` using ``cython --module-name``, so distributions no longer include a ``reader_c.py`` file that showed up as an uncovered module in coverage reports -- by :user:`bdraco`.

--- a/Makefile
+++ b/Makefile
@@ -60,8 +60,8 @@ aiohttp/_find_header.c: $(call to-hash,aiohttp/hdrs.py ./tools/gen.py)
 
 # Special case for reader since we want to be able to disable
 # the extension with AIOHTTP_NO_EXTENSIONS
-aiohttp/_websocket/reader_c.c: aiohttp/_websocket/reader_c.py
-	cython -3 -X freethreading_compatible=True $(CYTHON_EXTRA) -o $@ $< -I aiohttp -Werror
+aiohttp/_websocket/reader_c.c: aiohttp/_websocket/reader_py.py
+	cython -3 --module-name aiohttp._websocket.reader_c -X freethreading_compatible=True $(CYTHON_EXTRA) -o $@ $< -I aiohttp -Werror
 
 # _find_headers generator creates _headers.pyi as well
 aiohttp/%.c: aiohttp/%.pyx $(call to-hash,$(CYS)) aiohttp/_find_header.c

--- a/aiohttp/_websocket/reader_c.py
+++ b/aiohttp/_websocket/reader_c.py
@@ -1,1 +1,0 @@
-reader_py.py

--- a/aiohttp/_websocket/reader_py.py
+++ b/aiohttp/_websocket/reader_py.py
@@ -525,7 +525,7 @@ class WebSocketReader:
                 elif self._has_mask:
                     assert self._frame_mask is not None
                     payload_bytearray = data_cstr[f_start_pos:f_end_pos]  # type: ignore[assignment]
-                    if type(payload_bytearray) is not bytearray:  # pragma: no branch
+                    if type(payload_bytearray) is not bytearray:
                         # Cython will do the conversion for us
                         # but we need to do it for Python and we
                         # will always get here in Python


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Removes the `aiohttp/_websocket/reader_c.py` symlink; the extension is now compiled directly from `reader_py.py` using `cython --module-name aiohttp._websocket.reader_c`. The symlink only existed so Cython would pair the source with `reader_c.pxd` and emit the right module name, but after #13388 the wheel build materializes it as a regular file in site-packages, which coverage then reports as a new 0% file.

## Are there changes in behavior for the user?

No runtime changes; dists no longer contain a stray `reader_c.py` file, `reader_c` only exists as the compiled extension.

## Is it a substantial burden for the maintainers to support this?

No, it is one less special case; the Makefile rule is the only thing that changed.

## Related issue number

Follow up to #13388

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
  * N/A, build tooling only, covered by the existing websocket test suite with extensions enabled
- [ ] Documentation reflects the changes
  * N/A
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * N/A, already listed
- [x] Add a new news fragment into the `CHANGES/` folder
  * name it `<issue_or_pr_num>.<type>.rst` (e.g. `588.bugfix.rst`)

Drafted with Claude Code; reviewed by bdraco.
