### PR TITLE
fix: resume paused transport after websocket upgrade

### DIFF
--- a/CHANGES/13432.bugfix.rst
+++ b/CHANGES/13432.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed WebSocket connections remaining paused after an upgraded request in a pipelined HTTP burst -- by :user:`mmdverse`.

--- a/aiohttp/web_protocol.py
+++ b/aiohttp/web_protocol.py
@@ -449,6 +449,7 @@ class RequestHandler(BaseProtocol, Generic[_Request]):
 
         self._payload_parser = parser
         self._data_received_cb = data_received_cb
+        self._upgraded = True
 
         if self._message_tail:
             self._payload_parser.feed_data(self._message_tail)

--- a/aiohttp/web_protocol.py
+++ b/aiohttp/web_protocol.py
@@ -454,6 +454,9 @@ class RequestHandler(BaseProtocol, Generic[_Request]):
             self._payload_parser.feed_data(self._message_tail)
             self._message_tail = b""
 
+        if self._msg_queue_paused:
+            self._resume_msg_queue_reading()
+
     def eof_received(self) -> None:
         pass
 

--- a/tests/test_web_protocol.py
+++ b/tests/test_web_protocol.py
@@ -36,6 +36,24 @@ def test_set_parser_does_not_call_data_received_cb_for_tail(
     dummy_reader[1].feed_data.assert_called_once_with(b"tail")
 
 
+def test_set_parser_resumes_msg_queue_reading_after_upgrade(
+    event_loop: asyncio.AbstractEventLoop,
+    dummy_manager: Server[BaseRequest],
+    dummy_reader: tuple[WebSocketReader, mock.Mock],
+) -> None:
+    handler = RequestHandler(dummy_manager, loop=event_loop)
+    transport = mock.Mock()
+    handler.transport = transport
+    handler._upgraded = True
+    handler._msg_queue_paused = True
+    handler._reading_paused = False
+
+    handler.set_parser(dummy_reader[0])
+
+    assert handler._msg_queue_paused is False
+    transport.resume_reading.assert_called_once_with()
+
+
 def test_data_received_calls_data_received_cb(
     event_loop: asyncio.AbstractEventLoop,
     dummy_manager: Server[BaseRequest],

--- a/tests/test_web_protocol.py
+++ b/tests/test_web_protocol.py
@@ -44,12 +44,13 @@ def test_set_parser_resumes_msg_queue_reading_after_upgrade(
     handler = RequestHandler(dummy_manager, loop=event_loop)
     transport = mock.Mock()
     handler.transport = transport
-    handler._upgraded = True
+    handler._upgraded = False
     handler._msg_queue_paused = True
     handler._reading_paused = False
 
     handler.set_parser(dummy_reader[0])
 
+    assert handler._upgraded is True
     assert handler._msg_queue_paused is False
     transport.resume_reading.assert_called_once_with()
 

--- a/tests/test_web_websocket_functional.py
+++ b/tests/test_web_websocket_functional.py
@@ -118,9 +118,7 @@ async def test_pipelined_websocket_upgrade_resumes_paused_transport(
     reader, writer = await asyncio.open_connection(server.host, server.port)
     try:
         writer.write(
-            b"".join(
-                request(server.port, index == 32) for index in range(1, 65)
-            )
+            b"".join(request(server.port, index == 32) for index in range(1, 65))
         )
         await writer.drain()
 

--- a/tests/test_web_websocket_functional.py
+++ b/tests/test_web_websocket_functional.py
@@ -79,6 +79,63 @@ async def test_pipelined_request_after_failed_websocket_upgrade(
     assert b"426" in data
 
 
+async def test_pipelined_websocket_upgrade_resumes_paused_transport(
+    aiohttp_server: AiohttpServer,
+) -> None:
+    async def plain(_request: web.Request) -> web.Response:
+        return web.Response(text="ok")
+
+    async def websocket(request: web.Request) -> web.WebSocketResponse:
+        ws = web.WebSocketResponse()
+        await ws.prepare(request)
+        await ws.receive()
+        return ws
+
+    def request(port: int, upgrade: bool) -> bytes:
+        if upgrade:
+            return (
+                f"GET /ws HTTP/1.1\r\nHost: 127.0.0.1:{port}\r\n"
+                "Upgrade: websocket\r\nConnection: Upgrade\r\n"
+                "Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n"
+                "Sec-WebSocket-Version: 13\r\n\r\n"
+            ).encode()
+        return f"GET / HTTP/1.1\r\nHost: 127.0.0.1:{port}\r\n\r\n".encode()
+
+    async def read_response(reader: asyncio.StreamReader) -> bytes:
+        head = await reader.readuntil(b"\r\n\r\n")
+        content_length = 0
+        for line in head.split(b"\r\n"):
+            if line.lower().startswith(b"content-length:"):
+                content_length = int(line.split(b":", 1)[1].strip())
+        if content_length:
+            await reader.readexactly(content_length)
+        return head
+
+    app = web.Application()
+    app.router.add_get("/", plain)
+    app.router.add_get("/ws", websocket)
+    server = await aiohttp_server(app)
+    reader, writer = await asyncio.open_connection(server.host, server.port)
+    try:
+        writer.write(
+            b"".join(
+                request(server.port, index == 32) for index in range(1, 65)
+            )
+        )
+        await writer.drain()
+
+        for _ in range(32):
+            head = await asyncio.wait_for(read_response(reader), timeout=5)
+        assert b"101 Switching Protocols" in head
+
+        writer.write(b"\x89\x00")
+        await writer.drain()
+        assert await asyncio.wait_for(reader.readexactly(2), timeout=5) == b"\x8a\x00"
+    finally:
+        writer.close()
+        await writer.wait_closed()
+
+
 async def test_partial_pipelined_request_after_failed_websocket_upgrade(
     aiohttp_server: AiohttpServer,
 ) -> None:

--- a/tests/test_web_websocket_functional.py
+++ b/tests/test_web_websocket_functional.py
@@ -86,9 +86,11 @@ async def test_pipelined_websocket_upgrade_resumes_paused_transport(
         return web.Response(text="ok")
 
     async def websocket(request: web.Request) -> web.WebSocketResponse:
-        ws = web.WebSocketResponse()
+        ws = web.WebSocketResponse(autoping=False)
         await ws.prepare(request)
-        await ws.receive()
+        message = await ws.receive()
+        assert message.type is WSMsgType.PING
+        await ws.pong(message.data)
         return ws
 
     def request(port: int, upgrade: bool) -> bytes:
@@ -122,8 +124,9 @@ async def test_pipelined_websocket_upgrade_resumes_paused_transport(
         )
         await writer.drain()
 
-        for _ in range(32):
-            head = await asyncio.wait_for(read_response(reader), timeout=5)
+        for _ in range(31):
+            await asyncio.wait_for(read_response(reader), timeout=5)
+        head = await asyncio.wait_for(read_response(reader), timeout=5)
         assert b"101 Switching Protocols" in head
 
         writer.write(b"\x89\x00")


### PR DESCRIPTION
## Summary

Fixes #13432.

A pipelined HTTP burst can pause the transport while the request queue is full. If one queued request upgrades to WebSocket, `set_parser()` switches to the WebSocket parser but does not clear the message-queue pause. The upgraded connection can then stop reading frames after a successful `101 Switching Protocols` response.

Resume the paused transport when installing the WebSocket parser. At that point the handler is upgraded, so `_resume_msg_queue_reading()` skips HTTP tail reparsing and safely hands reading back to the WebSocket path.

## Regression coverage

- Unit coverage for installing a WebSocket parser while the message queue has paused transport reading
- Functional coverage for 64 pipelined requests with the 32nd request upgrading to WebSocket, followed by a ping/pong exchange

## Validation

- Regression test fails against the previous `set_parser()` behavior
- `pytest tests/test_web_protocol.py tests/test_web_websocket_functional.py -q` → 65 passed
- Added a `CHANGES/13432.bugfix.rst` fragment
