### PR TITLE
Accept case-insensitive range unit names in Range header

### DIFF
--- a/CHANGES/13580.bugfix.rst
+++ b/CHANGES/13580.bugfix.rst
@@ -1,0 +1,3 @@
+Accepted range unit names of any case (e.g. ``Range: Bytes=0-3``) when
+parsing the ``Range`` request header, per :rfc:`9110` section 14.1.1,
+which states that range unit names are case-insensitive -- by :user:`afonsojanu`.

--- a/aiohttp/web_request.py
+++ b/aiohttp/web_request.py
@@ -641,7 +641,7 @@ class BaseRequest(MutableMapping[str | RequestKey[Any], Any], HeadersMixin):
         if rng is not None:
             try:
                 pattern = r"^bytes=(\d*)-(\d*)$"
-                start, end = re.findall(pattern, rng, re.ASCII)[0]
+                start, end = re.findall(pattern, rng, re.ASCII | re.IGNORECASE)[0]
             except IndexError:  # pattern was not found in header
                 raise ValueError("range not in acceptable format")
 

--- a/tests/test_web_request.py
+++ b/tests/test_web_request.py
@@ -309,6 +309,15 @@ def test_range_to_slice_tail_stop() -> None:
     assert req.http_range.start == -500 and req.http_range.stop is None
 
 
+def test_range_to_slice_case_insensitive_unit() -> None:
+    # RFC 9110 sec 14.1.1: range unit names are case-insensitive.
+    req = make_mocked_request(
+        "GET", "/", headers=CIMultiDict([("RANGE", "Bytes=0-499")])
+    )
+    assert isinstance(req.http_range, slice)
+    assert req.http_range.start == 0 and req.http_range.stop == 500
+
+
 def test_range_non_ascii() -> None:
     # ५ = DEVANAGARI DIGIT FIVE
     req = make_mocked_request("GET", "/", headers=CIMultiDict([("RANGE", "bytes=4-५")]))


### PR DESCRIPTION
Closes #13580.

RFC 9110 section 14.1.1 states that range unit names are case-insensitive, but the regex used to parse the `Range` header only matched a lowercase `bytes` literal:

```python
pattern = r"^bytes=(\d*)-(\d*)$"
start, end = re.findall(pattern, rng, re.ASCII)[0]
```

A request sent with any other casing, such as `Range: Bytes=0-3` or `Range: BYTES=0-3`, raised `ValueError("range not in acceptable format")`, which `FileResponse` turns into a 416 response even though the range itself is perfectly satisfiable.

Added `re.IGNORECASE` to the existing pattern match flags and a regression test alongside the existing range-parsing tests, covering an uppercase-initial unit name. Ran the full `test_web_request.py` suite plus flake8 on the touched files.