### PR TITLE
Fix routing of percent-encodable fixed path segments

### DIFF
--- a/CHANGES/13433.bugfix.rst
+++ b/CHANGES/13433.bugfix.rst
@@ -1,0 +1,4 @@
+Fixed dynamic and static routes with percent-encodable fixed path segments
+(spaces, non-ASCII) being unreachable — the resolver walked the decoded path
+but the resource index key and regex pattern used the percent-encoded form
+-- by :user:`silentiris`.

--- a/CHANGES/13433.bugfix.rst
+++ b/CHANGES/13433.bugfix.rst
@@ -1,4 +1,4 @@
-Fixed dynamic and static routes with percent-encodable fixed path segments
-(spaces, non-ASCII) being unreachable — the resolver walked the decoded path
-but the resource index key and regex pattern used the percent-encoded form
+Fixed dynamic and static routes with spaces or non-ASCII characters in
+fixed path segments being unreachable — the resolver walked the decoded
+path but the resource index key and regex pattern used the encoded form
 -- by :user:`silentiris`.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -445,6 +445,7 @@ Yuval Ofir
 Yuvi Panda
 Zainab Lawal
 Zeal Wierslee
+Zhao Peiwen
 Zlatan Sičanica
 Łukasz Setla
 Марк Коренберг

--- a/aiohttp/web_urldispatcher.py
+++ b/aiohttp/web_urldispatcher.py
@@ -409,25 +409,31 @@ class DynamicResource(Resource):
         self._orig_path = path
         pattern = ""
         formatter = ""
+        canonical = ""
         for part in ROUTE_RE.split(path):
             match = self.DYN.fullmatch(part)
             if match:
                 pattern += "(?P<{}>{})".format(match.group("var"), self.GOOD)
                 formatter += "{" + match.group("var") + "}"
+                canonical += "{" + match.group("var") + "}"
                 continue
 
             match = self.DYN_WITH_RE.fullmatch(part)
             if match:
                 pattern += "(?P<{var}>{re})".format(**match.groupdict())
                 formatter += "{" + match.group("var") + "}"
+                canonical += "{" + match.group("var") + "}"
                 continue
 
             if "{" in part or "}" in part:
                 raise ValueError(f"Invalid path '{path}'['{part}']")
 
-            part = _requote_path(part)
-            formatter += part
+            # Use the decoded part for the regex pattern so it matches
+            # the decoded path_safe used by the resolver.  The formatter
+            # uses the encoded form so url_for() produces valid URLs.
             pattern += re.escape(part)
+            formatter += _requote_path(part)
+            canonical += part
 
         try:
             compiled = re.compile(pattern)
@@ -437,17 +443,19 @@ class DynamicResource(Resource):
         assert formatter.startswith("/")
         self._pattern = compiled
         self._formatter = formatter
+        self._canonical = canonical
 
     @property
     def canonical(self) -> str:
-        return self._formatter
+        return self._canonical
 
     def add_prefix(self, prefix: str) -> None:
         assert prefix.startswith("/")
         assert not prefix.endswith("/")
         assert len(prefix) > 1
         self._pattern = re.compile(re.escape(prefix) + self._pattern.pattern)
-        self._formatter = prefix + self._formatter
+        self._formatter = _requote_path(prefix) + self._formatter
+        self._canonical = prefix + self._canonical
 
     def _match(self, path: str) -> dict[str, str] | None:
         match = self._pattern.fullmatch(path)
@@ -477,8 +485,8 @@ class PrefixResource(AbstractResource):
         assert not prefix or prefix.startswith("/"), prefix
         assert prefix in ("", "/") or not prefix.endswith("/"), prefix
         super().__init__(name=name)
-        self._prefix = _requote_path(prefix)
-        self._prefix2 = self._prefix + "/"
+        self._prefix = prefix
+        self._prefix2 = prefix + "/"
 
     @property
     def canonical(self) -> str:
@@ -546,7 +554,7 @@ class StaticResource(PrefixResource):
             append_version = self._append_version
         filename = str(filename).lstrip("/")
 
-        url = URL.build(path=self._prefix, encoded=True)
+        url = URL.build(path=_requote_path(self._prefix), encoded=True)
         # filename is not encoded
         url = url / filename
 

--- a/tests/test_urldispatch.py
+++ b/tests/test_urldispatch.py
@@ -736,6 +736,51 @@ def test_route_dynamic_quoting(router: web.UrlDispatcher) -> None:
     )
 
 
+async def test_dynamic_match_with_percent_encoded_fixed_part(
+    router: web.UrlDispatcher,
+) -> None:
+    """A dynamic route with a percent-encodable fixed segment is resolvable.
+
+    Regression test for #13433: the fixed part was percent-encoded at
+    registration time and used for both the regex pattern and the resource
+    index key, but the resolver walks the *decoded* path.  The encoded
+    index key was never probed, so the resource was never a candidate.
+    """
+    handler = make_handler()
+    router.add_route("GET", "/hello world/{name}", handler)
+
+    req = make_mocked_request("GET", "/hello%20world/john")
+    match_info = await router.resolve(req)
+    assert {"name": "john"} == match_info
+
+
+async def test_dynamic_url_for_round_trip_with_percent_encoded_fixed_part(
+    router: web.UrlDispatcher,
+) -> None:
+    """url_for() produces a URL that the router can resolve back."""
+    handler = make_handler()
+    route = router.add_route("GET", "/hello world/{name}", handler)
+
+    url = route.url_for(name="john")
+    assert str(url) == "/hello%20world/john"
+
+    req = make_mocked_request("GET", str(url))
+    match_info = await router.resolve(req)
+    assert {"name": "john"} == match_info
+
+
+async def test_static_match_with_percent_encoded_prefix(
+    router: web.UrlDispatcher, tmp_path: pathlib.Path
+) -> None:
+    """A static route with a percent-encodable prefix is resolvable."""
+    (tmp_path / "file.txt").write_text("hello")
+    router.add_static("/static files", tmp_path)
+
+    req = make_mocked_request("GET", "/static%20files/file.txt")
+    match_info = await router.resolve(req)
+    assert match_info["filename"] == "file.txt"
+
+
 async def test_regular_match_info(router: web.UrlDispatcher) -> None:
     handler = make_handler()
     router.add_route("GET", "/get/{name}", handler)


### PR DESCRIPTION
## What do these changes do?

Fixes #13433

Dynamic routes (and static/prefix resources) whose fixed path segment contains characters that need percent-encoding — a space, non-ASCII, or some reserved characters — were unreachable: every request to them returned 404, and the URL produced by `url_for()` could not be routed back either.

**Root cause:** `DynamicResource.__init__` percent-encoded fixed parts with `_requote_path()` and used the encoded form for both the regex pattern and the resource index key. `PrefixResource.__init__` did the same with the prefix. But `UrlDispatcher.resolve` walks the **decoded** `request.rel_url.path_safe` backwards to find candidates. The encoded index key was never probed, so the resource was never a candidate. Even if it had been, the encoded regex pattern would not have matched the decoded path.

**Fix:**
- `DynamicResource`: use decoded fixed parts for the regex pattern and the `canonical` property (which feeds the resource index key); keep the encoded form in the formatter so `url_for()` still produces valid encoded URLs.
- `PrefixResource`: store the decoded prefix (used by `StaticResource.resolve` for prefix matching and by `canonical` for the index key); `StaticResource.url_for` now encodes the prefix on the fly.

## Are there changes in behavior for the user?

Routes with spaces or non-ASCII characters in fixed path segments (e.g. `/hello world/{name}` or `/static files/`) are now correctly resolvable. Previously they returned 404. `url_for()` output is unchanged — it still produces properly percent-encoded URLs.

## Is it a substantial burden for the maintainers to support?

No. The fix is a small, well-contained change in `web_urldispatcher.py` with three focused regression tests. No new dependencies, no configuration changes, no API changes.

## Related issue number

Fixes #13433

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes (N/A — internal routing fix, no user-facing API change)
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
- [x] Add a new news fragment into the `CHANGES/` folder

<details>
<summary>Test results</summary>

```
tests/test_urldispatch.py: 155 passed in 0.13s
tests/test_web_functional.py + test_web_response.py + test_urldispatch.py: 463 passed, 43 skipped, 2 deselected in 1.70s
```

</details>

Drafted with Claude Code; reviewed by silentiris.