### PR TITLE
[PR #13561/148205f2 backport][3.15] Add masked WebSocket read benchmarks and fix read benchmark backpressure

### DIFF
--- a/CHANGES/13561.contrib.rst
+++ b/CHANGES/13561.contrib.rst
@@ -1,0 +1,3 @@
+Added benchmarks for reading masked WebSocket messages and fixed the
+existing read benchmarks, which stopped measuring the parser after the
+eighth large frame due to the queue limit -- by :user:`bdraco`.

--- a/tests/test_benchmarks_http_websocket.py
+++ b/tests/test_benchmarks_http_websocket.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from aiohttp._websocket.helpers import MSG_SIZE, PACK_LEN3
+from aiohttp._websocket.helpers import MSG_SIZE, PACK_LEN1, PACK_LEN3, websocket_mask
 from aiohttp._websocket.reader import WebSocketDataQueue
 from aiohttp.base_protocol import BaseProtocol
 from aiohttp.helpers import DEFAULT_CHUNK_SIZE
@@ -18,25 +18,51 @@ else:
     BenchmarkFixture = pytest_codspeed.BenchmarkFixture
 
 
+# Large enough that a benchmark run never crosses the queue limit; hitting it
+# would engage read backpressure and silently stop the parser mid-benchmark.
+READ_QUEUE_LIMIT = 2**24
+MASK = b"\x9a\x3c\x71\xe5"
+
+
+def _make_reader(loop: asyncio.AbstractEventLoop) -> WebSocketReader:
+    protocol = BaseProtocol(loop)
+    # A WebSocket connection is always upgraded; without this, backpressure
+    # would hit ``assert self._parser is not None`` in pause_reading().
+    protocol._upgraded = True
+    queue = WebSocketDataQueue(protocol, READ_QUEUE_LIMIT, loop=loop)
+    return WebSocketReader(
+        queue, max_msg_size=DEFAULT_CHUNK_SIZE, compress=True, decode_text=True
+    )
+
+
+def _masked_frame(opcode: WSMsgType, payload: bytes) -> bytes:
+    """Build a client-to-server frame with a masked payload."""
+    masked = bytearray(payload)
+    websocket_mask(MASK, masked)
+    first_byte = 0x80 | opcode.value
+    length = len(payload)
+    assert length < 126 or length > 2**16
+    if length < 126:
+        header = PACK_LEN1(first_byte, 0x80 | length)
+    else:
+        header = PACK_LEN3(first_byte, 0x80 | 127, length)
+    return header + MASK + bytes(masked)
+
+
 def test_read_large_binary_websocket_messages(
     loop: asyncio.AbstractEventLoop, benchmark: BenchmarkFixture
 ) -> None:
     """Read one hundred large binary websocket messages."""
-    queue = WebSocketDataQueue(BaseProtocol(loop), DEFAULT_CHUNK_SIZE, loop=loop)
-    reader = WebSocketReader(
-        queue, max_msg_size=DEFAULT_CHUNK_SIZE, compress=True, decode_text=True
-    )
-
     # PACK3 has a minimum message length of 2**16 bytes.
     message = b"x" * ((2**16) + 1)
     msg_length = len(message)
     first_byte = 0x80 | 0 | WSMsgType.BINARY.value
     header = PACK_LEN3(first_byte, 127, msg_length)
     raw_message = header + message
-    feed_data = reader.feed_data
 
     @benchmark
     def _run() -> None:
+        feed_data = _make_reader(loop).feed_data
         for _ in range(100):
             feed_data(raw_message)
 
@@ -45,20 +71,42 @@ def test_read_one_hundred_websocket_text_messages(
     loop: asyncio.AbstractEventLoop, benchmark: BenchmarkFixture
 ) -> None:
     """Benchmark reading 100 WebSocket text messages."""
-    queue = WebSocketDataQueue(BaseProtocol(loop), DEFAULT_CHUNK_SIZE, loop=loop)
-    reader = WebSocketReader(
-        queue, max_msg_size=DEFAULT_CHUNK_SIZE, compress=True, decode_text=True
-    )
     raw_message = (
         b'\x81~\x01!{"id":1,"src":"shellyplugus-c049ef8c30e4","dst":"aios-1453812500'
         b'8","result":{"name":null,"id":"shellyplugus-c049ef8c30e4","mac":"C049EF8C30E'
         b'4","slot":1,"model":"SNPL-00116US","gen":2,"fw_id":"20231219-133953/1.1.0-g3'
         b'4b5d4f","ver":"1.1.0","app":"PlugUS","auth_en":false,"auth_domain":null}}'
     )
-    feed_data = reader.feed_data
 
     @benchmark
     def _run() -> None:
+        feed_data = _make_reader(loop).feed_data
+        for _ in range(100):
+            feed_data(raw_message)
+
+
+def test_read_one_hundred_masked_websocket_text_messages(
+    loop: asyncio.AbstractEventLoop, benchmark: BenchmarkFixture
+) -> None:
+    """Read 100 small masked text messages, as a server receives them."""
+    raw_message = _masked_frame(WSMsgType.TEXT, b'{"id":1,"type":"ping"}')
+
+    @benchmark
+    def _run() -> None:
+        feed_data = _make_reader(loop).feed_data
+        for _ in range(100):
+            feed_data(raw_message)
+
+
+def test_read_one_hundred_masked_large_binary_websocket_messages(
+    loop: asyncio.AbstractEventLoop, benchmark: BenchmarkFixture
+) -> None:
+    """Read 100 large masked binary messages, as a server receives them."""
+    raw_message = _masked_frame(WSMsgType.BINARY, b"x" * ((2**16) + 1))
+
+    @benchmark
+    def _run() -> None:
+        feed_data = _make_reader(loop).feed_data
         for _ in range(100):
             feed_data(raw_message)
 


### PR DESCRIPTION
**This is a backport of PR #13561 as merged into master (148205f2fdc477ad3e4de0439d817b2a495ccf1e).**

## What do these changes do?

The read benchmarks only fed unmasked frames, so the masked path a server takes for every frame from a client was invisible to CodSpeed; this adds masked variants for small text and large binary messages. It also fixes the existing read benchmarks; they stored an AssertionError from pause_reading after the eighth large frame and measured the early return path for the remaining feeds. The parser also stops parsing once the queue crosses its limit, so each benchmark round now uses a fresh reader with a queue limit the batch cannot reach.

CodSpeed will show a large regression on the large binary read benchmark; that is really restoring the benchmark to its original design. We missed `_upgraded = True` in the original, and after #11966 went in it would latch the AssertionError from pause_reading failing, so what looked like an improvement was the benchmark doing effectively nothing after 8 frames.

## Are there changes in behavior for the user?

No, benchmarks only.

## Is it a substantial burden for the maintainers to support this?

No, the new benchmarks follow the shape of the existing ones.

## Related issue number

Noticed while benchmarking #13559.

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist N/A, this is a benchmark change
- [ ] Documentation reflects the changes N/A
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt` N/A, already listed
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES/` folder
  * name it `<issue_or_pr_num>.<type>.rst` (e.g. `588.bugfix.rst`)
  * if you don't have an issue number, change it to the pull request
    number after creating the PR
    * `.bugfix`: A bug fix for something the maintainers deemed an
      improper undesired behavior that got corrected to match
      pre-agreed expectations.
    * `.feature`: A new behavior, public APIs. That sort of stuff.
    * `.deprecation`: A declaration of future API removals and breaking
      changes in behavior.
    * `.breaking`: When something public is removed in a breaking way.
      Could be deprecated in an earlier release.
    * `.doc`: Notable updates to the documentation structure or build
      process.
    * `.packaging`: Notes for downstreams about unobvious side effects
      and tooling. Changes in the test invocation considerations and
      runtime assumptions.
    * `.contrib`: Stuff that affects the contributor experience. e.g.
      Running tests, building the docs, setting up the development
      environment.
    * `.misc`: Changes that are hard to assign to any of the above
      categories.
  * Make sure to use full sentences with correct case and punctuation,
    for example:
    ```rst
    Fixed issue with non-ascii contents in doctest text files
    -- by :user:`contributor-gh-handle`.
    ```

    Use the past tense or the present tense a non-imperative mood,
    referring to what's changed compared to the last released version
    of this project.

Drafted with Claude Code (Fable 5); reviewed by @bdraco.


