### PR TITLE
fix: decode multiple Content-Encoding codings (RFC 9110 §8.4)

### DIFF
--- a/aiohttp/_http_parser.pyx
+++ b/aiohttp/_http_parser.pyx
@@ -31,7 +31,7 @@ from .http_exceptions import (
     PayloadEncodingError,
     TransferEncodingError,
 )
-from .http_parser import DeflateBuffer as _DeflateBuffer
+from .http_parser import DeflateBuffer as _DeflateBuffer, _wrap_decompression
 from .http_writer import (
     HttpVersion as _HttpVersion,
     HttpVersion10 as _HttpVersion10,
@@ -515,8 +515,16 @@ cdef class HttpParser:
         enc = self._content_encoding
         if enc is not None:
             self._content_encoding = None
-            if enc.isascii() and enc.lower() in {"gzip", "deflate", "br", "zstd"}:
-                encoding = enc
+            if enc.isascii():
+                enc_lower = enc.lower()
+                if enc_lower in {"gzip", "deflate", "br", "zstd"}:
+                    encoding = enc
+                elif "," in enc_lower:
+                    # Multiple codings (RFC 9110 §8.4). Record the raw value;
+                    # the payload wrapper decodes them in reverse order and
+                    # rejects unsupported or excessive coding lists via
+                    # _wrap_decompression().
+                    encoding = enc
 
         if self._cparser.type == cparser.HTTP_REQUEST:
             method = <str>_http_method[self._cparser.method]
@@ -549,7 +557,12 @@ cdef class HttpParser:
         self._payload = payload
         self._content_length_expected = self._cparser.content_length
         if encoding is not None and self._auto_decompress:
-            self._payload = DeflateBuffer(payload, encoding, max_decompress_size=self._limit)
+            self._payload = _wrap_decompression(
+                payload,
+                encoding,
+                self._limit,
+                payload_exception=self._payload_exception,
+            )
 
         self._messages.append((msg, payload))
         if self._max_msg_queue_size:

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -1307,17 +1307,23 @@ def _wrap_decompression(
     )
     if unsupported is not None:
         exc = ContentEncodingError(f"Can not decode content-encoding: {unsupported!r}")
-        set_exception(payload, payload_exception(str(exc)) if payload_exception else exc)
+        set_exception(
+            payload, payload_exception(str(exc)) if payload_exception else exc
+        )
         return payload
     if len(codings) > _MAX_CONTENT_ENCODING_LAYERS:
         exc = ContentEncodingError(
             f"Too many content-encodings: {len(codings)} "
             f"(max {_MAX_CONTENT_ENCODING_LAYERS})"
         )
-        set_exception(payload, payload_exception(str(exc)) if payload_exception else exc)
+        set_exception(
+            payload, payload_exception(str(exc)) if payload_exception else exc
+        )
         return payload
     for coding in codings:
-        payload = DeflateBuffer(payload, coding, max_decompress_size=max_decompress_size)
+        payload = DeflateBuffer(
+            payload, coding, max_decompress_size=max_decompress_size
+        )
     return payload
 
 

--- a/aiohttp/http_parser.py
+++ b/aiohttp/http_parser.py
@@ -91,6 +91,23 @@ VERSRE: Final[Pattern[str]] = re.compile(r"HTTP/(\d)\.(\d)", re.ASCII)
 DIGITS: Final[Pattern[str]] = re.compile(r"\d+", re.ASCII)
 HEXDIGITS: Final[Pattern[bytes]] = re.compile(rb"[0-9a-fA-F]+")
 
+# Content codings aiohttp can decode (RFC 9110 §8.4.1). Values are
+# case-insensitive on the wire; comparisons are done on lowercased input.
+_SUPPORTED_CONTENT_ENCODINGS: Final[frozenset[str]] = frozenset(
+    {"gzip", "deflate", "br", "zstd"}
+)
+
+# Hard cap on the number of content codings aiohttp will decode for one
+# payload (RFC 9110 §8.4 allows Content-Encoding to list several codings,
+# applied in the listed order and decoded in reverse). Each extra coding
+# costs one full decompression pass over the whole body, so an unbounded
+# list multiplies CPU use per byte received: a max_field_size (8190) byte
+# header could otherwise name ~1600 codings. Real-world servers use 1-3
+# codings (e.g. gzip at the origin plus gzip/br added by an intermediary);
+# 4 leaves headroom over that while keeping the worst case at a small
+# constant factor. Longer lists raise ContentEncodingError.
+_MAX_CONTENT_ENCODING_LAYERS: Final[int] = 4
+
 # RFC 9110 singleton headers — duplicates are rejected in strict mode.
 # In lax mode (response parser default), the check is skipped entirely
 # since real-world servers (e.g. Google APIs, Werkzeug) commonly send
@@ -454,6 +471,7 @@ class HttpParser(abc.ABC, Generic[_MsgT]):
                                 max_field_size=self.max_field_size,
                                 max_trailers=max_trailers,
                                 limit=self._limit,
+                                payload_exception=self.payload_exception,
                             )
                             if not payload_parser.done:
                                 self._payload_parser = payload_parser
@@ -481,6 +499,7 @@ class HttpParser(abc.ABC, Generic[_MsgT]):
                                 max_field_size=self.max_field_size,
                                 max_trailers=max_trailers,
                                 limit=self._limit,
+                                payload_exception=self.payload_exception,
                             )
                         elif not empty_body and length is None and self.read_until_eof:
                             payload = StreamReader(
@@ -504,6 +523,7 @@ class HttpParser(abc.ABC, Generic[_MsgT]):
                                 max_field_size=self.max_field_size,
                                 max_trailers=max_trailers,
                                 limit=self._limit,
+                                payload_exception=self.payload_exception,
                             )
                             if not payload_parser.done:
                                 self._payload_parser = payload_parser
@@ -625,8 +645,16 @@ class HttpParser(abc.ABC, Generic[_MsgT]):
 
         # encoding
         enc = headers.get(hdrs.CONTENT_ENCODING, "")
-        if enc.isascii() and enc.lower() in {"gzip", "deflate", "br", "zstd"}:
-            encoding = enc
+        if enc.isascii():
+            enc_lower = enc.lower()
+            if enc_lower in _SUPPORTED_CONTENT_ENCODINGS:
+                encoding = enc
+            elif "," in enc_lower:
+                # Multiple codings (RFC 9110 §8.4). Record the raw value; the
+                # payload parser decodes them in reverse order and rejects
+                # unsupported or excessive coding lists via
+                # _wrap_decompression().
+                encoding = enc
 
         # chunking
         te = headers.get(hdrs.TRANSFER_ENCODING)
@@ -868,6 +896,7 @@ class HttpPayloadParser:
         max_field_size: int = 8190,
         max_trailers: int = 128,
         limit: int = DEFAULT_CHUNK_SIZE,
+        payload_exception: type[BaseException] | None = None,
     ) -> None:
         self._length = 0
         self._paused = False
@@ -888,8 +917,11 @@ class HttpPayloadParser:
 
         # payload decompression wrapper
         if response_with_body and compression and self._auto_decompress:
-            real_payload: StreamReader | DeflateBuffer = DeflateBuffer(
-                payload, compression, max_decompress_size=limit
+            real_payload: StreamReader | DeflateBuffer = _wrap_decompression(
+                payload,
+                compression,
+                max_decompress_size=limit,
+                payload_exception=payload_exception,
             )
         else:
             real_payload = payload
@@ -1173,6 +1205,10 @@ class DeflateBuffer:
             self.decompressor = ZLibDecompressor(encoding=encoding)
 
         self._max_decompress_size = max_decompress_size
+        # Nested DeflateBuffers (multi-coding Content-Encoding) have no
+        # StreamReader buffer to fill, so bound their per-call output by the
+        # same decompression size limit. The value cascades through the chain.
+        self._low_water = getattr(out, "_low_water", max_decompress_size)
 
     def set_exception(
         self,
@@ -1213,7 +1249,12 @@ class DeflateBuffer:
             )
 
         if chunk:
-            self.out.feed_data(chunk)
+            return self.out.feed_data(chunk) or self.decompressor.data_available
+        if isinstance(self.out, DeflateBuffer):
+            # A nested DeflateBuffer (multi-coding Content-Encoding) may still
+            # hold pending output that an empty feed would drain; keep the
+            # parser's feed_data(b"") loop going in that case.
+            return self.out.feed_data(b"") or self.decompressor.data_available
         return self.decompressor.data_available
 
     def feed_eof(self) -> None:
@@ -1235,6 +1276,49 @@ class DeflateBuffer:
 
     def end_http_chunk_receiving(self) -> None:
         self.out.end_http_chunk_receiving()
+
+
+def _wrap_decompression(
+    payload: StreamReader,
+    encoding: str,
+    max_decompress_size: int = DEFAULT_CHUNK_SIZE,
+    *,
+    payload_exception: type[BaseException] | None = None,
+) -> StreamReader | DeflateBuffer:
+    """Wrap `payload` with the DeflateBuffer chain needed for `encoding`.
+
+    `encoding` is the Content-Encoding header value: either a single coding
+    (e.g. "gzip") or a comma-separated list of codings (RFC 9110 §8.4: they
+    are applied in the listed order and must be decoded in reverse). Nesting
+    one DeflateBuffer per coding in listed order decodes them in reverse,
+    since each wrapper decodes one coding and feeds the result to the next.
+
+    Unsupported codings and lists longer than _MAX_CONTENT_ENCODING_LAYERS
+    get a ContentEncodingError set on the payload instead of passing
+    undecodable bytes through to the consumer; the error is raised when the
+    body is read. Like mid-body decode failures, the error is rewrapped with
+    `payload_exception` (e.g. ClientPayloadError on the client) when one is
+    configured.
+    """
+    codings = [coding.strip().lower() for coding in encoding.split(",")]
+    unsupported = next(
+        (coding for coding in codings if coding not in _SUPPORTED_CONTENT_ENCODINGS),
+        None,
+    )
+    if unsupported is not None:
+        exc = ContentEncodingError(f"Can not decode content-encoding: {unsupported!r}")
+        set_exception(payload, payload_exception(str(exc)) if payload_exception else exc)
+        return payload
+    if len(codings) > _MAX_CONTENT_ENCODING_LAYERS:
+        exc = ContentEncodingError(
+            f"Too many content-encodings: {len(codings)} "
+            f"(max {_MAX_CONTENT_ENCODING_LAYERS})"
+        )
+        set_exception(payload, payload_exception(str(exc)) if payload_exception else exc)
+        return payload
+    for coding in codings:
+        payload = DeflateBuffer(payload, coding, max_decompress_size=max_decompress_size)
+    return payload
 
 
 HttpRequestParserPy = HttpRequestParser

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -1145,6 +1145,82 @@ def test_compression_unknown(parser: HttpRequestParser) -> None:
     msg = messages[0][0]
     assert msg.compression is None
 
+async def test_compression_multiple_codings_gzip_gzip(
+    response: HttpResponseParser,
+) -> None:
+    """Content-Encoding: gzip,gzip decodes both layers (RFC 9110 §8.4)."""
+    original = b"Hello, multiple codings! " * 4
+    compressed = gzip.compress(gzip.compress(original))
+    headers = (
+        b"HTTP/1.1 200 OK\x0d\x0a"
+        b"Content-Length: " + str(len(compressed)).encode() + b"\x0d\x0a"
+        b"Content-Encoding: gzip,gzip\x0d\x0a"
+        b"\x0d\x0a"
+    )
+    msgs, upgrade, tail = response.feed_data(headers + compressed)
+    payload = msgs[0][-1]
+    result = await payload.read()
+    assert result == original
+    assert payload.exception() is None
+
+
+async def test_compression_multiple_codings_mixed(
+    response: HttpResponseParser,
+) -> None:
+    """Mixed codings applied in listed order are decoded in reverse."""
+    original = b"Mixed coding payload! " * 4
+    # Content-Encoding: gzip,deflate -> first gzip, then deflate; decode in reverse.
+    compressed = zlib.compress(gzip.compress(original))
+    headers = (
+        b"HTTP/1.1 200 OK\x0d\x0a"
+        b"Content-Length: " + str(len(compressed)).encode() + b"\x0d\x0a"
+        b"Content-Encoding: gzip,deflate\x0d\x0a"
+        b"\x0d\x0a"
+    )
+    msgs, upgrade, tail = response.feed_data(headers + compressed)
+    payload = msgs[0][-1]
+    result = await payload.read()
+    assert result == original
+    assert payload.exception() is None
+
+
+async def test_compression_multiple_codings_unsupported(
+    response: HttpResponseParser,
+) -> None:
+    """A coding list containing an unsupported entry raises ContentEncodingError."""
+    original = b"payload"
+    compressed = gzip.compress(original)
+    headers = (
+        b"HTTP/1.1 200 OK\x0d\x0a"
+        b"Content-Length: " + str(len(compressed)).encode() + b"\x0d\x0a"
+        b"Content-Encoding: gzip,weird-coding\x0d\x0a"
+        b"\x0d\x0a"
+    )
+    msgs, upgrade, tail = response.feed_data(headers + compressed)
+    payload = msgs[0][-1]
+    with pytest.raises(http_exceptions.ContentEncodingError):
+        await payload.read()
+
+
+async def test_compression_multiple_codings_too_many(
+    response: HttpResponseParser,
+) -> None:
+    """More codings than the hard cap raises ContentEncodingError (DoS guard)."""
+    compressed = b"payload"
+    for _ in range(5):
+        compressed = gzip.compress(compressed)
+    headers = (
+        b"HTTP/1.1 200 OK\x0d\x0a"
+        b"Content-Length: " + str(len(compressed)).encode() + b"\x0d\x0a"
+        b"Content-Encoding: " + b",".join([b"gzip"] * 5) + b"\x0d\x0a"
+        b"\x0d\x0a"
+    )
+    msgs, upgrade, tail = response.feed_data(headers + compressed)
+    payload = msgs[0][-1]
+    with pytest.raises(http_exceptions.ContentEncodingError):
+        await payload.read()
+
+
 
 def test_url_connect(parser: HttpRequestParser) -> None:
     text = b"CONNECT www.google.com HTTP/1.1\r\nHost: a\r\ncontent-length: 0\r\n\r\n"

--- a/tests/test_http_parser.py
+++ b/tests/test_http_parser.py
@@ -1145,6 +1145,7 @@ def test_compression_unknown(parser: HttpRequestParser) -> None:
     msg = messages[0][0]
     assert msg.compression is None
 
+
 async def test_compression_multiple_codings_gzip_gzip(
     response: HttpResponseParser,
 ) -> None:
@@ -1219,7 +1220,6 @@ async def test_compression_multiple_codings_too_many(
     payload = msgs[0][-1]
     with pytest.raises(http_exceptions.ContentEncodingError):
         await payload.read()
-
 
 
 def test_url_connect(parser: HttpRequestParser) -> None:


### PR DESCRIPTION
## Summary

`Content-Encoding: gzip,gzip` (multiple codings, legal per RFC 9110 §8.4) currently passes raw compressed bytes to `resp.text()` / `resp.json()`, which then fail to decode. This PR decodes a comma-separated coding list in reverse order (as the RFC requires) by nesting one `DeflateBuffer` per coding, in both the pure-Python and Cython parsers.

Safety: a hard cap `_MAX_CONTENT_ENCODING_LAYERS = 4` guards against decompression-bomb header abuse (an 8190-byte header could otherwise name ~1600 codings). Unsupported codings and over-long lists now raise `ContentEncodingError` instead of silently passing undecodable bytes through.

Fixes #13364.

## Changes

- `aiohttp/http_parser.py`: `_SUPPORTED_CONTENT_ENCODINGS`, `_MAX_CONTENT_ENCODING_LAYERS`, `_wrap_decompression()`; multi-coding detection in header parsing; `payload_exception` threaded through so client-side errors keep their `ClientPayloadError` wrapping.
- `aiohttp/_http_parser.pyx`: same detection + `_wrap_decompression()` call.
- `tests/test_http_parser.py`: 4 regression tests (gzip,gzip; gzip,deflate mixed; unsupported coding; 5-layer over-cap) — fail before the fix, pass after, for both parser implementations.

## Test Plan

- New tests: 4 failed on unpatched code, 8 passed (py + c parsers) with the fix.
- Full suite on this branch: **4773 passed / 256 skipped / 7 xfailed / 0 failed**.

## Notes

- Layer cap rationale is documented in a code comment near `_MAX_CONTENT_ENCODING_LAYERS`.
- This follows the discussion in #13364: supporting arbitrary nesting was flagged as a cost/attack-surface concern; decoding the common 2-3 layer case with a hard cap addresses both sides.
