### PR TITLE
Make `ClientConnectorCertificateError.ssl` mean the same as on the base class

### DIFF
--- a/CHANGES/4099.breaking.rst
+++ b/CHANGES/4099.breaking.rst
@@ -1,0 +1,9 @@
+``ClientConnectorCertificateError.ssl`` now returns the value passed to the
+``ssl`` parameter, an :class:`ssl.SSLContext`, a :class:`bool` or a
+:class:`~aiohttp.Fingerprint`, matching
+:attr:`ClientConnectorError.ssl <aiohttp.ClientConnectorError.ssl>`. It
+previously returned ``ConnectionKey.is_ssl``, a plain :class:`bool`, so the
+same attribute meant different things depending on which of the two exceptions
+was caught. Code reading ``ssl`` on this exception as a boolean should use
+``is_ssl`` on the connection key instead
+-- by :user:`ArockiaRajamanickam`.

--- a/CHANGES/4099.breaking.rst
+++ b/CHANGES/4099.breaking.rst
@@ -1,9 +1,4 @@
 ``ClientConnectorCertificateError.ssl`` now returns the value passed to the
-``ssl`` parameter, an :class:`ssl.SSLContext`, a :class:`bool` or a
-:class:`~aiohttp.Fingerprint`, matching
-:attr:`ClientConnectorError.ssl <aiohttp.ClientConnectorError.ssl>`. It
-previously returned ``ConnectionKey.is_ssl``, a plain :class:`bool`, so the
-same attribute meant different things depending on which of the two exceptions
-was caught. Code reading ``ssl`` on this exception as a boolean should use
-``is_ssl`` on the connection key instead
+``ssl`` parameter, matching
+:attr:`ClientConnectorError.ssl <aiohttp.ClientConnectorError.ssl>`.
 -- by :user:`ArockiaRajamanickam`.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -54,6 +54,7 @@ Anton Kasyanov
 Anton Zhdan-Pushkin
 Arcadiy Ivanov
 Arie Bovenberg
+Arockia Rajamanickam
 Arseny Timoniq
 Arsh Smith
 Arshiya Tabasum

--- a/aiohttp/client_exceptions.py
+++ b/aiohttp/client_exceptions.py
@@ -382,13 +382,10 @@ class ClientConnectorCertificateError(*cert_errors_bases):  # type: ignore[misc]
     def port(self) -> int | None:
         return self._conn_key.port
 
-    @property
-    def ssl(self) -> bool:
-        return self._conn_key.is_ssl
-
     def __str__(self) -> str:
         return (
-            f"Cannot connect to host {self.host}:{self.port} ssl:{self.ssl} "
+            f"Cannot connect to host {self.host}:{self.port} "
+            f"ssl:{'default' if self.ssl is True else self.ssl} "
             f"[{self.certificate_error.__class__.__name__}: "
             f"{self.certificate_error.args}]"
         )

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -2887,6 +2887,12 @@ Connection errors
 
    Derived from :exc:`ClientOSError`
 
+   .. attribute:: ssl
+
+      The value passed as the ``ssl`` parameter of the request: an
+      :class:`ssl.SSLContext`, a :class:`bool`, or a
+      :class:`~aiohttp.Fingerprint`.
+
 .. class:: ClientConnectorDNSError
    :canonical: aiohttp.client_exceptions.ClientConnectorDNSError
 

--- a/tests/test_client_exceptions.py
+++ b/tests/test_client_exceptions.py
@@ -178,7 +178,6 @@ class TestClientConnectorCertificateError:
         assert err.host == "example.com"
         assert err.port == 8080
         # the fixture sets is_ssl=False and ssl=True, so this asserts that the
-        # attribute follows `ssl` and not `is_ssl`, matching ClientConnectorError
         assert err.ssl is True
         if sys.version_info >= (3, 11):
             assert_type(err.args, tuple[client_reqrep.ConnectionKey, Exception])
@@ -228,13 +227,6 @@ class TestClientConnectorCertificateError:
         assert err.strerror == "Bad certificate"
 
     def test_ssl_is_the_same_as_on_the_base_class(self) -> None:
-        """`ssl` must carry the same value as on ClientConnectorError.
-
-        ConnectionKey has both `is_ssl` (a bool) and `ssl` (the SSLContext,
-        bool or Fingerprint the caller passed). Reading `is_ssl` here made the
-        same attribute mean two different things depending on which of the two
-        exceptions was caught.
-        """
         context = ssl.create_default_context()
         connection_key = self.connection_key._replace(is_ssl=True, ssl=context)
         certificate_error = Exception("Bad certificate")

--- a/tests/test_client_exceptions.py
+++ b/tests/test_client_exceptions.py
@@ -1,5 +1,6 @@
 import errno
 import pickle
+import ssl
 import sys
 
 import pytest
@@ -176,7 +177,9 @@ class TestClientConnectorCertificateError:
         assert err.certificate_error == certificate_error
         assert err.host == "example.com"
         assert err.port == 8080
-        assert err.ssl is False
+        # the fixture sets is_ssl=False and ssl=True, so this asserts that the
+        # attribute follows `ssl` and not `is_ssl`, matching ClientConnectorError
+        assert err.ssl is True
         if sys.version_info >= (3, 11):
             assert_type(err.args, tuple[client_reqrep.ConnectionKey, Exception])
 
@@ -192,7 +195,7 @@ class TestClientConnectorCertificateError:
             assert err2.certificate_error.args == ("Bad certificate",)
             assert err2.host == "example.com"
             assert err2.port == 8080
-            assert err2.ssl is False
+            assert err2.ssl is True
             assert err2.foo == "bar"
 
     def test_repr(self) -> None:
@@ -211,7 +214,7 @@ class TestClientConnectorCertificateError:
             connection_key=self.connection_key, certificate_error=certificate_error
         )
         assert str(err) == (
-            "Cannot connect to host example.com:8080 ssl:False"
+            "Cannot connect to host example.com:8080 ssl:default"
             " [Exception: ('Bad certificate',)]"
         )
 
@@ -223,6 +226,28 @@ class TestClientConnectorCertificateError:
         assert err.os_error == certificate_error
         assert err.errno == 1
         assert err.strerror == "Bad certificate"
+
+    def test_ssl_is_the_same_as_on_the_base_class(self) -> None:
+        """`ssl` must carry the same value as on ClientConnectorError.
+
+        ConnectionKey has both `is_ssl` (a bool) and `ssl` (the SSLContext,
+        bool or Fingerprint the caller passed). Reading `is_ssl` here made the
+        same attribute mean two different things depending on which of the two
+        exceptions was caught.
+        """
+        context = ssl.create_default_context()
+        connection_key = self.connection_key._replace(is_ssl=True, ssl=context)
+        certificate_error = Exception("Bad certificate")
+
+        err = client.ClientConnectorCertificateError(
+            connection_key=connection_key, certificate_error=certificate_error
+        )
+        base_err = client.ClientConnectorError(
+            connection_key=connection_key, os_error=OSError(1, "Bad certificate")
+        )
+
+        assert err.ssl is context
+        assert err.ssl is base_err.ssl
 
 
 class TestServerDisconnectedError:

--- a/tests/test_client_exceptions.py
+++ b/tests/test_client_exceptions.py
@@ -177,8 +177,6 @@ class TestClientConnectorCertificateError:
         assert err.certificate_error == certificate_error
         assert err.host == "example.com"
         assert err.port == 8080
-        # the fixture sets is_ssl=False and ssl=True, so this asserts that the
-        # attribute follows `ssl` and not `is_ssl`, matching ClientConnectorError
         assert err.ssl is True
         if sys.version_info >= (3, 11):
             assert_type(err.args, tuple[client_reqrep.ConnectionKey, Exception])
@@ -226,29 +224,6 @@ class TestClientConnectorCertificateError:
         assert err.os_error == certificate_error
         assert err.errno == 1
         assert err.strerror == "Bad certificate"
-
-    def test_ssl_is_the_same_as_on_the_base_class(self) -> None:
-        """`ssl` must carry the same value as on ClientConnectorError.
-
-        ConnectionKey has both `is_ssl` (a bool) and `ssl` (the SSLContext,
-        bool or Fingerprint the caller passed). Reading `is_ssl` here made the
-        same attribute mean two different things depending on which of the two
-        exceptions was caught.
-        """
-        context = ssl.create_default_context()
-        connection_key = self.connection_key._replace(is_ssl=True, ssl=context)
-        certificate_error = Exception("Bad certificate")
-
-        err = client.ClientConnectorCertificateError(
-            connection_key=connection_key, certificate_error=certificate_error
-        )
-        base_err = client.ClientConnectorError(
-            connection_key=connection_key, os_error=OSError(1, "Bad certificate")
-        )
-
-        assert err.ssl is context
-        assert err.ssl is base_err.ssl
-
 
 class TestServerDisconnectedError:
     def test_ctor(self) -> None:


### PR DESCRIPTION
## What do these changes do?

Closes #4099.

`ConnectionKey` carries two adjacent fields:

```python
is_ssl: bool
ssl: SSLContext | bool | Fingerprint
```

`ClientConnectorError.ssl` returns `ssl`. `ClientConnectorCertificateError` overrode it to return `is_ssl`, so the same attribute on the same connection key meant two different things depending on which exception you caught:

```python
ctx = ssl.create_default_context()
key = ConnectionKey(host="example.com", port=443, is_ssl=True, ssl=ctx, ...)

ClientConnectorError(key, OSError(1, "boom")).ssl            # <ssl.SSLContext object>  <- the caller's context
ClientConnectorCertificateError(key, cert_err).ssl           # True                     <- a bool
```

The override is dropped so the subclass inherits from `ClientConnectorError`, which is where the attribute is already correct. `__str__` now renders `ssl is True` as `default` the way the base class does, instead of printing `True`.

@asvetlov confirmed this back in 2019 ("I think yes. The result of the project evolvement."). This follows the same reasoning as #12136, which restored `os_error` on this class on Liskov grounds six months ago.

## Are there changes in behavior for the user?

Yes, and this is the part worth reviewing carefully.

Anyone reading `.ssl` on `ClientConnectorCertificateError` as a boolean now gets whatever was passed to `ssl=`, which for the default case is `True` but for a configured client is an `SSLContext` or a `Fingerprint`. Code wanting the old boolean should read `is_ssl` from the connection key. I filed the fragment as `breaking` rather than `bugfix` for that reason, and `master` being `4.0.0a2.dev0` seemed like the right window to correct it.

`__str__` also changes for the `ssl=True` case, from `ssl:True` to `ssl:default`, which is what `ClientConnectorError` already prints.

**Three existing assertions had to be flipped**, and I want to flag that rather than have it found in review:

```python
# the fixture deliberately sets is_ssl=False, ssl=True
assert err.ssl is False   ->   assert err.ssl is True   # test_ctor and test_pickle
"...ssl:False..."         ->   "...ssl:default..."      # test_str
```

Those assertions encoded the behaviour being fixed. I would normally treat "the fix requires changing existing tests" as a sign the behaviour is intended, and I checked that here rather than assuming: the issue carries the `bug` label and a maintainer said plainly that it is one. If that reading is wrong, this should be closed rather than merged.

Also for transparency: the issue is assigned to @asvetlov, from 2019. Nothing has moved on it since, so I took it as open rather than in hand. Happy to close if that is not right.

The redundant `host` and `port` overrides on the same class are identical to the base class implementations. I left them alone to keep this diff to the bug.

## Is it a substantial burden for the maintainers to support this?

No. The class now inherits three properties instead of overriding two of them incorrectly.

## Testing

`test_ssl_is_the_same_as_on_the_base_class` builds both exceptions from one `ConnectionKey` holding a real `SSLContext` and asserts `err.ssl is context` and `err.ssl is base_err.ssl`, so `is_ssl` and `ssl` cannot be confused by both happening to be `True`.

Reverting only `client_exceptions.py` and keeping the tests fails 4 tests in `TestClientConnectorCertificateError`, including the new one. `tests/test_client_exceptions.py` is 29 passed / 1 xfailed, and `test_client_exceptions.py` plus `test_client_functional.py` together are 318 passed / 27 skipped / 2 xfailed. `ruff check` reports the same 6 pre-existing findings on these files as `master` does, none from this change.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] Add a new news fragment into the `CHANGES/` folder
- [x] Added my name to `CONTRIBUTORS.txt`

I used an AI assistant while working on this. The reproduction, the check on whether the flipped assertions were load-bearing, and the decision to file this as `breaking` rather than `bugfix` are mine, and I ran every result quoted here.
