### PR TITLE
Only run fragment check on master

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -220,7 +220,12 @@ jobs:
         pip install -r requirements/base.in -c requirements/base.txt
         slotscheck -v -m aiohttp
     - name: Verify CHANGES fragment references PR
-      if: github.event_name == 'pull_request'
+      # Skipped on backport PRs: their fragments are numbered for the original
+      # PR/issue, so the check would never pass. The workflow itself stays
+      # identical across branches.
+      if: >-
+        github.event_name == 'pull_request'
+        && github.event.pull_request.base.ref == 'master'
       env:
         GH_TOKEN: ${{ github.token }}
         PR_NUMBER: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
This check should only be on master. This approach should satisfy webknjaz in keeping the workflow in sync on the backport branches.