### PR TITLE
cap base64 body-part reads at the declared Content-Length

### DIFF
--- a/CHANGES/13497.bugfix.rst
+++ b/CHANGES/13497.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed base64 multipart body parts declaring a ``Content-Length`` reading past the declared part length into the boundary and the following parts -- by :user:`arshsmith1`.

--- a/aiohttp/multipart.py
+++ b/aiohttp/multipart.py
@@ -379,7 +379,16 @@ class BodyPartReader:
                     self._prev_chunk = self._prev_chunk[len(over_chunk) :]
 
                 if len(over_chunk) != over_chunk_size:
-                    over_chunk += await self._content.read(4 - len(over_chunk))
+                    to_read = 4 - len(over_chunk)
+                    if self._length is not None:
+                        # A length-delimited part must never read past its
+                        # Content-Length: the bytes beyond it are the boundary
+                        # and the parts that follow, not this part's data.
+                        to_read = min(
+                            to_read, self._length - self._read_bytes - len(chunk)
+                        )
+                    if to_read > 0:
+                        over_chunk += await self._content.read(to_read)
 
                 if not over_chunk:
                     self._at_eof = True

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -418,6 +418,30 @@ class TestPartReader:
             result = await obj.read(decode=True)
         assert b"Time to Relax!" == result
 
+    async def test_read_chunk_base64_content_length_no_overread(self) -> None:
+        # A base64 part whose Content-Length is not a multiple of 4 must not
+        # let the base64 realignment loop read past the declared length into
+        # the boundary and the parts that follow.
+        b64 = b"VGltZSB0byBSZWxheCE"  # 19 chars, 19 % 4 == 3 (unpadded)
+        secret = b"secret-from-next-part"
+        rest = b"\r\n--:\r\nContent-Length: %d\r\n\r\n%s\r\n--:--\r\n" % (
+            len(secret),
+            secret,
+        )
+        h = HeadersDictProxy(
+            CIMultiDict(
+                {"CONTENT-LENGTH": str(len(b64)), CONTENT_TRANSFER_ENCODING: "base64"}
+            )
+        )
+        with Stream(b64 + rest) as stream:
+            obj = aiohttp.BodyPartReader(BOUNDARY, h, stream)
+            chunk = await obj.read_chunk(8192)
+            assert chunk == b64
+            assert obj.at_eof()
+            assert secret not in chunk
+            # The following part is left intact on the stream.
+            assert secret in await stream.read()
+
     async def test_decode_with_content_transfer_encoding_base64(self) -> None:
         h = HeadersDictProxy(CIMultiDict({CONTENT_TRANSFER_ENCODING: "base64"}))
         with Stream(b"VG\r\r\nltZSB0byBSZ\r\nWxheCE=\r\n--:--") as stream:


### PR DESCRIPTION
## What do these changes do?

`BodyPartReader.read_chunk` pads base64 body-part data out to whole 4-byte groups by topping up from the stream. For a length-delimited part (one carrying `Content-Length`, e.g. inside `multipart/mixed`) that top-up read went straight to `self._content.read()` with no bound, so when a part's whitespace-stripped base64 length is not a multiple of 4 it reads past the declared length into the trailing CRLF, the boundary and the parts that follow. A part sent with `Content-Length: 19` comes back as 75 bytes carrying a later part's data, and once `_read_bytes` overshoots `_length` a subsequent read can pass a negative size to `StreamReader.read` and drain the rest of the stream. The top-up read is now capped at the bytes still owed by the declared part length, so a length-delimited part stops at its boundary.

## Are there changes in behavior for the user?

Only for the malformed case. A base64 part whose declared length is a proper multiple of 4 (including CRLF-wrapped bodies) reads and decodes exactly as before across chunk sizes; a part that previously over-read now returns just its declared bytes and reaches EOF at the boundary instead of pulling in the following parts.

## Is it a substantial burden for the maintainers to support this?

No. It bounds one existing read by the part length the reader already tracks.

## Related issue number

None.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes - N/A, no public API change
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt` (already listed)
- [x] Add a new news fragment into the `CHANGES/` folder