### PR TITLE
Document the real readuntil() signature

### DIFF
--- a/CHANGES/13686.doc.rst
+++ b/CHANGES/13686.doc.rst
@@ -1,0 +1,3 @@
+Corrected the documented signature of :py:meth:`~aiohttp.StreamReader.readuntil`, which
+showed a ``str`` separator although the method takes ``bytes``, and documented its
+keyword-only ``max_size`` argument -- by :user:`hxperl`.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -157,6 +157,7 @@ Gary Leung
 Gary Wilson Jr.
 Gene Hoffman
 Gennady Andreyev
+Geonseok Lee
 George Fifth
 Georges Dubus
 goingforstudying-ctrl

--- a/docs/streams.rst
+++ b/docs/streams.rst
@@ -79,7 +79,7 @@ Reading Attributes and Methods
 
    :return bytes: the given line
 
-.. method:: StreamReader.readuntil(separator="\n")
+.. method:: StreamReader.readuntil(separator=b"\n", *, max_size=None)
       :async:
 
    Read until separator, where `separator` is a sequence of bytes.
@@ -91,6 +91,10 @@ Reading Attributes and Methods
    empty bytes object.
 
    .. versionadded:: 3.8
+
+   :param int max_size: maximum number of bytes to buffer while searching for
+      *separator*; exceeding it raises ``LineTooLong``. ``None``, the default,
+      uses the stream's high-water limit.
 
    :return bytes: the given data
 


### PR DESCRIPTION
## What do these changes do?

`docs/streams.rst` documents `StreamReader.readuntil` as taking a `str` separator:

```rst
.. method:: StreamReader.readuntil(separator="\n")
```

The implementation takes `bytes` (`aiohttp/streams.py:381`), so the documented call raises `TypeError`. The prose directly under the directive already says "*where `separator` is a sequence of bytes*", so the signature line contradicts the sentence below it as well as the code. `max_size` is keyword-only and appears nowhere in `docs/`.

## Are there changes in behavior for the user?

No. Documentation only — the rendered signature becomes `readuntil(separator=b'\n', *, max_size=None)`.

## Is it a substantial burden for the maintainers to support this?

No. One directive line plus one `:param:` in a single `.rst`.

## Related issue number

None filed; found by comparing documented signatures against real ones.

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] Added to `CONTRIBUTORS.txt`
- [x] Added a news fragment in `CHANGES/`

Verified on macOS arm64, Python 3.14, pure-Python mode: `tests/test_streams.py` 136 passed, and the docs build renders the corrected signature. I did not run the full suite or build the Cython extensions, which this does not touch.

Drafted with Claude Opus 5; reviewed by hxperl.
