### PR TITLE
Add BaseRunner serve_forever

### DIFF
--- a/CHANGES/2746.feature.rst
+++ b/CHANGES/2746.feature.rst
@@ -1,0 +1,3 @@
+Added :meth:`BaseRunner.serve_forever() <aiohttp.web.BaseRunner.serve_forever>`
+to serve registered sites until cancellation or runner cleanup
+-- by :user:`ryux1`.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -347,6 +347,7 @@ Roman Podoliaka
 Roman Postnov
 Rong Zhang
 Rouven Bauer
+ryux1
 Samir Akarioh
 Samuel Colvin
 Samuel Gaist

--- a/THREAT_MODEL.md
+++ b/THREAT_MODEL.md
@@ -30,7 +30,7 @@ Key public APIs (non-exhaustive):
 
 | Surface | Entry points |
 | --- | --- |
-| Server | `aiohttp.web.Application`, `web.RouteTableDef`, `web.run_app`, `web.AppRunner`, `web.WebSocketResponse`, `web.FileResponse` |
+| Server | `aiohttp.web.Application`, `web.RouteTableDef`, `web.run_app`, `web.AppRunner`, `web.BaseRunner.serve_forever`, `web.WebSocketResponse`, `web.FileResponse` |
 | Client | `aiohttp.ClientSession`, `aiohttp.TCPConnector`, `aiohttp.ClientResponse`, `aiohttp.WSMessage`, `aiohttp.BasicAuth` |
 | Shared | `aiohttp.MultipartReader`/`MultipartWriter`, `aiohttp.CookieJar`, `aiohttp.TraceConfig`, `aiohttp.resolver.AsyncResolver` |
 

--- a/aiohttp/web_runner.py
+++ b/aiohttp/web_runner.py
@@ -296,7 +296,14 @@ class SockSite(BaseSite):
 
 
 class BaseRunner(ABC, Generic[_Request]):
-    __slots__ = ("_handle_signals", "_kwargs", "_server", "_sites", "_shutdown_timeout")
+    __slots__ = (
+        "_handle_signals",
+        "_kwargs",
+        "_server",
+        "_serving_forever_fut",
+        "_sites",
+        "_shutdown_timeout",
+    )
 
     def __init__(
         self,
@@ -308,6 +315,7 @@ class BaseRunner(ABC, Generic[_Request]):
         self._handle_signals = handle_signals
         self._kwargs = kwargs
         self._server: Server[_Request] | None = None
+        self._serving_forever_fut: asyncio.Future[None] | None = None
         self._sites: list[BaseSite] = []
         self._shutdown_timeout = shutdown_timeout
 
@@ -374,6 +382,29 @@ class BaseRunner(ABC, Generic[_Request]):
             except NotImplementedError:
                 # remove_signal_handler is not implemented on Windows
                 pass
+
+        serving_forever_fut = self._serving_forever_fut
+        if serving_forever_fut is not None and not serving_forever_fut.done():
+            serving_forever_fut.set_result(None)
+
+    async def serve_forever(self) -> None:
+        if self._serving_forever_fut is not None:
+            raise RuntimeError(f"Runner {self!r} is already being awaited")
+        if self._server is None:
+            raise RuntimeError(f"Call runner.setup() before serve_forever(): {self!r}")
+        if not self._sites:
+            raise RuntimeError(f"Runner {self!r} has no started sites")
+
+        self._serving_forever_fut = asyncio.get_running_loop().create_future()
+        try:
+            await self._serving_forever_fut
+        except asyncio.CancelledError:
+            try:
+                await self.cleanup()
+            finally:
+                raise
+        finally:
+            self._serving_forever_fut = None
 
     @abstractmethod
     async def _make_server(self) -> Server[_Request]:

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -2831,7 +2831,7 @@ application on specific TCP or Unix socket, e.g.::
       :async:
 
       Serve all registered sites until the coroutine is cancelled or
-      :meth:`cleanup` is called. Cancelling the coroutine cleans up the runner
+      :meth:`cleanup` is called. Canceling the coroutine cleans up the runner
       and re-raises :exc:`asyncio.CancelledError`.
 
       :meth:`setup` and at least one site's ``start()`` method must be called

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -2783,8 +2783,7 @@ application on specific TCP or Unix socket, e.g.::
     await runner.setup()
     site = web.TCPSite(runner, 'localhost', 8080)
     await site.start()
-    # wait for finish signal
-    await runner.cleanup()
+    await runner.serve_forever()
 
 
 .. versionadded:: 3.0
@@ -2827,6 +2826,17 @@ application on specific TCP or Unix socket, e.g.::
       :async:
 
       Stop handling all registered sites and cleanup used resources.
+
+   .. method:: serve_forever()
+      :async:
+
+      Serve all registered sites until the coroutine is cancelled or
+      :meth:`cleanup` is called. Cancelling the coroutine cleans up the runner
+      and re-raises :exc:`asyncio.CancelledError`.
+
+      :meth:`setup` and at least one site's ``start()`` method must be called
+      before this method. Only one ``serve_forever()`` coroutine may await a
+      runner at a time.
 
 
 .. class:: AppRunner(app, *, handle_signals=False, **kwargs)

--- a/tests/test_web_runner.py
+++ b/tests/test_web_runner.py
@@ -232,6 +232,54 @@ async def test_addresses(make_runner: _RunnerMaker, unix_sockname: str) -> None:
     assert actual_addrs == [(expected_host, expected_post), unix_sockname]
 
 
+async def test_runner_serve_forever_requires_setup_and_site(
+    make_runner: _RunnerMaker,
+) -> None:
+    runner = make_runner()
+
+    with pytest.raises(RuntimeError, match=r"Call runner\.setup\(\)"):
+        await runner.serve_forever()
+
+    await runner.setup()
+    with pytest.raises(RuntimeError, match="has no started sites"):
+        await runner.serve_forever()
+
+
+async def test_runner_serve_forever_rejects_concurrent_waiter(
+    make_runner: _RunnerMaker,
+) -> None:
+    runner = make_runner()
+    await runner.setup()
+    site = web.TCPSite(runner, host="127.0.0.1", port=0)
+    await site.start()
+    serve_task = asyncio.create_task(runner.serve_forever())
+    await asyncio.sleep(0)
+
+    with pytest.raises(RuntimeError, match="is already being awaited"):
+        await runner.serve_forever()
+
+    await runner.cleanup()
+    await serve_task
+
+
+async def test_runner_serve_forever_cancellation_cleans_up(
+    make_runner: _RunnerMaker,
+) -> None:
+    runner = make_runner()
+    await runner.setup()
+    site = web.TCPSite(runner, host="127.0.0.1", port=0)
+    await site.start()
+    serve_task = asyncio.create_task(runner.serve_forever())
+    await asyncio.sleep(0)
+
+    serve_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await serve_task
+
+    assert runner.server is None
+    assert not runner.sites
+
+
 @pytest.mark.skipif(
     platform.system() != "Windows", reason="Proactor Event loop present only in Windows"
 )


### PR DESCRIPTION
## What do these changes do?

Add `BaseRunner.serve_forever()` as the runner-level counterpart to `asyncio.Server.serve_forever()`. It waits on a single internal future, performs runner cleanup when cancelled, and can also finish normally when another task calls `runner.cleanup()`.

Focused tests cover setup/site preconditions, concurrent waiter rejection, external cleanup, and cancellation-driven cleanup. The runner reference, changelog, contributor list, and public-API threat-model inventory are updated with the new surface.

## Are there changes in behavior for the user?

Yes. After setting up a runner and starting at least one site, applications can now `await runner.serve_forever()` instead of creating their own never-ending wait. Cancelling that coroutine closes the registered sites and cleans up the runner before re-raising `CancelledError`.

## Is it a substantial burden for the maintainers to support this?

The ongoing surface is one small lifecycle method and one private future per runner. Its state checks and cancellation behavior follow `asyncio.Server.serve_forever()`, while cleanup remains centralized in the existing `BaseRunner.cleanup()` implementation.

## Related issue number

Fixes #2746.

## Checklist

- [ ] I think the code is well written — pending account-owner review
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] Added myself to `CONTRIBUTORS.txt`
- [x] Added `CHANGES/2746.feature.rst`

<details>
<summary>Validation</summary>

- `PYTHON_GIL=1 PYTHONPATH=. AIOHTTP_NO_EXTENSIONS=1 .venv/bin/pytest -q --numprocesses=auto`
  - 4,634 passed, 131 skipped, 14 expected failures
- `PYTHON_GIL=1 PYTHONPATH=. AIOHTTP_NO_EXTENSIONS=1 .venv/bin/pytest -q tests/test_web_runner.py tests/test_run_app.py tests/test_web_server.py`
  - 106 passed, 2 Windows-only skips
- `slotscheck aiohttp`
  - 51 modules and 303 classes scanned; all OK
- Pre-commit on every changed file
  - all applicable hooks passed, including black, isort, flake8, changelog validation, reStructuredText checks, and codespell
- Sphinx HTML build
  - built successfully and resolved the new API references; one local warning reports the separately installed Graphviz `dot` executable is unavailable
- The pinned mypy run reaches unrelated existing errors in `compression_utils.py`, `client_reqrep.py`, and `worker.py`; it reports no new error in the added method.

</details>

Drafted with Codex (GPT-5); human review by @ryux1 pending.
