### PR TITLE
Stop the benchmark CI job hanging on apt

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -498,7 +498,7 @@ jobs:
     if: >-
       needs.pre-setup.outputs.upstream-repository-id == github.repository_id
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
     steps:
     - name: Checkout project
       uses: actions/checkout@v7  # despite sdist, codspeed needs Git
@@ -538,6 +538,25 @@ jobs:
         lsb_release -a
         uname -r
         openssl version -a
+    - name: Install libc6-dbg
+      # The CodSpeed runner installs this itself with a plain apt-get call
+      # that has no timeout, so a slow apt mirror hangs the job until
+      # timeout-minutes kills it. Installing it here with a bounded retry
+      # also lets the runner find it already present after restoring
+      # valgrind from its cache and skip apt entirely.
+      run: |
+        for attempt in 1 2 3; do
+          if timeout 300 sudo apt-get update \
+            && timeout 300 sudo DEBIAN_FRONTEND=noninteractive \
+              apt-get install -y libc6-dbg
+          then
+            exit 0
+          fi
+          echo "apt-get attempt ${attempt} failed, retrying"
+          sudo dpkg --configure -a || true
+          sleep 10
+        done
+        exit 1
     - name: Run benchmarks
       uses: CodSpeedHQ/action@v5.0.3
       with:

--- a/CHANGES/13489.contrib.rst
+++ b/CHANGES/13489.contrib.rst
@@ -1,0 +1,3 @@
+Stopped the benchmark CI job from hanging in the CodSpeed runner's apt
+install by preinstalling ``libc6-dbg`` with a bounded retry, and raised the
+job timeout from 15 to 30 minutes -- by :user:`bdraco`.

--- a/CHANGES/13489.contrib.rst
+++ b/CHANGES/13489.contrib.rst
@@ -1,3 +1,3 @@
 Stopped the benchmark CI job from hanging in the CodSpeed runner's apt
-install by preinstalling ``libc6-dbg`` with a bounded retry, and raised the
-job timeout from 15 to 30 minutes -- by :user:`bdraco`.
+install by installing ``libc6-dbg`` up front with a bounded retry, and raised
+the job timeout from 15 to 30 minutes -- by :user:`bdraco`.


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

The `Benchmark` job has been getting cancelled at its 15 minute limit, so CodSpeed stopped reporting on some PRs (for example https://github.com/aio-libs/aiohttp/actions/runs/32157680880/job/95779217306). The job logs show it stuck right after the CodSpeed runner prints `Installing packages: /tmp/valgrind-codspeed.deb, libc6-dbg`; that is a plain `apt-get update` plus `apt-get install libc6-dbg` inside the runner with no timeout, and it has taken anywhere from 37 seconds to over 14 minutes on the same runner image today. It runs even after the runner restores valgrind from its cache, because the runner also checks `dpkg -s libc6-dbg` and the cache only copies files.

This adds a step that installs `libc6-dbg` before the CodSpeed action with a `timeout` and a retry loop, so a stalled mirror fails fast and retries instead of hanging; once it is registered in dpkg the runner finds it present after its cache restore and skips apt entirely. It also raises the job timeout to 30 minutes, since a slow install plus the ~9 minute benchmark suite already blew past 15 in one run.

## Are there changes in behavior for the user?

No, CI only.

## Is it a substantial burden for the maintainers to support this?

No; one extra workflow step and a timeout bump.

## Related issue number

None.

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist N/A
- [ ] Documentation reflects the changes N/A
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt` N/A
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES/` folder
  * name it `<issue_or_pr_num>.<type>.rst` (e.g. `588.bugfix.rst`)
  * if you don't have an issue number, change it to the pull request
    number after creating the PR
    * `.bugfix`: A bug fix for something the maintainers deemed an
      improper undesired behavior that got corrected to match
      pre-agreed expectations.
    * `.feature`: A new behavior, public APIs. That sort of stuff.
    * `.deprecation`: A declaration of future API removals and breaking
      changes in behavior.
    * `.breaking`: When something public is removed in a breaking way.
      Could be deprecated in an earlier release.
    * `.doc`: Notable updates to the documentation structure or build
      process.
    * `.packaging`: Notes for downstreams about unobvious side effects
      and tooling. Changes in the test invocation considerations and
      runtime assumptions.
    * `.contrib`: Stuff that affects the contributor experience. e.g.
      Running tests, building the docs, setting up the development
      environment.
    * `.misc`: Changes that are hard to assign to any of the above
      categories.
  * Make sure to use full sentences with correct case and punctuation,
    for example:
    ```rst
    Fixed issue with non-ascii contents in doctest text files
    -- by :user:`contributor-gh-handle`.
    ```

    Use the past tense or the present tense a non-imperative mood,
    referring to what's changed compared to the last released version
    of this project.
