### PR TITLE
reject reserved close code 1006 in websocket reader

### DIFF
--- a/CHANGES/13536.bugfix.rst
+++ b/CHANGES/13536.bugfix.rst
@@ -1,0 +1,7 @@
+Fixed the WebSocket reader accepting close code ``1006`` in a Close frame
+received from the peer -- by :user:`arshsmith1`.
+
+``1006`` (``ABNORMAL_CLOSURE``), like ``1005`` and ``1015``, is reserved by
+:rfc:`6455#section-7.4.1` and must not be sent as a status code on the wire;
+a Close frame carrying it is now rejected as a protocol error instead of being
+delivered as a valid close code.

--- a/CHANGES/13536.bugfix.rst
+++ b/CHANGES/13536.bugfix.rst
@@ -1,7 +1,2 @@
 Fixed the WebSocket reader accepting close code ``1006`` in a Close frame
 received from the peer -- by :user:`arshsmith1`.
-
-``1006`` (``ABNORMAL_CLOSURE``), like ``1005`` and ``1015``, is reserved by
-:rfc:`6455#section-7.4.1` and must not be sent as a status code on the wire;
-a Close frame carrying it is now rejected as a protocol error instead of being
-delivered as a valid close code.

--- a/aiohttp/_websocket/reader_py.py
+++ b/aiohttp/_websocket/reader_py.py
@@ -24,13 +24,9 @@ from .models import (
     WSMsgType,
 )
 
-# WSCloseCode.ABNORMAL_CLOSURE (1006) is reported locally when a connection
-# drops without a Close frame; RFC 6455 7.4.1 reserves it (along with 1005 and
-# 1015) and forbids it on the wire, so a Close frame that carries it must be
-# rejected rather than accepted as a valid code.
-ALLOWED_CLOSE_CODES: set[int] = {int(i) for i in WSCloseCode} - {
-    int(WSCloseCode.ABNORMAL_CLOSURE)
-}
+# ABNORMAL_CLOSURE is used internally, should never be accepted from a client.
+# https://datatracker.ietf.org/doc/html/rfc6455#section-7.4.1
+ALLOWED_CLOSE_CODES = {int(i) for i in WSCloseCode} - {int(WSCloseCode.ABNORMAL_CLOSURE)}
 
 # States for the reader, used to parse the WebSocket frame
 # integer values are used so they can be cythonized

--- a/aiohttp/_websocket/reader_py.py
+++ b/aiohttp/_websocket/reader_py.py
@@ -2,10 +2,10 @@
 
 import asyncio
 import builtins
-from typing import Final
 import sys
 import weakref
 from collections import deque
+from typing import Final
 
 from ..base_protocol import BaseProtocol
 from ..compression_utils import TooManyMembersError, ZLibDecompressor

--- a/aiohttp/_websocket/reader_py.py
+++ b/aiohttp/_websocket/reader_py.py
@@ -28,7 +28,9 @@ from .models import (
 
 # ABNORMAL_CLOSURE is used internally, should never be accepted from a client.
 # https://datatracker.ietf.org/doc/html/rfc6455#section-7.4.1
-ALLOWED_CLOSE_CODES = {int(i) for i in WSCloseCode} - {int(WSCloseCode.ABNORMAL_CLOSURE)}
+ALLOWED_CLOSE_CODES = {int(i) for i in WSCloseCode} - {
+    int(WSCloseCode.ABNORMAL_CLOSURE)
+}
 
 # States for the reader, used to parse the WebSocket frame
 # integer values are used so they can be cythonized

--- a/aiohttp/_websocket/reader_py.py
+++ b/aiohttp/_websocket/reader_py.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import builtins
+from typing import Final
 import sys
 import weakref
 from collections import deque
@@ -28,7 +29,7 @@ from .models import (
 
 # ABNORMAL_CLOSURE is used internally, should never be accepted from a client.
 # https://datatracker.ietf.org/doc/html/rfc6455#section-7.4.1
-ALLOWED_CLOSE_CODES = {int(i) for i in WSCloseCode} - {
+ALLOWED_CLOSE_CODES: Final = {int(i) for i in WSCloseCode} - {
     int(WSCloseCode.ABNORMAL_CLOSURE)
 }
 

--- a/aiohttp/_websocket/reader_py.py
+++ b/aiohttp/_websocket/reader_py.py
@@ -5,7 +5,6 @@ import builtins
 import sys
 import weakref
 from collections import deque
-from typing import Final
 
 from ..base_protocol import BaseProtocol
 from ..compression_utils import TooManyMembersError, ZLibDecompressor
@@ -29,7 +28,7 @@ from .models import (
 
 # ABNORMAL_CLOSURE is used internally, should never be accepted from a client.
 # https://datatracker.ietf.org/doc/html/rfc6455#section-7.4.1
-ALLOWED_CLOSE_CODES: Final = {int(i) for i in WSCloseCode} - {
+ALLOWED_CLOSE_CODES = {int(i) for i in WSCloseCode} - {
     int(WSCloseCode.ABNORMAL_CLOSURE)
 }
 

--- a/aiohttp/_websocket/reader_py.py
+++ b/aiohttp/_websocket/reader_py.py
@@ -24,7 +24,13 @@ from .models import (
     WSMsgType,
 )
 
-ALLOWED_CLOSE_CODES: set[int] = {int(i) for i in WSCloseCode}
+# WSCloseCode.ABNORMAL_CLOSURE (1006) is reported locally when a connection
+# drops without a Close frame; RFC 6455 7.4.1 reserves it (along with 1005 and
+# 1015) and forbids it on the wire, so a Close frame that carries it must be
+# rejected rather than accepted as a valid code.
+ALLOWED_CLOSE_CODES: set[int] = {int(i) for i in WSCloseCode} - {
+    int(WSCloseCode.ABNORMAL_CLOSURE)
+}
 
 # States for the reader, used to parse the WebSocket frame
 # integer values are used so they can be cythonized

--- a/tests/autobahn/test_autobahn.py
+++ b/tests/autobahn/test_autobahn.py
@@ -124,7 +124,6 @@ def test_client(report_dir: Path, request: pytest.FixtureRequest) -> None:
 
     results = get_test_results(report_dir / "clients", "aiohttp")
     xfail = {
-        "7.9.5": "The close code should have been 1002 or empty",
         "9.1.4": "Did not receive message within 100 seconds.",
         "9.1.5": "Did not receive message within 100 seconds.",
         "9.1.6": "Did not receive message within 100 seconds.",
@@ -194,7 +193,6 @@ def test_server(report_dir: Path, request: pytest.FixtureRequest) -> None:
 
     results = get_test_results(report_dir / "servers", "AutobahnServer")
     xfail = {
-        "7.9.5": "The close code should have been 1002 or empty",
         "9.1.4": "Did not receive message within 100 seconds.",
         "9.1.5": "Did not receive message within 100 seconds.",
         "9.1.6": "Did not receive message within 100 seconds.",

--- a/tests/test_websocket_parser.py
+++ b/tests/test_websocket_parser.py
@@ -327,9 +327,10 @@ def test_close_frame_invalid_code_above_range(
 
 @pytest.mark.parametrize("code", (1004, 1005, 1006, 1015))
 def test_close_frame_reserved_code(parser: PatchableWebSocketReader, code: int) -> None:
-    # RFC 6455 7.4.1 reserves 1004, 1005, 1006 and 1015 and forbids them as a
+    # https://datatracker.ietf.org/doc/html/rfc6455#section-7.4.1
+    # 1004, 1005, 1006 and 1015 are resreved and forbidden as a
     # status code in a Close frame on the wire. 1006 is a WSCloseCode member
-    # (aiohttp reports it locally), so it must still be rejected on receipt.
+    # (aiohttp uses it locally), so it must still be rejected on receipt.
     data = build_close_frame(code=code)
 
     with pytest.raises(WebSocketError) as ctx:

--- a/tests/test_websocket_parser.py
+++ b/tests/test_websocket_parser.py
@@ -325,6 +325,19 @@ def test_close_frame_invalid_code_above_range(
     assert ctx.value.code == WSCloseCode.PROTOCOL_ERROR
 
 
+@pytest.mark.parametrize("code", (1004, 1005, 1006, 1015))
+def test_close_frame_reserved_code(parser: PatchableWebSocketReader, code: int) -> None:
+    # RFC 6455 7.4.1 reserves 1004, 1005, 1006 and 1015 and forbids them as a
+    # status code in a Close frame on the wire. 1006 is a WSCloseCode member
+    # (aiohttp reports it locally), so it must still be rejected on receipt.
+    data = build_close_frame(code=code)
+
+    with pytest.raises(WebSocketError) as ctx:
+        parser._feed_data(data)
+
+    assert ctx.value.code == WSCloseCode.PROTOCOL_ERROR
+
+
 def test_close_frame_unicode_err(parser: PatchableWebSocketReader) -> None:
     data = build_close_frame(code=1000, message=b"\xf4\x90\x80\x80")
 


### PR DESCRIPTION
A `Close` frame's status code is checked in `WebSocketReader._handle_frame` against `ALLOWED_CLOSE_CODES`, a set built from the `WSCloseCode` enum. The enum carries `ABNORMAL_CLOSURE` (1006), which aiohttp only sets locally when a connection drops without a Close frame, so a frame that arrives with `1006` on the wire passed the check and was delivered as a valid close code (and could be echoed back in aiohttp's own close frame). RFC 6455 7.4.1 reserves `1006`, along with `1005` and `1015`, and forbids it as a status code on the wire, so `1006` is now rejected as a protocol error the same way `1005` and `1015` already are.

## What do these changes do?

Exclude `ABNORMAL_CLOSURE` from the incoming-frame acceptance set so a Close frame carrying `1006` fails with a protocol error. `1005` and `1015` were already rejected because they are not enum members; only `1006` slipped through.

## Are there changes in behavior for the user?

Only for the malformed case. A peer that sends `1006` in a Close frame now trips a protocol error instead of surfacing as a close message. The locally-generated `1006` for an abnormal closure (no Close frame received) is unchanged.

## Is it a substantial burden for the maintainers to support this?

No. It drops one reserved code from the acceptance set and adds a regression test beside the existing close-code tests.

## Related issue number

None.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes - N/A, no public API change
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt` (already listed)
- [x] Add a new news fragment into the `CHANGES/` folder