### PR TITLE
Remove Gitter chat links from issue template and docs badges

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -7,6 +7,3 @@ contact_links:
 - name: 💬 Github Discussions
   url: https://github.com/aio-libs/aiohttp/discussions
   about: Please start usage discussions here
-- name: 💬 Gitter Chat
-  url: https://gitter.im/aio-libs/Lobby
-  about: Chat with devs and community

--- a/CHANGES/13608.misc.rst
+++ b/CHANGES/13608.misc.rst
@@ -1,0 +1,2 @@
+Removed the dead Gitter chat links from the issue template and docs
+-- by :user:`KuligKamil`.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -229,12 +229,6 @@ html_theme_options = {
             "height": "20",
             "alt": "Latest PyPI package version",
         },
-        {
-            "image": "https://badges.gitter.im/Join%20Chat.svg",
-            "target": f"https://gitter.im/{github_repo_org}/Lobby",
-            "height": "20",
-            "alt": "Chat on Gitter",
-        },
     ],
 }
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

Removes the dead Gitter chat links from the issue template contact links
(`.github/ISSUE_TEMPLATE/config.yml`) and from the badge list in the docs
sidebar (`docs/conf.py`). The aio-libs community has moved off Gitter to
Matrix, so the badge and the "Chat with devs" link pointed to a channel
that's no longer actively used.

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->

No behavioral/API changes. Users opening a new issue will no longer see
a "Gitter Chat" option in the template chooser, and the docs sidebar will
no longer show the (dead) Gitter badge.

## Is it a substantial burden for the maintainers to support this?

<!--
Stop right there! Pause. Just for a minute... Can you think of anything
obvious that would complicate the ongoing development of this project?

Try to consider if you'd be able to maintain it throughout the next
5 years. Does it seem viable? Tell us your thoughts! We'd very much
love to hear what the consequences of merging this patch might be...

This will help us assess if your change is something we'd want to
entertain early in the review process. Thank you in advance!
-->

No — this only removes stale links/config, nothing to maintain going forward.

## Related issue number

<!-- Will this resolve any open issues? -->
<!-- Remember to prefix with 'Fixes' if it closes an issue (e.g. 'Fixes #123'). -->

N/A

## Checklist

- [X] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
- [ ] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is &lt;Name&gt; &lt;Surname&gt;.
  * Please keep alphabetical order, the file is sorted by names.
- [ ] Add a new news fragment into the `CHANGES/` folder
  * name it `<issue_or_pr_num>.<type>.rst` (e.g. `588.bugfix.rst`)
  * if you don't have an issue number, change it to the pull request
    number after creating the PR
    * `.bugfix`: A bug fix for something the maintainers deemed an
      improper undesired behavior that got corrected to match
      pre-agreed expectations.
    * `.feature`: A new behavior, public APIs. That sort of stuff.
    * `.deprecation`: A declaration of future API removals and breaking
      changes in behavior.
    * `.breaking`: When something public is removed in a breaking way.
      Could be deprecated in an earlier release.
    * `.doc`: Notable updates to the documentation structure or build
      process.
    * `.packaging`: Notes for downstreams about unobvious side effects
      and tooling. Changes in the test invocation considerations and
      runtime assumptions.
    * `.contrib`: Stuff that affects the contributor experience. e.g.
      Running tests, building the docs, setting up the development
      environment.
    * `.misc`: Changes that are hard to assign to any of the above
      categories.
  * Make sure to use full sentences with correct case and punctuation,
    for example:
    ```rst
    Fixed issue with non-ascii contents in doctest text files
    -- by :user:`contributor-gh-handle`.
    ```

    Use the past tense or the present tense a non-imperative mood,
    referring to what's changed compared to the last released version
    of this project.
