### PR TITLE
Reject control characters in the request target to prevent request splitting

### DIFF
--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -790,6 +790,12 @@ class ClientResponse(HeadersMixin):
         await self.wait_for_close()
 
 
+_contains_disallowed_target_pchar_re = re.compile("[\x00-\x1f\x7f]")
+"""Control characters are never valid in a request target; prevents
+request splitting via encoded URLs (cf. the CPython http.client
+CVE-2019-9740 fix and aiohttp GHSA-pwcp-vr8x-fp2x report)."""
+
+
 class ClientRequestBase:
     """An internal class for proxy requests."""
 
@@ -952,6 +958,12 @@ class ClientRequestBase:
         else:
             path = self.url.raw_path_qs
 
+
+        if _contains_disallowed_target_pchar_re.search(path):
+            raise ValueError(
+                "Request URL can't contain control characters. "
+                "Potential request splitting attack."
+            )
         protocol = conn.protocol
         assert protocol is not None
         writer = self._create_writer(protocol)

--- a/aiohttp/client_reqrep.py
+++ b/aiohttp/client_reqrep.py
@@ -958,7 +958,6 @@ class ClientRequestBase:
         else:
             path = self.url.raw_path_qs
 
-
         if _contains_disallowed_target_pchar_re.search(path):
             raise ValueError(
                 "Request URL can't contain control characters. "

--- a/tests/test_client_request.py
+++ b/tests/test_client_request.py
@@ -2325,7 +2325,9 @@ async def test_empty_body_isolation_after_update(
     assert ClientRequest._EMPTY_BODY.size == 0
 
 
-async def test_request_target_with_crlf_raises(loop: Any, conn: Any) -> None:
+async def test_request_target_with_crlf_raises(
+    conn: mock.Mock, make_client_request: _RequestMaker
+) -> None:
     """CR/LF in an encoded request target must raise, not hit the wire (GHSA-pwcp-vr8x-fp2x)."""
     url = URL.build(
         scheme="http",
@@ -2333,6 +2335,6 @@ async def test_request_target_with_crlf_raises(loop: Any, conn: Any) -> None:
         path="/legit\r\nX-Injected: 1\r\nGET /admin",
         encoded=True,
     )
-    req = ClientRequest("GET", url, loop=loop)
+    req = make_client_request("get", url)
     with pytest.raises(ValueError, match="request splitting"):
-        await req.send(conn)
+        await req._send(conn)

--- a/tests/test_client_request.py
+++ b/tests/test_client_request.py
@@ -2323,3 +2323,16 @@ async def test_empty_body_isolation_after_update(
 
     assert ClientRequest._EMPTY_BODY.consumed is False
     assert ClientRequest._EMPTY_BODY.size == 0
+
+
+async def test_request_target_with_crlf_raises(loop: Any, conn: Any) -> None:
+    """CR/LF in an encoded request target must raise, not hit the wire (GHSA-pwcp-vr8x-fp2x)."""
+    url = URL.build(
+        scheme="http",
+        host="example.com",
+        path="/legit\r\nX-Injected: 1\r\nGET /admin",
+        encoded=True,
+    )
+    req = ClientRequest("GET", url, loop=loop)
+    with pytest.raises(ValueError, match="request splitting"):
+        await req.send(conn)


### PR DESCRIPTION
## Reject control characters in the request target (request splitting)

### Problem

`ClientRequest.send()` builds the status line from `self.url.raw_path_qs`
without any validation:

```python
path = self.url.raw_path_qs
...
status_line = f"{self.method} {path} HTTP/{v.major}.{v.minor}"
```

When the request target is a `yarl.URL` constructed with `encoded=True`
(a documented, supported public API) and its path contains CR/LF bytes,
those bytes are serialized verbatim into the request line. The server then
parses the trailing bytes as additional request lines — full
request splitting / smuggling controlled by whoever influences the URL
(CWE-444).

Dynamically reproduced on 3.8.6 and confirmed by source inspection that the
status-line construction remains unvalidated on `master` (3.14.x line):
`client_reqrep.py` still assigns `path = self.url.raw_path_qs` with no
newline check, while header names/values ARE checked (`_safe_header`).

### Why fix this in aiohttp

1. **Precedent — CPython stdlib**: `http.client.putrequest` has rejected
   control characters in the request target since 2019
   (CVE-2019-9740, `_contains_disallowed_url_pchar_re`,
   Lib/http/client.py:159): *"Prevents CVE-2019-9740. Includes control
   characters such as \r\n."* The stdlib treats the client — not the URL
   parser — as the enforcement point for request-line integrity.
2. **Precedent — aiohttp itself**: the two 2023 request-line injection CVEs
   were fixed at this exact level: `version` is now type-constrained to
   `HttpVersion` (1e86b777, CVE-2023-49081) and the `method` fix followed
   the same principle (CVE-2023-49082). The request target is the only
   status-line component still concatenated without validation — this PR
   closes that remaining gap symmetrically.
3. yarl's `encoded=True` is documented pass-through behavior ("the URL is
   assumed to be already encoded"), so it is not a security boundary we can
   rely on.

### Fix

Mirror the stdlib check: reject the request target when it contains control
characters (`[\x00-\x1f\x7f]`), raising `ValueError` at send time. Plain
`str` URLs are unaffected (yarl re-quotes and strips CR/LF); only
pre-encoded paths carrying raw control bytes are rejected — precisely the
splitting vector.

```python
_contains_disallowed_target_pchar_re = re.compile("[\x00-\x1f\x7f]")
...
if _contains_disallowed_target_pchar_re.search(path):
    raise ValueError(
        "Request URL can't contain control characters. "
        "Potential request splitting attack."
    )
```

### Testing

- `test_request_target_with_crlf_raises`: builds the encoded URL from the
  report PoC and asserts `ValueError` on send.
- Existing suite unaffected (plain/quoted URLs never contain raw control
  bytes after yarl re-quoting).

### Related

- Private advisory GHSA-pwcp-vr8x-fp2x (closed with maintainer guidance to
  follow up via PR — this is that PR).
- yarl side: we chose not to file a separate report. `encoded=True` is
  documented pass-through behavior, and per the discussion the client-level
  request-line integrity check (this PR) is the appropriate enforcement
  point — the same conclusion the stdlib reached in 2019.
