### PR TITLE
Drop the mock protocol from the multipart benchmarks

### DIFF
--- a/tests/test_benchmarks_multipart.py
+++ b/tests/test_benchmarks_multipart.py
@@ -3,11 +3,11 @@
 import asyncio
 import base64
 from typing import TYPE_CHECKING
-from unittest import mock
 
 import pytest
 from multidict import CIMultiDict
 
+from aiohttp.base_protocol import BaseProtocol
 from aiohttp.hdrs import CONTENT_TRANSFER_ENCODING
 from aiohttp.helpers import DEFAULT_CHUNK_SIZE, HeadersDictProxy
 from aiohttp.multipart import BodyPartReader
@@ -23,10 +23,18 @@ BOUNDARY = b"--:"
 BASE64_HEADERS: CIMultiDict[str] = CIMultiDict({CONTENT_TRANSFER_ENCODING: "base64"})
 
 
+class _NoFlowControlProtocol(BaseProtocol):
+    """The whole body is fed up front, so there is nothing to pause or resume."""
+
+    def pause_reading(self) -> None:
+        """Swallow pause."""
+
+    def resume_reading(self, resume_parser: bool = True) -> None:
+        """Swallow resume."""
+
+
 def _part(body: bytes, loop: asyncio.AbstractEventLoop) -> BodyPartReader:
-    stream = StreamReader(
-        mock.Mock(_reading_paused=False), DEFAULT_CHUNK_SIZE, loop=loop
-    )
+    stream = StreamReader(_NoFlowControlProtocol(loop), DEFAULT_CHUNK_SIZE, loop=loop)
     stream.feed_data(body)
     stream.feed_eof()
     return BodyPartReader(


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

The multipart benchmarks built their `StreamReader` on a `mock.Mock` protocol, so every chunk read went through a mock `resume_reading()` call; that was about a third of the measured time and it is sensitive to the runner environment, which showed up as a spurious 10% regression on #13514. Use a `BaseProtocol` subclass with no-op flow control instead, as the websocket benchmarks already do.

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->

No, benchmarks only.

## Is it a substantial burden for the maintainers to support this?

<!--
Stop right there! Pause. Just for a minute... Can you think of anything
obvious that would complicate the ongoing development of this project?

Try to consider if you'd be able to maintain it throughout the next
5 years. Does it seem viable? Tell us your thoughts! We'd very much
love to hear what the consequences of merging this patch might be...

This will help us assess if your change is something we'd want to
entertain early in the review process. Thank you in advance!
-->

No.

## Related issue number

<!-- Will this resolve any open issues? -->
<!-- Remember to prefix with 'Fixes' if it closes an issue (e.g. 'Fixes #123'). -->

Follow up to #13509, noise seen on #13514.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes N/A
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt` N/A
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES/` folder N/A
  * name it `<issue_or_pr_num>.<type>.rst` (e.g. `588.bugfix.rst`)
  * if you don't have an issue number, change it to the pull request
    number after creating the PR
    * `.bugfix`: A bug fix for something the maintainers deemed an
      improper undesired behavior that got corrected to match
      pre-agreed expectations.
    * `.feature`: A new behavior, public APIs. That sort of stuff.
    * `.deprecation`: A declaration of future API removals and breaking
      changes in behavior.
    * `.breaking`: When something public is removed in a breaking way.
      Could be deprecated in an earlier release.
    * `.doc`: Notable updates to the documentation structure or build
      process.
    * `.packaging`: Notes for downstreams about unobvious side effects
      and tooling. Changes in the test invocation considerations and
      runtime assumptions.
    * `.contrib`: Stuff that affects the contributor experience. e.g.
      Running tests, building the docs, setting up the development
      environment.
    * `.misc`: Changes that are hard to assign to any of the above
      categories.
  * Make sure to use full sentences with correct case and punctuation,
    for example:
    ```rst
    Fixed issue with non-ascii contents in doctest text files
    -- by :user:`contributor-gh-handle`.
    ```

    Use the past tense or the present tense a non-imperative mood,
    referring to what's changed compared to the last released version
    of this project.

Drafted with Claude Fable 5; reviewed by @bdraco.
