### PR TITLE
reject interleaved data frame in a fragmented websocket message

### DIFF
--- a/CHANGES/13553.bugfix.rst
+++ b/CHANGES/13553.bugfix.rst
@@ -1,0 +1,4 @@
+Fixed the WebSocket reader accepting a new data frame injected between the
+fragments of an in-progress message; per :rfc:`6455#section-5.4` every frame
+after the first fragment and before the ``FIN`` must be a continuation, and
+such a stream is now rejected as a protocol error -- by :user:`arshsmith1`.

--- a/aiohttp/_websocket/reader_py.py
+++ b/aiohttp/_websocket/reader_py.py
@@ -262,6 +262,16 @@ class WebSocketReader:
             if not fin:
                 # got partial frame payload
                 if opcode != OP_CODE_CONTINUATION:
+                    # RFC 6455 §5.4: after the first fragment every frame up to
+                    # the FIN must be a continuation. A new data frame arriving
+                    # mid-message is only rejected below when it carries FIN, so
+                    # reject the non-fin case here too.
+                    if self._opcode != OP_CODE_NOT_SET:
+                        raise WebSocketError(
+                            WSCloseCode.PROTOCOL_ERROR,
+                            "The opcode in non-fin frame is expected "
+                            f"to be zero, got {opcode!r}",
+                        )
                     self._opcode = opcode
                 self._partial += payload
                 return

--- a/tests/test_websocket_parser.py
+++ b/tests/test_websocket_parser.py
@@ -477,6 +477,17 @@ def test_continuation_err(
         parser._handle_frame(True, WSMsgType.TEXT, b"line2", 0)
 
 
+def test_continuation_non_fin_err(
+    out: WebSocketDataQueue, parser: PatchableWebSocketReader
+) -> None:
+    # RFC 6455 §5.4: a new data frame injected between the initial fragment and
+    # its continuation must fail the connection, even when it clears FIN.
+    parser._handle_frame(False, WSMsgType.TEXT, b"line1", 0)
+    with pytest.raises(WebSocketError) as ctx:
+        parser._handle_frame(False, WSMsgType.TEXT, b"line2", 0)
+    assert ctx.value.code == WSCloseCode.PROTOCOL_ERROR
+
+
 def test_continuation_with_close(
     out: WebSocketDataQueue, parser: WebSocketReader
 ) -> None:


### PR DESCRIPTION
## What do these changes do?

`WebSocketReader._handle_frame` enforces RFC 6455 section 5.4 fragmentation only when a frame carries FIN. The not-fin branch appends the fragment and returns without checking whether a message is already in progress, so a new TEXT/BINARY frame with FIN cleared, sent between the opening fragment and its continuation, is silently merged into the message instead of failing the connection. The guard that rejects a non-continuation opcode mid-message is only reached for FIN=1 frames.

A spec-following peer or on-path proxy fails such a stream, so the reader assembles a message a compliant party would reject. This puts the same in-progress check on the not-fin branch, reusing the existing protocol-error path.

## Are there changes in behavior for the user?

Only for the malformed case. A normal fragmented message (initial data fragment, continuation frames, interleaved control frames) is unaffected; a data frame arriving mid-message now closes with a protocol error, matching the FIN=1 handling already in place.

## Is it a substantial burden for the maintainers to support this?

No. A few lines at the single frame-assembly site, with a regression test beside the existing continuation tests.

## Related issue number

N/A

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes (N/A, no public API change)
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
- [x] Add a new news fragment into the `CHANGES/` folder