### PR TITLE
Copy caller-supplied Morsels in CookieJar.update_cookies

### DIFF
--- a/CHANGES/13634.bugfix.rst
+++ b/CHANGES/13634.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed ``CookieJar.update_cookies()`` storing a caller-supplied ``http.cookies.Morsel`` by reference so later mutations of that object could silently change jar state -- by :user:`vyrnsynx`.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -421,6 +421,7 @@ Vladimir Zakharov
 Vladyslav Bohaichuk
 Vladyslav Bondar
 Vojtěch Boček
+Vyrn Synx
 W. Trevor King
 Wei Lin
 Weiwei Wang

--- a/aiohttp/cookiejar.py
+++ b/aiohttp/cookiejar.py
@@ -1,5 +1,6 @@
 import calendar
 import contextlib
+import copy
 import datetime
 import heapq
 import itertools
@@ -338,6 +339,10 @@ class CookieJar(AbstractCookieJar):
                 tmp = SimpleCookie()
                 tmp[name] = cookie  # type: ignore[assignment]
                 cookie = tmp[name]
+            else:
+                # Copy so jar state is independent of the caller's Morsel
+                # and so jar mutations (domain/path) do not affect the caller.
+                cookie = copy.copy(cookie)
 
             domain = cookie["domain"]
 

--- a/tests/test_cookiejar.py
+++ b/tests/test_cookiejar.py
@@ -169,8 +169,17 @@ async def test_constructor(
     jar_cookies = SimpleCookie()
     for cookie in jar:
         dict.__setitem__(jar_cookies, cookie.key, cookie)
-    expected_cookies = cookies_to_send
+
+    # Input Morsels are copied, so compare against another jar fed the same
+    # raw input rather than the caller's (unmutated) cookie objects.
+    expected_jar = CookieJar()
+    expected_jar.update_cookies(_cookies_to_send())
+    expected_cookies = SimpleCookie()
+    for cookie in expected_jar:
+        dict.__setitem__(expected_cookies, cookie.key, cookie)
     assert jar_cookies == expected_cookies
+    # Caller objects must remain untouched by jar path/domain normalization.
+    assert cookies_to_send["domain-cookie"]["path"] == ""
 
 
 async def test_constructor_with_expired(
@@ -200,11 +209,7 @@ def test_save_load(
     jar_load = CookieJar()
     jar_load.load(file_path=file_path)
 
-    jar_test = SimpleCookie()
-    for cookie in jar_load:
-        jar_test[cookie.key] = cookie
-
-    assert jar_test == cookies_to_receive
+    assert jar_save._cookies == jar_load._cookies
 
 
 def test_save_load_partitioned_cookies(tmp_path: Path) -> None:
@@ -845,6 +850,33 @@ async def test_loose_cookies_types() -> None:
 
     for loose_cookies_type in accepted_types:
         jar.update_cookies(cookies=loose_cookies_type)
+
+
+async def test_update_cookies_copies_caller_morsel() -> None:
+    """Caller-supplied Morsels must be copied; later mutations must not leak."""
+    url = URL("http://example.com/")
+    jar = CookieJar()
+    morsels = SimpleCookie()
+    morsels["auth"] = "user-a-token"
+    morsels["auth"]["path"] = "/"
+    morsels["auth"]["httponly"] = True
+    caller_morsel = morsels["auth"]
+
+    jar.update_cookies({"auth": caller_morsel}, url)
+
+    # Mutate the caller's Morsel after it was stored in the jar.
+    caller_morsel.set("auth", "unexpected-value", "unexpected-value")
+    caller_morsel["path"] = "/hijacked"
+    caller_morsel["httponly"] = False
+
+    sent = jar.filter_cookies(url)
+    assert sent["auth"].value == "user-a-token"
+
+    stored = next(c for c in jar if c.key == "auth")
+    assert stored is not caller_morsel
+    assert stored.value == "user-a-token"
+    assert stored["path"] == "/"
+    assert stored["httponly"] is True
 
 
 async def test_cookie_jar_clear_all() -> None:


### PR DESCRIPTION
## What do these changes do?

`CookieJar.update_cookies()` now shallow-copies a caller-supplied `http.cookies.Morsel` before storing it (and before applying domain/path normalization). Previously a Morsel was stored by reference, so later mutations of the caller's object silently changed jar state. String/`BaseCookie` inputs already created a new Morsel via `SimpleCookie`; this aligns the Morsel path with that behavior.

## Are there changes in behavior for the user?

Yes, for callers that intentionally relied on sharing object identity with the jar (unlikely and undocumented): mutating a Morsel after `update_cookies()` no longer affects stored cookies. Jar-side path/domain normalization also no longer mutates the caller's Morsel.

## Is it a substantial burden for the maintainers to support this?

No. One `copy.copy()` on the Morsel path; tests cover the aliasing bug and adjust two existing tests that accidentally depended on in-place mutation of fixture Morsels.

## Related issue number

Fixes #13634

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [ ] Documentation reflects the changes N/A (bugfix; behavior now matches the documented LooseCookies intent)
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
  * The format is <Name> <Surname>.
  * Please keep alphabetical order, the file is sorted by names.
- [x] Add a new news fragment into the `CHANGES/` folder
  * name it `<issue_or_pr_num>.<type>.rst` (e.g. `588.bugfix.rst`)
  * if you don't have an issue number, change it to the pull request
    number after creating the PR
    * `.bugfix`: A bug fix for something the maintainers deemed an
      improper undesired behavior that got corrected to match
      pre-agreed expectations.

<details>
<summary>Test run</summary>

```
PYTHONPATH='.' AIOHTTP_NO_EXTENSIONS=1 pytest tests/test_cookiejar.py -v -o addopts= -p no:aiohttp
============================== 92 passed in 0.61s ==============================
```

</details>

Drafted with AI coding assistant; reviewed by @vyrnsynx.