### PR TITLE
Add runner.serve_forever() method

### DIFF
--- a/aiohttp/web_runner.py
+++ b/aiohttp/web_runner.py
@@ -497,5 +497,16 @@ class AppRunner(BaseRunner[Request]):
             pre_handler_error=pre_handler_error,
         )
 
+    async def serve_forever(self) -> None:
+        """Serve forever until the runner is stopped.
+
+        This is a convenience method that calls serve_forever() on the
+        underlying asyncio.Server, matching the interface of
+        asyncio.Server.serve_forever().
+        """
+        if self._server is None:
+            raise RuntimeError("Call runner.setup() before calling serve_forever()")
+        await self._server.serve_forever()
+
     async def _cleanup_server(self) -> None:
         await self._app.cleanup()

--- a/tests/test_web_runner.py
+++ b/tests/test_web_runner.py
@@ -300,6 +300,34 @@ async def test_tcpsite_ephemeral_port(make_runner: _RunnerMaker) -> None:
     await site.stop()
 
 
+async def test_serve_forever(make_runner: _RunnerMaker) -> None:
+    import aiohttp
+
+    runner = make_runner()
+    await runner.setup()
+    site = web.TCPSite(runner, host="127.0.0.1", port=0)
+    await site.start()
+
+    async def serve() -> None:
+        await runner.serve_forever()
+
+    serve_task = asyncio.create_task(serve())
+    # Give the server a moment to start
+    await asyncio.sleep(0.05)
+
+    # Verify the server is actually serving
+    async with aiohttp.ClientSession() as session:
+        async with session.get(site.name) as resp:
+            assert resp.status == 404  # Default aiohttp response for unknown route
+
+    serve_task.cancel()
+    try:
+        await serve_task
+    except asyncio.CancelledError:
+        pass
+    await runner.cleanup()
+
+
 def test_run_after_asyncio_run() -> None:
     called = False
 


### PR DESCRIPTION
## Summary

Adds `AppRunner.serve_forever()` method to match the pattern used in other async web frameworks like uvicorn and hypercorn.

## Changes

- `aiohttp/web_runner.py`: Added `AppRunner.serve_forever()` method that blocks the current task by delegating to `asyncio.Server.serve_forever()` on the underlying server. Raises `RuntimeError` if `setup()` was not called first.
- `tests/test_web_runner.py`: Added `test_serve_forever` to verify the method works correctly with a live server.

Fixes #2746

🤖 Generated with [Claude Code](https://claude.com/claude-code)