### PR TITLE
Strip Content-Length when Transfer-Encoding is present in StreamResponse

### DIFF
--- a/CHANGES/13431.bugfix.rst
+++ b/CHANGES/13431.bugfix.rst
@@ -1,0 +1,4 @@
+Stripped ``Content-Length`` from chunked responses when the header was set
+directly through ``resp.headers`` after calling
+:meth:`~aiohttp.web.StreamResponse.enable_chunked_encoding` -- by
+:user:`silentiris`.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -445,6 +445,7 @@ Yuval Ofir
 Yuvi Panda
 Zainab Lawal
 Zeal Wierslee
+Zhao Peiwen
 Zlatan Sičanica
 Łukasz Setla
 Марк Коренберг

--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -407,6 +407,11 @@ class StreamResponse(
                 elif not self._must_be_empty_body:
                     keep_alive = False
 
+        # RFC 9112 §6.3: a sender MUST NOT send Content-Length in a message
+        # that contains a Transfer-Encoding header field.
+        if hdrs.TRANSFER_ENCODING in headers:
+            headers.pop(hdrs.CONTENT_LENGTH, None)
+
         # HTTP 1.1: https://tools.ietf.org/html/rfc7230#section-3.3.2
         # HTTP 1.0: https://tools.ietf.org/html/rfc1945#section-10.4
         if self._must_be_empty_body:

--- a/tests/test_web_response.py
+++ b/tests/test_web_response.py
@@ -463,6 +463,26 @@ def test_enable_chunked_encoding_with_content_length() -> None:
         resp.enable_chunked_encoding()
 
 
+async def test_chunked_encoding_strips_content_length_set_via_headers() -> None:
+    """Content-Length set via headers after enable_chunked_encoding is stripped.
+
+    RFC 9112 §6.3: a sender MUST NOT send Content-Length in a message that
+    contains a Transfer-Encoding header field. The enable_chunked_encoding()
+    guard only blocks the content_length setter; writing directly through
+    resp.headers bypasses it.
+    """
+    req = make_request("GET", "/")
+    resp = web.StreamResponse()
+    resp.enable_chunked_encoding()
+    # Bypass the content_length setter guard
+    resp.headers[hdrs.CONTENT_LENGTH] = "100"
+
+    await resp.prepare(req)
+
+    assert hdrs.CONTENT_LENGTH not in resp.headers
+    assert resp.headers[hdrs.TRANSFER_ENCODING] == "chunked"
+
+
 async def test_chunked_encoding_forbidden_for_http_10() -> None:
     req = make_request("GET", "/", version=HttpVersion10)
     resp = web.StreamResponse()


### PR DESCRIPTION
## What do these changes do?

Fixes #13431

`StreamResponse` could emit both `Content-Length` and `Transfer-Encoding: chunked` in the same HTTP/1.1 response. The `enable_chunked_encoding()` guard only blocks the `content_length` setter; writing `Content-Length` directly through `resp.headers` bypasses it. `_prepare_headers` then added `Transfer-Encoding: chunked` without removing the existing `Content-Length`, violating RFC 9112 §6.3 and creating a CL/TE desync precondition.

The fix adds a single check in `_prepare_headers` that removes `Content-Length` whenever `Transfer-Encoding` is set, covering both the explicit `enable_chunked_encoding()` path and the auto-chunked path where `writer.length is None`.

## Are there changes in behavior for the user?

Responses that previously sent both `Content-Length` and `Transfer-Encoding: chunked` (an RFC violation) now correctly send only `Transfer-Encoding: chunked`. Applications that set `Content-Length` through `resp.headers` after calling `enable_chunked_encoding()` will no longer have that header on the wire — which is the correct behavior per RFC 9112.

## Is it a substantial burden for the maintainers to support?

No. The fix is a 3-line check in `_prepare_headers` with a single focused test. No new dependencies, no API changes, no configuration options.

## Related issue number

Fixes #13431

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes (N/A — internal header fix, no user-facing API change)
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
- [x] Add a new news fragment into the `CHANGES/` folder

<details>
<summary>Test results</summary>

```
tests/test_web_response.py::test_chunked_encoding_strips_content_length_set_via_headers PASSED
176 passed, 32 skipped (zlib_ng/isal not installed), 2 deselected in 0.66s
tests/test_web_functional.py: 133 passed, 11 skipped in 1.00s
```

</details>

Drafted with Claude Code; reviewed by silentiris.