### PR TITLE
honor entity-tag If-Range in FileResponse range requests

### DIFF
--- a/CHANGES/13480.bugfix.rst
+++ b/CHANGES/13480.bugfix.rst
@@ -1,0 +1,5 @@
+Fixed :class:`~aiohttp.web.FileResponse` ignoring the entity-tag form of the
+``If-Range`` request header, which caused a ``Range`` request with a stale
+``If-Range: "<etag>"`` validator to be served a ``206`` partial from a changed
+file instead of the full ``200`` representation, per :rfc:`9110#section-13.1.5`
+-- by :user:`arshsmith1`.

--- a/CHANGES/13480.bugfix.rst
+++ b/CHANGES/13480.bugfix.rst
@@ -1,5 +1,5 @@
 Fixed :class:`~aiohttp.web.FileResponse` ignoring the entity-tag form of the
 ``If-Range`` request header, which caused a ``Range`` request with a stale
-``If-Range: "<etag>"`` validator to be served a ``206`` partial from a changed
+``If-Range: "<etag>"`` to be served a ``206`` partial from a changed
 file instead of the full ``200`` representation, per :rfc:`9110#section-13.1.5`
 -- by :user:`arshsmith1`.

--- a/aiohttp/web_fileresponse.py
+++ b/aiohttp/web_fileresponse.py
@@ -13,7 +13,13 @@ from typing import TYPE_CHECKING, BinaryIO, Final, Optional
 
 from . import hdrs
 from .abc import AbstractStreamWriter
-from .helpers import DEFAULT_CHUNK_SIZE, ETAG_ANY, ETag, must_be_empty_body
+from .helpers import (
+    DEFAULT_CHUNK_SIZE,
+    ETAG_ANY,
+    ETag,
+    must_be_empty_body,
+    parse_http_date,
+)
 from .typedefs import LooseHeaders, PathLike
 from .web_exceptions import (
     HTTPForbidden,
@@ -305,10 +311,25 @@ class FileResponse(StreamResponse):
         file_mtime: float = st.st_mtime
         count: int = file_size
         start: int | None = None
+        etag_value = f"{st.st_mtime_ns:x}-{st.st_size:x}"
 
-        if (ifrange := request.if_range) is None or file_mtime <= ifrange.timestamp():
+        # If-Range: only honor the Range when the validator still matches the
+        # current representation, otherwise serve the whole 200 (RFC 9110
+        # section 13.1.5). request.if_range parses the HTTP-date form; the
+        # entity-tag form is handled here with the strong comparison If-Range
+        # requires, so a stale ETag no longer yields a partial from a changed
+        # file.
+        if_range = request.headers.get(hdrs.IF_RANGE)
+        if if_range is None:
+            range_applies = True
+        elif (if_range_date := parse_http_date(if_range)) is not None:
+            range_applies = file_mtime <= if_range_date.timestamp()
+        else:
+            range_applies = if_range.strip() == f'"{etag_value}"'
+
+        if range_applies:
             # If-Range header check:
-            # condition = cached date >= last modification date
+            # condition = cached validator matches current representation.
             # return 206 if True else 200.
             # if False:
             #   Range header would not be processed, return 200
@@ -391,7 +412,7 @@ class FileResponse(StreamResponse):
             # compress.
             self._compression = False
 
-        self.etag = f"{st.st_mtime_ns:x}-{st.st_size:x}"
+        self.etag = etag_value
         self.last_modified = file_mtime
         self.content_length = count
 

--- a/aiohttp/web_fileresponse.py
+++ b/aiohttp/web_fileresponse.py
@@ -1,5 +1,6 @@
 import asyncio
 import io
+import math
 import os
 import pathlib
 import sys
@@ -13,13 +14,7 @@ from typing import TYPE_CHECKING, BinaryIO, Final, Optional
 
 from . import hdrs
 from .abc import AbstractStreamWriter
-from .helpers import (
-    DEFAULT_CHUNK_SIZE,
-    ETAG_ANY,
-    ETag,
-    must_be_empty_body,
-    parse_http_date,
-)
+from .helpers import DEFAULT_CHUNK_SIZE, ETAG_ANY, ETag, must_be_empty_body
 from .typedefs import LooseHeaders, PathLike
 from .web_exceptions import (
     HTTPForbidden,
@@ -313,19 +308,18 @@ class FileResponse(StreamResponse):
         start: int | None = None
         etag_value = f"{st.st_mtime_ns:x}-{st.st_size:x}"
 
-        # If-Range: only honor the Range when the validator still matches the
-        # current representation, otherwise serve the whole 200 (RFC 9110
-        # section 13.1.5). request.if_range parses the HTTP-date form; the
-        # entity-tag form is handled here with the strong comparison If-Range
-        # requires, so a stale ETag no longer yields a partial from a changed
-        # file.
-        if_range = request.headers.get(hdrs.IF_RANGE)
+        # https://www.rfc-editor.org/info/rfc9110/#name-if-range
+        if_range = request.if_range
         if if_range is None:
             range_applies = True
-        elif (if_range_date := parse_http_date(if_range)) is not None:
-            range_applies = file_mtime <= if_range_date.timestamp()
+        elif isinstance(if_range, ETag):
+            # https://www.rfc-editor.org/info/rfc9110/#section-13.1.5-12.1
+            range_applies = not if_range.is_weak and if_range.value == etag_value
         else:
-            range_applies = if_range.strip() == f'"{etag_value}"'
+            # https://www.rfc-editor.org/info/rfc9110/#section-13.1.5-10.2
+            # Last-Modified is emitted as math.ceil(mtime), so the strong
+            # comparison is against that same rounded value.
+            range_applies = math.ceil(file_mtime) == if_range.timestamp()
 
         if range_applies:
             # If-Range header check:

--- a/aiohttp/web_request.py
+++ b/aiohttp/web_request.py
@@ -32,6 +32,7 @@ from .helpers import (
     DEFAULT_CHUNK_SIZE,
     ETAG_ANY,
     LIST_QUOTED_ETAG_RE,
+    QUOTED_ETAG_RE,
     ChainMapProxy,
     ETag,
     HeadersDictProxy,
@@ -601,12 +602,21 @@ class BaseRequest(MutableMapping[str | RequestKey[Any], Any], HeadersMixin):
         return self._if_match_or_none_impl(self.headers.get(hdrs.IF_NONE_MATCH))
 
     @reify
-    def if_range(self) -> datetime.datetime | None:
+    def if_range(self) -> datetime.datetime | ETag | None:
         """The value of If-Range HTTP header, or None.
 
-        This header is represented as a `datetime` object.
+        This header is represented as a `datetime` (HTTP-date form) or an
+        `ETag` (entity-tag form) object.
         """
-        return parse_http_date(self.headers.get(hdrs.IF_RANGE))
+        if_range = self.headers.get(hdrs.IF_RANGE)
+        if if_range is None:
+            return None
+        if (date := parse_http_date(if_range)) is not None:
+            return date
+        match = QUOTED_ETAG_RE.fullmatch(if_range.strip())
+        if match is None:
+            return None
+        return ETag(is_weak=bool(match.group(1)), value=match.group(2))
 
     @reify
     def keep_alive(self) -> bool:

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -374,7 +374,7 @@ and :ref:`aiohttp-web-signals` handlers.
 
    .. attribute:: if_range
 
-      Read-only property that returns the validator specified in the
+      Read-only property that returns the value specified in the
       *If-Range* header.
 
       Returns :class:`datetime.datetime` for the HTTP-date form, an
@@ -386,8 +386,7 @@ and :ref:`aiohttp-web-signals` handlers.
       .. versionchanged:: 4.0
 
          The entity-tag form is now parsed and returned as an
-         :class:`~aiohttp.ETag`; previously only the HTTP-date form was
-         recognised.
+         :class:`~aiohttp.ETag`.
 
    .. method:: clone(*, method=..., rel_url=..., headers=...)
 

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -383,7 +383,7 @@ and :ref:`aiohttp-web-signals` handlers.
 
       .. versionadded:: 3.1
 
-      .. versionchanged:: 4.0
+      .. versionchanged:: 3.15
 
          The entity-tag form is now parsed and returned as an
          :class:`~aiohttp.ETag`.

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -383,7 +383,7 @@ and :ref:`aiohttp-web-signals` handlers.
 
       .. versionadded:: 3.1
 
-      .. versionchanged:: 3.15
+      .. versionchanged:: 4.0
 
          The entity-tag form is now parsed and returned as an
          :class:`~aiohttp.ETag`.

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -374,14 +374,20 @@ and :ref:`aiohttp-web-signals` handlers.
 
    .. attribute:: if_range
 
-      Read-only property that returns the date specified in the
+      Read-only property that returns the validator specified in the
       *If-Range* header.
 
-      Returns :class:`datetime.datetime` or ``None`` if
-      *If-Range* header is absent or is not a valid
-      HTTP date.
+      Returns :class:`datetime.datetime` for the HTTP-date form, an
+      :class:`~aiohttp.ETag` for the entity-tag form, or ``None`` if the
+      *If-Range* header is absent or malformed.
 
       .. versionadded:: 3.1
+
+      .. versionchanged:: 4.0
+
+         The entity-tag form is now parsed and returned as an
+         :class:`~aiohttp.ETag`; previously only the HTTP-date form was
+         recognised.
 
    .. method:: clone(*, method=..., rel_url=..., headers=...)
 

--- a/tests/test_web_sendfile_functional.py
+++ b/tests/test_web_sendfile_functional.py
@@ -986,6 +986,41 @@ async def test_static_file_if_range_future_with_range(
     await client.close()
 
 
+async def test_static_file_if_range_etag_match_with_range(
+    aiohttp_client: AiohttpClient, app_with_static_route: web.Application
+) -> None:
+    client = await aiohttp_client(app_with_static_route)
+
+    resp = await client.get("/")
+    assert 200 == resp.status
+    etag = resp.headers["ETag"]
+    resp.release()
+
+    resp = await client.get("/", headers={"If-Range": etag, "Range": "bytes=2-"})
+    assert 206 == resp.status
+    assert resp.headers["Content-Range"] == "bytes 2-12/13"
+    assert resp.headers["Content-Length"] == "11"
+    resp.close()
+    resp.release()
+    await client.close()
+
+
+async def test_static_file_if_range_stale_etag_with_range(
+    aiohttp_client: AiohttpClient, app_with_static_route: web.Application
+) -> None:
+    client = await aiohttp_client(app_with_static_route)
+
+    resp = await client.get(
+        "/", headers={"If-Range": '"stale-etag"', "Range": "bytes=2-"}
+    )
+    assert 200 == resp.status
+    assert resp.headers["Content-Length"] == "13"
+    assert "Content-Range" not in resp.headers
+    resp.close()
+    resp.release()
+    await client.close()
+
+
 async def test_static_file_if_unmodified_since_past_without_range(
     aiohttp_client: AiohttpClient, app_with_static_route: web.Application
 ) -> None:

--- a/tests/test_web_sendfile_functional.py
+++ b/tests/test_web_sendfile_functional.py
@@ -974,21 +974,16 @@ async def test_static_file_if_range_matching_date_with_range(
 ) -> None:
     client = await aiohttp_client(app_with_static_route)
 
-    resp = await client.get("/")
-    assert 200 == resp.status
-    last_modified = resp.headers["Last-Modified"]
-    resp.release()
+    async with client.get("/") as resp:
+        assert 200 == resp.status
+        last_modified = resp.headers["Last-Modified"]
 
-    resp = await client.get(
+    async with client.get(
         "/", headers={"If-Range": last_modified, "Range": "bytes=2-"}
-    )
-    assert 206 == resp.status
-    assert resp.headers["Content-Range"] == "bytes 2-12/13"
-    assert resp.headers["Content-Length"] == "11"
-    resp.close()
-
-    resp.release()
-    await client.close()
+    ) as resp:
+        assert 206 == resp.status
+        assert resp.headers["Content-Range"] == "bytes 2-12/13"
+        assert resp.headers["Content-Length"] == "11"
 
 
 async def test_static_file_if_range_etag_match_with_range(
@@ -996,18 +991,14 @@ async def test_static_file_if_range_etag_match_with_range(
 ) -> None:
     client = await aiohttp_client(app_with_static_route)
 
-    resp = await client.get("/")
-    assert 200 == resp.status
-    etag = resp.headers["ETag"]
-    resp.release()
+    async with client.get("/") as resp:
+        assert 200 == resp.status
+        etag = resp.headers["ETag"]
 
-    resp = await client.get("/", headers={"If-Range": etag, "Range": "bytes=2-"})
-    assert 206 == resp.status
-    assert resp.headers["Content-Range"] == "bytes 2-12/13"
-    assert resp.headers["Content-Length"] == "11"
-    resp.close()
-    resp.release()
-    await client.close()
+    async with client.get("/", headers={"If-Range": etag, "Range": "bytes=2-"}) as resp:
+        assert 206 == resp.status
+        assert resp.headers["Content-Range"] == "bytes 2-12/13"
+        assert resp.headers["Content-Length"] == "11"
 
 
 async def test_static_file_if_range_stale_etag_with_range(
@@ -1015,15 +1006,12 @@ async def test_static_file_if_range_stale_etag_with_range(
 ) -> None:
     client = await aiohttp_client(app_with_static_route)
 
-    resp = await client.get(
+    async with client.get(
         "/", headers={"If-Range": '"stale-etag"', "Range": "bytes=2-"}
-    )
-    assert 200 == resp.status
-    assert resp.headers["Content-Length"] == "13"
-    assert "Content-Range" not in resp.headers
-    resp.close()
-    resp.release()
-    await client.close()
+    ) as resp:
+        assert 200 == resp.status
+        assert resp.headers["Content-Length"] == "13"
+        assert "Content-Range" not in resp.headers
 
 
 async def test_static_file_if_unmodified_since_past_without_range(

--- a/tests/test_web_sendfile_functional.py
+++ b/tests/test_web_sendfile_functional.py
@@ -969,14 +969,19 @@ async def test_static_file_if_range_past_with_range(
     await client.close()
 
 
-async def test_static_file_if_range_future_with_range(
+async def test_static_file_if_range_matching_date_with_range(
     aiohttp_client: AiohttpClient, app_with_static_route: web.Application
 ) -> None:
     client = await aiohttp_client(app_with_static_route)
 
-    lastmod = "Fri, 31 Dec 9999 23:59:59 GMT"
+    resp = await client.get("/")
+    assert 200 == resp.status
+    last_modified = resp.headers["Last-Modified"]
+    resp.release()
 
-    resp = await client.get("/", headers={"If-Range": lastmod, "Range": "bytes=2-"})
+    resp = await client.get(
+        "/", headers={"If-Range": last_modified, "Range": "bytes=2-"}
+    )
     assert 206 == resp.status
     assert resp.headers["Content-Range"] == "bytes 2-12/13"
     assert resp.headers["Content-Length"] == "11"


### PR DESCRIPTION
## What do these changes do?

`FileResponse` only looked at the HTTP-date form of `If-Range`. `request.if_range` runs the value through `parse_http_date` and returns `None` for anything that is not a date, so an `If-Range` carrying an entity-tag was treated as absent and the `Range` was honored unconditionally. A client resuming a download with `If-Range: "<etag>"` after the file had changed therefore received a `206` partial that it stitched onto the stale bytes it already held, producing a corrupt file. :rfc:`9110#section-13.1.5` wants the `Range` honored only when the validator still matches, otherwise the full `200`. The strong entity-tag comparison now happens inside `_prepare_open_file`, next to where the date form was already handled, so a stale (or weak) validator falls back to a full `200`.

## Are there changes in behavior for the user?

Only for the entity-tag `If-Range` case. Requests with no `If-Range`, and the date form, behave exactly as before; a matching strong ETag still serves the `206`.

## Is it a substantial burden for the maintainers to support this?

No. It reads the raw `If-Range` header where the date form was already parsed and adds one strong comparison, with two regression tests beside the existing `If-Range` date tests.

## Related issue number

None.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes — N/A, no public API change
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
- [x] Add a new news fragment into the `CHANGES/` folder