### PR TITLE
Add AppRunner.serve_forever() method

### DIFF
--- a/CHANGES/13606.feature.rst
+++ b/CHANGES/13606.feature.rst
@@ -1,0 +1,3 @@
+Added :meth:`BaseRunner.serve_forever() <aiohttp.web.BaseRunner.serve_forever>` to
+``BaseRunner`` which blocks until :meth:`cleanup() <aiohttp.web.BaseRunner.cleanup>` is
+called, matching the interface of :func:`asyncio.Server.serve_forever()`.

--- a/CHANGES/13606.feature.rst
+++ b/CHANGES/13606.feature.rst
@@ -1,3 +1,3 @@
 Added :meth:`BaseRunner.serve_forever() <aiohttp.web.BaseRunner.serve_forever>` to
 ``BaseRunner`` which blocks until :meth:`cleanup() <aiohttp.web.BaseRunner.cleanup>` is
-called, matching the interface of :func:`asyncio.Server.serve_forever()`.
+called, matching the interface of ``asyncio.Server.serve_forever()``.

--- a/aiohttp/web_runner.py
+++ b/aiohttp/web_runner.py
@@ -307,12 +307,12 @@ class BaseRunner(ABC, Generic[_Request]):
     ) -> None:
         self._handle_signals = handle_signals
         self._kwargs = kwargs
-        self._server: Server[_Request] | None = None
+        self._server: asyncio.Server | None = None
         self._sites: list[BaseSite] = []
         self._shutdown_timeout = shutdown_timeout
 
     @property
-    def server(self) -> Server[_Request] | None:
+    def server(self) -> asyncio.Server | None:
         return self._server
 
     @property
@@ -500,13 +500,17 @@ class AppRunner(BaseRunner[Request]):
     async def serve_forever(self) -> None:
         """Serve forever until the runner is stopped.
 
-        This is a convenience method that calls serve_forever() on the
-        underlying asyncio.Server, matching the interface of
+        This is a convenience method that blocks until the runner is stopped
+        (via cleanup() or shutdown()), matching the interface of
         asyncio.Server.serve_forever().
         """
         if self._server is None:
             raise RuntimeError("Call runner.setup() before calling serve_forever()")
-        await self._server.serve_forever()
+        try:
+            while self._server is not None:
+                await asyncio.sleep(3600)
+        except asyncio.CancelledError:
+            pass
 
     async def _cleanup_server(self) -> None:
         await self._app.cleanup()

--- a/aiohttp/web_runner.py
+++ b/aiohttp/web_runner.py
@@ -296,7 +296,14 @@ class SockSite(BaseSite):
 
 
 class BaseRunner(ABC, Generic[_Request]):
-    __slots__ = ("_handle_signals", "_kwargs", "_server", "_sites", "_shutdown_timeout", "_main_server")
+    __slots__ = (
+        "_handle_signals",
+        "_kwargs",
+        "_server",
+        "_sites",
+        "_shutdown_timeout",
+        "_main_server",
+    )
 
     def __init__(
         self,

--- a/aiohttp/web_runner.py
+++ b/aiohttp/web_runner.py
@@ -185,7 +185,6 @@ class TCPSite(BaseSite):
             reuse_address=self._reuse_address,
             reuse_port=self._reuse_port,
         )
-        self._runner._update_main_server()
         if self._server.sockets:
             self._bound_port = self._server.sockets[0].getsockname()[1]
         else:
@@ -226,7 +225,6 @@ class UnixSite(BaseSite):
             ssl=self._ssl_context,
             backlog=self._backlog,
         )
-        self._runner._update_main_server()
 
 
 class NamedPipeSite(BaseSite):
@@ -256,7 +254,6 @@ class NamedPipeSite(BaseSite):
             server, self._path
         )
         self._server = _server[0]
-        self._runner._update_main_server()
 
 
 class SockSite(BaseSite):
@@ -296,7 +293,6 @@ class SockSite(BaseSite):
         self._server = await create_server(
             loop, server, sock=self._sock, ssl=self._ssl_context, backlog=self._backlog
         )
-        self._runner._update_main_server()
 
 
 class BaseRunner(ABC, Generic[_Request]):
@@ -306,7 +302,6 @@ class BaseRunner(ABC, Generic[_Request]):
         "_server",
         "_sites",
         "_shutdown_timeout",
-        "_main_server",
         "_site_started",
         "_stopped",
     )
@@ -323,7 +318,6 @@ class BaseRunner(ABC, Generic[_Request]):
         self._server: Server[_Request] | None = None
         self._sites: list[BaseSite] = []
         self._shutdown_timeout = shutdown_timeout
-        self._main_server: asyncio.Server | None = None
         self._site_started = asyncio.Event()
         self._stopped = asyncio.Event()
 
@@ -360,8 +354,6 @@ class BaseRunner(ABC, Generic[_Request]):
 
         self._server = await self._make_server()
         # Reset so a fresh serve_forever() call on a reused runner waits for the next site.
-        self._sites = []
-        self._main_server = None
         self._site_started.clear()
         self._stopped.clear()
 
@@ -379,7 +371,8 @@ class BaseRunner(ABC, Generic[_Request]):
 
         # Unblock serve_forever() if it is waiting for a site to start.
         self._site_started.set()
-        # Also set _stopped so serve_forever() raises CancelledError promptly.
+        # Signal that the runner has been stopped; serve_forever() will
+        # raise CancelledError to indicate the runner is no longer serving.
         self._stopped.set()
 
         if self._server:  # If setup succeeded
@@ -392,7 +385,6 @@ class BaseRunner(ABC, Generic[_Request]):
         await self._cleanup_server()
 
         self._server = None
-        self._main_server = None
         self._sites = []
         if self._handle_signals:
             loop = asyncio.get_running_loop()
@@ -402,6 +394,31 @@ class BaseRunner(ABC, Generic[_Request]):
             except NotImplementedError:
                 # remove_signal_handler is not implemented on Windows
                 pass
+
+    async def serve_forever(self) -> None:
+        """Serve forever until the runner is stopped.
+
+        This is a convenience method that blocks until ``cleanup()`` is called,
+        matching the interface of ``asyncio.Server.serve_forever()``.
+
+        Raise :exc:`RuntimeError` if called before :meth:`setup`.
+        """
+        if self._server is None:
+            raise RuntimeError("Call runner.setup() before calling serve_forever()")
+
+        # Wait until a site starts serving or until cleanup is called.
+        await self._site_started.wait()
+
+        # If cleanup was called while waiting for a site, _stopped is set
+        # and the runner is shutting down.
+        if self._stopped.is_set():
+            raise asyncio.CancelledError
+
+        # Block until cleanup() sets _stopped, which signals that the runner
+        # is shutting down.  We raise CancelledError so callers can handle
+        # the cancellation naturally.
+        await self._stopped.wait()
+        raise asyncio.CancelledError
 
     @abstractmethod
     async def _make_server(self) -> Server[_Request]:
@@ -415,7 +432,6 @@ class BaseRunner(ABC, Generic[_Request]):
         if site in self._sites:
             raise RuntimeError(f"Site {site} is already registered in runner {self}")
         self._sites.append(site)
-        self._update_main_server()
         self._site_started.set()
 
     def _check_site(self, site: BaseSite) -> None:
@@ -426,19 +442,6 @@ class BaseRunner(ABC, Generic[_Request]):
         if site not in self._sites:
             raise RuntimeError(f"Site {site} is not registered in runner {self}")
         self._sites.remove(site)
-        if self._main_server is site._server:
-            self._main_server = None
-
-    def _update_main_server(self) -> None:
-        """Pick a live server from the registered sites, if any."""
-        if self._main_server is not None and self._main_server.start_serving:
-            # Already serving (start_serving is True until the server closes).
-            return
-        self._main_server = None
-        for site in self._sites:
-            if site._server is not None and site._server.start_serving:
-                self._main_server = site._server
-                break
 
 
 class ServerRunner(BaseRunner[BaseRequest]):
@@ -539,55 +542,6 @@ class AppRunner(BaseRunner[Request]):
             client_max_size=self.app._client_max_size,
             pre_handler_error=pre_handler_error,
         )
-
-    async def serve_forever(self) -> None:
-        """Serve forever until the runner is stopped.
-
-        This is a convenience method that blocks until the runner is stopped
-        (via cleanup() or shutdown()), matching the interface of
-        asyncio.Server.serve_forever().
-        """
-        if self._server is None:
-            raise RuntimeError("Call runner.setup() before calling serve_forever()")
-        while True:
-            if self._main_server is None and not self._stopped.is_set():
-                # Wait for a site to start OR cleanup to be called.
-                _, pending = await asyncio.wait(
-                    {
-                        asyncio.create_task(self._site_started.wait()),
-                        asyncio.shield(self._stopped.wait()),
-                    },
-                    return_when=asyncio.FIRST_COMPLETED,
-                )
-                for f in pending:
-                    f.cancel()
-                if self._stopped.is_set():
-                    raise asyncio.CancelledError
-                # _site_started was set, but _main_server may still be None
-                # if the site was registered before its asyncio.Server was created.
-                # Loop back and try again — _main_server will be set once the
-                # site's server is available.
-                continue
-            if self._main_server is None and self._stopped.is_set():
-                raise asyncio.CancelledError
-            # Server is running; wait for it to close or for cleanup to be called.
-            _, pending = await asyncio.wait(
-                {
-                    asyncio.create_task(self._main_server.wait_closed()),
-                    asyncio.shield(self._stopped.wait()),
-                },
-                return_when=asyncio.FIRST_COMPLETED,
-            )
-            for f in pending:
-                f.cancel()
-            if self._stopped.is_set():
-                raise asyncio.CancelledError
-            # Server closed. Re-select a live server from remaining sites,
-            # or wait for a new site on a reused runner.
-            self._main_server = None
-            self._update_main_server()
-            # Loop back; if _main_server is None, wait for _site_started.
-            # If _main_server was set, wait_closed() again.
 
     async def _cleanup_server(self) -> None:
         await self._app.cleanup()

--- a/aiohttp/web_runner.py
+++ b/aiohttp/web_runner.py
@@ -549,7 +549,7 @@ class AppRunner(BaseRunner[Request]):
             # Server is running; wait for it to close or for cleanup to be called.
             _, pending = await asyncio.wait(
                 {
-                    self._main_server.wait_closed(),
+                    asyncio.create_task(self._main_server.wait_closed()),
                     asyncio.shield(self._stopped.wait()),
                 },
                 return_when=asyncio.FIRST_COMPLETED,

--- a/aiohttp/web_runner.py
+++ b/aiohttp/web_runner.py
@@ -303,6 +303,7 @@ class BaseRunner(ABC, Generic[_Request]):
         "_sites",
         "_shutdown_timeout",
         "_main_server",
+        "_site_started",
     )
 
     def __init__(
@@ -318,6 +319,7 @@ class BaseRunner(ABC, Generic[_Request]):
         self._sites: list[BaseSite] = []
         self._shutdown_timeout = shutdown_timeout
         self._main_server: asyncio.Server | None = None
+        self._site_started = asyncio.Event()
 
     @property
     def server(self) -> Server[_Request] | None:
@@ -351,6 +353,8 @@ class BaseRunner(ABC, Generic[_Request]):
                 pass
 
         self._server = await self._make_server()
+        # Reset so a fresh serve_forever() call on a reused runner waits for the next site.
+        self._site_started.clear()
 
     @abstractmethod
     async def shutdown(self) -> None:
@@ -363,6 +367,9 @@ class BaseRunner(ABC, Generic[_Request]):
         # still present on failure
         for site in list(self._sites):
             await site.stop()
+
+        # Unblock serve_forever() if it is waiting for a site to start.
+        self._site_started.set()
 
         if self._server:  # If setup succeeded
             # Yield to event loop to ensure incoming requests prior to stopping the sites
@@ -397,6 +404,7 @@ class BaseRunner(ABC, Generic[_Request]):
         self._sites.append(site)
         if self._main_server is None and site._server is not None:
             self._main_server = site._server
+        self._site_started.set()
 
     def _check_site(self, site: BaseSite) -> None:
         if site not in self._sites:
@@ -520,8 +528,10 @@ class AppRunner(BaseRunner[Request]):
             await self._main_server.wait_closed()
         else:
             # No site has started yet; wait indefinitely until cancelled.
-            while True:
-                await asyncio.sleep(3600)
+            # Use an event so that _reg_site() waking a new site can interrupt us.
+            await self._site_started.wait()
+            if self._main_server is not None:
+                await self._main_server.wait_closed()
 
     async def _cleanup_server(self) -> None:
         await self._app.cleanup()

--- a/aiohttp/web_runner.py
+++ b/aiohttp/web_runner.py
@@ -185,6 +185,7 @@ class TCPSite(BaseSite):
             reuse_address=self._reuse_address,
             reuse_port=self._reuse_port,
         )
+        self._runner._update_main_server()
         if self._server.sockets:
             self._bound_port = self._server.sockets[0].getsockname()[1]
         else:
@@ -225,6 +226,7 @@ class UnixSite(BaseSite):
             ssl=self._ssl_context,
             backlog=self._backlog,
         )
+        self._runner._update_main_server()
 
 
 class NamedPipeSite(BaseSite):
@@ -254,6 +256,7 @@ class NamedPipeSite(BaseSite):
             server, self._path
         )
         self._server = _server[0]
+        self._runner._update_main_server()
 
 
 class SockSite(BaseSite):
@@ -293,6 +296,7 @@ class SockSite(BaseSite):
         self._server = await create_server(
             loop, server, sock=self._sock, ssl=self._ssl_context, backlog=self._backlog
         )
+        self._runner._update_main_server()
 
 
 class BaseRunner(ABC, Generic[_Request]):
@@ -356,6 +360,8 @@ class BaseRunner(ABC, Generic[_Request]):
 
         self._server = await self._make_server()
         # Reset so a fresh serve_forever() call on a reused runner waits for the next site.
+        self._sites = []
+        self._main_server = None
         self._site_started.clear()
         self._stopped.clear()
 
@@ -386,6 +392,8 @@ class BaseRunner(ABC, Generic[_Request]):
         await self._cleanup_server()
 
         self._server = None
+        self._main_server = None
+        self._sites = []
         if self._handle_signals:
             loop = asyncio.get_running_loop()
             try:
@@ -407,8 +415,7 @@ class BaseRunner(ABC, Generic[_Request]):
         if site in self._sites:
             raise RuntimeError(f"Site {site} is already registered in runner {self}")
         self._sites.append(site)
-        if self._main_server is None and site._server is not None:
-            self._main_server = site._server
+        self._update_main_server()
         self._site_started.set()
 
     def _check_site(self, site: BaseSite) -> None:
@@ -419,6 +426,19 @@ class BaseRunner(ABC, Generic[_Request]):
         if site not in self._sites:
             raise RuntimeError(f"Site {site} is not registered in runner {self}")
         self._sites.remove(site)
+        if self._main_server is site._server:
+            self._main_server = None
+
+    def _update_main_server(self) -> None:
+        """Pick a live server from the registered sites, if any."""
+        if self._main_server is not None and self._main_server.start_serving:
+            # Already serving (start_serving is True until the server closes).
+            return
+        self._main_server = None
+        for site in self._sites:
+            if site._server is not None and site._server.start_serving:
+                self._main_server = site._server
+                break
 
 
 class ServerRunner(BaseRunner[BaseRequest]):
@@ -530,9 +550,8 @@ class AppRunner(BaseRunner[Request]):
         if self._server is None:
             raise RuntimeError("Call runner.setup() before calling serve_forever()")
         while True:
-            if self._main_server is None:
-                # Wait for either the first site to start OR cleanup to be called.
-                # _stopped being set means cleanup() ran first — raise CancelledError.
+            if self._main_server is None and not self._stopped.is_set():
+                # Wait for a site to start OR cleanup to be called.
                 _, pending = await asyncio.wait(
                     {
                         asyncio.create_task(self._site_started.wait()),
@@ -544,8 +563,13 @@ class AppRunner(BaseRunner[Request]):
                     f.cancel()
                 if self._stopped.is_set():
                     raise asyncio.CancelledError
-                # _site_started was set; a site registered. _main_server is now set.
+                # _site_started was set, but _main_server may still be None
+                # if the site was registered before its asyncio.Server was created.
+                # Loop back and try again — _main_server will be set once the
+                # site's server is available.
                 continue
+            if self._main_server is None and self._stopped.is_set():
+                raise asyncio.CancelledError
             # Server is running; wait for it to close or for cleanup to be called.
             _, pending = await asyncio.wait(
                 {
@@ -558,8 +582,12 @@ class AppRunner(BaseRunner[Request]):
                 f.cancel()
             if self._stopped.is_set():
                 raise asyncio.CancelledError
-            # Server closed normally (cleanup() was called, server shutdown completed).
-            # Loop to wait for the next site on a reused runner.
+            # Server closed. Re-select a live server from remaining sites,
+            # or wait for a new site on a reused runner.
+            self._main_server = None
+            self._update_main_server()
+            # Loop back; if _main_server is None, wait for _site_started.
+            # If _main_server was set, wait_closed() again.
 
     async def _cleanup_server(self) -> None:
         await self._app.cleanup()

--- a/aiohttp/web_runner.py
+++ b/aiohttp/web_runner.py
@@ -497,5 +497,16 @@ class AppRunner(BaseRunner[Request]):
             pre_handler_error=pre_handler_error,
         )
 
+    async def serve_forever(self) -> None:
+        """Serve forever until the runner is stopped.
+
+        This is a convenience method that calls serve_forever() on the
+        underlying asyncio.Server, matching the interface of
+        asyncio.Server.serve_forever().
+        """
+        if self._server is None:
+            raise RuntimeError("Call runner.setup() before calling serve_forever()")
+        await self._server.serve_forever()
+
     async def _cleanup_server(self) -> None:
         await self._app.cleanup()

--- a/aiohttp/web_runner.py
+++ b/aiohttp/web_runner.py
@@ -304,6 +304,7 @@ class BaseRunner(ABC, Generic[_Request]):
         "_shutdown_timeout",
         "_main_server",
         "_site_started",
+        "_stopped",
     )
 
     def __init__(
@@ -320,6 +321,7 @@ class BaseRunner(ABC, Generic[_Request]):
         self._shutdown_timeout = shutdown_timeout
         self._main_server: asyncio.Server | None = None
         self._site_started = asyncio.Event()
+        self._stopped = asyncio.Event()
 
     @property
     def server(self) -> Server[_Request] | None:
@@ -355,6 +357,7 @@ class BaseRunner(ABC, Generic[_Request]):
         self._server = await self._make_server()
         # Reset so a fresh serve_forever() call on a reused runner waits for the next site.
         self._site_started.clear()
+        self._stopped.clear()
 
     @abstractmethod
     async def shutdown(self) -> None:
@@ -370,6 +373,8 @@ class BaseRunner(ABC, Generic[_Request]):
 
         # Unblock serve_forever() if it is waiting for a site to start.
         self._site_started.set()
+        # Also set _stopped so serve_forever() raises CancelledError promptly.
+        self._stopped.set()
 
         if self._server:  # If setup succeeded
             # Yield to event loop to ensure incoming requests prior to stopping the sites
@@ -524,14 +529,37 @@ class AppRunner(BaseRunner[Request]):
         """
         if self._server is None:
             raise RuntimeError("Call runner.setup() before calling serve_forever()")
-        if self._main_server is not None:
-            await self._main_server.wait_closed()
-        else:
-            # No site has started yet; wait indefinitely until cancelled.
-            # Use an event so that _reg_site() waking a new site can interrupt us.
-            await self._site_started.wait()
-            if self._main_server is not None:
-                await self._main_server.wait_closed()
+        while True:
+            if self._main_server is None:
+                # Wait for either the first site to start OR cleanup to be called.
+                # _stopped being set means cleanup() ran first — raise CancelledError.
+                _, pending = await asyncio.wait(
+                    {
+                        asyncio.create_task(self._site_started.wait()),
+                        asyncio.shield(self._stopped.wait()),
+                    },
+                    return_when=asyncio.FIRST_COMPLETED,
+                )
+                for f in pending:
+                    f.cancel()
+                if self._stopped.is_set():
+                    raise asyncio.CancelledError
+                # _site_started was set; a site registered. _main_server is now set.
+                continue
+            # Server is running; wait for it to close or for cleanup to be called.
+            _, pending = await asyncio.wait(
+                {
+                    self._main_server.wait_closed(),
+                    asyncio.shield(self._stopped.wait()),
+                },
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+            for f in pending:
+                f.cancel()
+            if self._stopped.is_set():
+                raise asyncio.CancelledError
+            # Server closed normally (cleanup() was called, server shutdown completed).
+            # Loop to wait for the next site on a reused runner.
 
     async def _cleanup_server(self) -> None:
         await self._app.cleanup()

--- a/aiohttp/web_runner.py
+++ b/aiohttp/web_runner.py
@@ -296,7 +296,7 @@ class SockSite(BaseSite):
 
 
 class BaseRunner(ABC, Generic[_Request]):
-    __slots__ = ("_handle_signals", "_kwargs", "_server", "_sites", "_shutdown_timeout")
+    __slots__ = ("_handle_signals", "_kwargs", "_server", "_sites", "_shutdown_timeout", "_main_server")
 
     def __init__(
         self,
@@ -307,12 +307,13 @@ class BaseRunner(ABC, Generic[_Request]):
     ) -> None:
         self._handle_signals = handle_signals
         self._kwargs = kwargs
-        self._server: asyncio.Server | None = None
+        self._server: Server[_Request] | None = None
         self._sites: list[BaseSite] = []
         self._shutdown_timeout = shutdown_timeout
+        self._main_server: asyncio.Server | None = None
 
     @property
-    def server(self) -> asyncio.Server | None:
+    def server(self) -> Server[_Request] | None:
         return self._server
 
     @property
@@ -387,6 +388,8 @@ class BaseRunner(ABC, Generic[_Request]):
         if site in self._sites:
             raise RuntimeError(f"Site {site} is already registered in runner {self}")
         self._sites.append(site)
+        if self._main_server is None and site._server is not None:
+            self._main_server = site._server
 
     def _check_site(self, site: BaseSite) -> None:
         if site not in self._sites:
@@ -506,11 +509,12 @@ class AppRunner(BaseRunner[Request]):
         """
         if self._server is None:
             raise RuntimeError("Call runner.setup() before calling serve_forever()")
-        try:
-            while self._server is not None:
+        if self._main_server is not None:
+            await self._main_server.wait_closed()
+        else:
+            # No site has started yet; wait indefinitely until cancelled.
+            while True:
                 await asyncio.sleep(3600)
-        except asyncio.CancelledError:
-            pass
 
     async def _cleanup_server(self) -> None:
         await self._app.cleanup()

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -2804,6 +2804,17 @@ application on specific TCP or Unix socket, e.g.::
 
       Stop handling all registered sites and cleanup used resources.
 
+   .. method:: serve_forever()
+      :async:
+
+      Serve until :meth:`cleanup` is called.
+
+      Convenience method that blocks until the runner is stopped.
+      Raises :exc:`asyncio.CancelledError` when :meth:`cleanup`
+      is called.
+
+      .. versionadded:: 3.11
+
 
 .. class:: AppRunner(app, *, handle_signals=False, **kwargs)
    :canonical: aiohttp.web_runner.AppRunner

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -2813,7 +2813,7 @@ application on specific TCP or Unix socket, e.g.::
       Raises :exc:`asyncio.CancelledError` when :meth:`cleanup`
       is called.
 
-      .. versionadded:: 3.11
+      .. versionadded:: 4.0
 
 
 .. class:: AppRunner(app, *, handle_signals=False, **kwargs)

--- a/tests/test_web_runner.py
+++ b/tests/test_web_runner.py
@@ -359,6 +359,36 @@ async def test_serve_forever_without_site(make_runner: _RunnerMaker) -> None:
         pass
 
 
+async def test_serve_forever_with_cleanup(make_runner: _RunnerMaker) -> None:
+    """serve_forever() exits promptly when runner.cleanup() is called."""
+    import aiohttp
+
+    runner = make_runner()
+    await runner.setup()
+
+    serve_task = asyncio.create_task(runner.serve_forever())
+    await asyncio.sleep(0.05)
+    await runner.cleanup()
+    with pytest.raises(asyncio.CancelledError):
+        await serve_task
+
+
+async def test_serve_forever_with_cancel(make_runner: _RunnerMaker) -> None:
+    """serve_forever() raises CancelledError when the calling task is cancelled."""
+    import aiohttp
+
+    runner = make_runner()
+    await runner.setup()
+    site = web.TCPSite(runner, host="127.0.0.1", port=0)
+    await site.start()
+    serve_task = asyncio.create_task(runner.serve_forever())
+    await asyncio.sleep(0.05)
+    serve_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await serve_task
+    await runner.cleanup()
+
+
 def test_run_after_asyncio_run() -> None:
     called = False
 

--- a/tests/test_web_runner.py
+++ b/tests/test_web_runner.py
@@ -408,3 +408,95 @@ def test_run_after_asyncio_run() -> None:
 
     web.run_app(app)
     assert called, "run_app() should work after asyncio.run()."
+
+
+async def test_serve_forever_resumes_after_server_close(
+    make_runner: _RunnerMaker,
+) -> None:
+    """serve_forever() should not busy-loop when the main server closes.
+
+    After a site's asyncio.Server closes, serve_forever() must re-evaluate
+    remaining sites rather than spinning, and a reused runner should be able
+    to serve a new site without leftover stale _main_server state.
+    """
+    import aiohttp
+
+    runner = make_runner()
+    await runner.setup()
+    site = web.TCPSite(runner, host="127.0.0.1", port=0)
+    await site.start()
+
+    serve_task = asyncio.create_task(runner.serve_forever())
+    await asyncio.sleep(0.05)
+
+    # Close the running server and verify serve_forever() does not busy-loop.
+    site._server.close()  # type: ignore[union-attr]
+    await site._server.wait_closed()  # type: ignore[union-attr]
+
+    # Give serve_forever() time to detect the close — if it busy-loops it
+    # would spin here indefinitely or raise spuriously.
+    await asyncio.sleep(0.1)
+    assert not serve_task.done(), "serve_forever() should still be running"
+
+    # Now serve again on a new site with the same runner (reuse).
+    new_site = web.TCPSite(runner, host="127.0.0.1", port=0)
+    await new_site.start()
+
+    await asyncio.sleep(0.05)
+    async with aiohttp.ClientSession() as session:
+        async with session.get(new_site.name) as resp:
+            assert resp.status == 404
+
+    await runner.cleanup()
+    with pytest.raises(asyncio.CancelledError):
+        await serve_task
+
+
+async def test_runner_reuse_after_cleanup(make_runner: _RunnerMaker) -> None:
+    """A runner should be reusable after cleanup — _main_server / _sites reset."""
+    runner = make_runner()
+    await runner.setup()
+    site = web.TCPSite(runner, host="127.0.0.1", port=0)
+    await site.start()
+
+    serve_task = asyncio.create_task(runner.serve_forever())
+    await asyncio.sleep(0.05)
+    await runner.cleanup()
+    with pytest.raises(asyncio.CancelledError):
+        await serve_task
+
+    # Verify internal state is reset for reuse.
+    assert runner._sites == []
+    assert runner._main_server is None
+    assert runner._server is None
+
+    # Reuse the runner.
+    await runner.setup()
+    site2 = web.TCPSite(runner, host="127.0.0.1", port=0)
+    await site2.start()
+
+    serve_task2 = asyncio.create_task(runner.serve_forever())
+    await asyncio.sleep(0.05)
+    assert not serve_task2.done(), "serve_forever() should be running on reused runner"
+    await runner.cleanup()
+    with pytest.raises(asyncio.CancelledError):
+        await serve_task2
+
+
+async def test_serve_forever_without_setup(make_runner: _RunnerMaker) -> None:
+    """serve_forever() raises RuntimeError if setup() was not called."""
+    runner = make_runner()
+    with pytest.raises(RuntimeError, match="Call runner.setup"):
+        await runner.serve_forever()
+
+
+async def test_serve_forever_cleanup_during_wait(make_runner: _RunnerMaker) -> None:
+    """serve_forever() exits promptly when cleanup() is called while waiting for a site."""
+    runner = make_runner()
+    await runner.setup()
+    serve_task = asyncio.create_task(runner.serve_forever())
+    await asyncio.sleep(0.05)
+    # Cleanup while serve_forever is waiting for _site_started / _stopped.
+    await runner.cleanup()
+    with pytest.raises(asyncio.CancelledError):
+        await serve_task

--- a/tests/test_web_runner.py
+++ b/tests/test_web_runner.py
@@ -361,8 +361,6 @@ async def test_serve_forever_without_site(make_runner: _RunnerMaker) -> None:
 
 async def test_serve_forever_with_cleanup(make_runner: _RunnerMaker) -> None:
     """serve_forever() exits promptly when runner.cleanup() is called."""
-    import aiohttp
-
     runner = make_runner()
     await runner.setup()
 
@@ -375,8 +373,6 @@ async def test_serve_forever_with_cleanup(make_runner: _RunnerMaker) -> None:
 
 async def test_serve_forever_with_cancel(make_runner: _RunnerMaker) -> None:
     """serve_forever() raises CancelledError when the calling task is cancelled."""
-    import aiohttp
-
     runner = make_runner()
     await runner.setup()
     site = web.TCPSite(runner, host="127.0.0.1", port=0)

--- a/tests/test_web_runner.py
+++ b/tests/test_web_runner.py
@@ -8,6 +8,7 @@ from unittest import mock
 
 import pytest
 
+import aiohttp
 from aiohttp import web, web_runner as web_runner_module
 from aiohttp.abc import AbstractAccessLogger
 from aiohttp.test_utils import REUSE_ADDRESS
@@ -301,17 +302,12 @@ async def test_tcpsite_ephemeral_port(make_runner: _RunnerMaker) -> None:
 
 
 async def test_serve_forever(make_runner: _RunnerMaker) -> None:
-    import aiohttp
-
     runner = make_runner()
     await runner.setup()
     site = web.TCPSite(runner, host="127.0.0.1", port=0)
     await site.start()
 
-    async def serve() -> None:
-        await runner.serve_forever()
-
-    serve_task = asyncio.create_task(serve())
+    serve_task = asyncio.create_task(runner.serve_forever())
     # Give the server a moment to start
     await asyncio.sleep(0.05)
 
@@ -320,28 +316,20 @@ async def test_serve_forever(make_runner: _RunnerMaker) -> None:
         async with session.get(site.name) as resp:
             assert resp.status == 404  # Default aiohttp response for unknown route
 
-    serve_task.cancel()
-    try:
-        await serve_task
-    except asyncio.CancelledError:
-        pass
     await runner.cleanup()
+    # cleanup() causes serve_forever() to raise CancelledError
+    with pytest.raises(asyncio.CancelledError):
+        await serve_task
 
 
 async def test_serve_forever_without_site(make_runner: _RunnerMaker) -> None:
     """serve_forever() should wait for the first site to start before returning."""
-    import aiohttp
-
     runner = make_runner()
     await runner.setup()
 
-    async def serve() -> None:
-        await runner.serve_forever()
+    serve_task = asyncio.create_task(runner.serve_forever())
 
-    serve_task = asyncio.create_task(serve())
-
-    # Start a site — this should cause serve_forever() to exit the wait
-    # and move into wait_closed().
+    # Start a site — this should unblock the wait in serve_forever().
     site = web.TCPSite(runner, host="127.0.0.1", port=0)
     await site.start()
 
@@ -351,12 +339,10 @@ async def test_serve_forever_without_site(make_runner: _RunnerMaker) -> None:
         async with session.get(site.name) as resp:
             assert resp.status == 404
 
-    # Cleanup unblocks serve_forever() via wait_closed().
+    # Cleanup unblocks serve_forever() and causes it to raise CancelledError.
     await runner.cleanup()
-    try:
+    with pytest.raises(asyncio.CancelledError):
         await serve_task
-    except asyncio.CancelledError:
-        pass
 
 
 async def test_serve_forever_with_cleanup(make_runner: _RunnerMaker) -> None:
@@ -413,14 +399,11 @@ def test_run_after_asyncio_run() -> None:
 async def test_serve_forever_resumes_after_server_close(
     make_runner: _RunnerMaker,
 ) -> None:
-    """serve_forever() should not busy-loop when the main server closes.
+    """serve_forever() should not busy-loop when a site's server closes.
 
-    After a site's asyncio.Server closes, serve_forever() must re-evaluate
-    remaining sites rather than spinning, and a reused runner should be able
-    to serve a new site without leftover stale _main_server state.
+    After a site's asyncio.Server closes, serve_forever() must continue
+    running and a reused runner should be able to serve a new site.
     """
-    import aiohttp
-
     runner = make_runner()
     await runner.setup()
     site = web.TCPSite(runner, host="127.0.0.1", port=0)
@@ -429,7 +412,8 @@ async def test_serve_forever_resumes_after_server_close(
     serve_task = asyncio.create_task(runner.serve_forever())
     await asyncio.sleep(0.05)
 
-    # Close the running server and verify serve_forever() does not busy-loop.
+    # Close the running server and verify serve_forever() does not raise
+    # or complete.
     site._server.close()  # type: ignore[union-attr]
     await site._server.wait_closed()  # type: ignore[union-attr]
 
@@ -453,7 +437,7 @@ async def test_serve_forever_resumes_after_server_close(
 
 
 async def test_runner_reuse_after_cleanup(make_runner: _RunnerMaker) -> None:
-    """A runner should be reusable after cleanup — _main_server / _sites reset."""
+    """A runner should be reusable after cleanup — _sites reset."""
     runner = make_runner()
     await runner.setup()
     site = web.TCPSite(runner, host="127.0.0.1", port=0)
@@ -467,7 +451,6 @@ async def test_runner_reuse_after_cleanup(make_runner: _RunnerMaker) -> None:
 
     # Verify internal state is reset for reuse.
     assert runner._sites == []
-    assert runner._main_server is None
     assert runner._server is None
 
     # Reuse the runner.

--- a/tests/test_web_runner.py
+++ b/tests/test_web_runner.py
@@ -328,6 +328,37 @@ async def test_serve_forever(make_runner: _RunnerMaker) -> None:
     await runner.cleanup()
 
 
+async def test_serve_forever_without_site(make_runner: _RunnerMaker) -> None:
+    """serve_forever() should wait for the first site to start before returning."""
+    import aiohttp
+
+    runner = make_runner()
+    await runner.setup()
+
+    async def serve() -> None:
+        await runner.serve_forever()
+
+    serve_task = asyncio.create_task(serve())
+
+    # Start a site — this should cause serve_forever() to exit the wait
+    # and move into wait_closed().
+    site = web.TCPSite(runner, host="127.0.0.1", port=0)
+    await site.start()
+
+    # Verify server is actually serving.
+    await asyncio.sleep(0.05)
+    async with aiohttp.ClientSession() as session:
+        async with session.get(site.name) as resp:
+            assert resp.status == 404
+
+    # Cleanup unblocks serve_forever() via wait_closed().
+    await runner.cleanup()
+    try:
+        await serve_task
+    except asyncio.CancelledError:
+        pass
+
+
 def test_run_after_asyncio_run() -> None:
     called = False
 

--- a/tests/test_web_runner.py
+++ b/tests/test_web_runner.py
@@ -300,6 +300,34 @@ async def test_tcpsite_ephemeral_port(make_runner: _RunnerMaker) -> None:
     await site.stop()
 
 
+async def test_serve_forever(make_runner: _RunnerMaker) -> None:
+    import aiohttp
+
+    runner = make_runner()
+    await runner.setup()
+    site = web.TCPSite(runner, host="127.0.0.1", port=0)
+    await site.start()
+
+    async def serve() -> None:
+        await runner.serve_forever()
+
+    serve_task = asyncio.create_task(serve())
+    # Give the server a moment to start
+    await asyncio.sleep(0.05)
+
+    # Verify the server is actually serving
+    async with aiohttp.ClientSession() as session:
+        async with session.get(site.name) as resp:
+            assert resp.status == 404  # Default aiohttp response for unknown route
+
+    serve_task.cancel()
+    try:
+        await serve_task
+    except asyncio.CancelledError:
+        pass
+    await runner.cleanup()
+
+
 def test_run_after_asyncio_run() -> None:
     called = False
 


### PR DESCRIPTION
## Summary

Adds a `BaseRunner.serve_forever()` convenience method, matching the interface of `asyncio.Server.serve_forever()`. Closes #2746.

## Changes

### `aiohttp/web_runner.py`

1. **New `serve_forever()` method** on `BaseRunner` (inherited by `AppRunner` and `ServerRunner`) that blocks until the runner is stopped (via `cleanup()`).

2. Simplified implementation: the method waits on `_site_started` and `_stopped` events instead of tracking a `_main_server` asyncio.Server reference, which had race conditions where sites registered after `serve_forever()` was called.

3. Removed `_main_server` attribute and `_update_main_server()` method entirely — the race detection logic was flawed because `_reg_site()` was called before sites set their `_server`.

4. Reset `_sites` in `cleanup()` for proper runner reuse.

### `tests/test_web_runner.py`

- Added tests for `serve_forever()` covering: basic serving, cleanup cancellation, site registration after call, runner reuse, and pre-setup RuntimeError.

Refs: #2746

CHANGES: 13606