### PR TITLE
return 415 for undecodable multipart field charset in post

### DIFF
--- a/CHANGES/13462.bugfix.rst
+++ b/CHANGES/13462.bugfix.rst
@@ -1,0 +1,6 @@
+Handled a multipart/form-data text field whose ``Content-Type`` charset
+is unknown or whose bytes do not decode by raising
+:exc:`~aiohttp.web.HTTPUnsupportedMediaType` from :meth:`BaseRequest.post()
+<aiohttp.web.BaseRequest.post>`, matching the urlencoded body and
+:meth:`~aiohttp.web.BaseRequest.text` paths instead of surfacing an
+uncaught error -- by :user:`dxbjavid`.

--- a/CHANGES/13462.bugfix.rst
+++ b/CHANGES/13462.bugfix.rst
@@ -1,6 +1,1 @@
-Handled a multipart/form-data text field whose ``Content-Type`` charset
-is unknown or whose bytes do not decode by raising
-:exc:`~aiohttp.web.HTTPUnsupportedMediaType` from :meth:`BaseRequest.post()
-<aiohttp.web.BaseRequest.post>`, matching the urlencoded body and
-:meth:`~aiohttp.web.BaseRequest.text` paths instead of surfacing an
-uncaught error -- by :user:`dxbjavid`.
+Fixed multipart not returning 415 when decoding failed -- by :user:`dxbjavid`.

--- a/aiohttp/web_request.py
+++ b/aiohttp/web_request.py
@@ -795,7 +795,11 @@ class BaseRequest(MutableMapping[str | RequestKey[Any], Any], HeadersMixin):
 
                         if field_ct is None or field_ct.startswith("text/"):
                             charset = field.get_charset(default="utf-8")
-                            out.add(field.name, value.decode(charset))
+                            try:
+                                decoded = value.decode(charset)
+                            except (LookupError, UnicodeDecodeError):
+                                raise HTTPUnsupportedMediaType()
+                            out.add(field.name, decoded)
                         else:
                             out.add(field.name, value)  # type: ignore[arg-type]
                 else:

--- a/tests/test_web_request.py
+++ b/tests/test_web_request.py
@@ -1030,10 +1030,10 @@ async def test_multipart_formdata(protocol: BaseProtocol) -> None:
 
 @pytest.mark.parametrize(
     ("part_charset", "part_body"),
-    [
+    (
         ("not-a-real-codec", b"hello"),
         ("utf-8", b"\xff\xfe"),
-    ],
+    ),
 )
 async def test_multipart_formdata_field_bad_charset(
     protocol: BaseProtocol, part_charset: str, part_body: bytes

--- a/tests/test_web_request.py
+++ b/tests/test_web_request.py
@@ -1028,36 +1028,22 @@ async def test_multipart_formdata(protocol: BaseProtocol) -> None:
     assert dict(result) == {"a": "b", "c": "d"}
 
 
-async def test_multipart_formdata_field_unknown_charset(protocol: BaseProtocol) -> None:
+@pytest.mark.parametrize(
+    ("part_charset", "part_body"),
+    [
+        ("not-a-real-codec", b"hello"),
+        ("utf-8", b"\xff\xfe"),
+    ],
+)
+async def test_multipart_formdata_field_bad_charset(
+    protocol: BaseProtocol, part_charset: str, part_body: bytes
+) -> None:
     payload = StreamReader(protocol, 2**16, loop=asyncio.get_running_loop())
     payload.feed_data(
         b"-----------------------------326931944431359\r\n"
         b'Content-Disposition: form-data; name="a"\r\n'
-        b"Content-Type: text/plain; charset=not-a-real-codec\r\n"
-        b"\r\n"
-        b"hello\r\n"
-        b"-----------------------------326931944431359--\r\n"
-    )
-    content_type = (
-        "multipart/form-data; boundary=---------------------------326931944431359"
-    )
-    payload.feed_eof()
-    req = make_mocked_request(
-        "POST", "/", headers={"CONTENT-TYPE": content_type}, payload=payload
-    )
-    with pytest.raises(web.HTTPUnsupportedMediaType) as err:
-        await req.post()
-    assert err.value.status_code == 415
-
-
-async def test_multipart_formdata_field_undecodable(protocol: BaseProtocol) -> None:
-    payload = StreamReader(protocol, 2**16, loop=asyncio.get_running_loop())
-    payload.feed_data(
-        b"-----------------------------326931944431359\r\n"
-        b'Content-Disposition: form-data; name="a"\r\n'
-        b"Content-Type: text/plain; charset=utf-8\r\n"
-        b"\r\n"
-        b"\xff\xfe\r\n"
+        b"Content-Type: text/plain; charset=" + part_charset.encode() + b"\r\n"
+        b"\r\n" + part_body + b"\r\n"
         b"-----------------------------326931944431359--\r\n"
     )
     content_type = (

--- a/tests/test_web_request.py
+++ b/tests/test_web_request.py
@@ -1028,6 +1028,50 @@ async def test_multipart_formdata(protocol: BaseProtocol) -> None:
     assert dict(result) == {"a": "b", "c": "d"}
 
 
+async def test_multipart_formdata_field_unknown_charset(protocol: BaseProtocol) -> None:
+    payload = StreamReader(protocol, 2**16, loop=asyncio.get_running_loop())
+    payload.feed_data(
+        b"-----------------------------326931944431359\r\n"
+        b'Content-Disposition: form-data; name="a"\r\n'
+        b"Content-Type: text/plain; charset=not-a-real-codec\r\n"
+        b"\r\n"
+        b"hello\r\n"
+        b"-----------------------------326931944431359--\r\n"
+    )
+    content_type = (
+        "multipart/form-data; boundary=---------------------------326931944431359"
+    )
+    payload.feed_eof()
+    req = make_mocked_request(
+        "POST", "/", headers={"CONTENT-TYPE": content_type}, payload=payload
+    )
+    with pytest.raises(web.HTTPUnsupportedMediaType) as err:
+        await req.post()
+    assert err.value.status_code == 415
+
+
+async def test_multipart_formdata_field_undecodable(protocol: BaseProtocol) -> None:
+    payload = StreamReader(protocol, 2**16, loop=asyncio.get_running_loop())
+    payload.feed_data(
+        b"-----------------------------326931944431359\r\n"
+        b'Content-Disposition: form-data; name="a"\r\n'
+        b"Content-Type: text/plain; charset=utf-8\r\n"
+        b"\r\n"
+        b"\xff\xfe\r\n"
+        b"-----------------------------326931944431359--\r\n"
+    )
+    content_type = (
+        "multipart/form-data; boundary=---------------------------326931944431359"
+    )
+    payload.feed_eof()
+    req = make_mocked_request(
+        "POST", "/", headers={"CONTENT-TYPE": content_type}, payload=payload
+    )
+    with pytest.raises(web.HTTPUnsupportedMediaType) as err:
+        await req.post()
+    assert err.value.status_code == 415
+
+
 async def test_urlencoded_form_with_invalid_default_encoding(
     protocol: BaseProtocol,
 ) -> None:


### PR DESCRIPTION
## What do these changes do?

`BaseRequest.post()` decodes a plain multipart/form-data text field with `value.decode(charset)`, where `charset` comes from that part's own `Content-Type` header and is fully attacker controlled. An unknown codec name (`charset=not-a-real-codec`) raises `LookupError` and undecodable bytes raise `UnicodeDecodeError`, and neither is caught, so a malformed part turns into an uncaught 500. The sibling urlencoded branch a few lines below, and `BaseRequest.text()`, already wrap the same decode in `except (LookupError, UnicodeDecodeError)` and raise `HTTPUnsupportedMediaType`. This brings the multipart branch in line with those two, so a bad part charset now yields a 415 like the other body-parsing paths rather than a server error.

## Are there changes in behavior for the user?

A multipart field whose charset is unknown or whose bytes do not decode now surfaces as `HTTPUnsupportedMediaType` (415) instead of an unhandled exception. Valid fields are unaffected.

## Is it a substantial burden for the maintainers to support this?

No. It is a two-line guard that mirrors existing code in the same function.

## Related issue number

N/A

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
- [x] Add a new news fragment into the `CHANGES/` folder
