### PR TITLE
Document that max_redirects=0 means no limit

### DIFF
--- a/CHANGES/13658.doc.rst
+++ b/CHANGES/13658.doc.rst
@@ -1,0 +1,1 @@
+Documented that ``max_redirects=0`` means no limit and that ``allow_redirects=False`` disables redirects -- by :user:`monasco`.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -295,6 +295,7 @@ Mikhail Nacharov
 Mingjie Zhao
 Misha Behersky
 Mitchell Ferree
+monasco
 Morgan Delahaye-Prat
 Moss Collum
 Mun Gwan-gyeong

--- a/docs/client_reference.rst
+++ b/docs/client_reference.rst
@@ -478,6 +478,8 @@ The client session supports the context manager protocol for self closing.
 
       :param int max_redirects: Maximum number of redirects to follow.
          :exc:`TooManyRedirects` is raised if the number is exceeded.
+         ``0`` means no limit, redirects are followed until the request
+         times out. Use ``allow_redirects=False`` to not follow redirects at all.
          Ignored when ``allow_redirects=False``.
          ``10`` by default.
 
@@ -970,6 +972,8 @@ certification chaining.
 
    :param int max_redirects: Maximum number of redirects to follow.
       :exc:`TooManyRedirects` is raised if the number is exceeded.
+      ``0`` means no limit, redirects are followed until the request
+      times out. Use ``allow_redirects=False`` to not follow redirects at all.
       Ignored when ``allow_redirects=False``.
       ``10`` by default.
 


### PR DESCRIPTION
## What do these changes do?

Documents that `max_redirects=0` means no limit and that `allow_redirects=False` is the way to not follow redirects. No code change.

## Are there changes in behavior for the user?

No.

## Is it a substantial burden for the maintainers to support this?

No.

## Related issue number

Fixes #13658

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
- [x] Add a new news fragment into the `CHANGES/` folder