### PR TITLE
fix(multipart): apply Content-Encoding in MultipartWriter.as_bytes()

### DIFF
--- a/aiohttp/multipart.py
+++ b/aiohttp/multipart.py
@@ -1148,20 +1148,34 @@ class MultipartWriter(Payload):
         """Return bytes representation of the multipart data.
 
         This method is async-safe and calls as_bytes on underlying payloads.
+        Applies Content-Encoding and Content-Transfer-Encoding when the part
+        headers declare them, matching the behaviour of :meth:`write`.
         """
         parts: list[bytes] = []
 
         # Process each part
-        for part, _e, _te in self._parts:
+        for part, ce_encoding, te_encoding in self._parts:
             # Add boundary
             parts.append(b"--" + self._boundary + b"\r\n")
 
             # Add headers
             parts.append(part._binary_headers)
 
-            # Add payload content using as_bytes for async safety
-            part_bytes = await part.as_bytes(encoding, errors)
-            parts.append(part_bytes)
+            if ce_encoding or te_encoding:
+                # Apply the same encoding/compression as write()
+                buf = _BufferStreamWriter()
+                mpw = MultipartPayloadWriter(buf)
+                if ce_encoding:
+                    mpw.enable_compression(ce_encoding)
+                if te_encoding:
+                    mpw.enable_encoding(te_encoding)
+                await part.write(mpw)  # type: ignore[arg-type]
+                await mpw.write_eof()
+                parts.append(bytes(buf.data))
+            else:
+                # Add payload content using as_bytes for async safety
+                part_bytes = await part.as_bytes(encoding, errors)
+                parts.append(part_bytes)
 
             # Add trailing CRLF
             parts.append(b"\r\n")
@@ -1224,6 +1238,33 @@ class MultipartWriter(Payload):
                     internal_logger.error(
                         "Failed to close multipart part %d: %s", idx, exc, exc_info=True
                     )
+
+
+class _BufferStreamWriter(AbstractStreamWriter):
+    """Minimal in-memory stream writer for use with MultipartPayloadWriter in as_bytes()."""
+
+    def __init__(self) -> None:
+        self.data = bytearray()
+
+    async def write(
+        self, chunk: "bytes | bytearray | memoryview[int] | memoryview[bytes]"
+    ) -> None:
+        self.data.extend(chunk)
+
+    async def write_eof(self, chunk: bytes = b"") -> None:
+        if chunk:
+            self.data.extend(chunk)
+
+    async def drain(self) -> None:
+        pass
+
+    def enable_compression(
+        self, encoding: str = "deflate", strategy: int | None = None
+    ) -> None:
+        pass
+
+    def enable_chunking(self) -> None:
+        pass
 
 
 class MultipartPayloadWriter:

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -2009,3 +2009,64 @@ async def test_multipart_writer_consumed_follows_body_part_reader() -> None:
 
         assert part.consumed is True
         assert writer.consumed is True
+
+
+@pytest.mark.skipif(sys.version_info < (3, 11), reason="No wbits parameter")
+async def test_multipart_writer_as_bytes_applies_content_encoding() -> None:
+    """as_bytes() must apply Content-Encoding compression, matching write()."""
+    import zlib
+
+    content = b"Hello, world!"
+    compressed = zlib.compress(content)
+
+    mp = aiohttp.MultipartWriter("mixed", boundary="XBOUND")
+    part = aiohttp.payload.StringPayload(content)
+    part.headers["Content-Encoding"] = "deflate"
+    mp.append_payload(part)
+
+    result = await mp.as_bytes()
+
+    # The result should contain the compressed content, not the raw content
+    assert compressed in result
+    assert content not in result
+
+    # Verify we can decompress it back
+    # Find the payload between headers and closing boundary
+    header_end = result.find(b"\r\n\r\n") + 4
+    boundary_marker = b"\r\n--XBOUND"
+    payload_end = result.find(boundary_marker, header_end)
+    payload_data = result[header_end:payload_end]
+    assert zlib.decompress(payload_data) == content
+
+
+@pytest.mark.skipif(sys.version_info < (3, 11), reason="No wbits parameter")
+async def test_multipart_writer_as_bytes_applies_content_transfer_encoding() -> None:
+    """as_bytes() must apply Content-Transfer-Encoding (base64), matching write()."""
+    import base64
+
+    content = b"Hello, world!"
+    encoded = base64.b64encode(content)
+
+    mp = aiohttp.MultipartWriter("mixed", boundary="XBOUND")
+    part = aiohttp.payload.StringPayload(content)
+    part.headers["Content-Transfer-Encoding"] = "base64"
+    mp.append_payload(part)
+
+    result = await mp.as_bytes()
+
+    # The result should contain the base64-encoded content
+    assert encoded in result
+    # Raw content should not appear
+    assert content not in result
+
+
+async def test_multipart_writer_as_bytes_no_encoding_matches_write() -> None:
+    """as_bytes() without encoding should match the raw content (no regression)."""
+    content = b"Hello, world!"
+
+    mp = aiohttp.MultipartWriter("mixed", boundary="XBOUND")
+    part = aiohttp.payload.StringPayload(content)
+    mp.append_payload(part)
+
+    result = await mp.as_bytes()
+    assert content in result


### PR DESCRIPTION
## Summary

`MultipartWriter.as_bytes()` returned raw, untransformed part content even when the part headers declared `Content-Encoding` (gzip/deflate) or `Content-Transfer-Encoding` (base64/quoted-printable). `write()` applied these transformations via `MultipartPayloadWriter`, but `as_bytes()` called `part.as_bytes()` directly, skipping the encoding pipeline entirely.

This broke digest authentication with `qop=auth-int` (the entity hash computed from `as_bytes()` never matched what was actually sent) and returned inconsistent results between `as_bytes()` and `write()`.

## Fix

When a part has encoding or transfer-encoding headers, route it through `MultipartPayloadWriter` with a buffer writer, matching the `write()` code path exactly. Added `_BufferStreamWriter` (minimal `AbstractStreamWriter` implementation for in-memory buffering).

## Tests

Added 3 regression tests:
- Content-Encoding (deflate): verifies compression is applied and round-trips correctly
- Content-Transfer-Encoding (base64): verifies base64 encoding is applied
- No encoding: verifies no regression for parts without encoding headers

Fixes #13495
