### PR TITLE
Skip lingering close for explicit response.force_close()

### DIFF
--- a/CHANGES/13687.bugfix.rst
+++ b/CHANGES/13687.bugfix.rst
@@ -1,0 +1,1 @@
+1800.bugfix.rst

--- a/CHANGES/1800.bugfix.rst
+++ b/CHANGES/1800.bugfix.rst
@@ -1,0 +1,1 @@
+``Response.force_close()`` now closes the connection right after the response is written instead of draining the unread request body (lingering close) -- by :user:`istoolsfox`.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -187,6 +187,7 @@ Illia Volochii
 Ilya Chichak
 Ilya Gruzinov
 Ingmar Steen
+istoolsfox
 Ivan Lakovic
 Ivan Larin
 J. Nick Koston

--- a/aiohttp/web_protocol.py
+++ b/aiohttp/web_protocol.py
@@ -827,7 +827,13 @@ class RequestHandler(BaseProtocol, Generic[_Request]):
                 if not payload.is_eof():
                     lingering_time = self._lingering_time
                     # Could be force closed while awaiting above tasks.
-                    if not self._force_close and lingering_time:  # type: ignore[redundant-expr]
+                    # An explicit resp.force_close() opts out of lingering:
+                    # the connection closes right after the response (#1800).
+                    if (
+                        not self._force_close  # type: ignore[redundant-expr]
+                        and not resp._force_close
+                        and lingering_time
+                    ):
                         self.log_debug(
                             "Start lingering close timer for %s sec.", lingering_time
                         )
@@ -978,6 +984,10 @@ class RequestHandler(BaseProtocol, Generic[_Request]):
                 message = title + "\n\n" + msg
 
         resp = Response(status=status, text=message, content_type=ct)
-        resp.force_close()
+        # Keep-alive off without response force_close(): the graceful drain
+        # must stay for internally generated error responses so the client
+        # can still read the error page -- skipping the drain is reserved
+        # for an explicit force_close() in handler code (#1800).
+        resp._keep_alive = False
 
         return resp

--- a/aiohttp/web_response.py
+++ b/aiohttp/web_response.py
@@ -78,6 +78,7 @@ class StreamResponse(
     _length_check = True
     _body = None
     _keep_alive: bool | None = None
+    _force_close: bool = False
     _chunked: bool = False
     _compression: bool = False
     _compression_strategy: int | None = None
@@ -165,7 +166,14 @@ class StreamResponse(
         return self._keep_alive
 
     def force_close(self) -> None:
+        """Disable :attr:`keep_alive` for connection.
+
+        There are no ways to enable it back. The connection is closed right
+        after the response is written -- the unread part of the request body
+        is not drained (no lingering close).
+        """
         self._keep_alive = False
+        self._force_close = True
 
     @property
     def body_length(self) -> int:

--- a/aiohttp/web_ws.py
+++ b/aiohttp/web_ws.py
@@ -366,7 +366,13 @@ class WebSocketResponse(StreamResponse, Generic[_DecodeText]):
 
         self.set_status(101)
         self.headers.update(headers)
-        self.force_close()
+        # Keep-alive off without response force_close(): the upgraded
+        # connection stays open for the websocket protocol, so "close right
+        # after the response" does not apply, and the handler's lingering
+        # drain is load-bearing here -- it seats an unread request body tail
+        # for the upgraded connection (_replay_message_tail()).
+        self._force_close = False
+        self._keep_alive = False
         self._compress = compress
         transport = request._protocol.transport
         if transport is None:

--- a/docs/web_reference.rst
+++ b/docs/web_reference.rst
@@ -677,6 +677,10 @@ and :ref:`aiohttp-web-signals` handlers::
       Disable :attr:`keep_alive` for connection. There are no ways to
       enable it back.
 
+      The connection is closed right after the response is written --
+      the unread part of the request body is not drained (no lingering
+      close).
+
    .. attribute:: compression
 
       Read-only :class:`bool` property, ``True`` if compression is enabled.

--- a/tests/test_web_functional.py
+++ b/tests/test_web_functional.py
@@ -2211,9 +2211,10 @@ async def test_force_close_response_skips_lingering_close(
         # clean EOF or a reset (the kernel may RST a socket closed with an
         # unread receive buffer) proves the server did not linger. A lingering
         # server instead holds the socket open until wait_for() times out.
-        data = b""
-        with suppress(ConnectionResetError):
+        try:
             data = await asyncio.wait_for(reader.read(4096), 2.0)
+        except ConnectionResetError:
+            data = b""
         assert data == b"", data
     finally:
         writer.close()

--- a/tests/test_web_functional.py
+++ b/tests/test_web_functional.py
@@ -2174,6 +2174,105 @@ async def test_pipelined_requests_after_deferred_upgrade_are_served(
     assert responses.count(b"HTTP/1.1 ") == len(expected), responses[:200]
 
 
+async def test_force_close_response_skips_lingering_close(
+    aiohttp_server: AiohttpServer,
+) -> None:
+    """resp.force_close() must close the connection promptly (#1800).
+
+    The client announces a large body but never finishes sending it. With the
+    bug the server lingers up to lingering_time waiting for the rest; with the
+    fix, the connection is closed right after the response is written.
+    """
+
+    async def handler(request: web.Request) -> web.Response:
+        resp = web.Response(text="done")
+        resp.force_close()
+        return resp
+
+    app = web.Application()
+    app.router.add_post("/", handler)
+    server = await aiohttp_server(app, lingering_time=10.0)
+
+    reader, writer = await asyncio.open_connection(server.host, server.port)
+    try:
+        writer.write(
+            b"POST / HTTP/1.1\r\nHost: localhost\r\n"
+            b"Content-Length: 65536\r\n\r\n" + b"x" * 512
+        )
+        await writer.drain()
+        # Never send the remaining 65024 body bytes.
+        response = b""
+        while b"done" not in response:
+            chunk = await asyncio.wait_for(reader.read(4096), 5)
+            assert chunk, f"connection closed before response completed: {response!r}"
+            response += chunk
+
+        # A close right after the response is the contract here: either a
+        # clean EOF or a reset (the kernel may RST a socket closed with an
+        # unread receive buffer) proves the server did not linger.
+        try:
+            data = await asyncio.wait_for(reader.read(4096), 2.0)
+        except asyncio.TimeoutError:
+            pytest.fail("connection still open: lingering close was not skipped")
+        except ConnectionResetError:
+            data = b""
+        assert data == b"", data
+    finally:
+        writer.close()
+        with suppress(ConnectionResetError, BrokenPipeError):
+            await writer.wait_closed()
+
+
+@pytest.mark.parametrize(
+    "request_head",
+    [
+        b"POST / HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n",
+        b"POST / HTTP/1.0\r\nHost: localhost\r\n",
+    ],
+    ids=["connection-close", "http10"],
+)
+async def test_connection_close_request_still_drains_unread_body(
+    aiohttp_server: AiohttpServer,
+    request_head: bytes,
+) -> None:
+    """Declining keep-alive without force_close() must keep the graceful drain.
+
+    ``Connection: close`` and HTTP/1.0 end the connection without reuse, but
+    the lingering close stays: it drains the unread request body so the client
+    can finish sending and read the response without a reset (#1800).
+    """
+
+    async def handler(request: web.Request) -> web.Response:
+        return web.Response(text="done")
+
+    app = web.Application()
+    app.router.add_post("/", handler)
+    server = await aiohttp_server(app, lingering_time=10.0)
+
+    reader, writer = await asyncio.open_connection(server.host, server.port)
+    try:
+        writer.write(request_head + b"Content-Length: 65536\r\n\r\n" + b"x" * 512)
+        await writer.drain()
+        response = b""
+        while b"done" not in response:
+            chunk = await asyncio.wait_for(reader.read(4096), 5)
+            assert chunk, f"connection closed before response completed: {response!r}"
+            response += chunk
+
+        # The graceful drain must hold the connection open while the body is
+        # incomplete, then close as soon as the announced body arrives.
+        eof = asyncio.ensure_future(reader.read(4096))
+        await asyncio.sleep(0.5)
+        assert not eof.done(), "server stopped draining before the body was complete"
+        writer.write(b"y" * 65024)
+        await writer.drain()
+        assert await asyncio.wait_for(eof, 5) == b""
+    finally:
+        writer.close()
+        with suppress(ConnectionResetError, BrokenPipeError):
+            await writer.wait_closed()
+
+
 async def test_websocket_prepared_with_unread_body_does_not_stall(
     aiohttp_server: AiohttpServer,
 ) -> None:

--- a/tests/test_web_functional.py
+++ b/tests/test_web_functional.py
@@ -2209,13 +2209,11 @@ async def test_force_close_response_skips_lingering_close(
 
         # A close right after the response is the contract here: either a
         # clean EOF or a reset (the kernel may RST a socket closed with an
-        # unread receive buffer) proves the server did not linger.
-        try:
+        # unread receive buffer) proves the server did not linger. A lingering
+        # server instead holds the socket open until wait_for() times out.
+        data = b""
+        with suppress(ConnectionResetError):
             data = await asyncio.wait_for(reader.read(4096), 2.0)
-        except asyncio.TimeoutError:
-            pytest.fail("connection still open: lingering close was not skipped")
-        except ConnectionResetError:
-            data = b""
         assert data == b"", data
     finally:
         writer.close()


### PR DESCRIPTION
## What do these changes do?

An explicit `resp.force_close()` now closes the connection right after the response is written instead of starting the lingering close: the unread part of the request body is no longer drained for up to `lingering_time` seconds.

The lingering gate in `RequestHandler.start()` now also consults an explicit response-level intent (`StreamResponse._force_close`), which only `force_close()` sets. Internally generated error responses (`RequestHandler._handle_error`) and the websocket upgrade (`WebSocketResponse._pre_start`) switch `keep_alive` off directly and keep the graceful drain:

- the upgrade path depends on the drain to seat an unread request body tail for the upgraded connection (see `_replay_message_tail()`), and
- error pages should stay readable for clients that are still sending their request body.

## Are there changes in behavior for the user?

Handlers that call `resp.force_close()` get a prompt connection close: a client that is still uploading sees the connection end (EOF or reset) immediately after the response instead of after `lingering_time`. This is the behavior requested in #1800. Apps that relied on `force_close()` responses implicitly draining a slow client will see that drain go away — `lingering_time` remains the global knob for the other non-keep-alive cases (HTTP/1.0, `Connection: close`), which keep their graceful drain unchanged.

## Is it a substantial burden for the maintainers to support this?

The semantic question here is real, and I'd like to be explicit about the alternative: if maintainers prefer `force_close()` to keep its documented "disable keep-alive" meaning and retain the graceful drain, the other direction is a docs/tests clarification only. The implementation is deliberately small — one boolean carried on the response, read at the existing decision point, with the two internal call sites excluded — so the long-term support burden is a single extra condition and its tests. Happy to pivot to the docs-only resolution if that's the preferred call.

## Related issue number

Fixes #1800

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
- [x] If you provide code modification, please add yourself to `CONTRIBUTORS.txt`
- [x] Add a new news fragment into the `CHANGES/` folder

---

Verification (local, macOS, Python 3.14, `AIOHTTP_NO_EXTENSIONS=1`):

- New `test_force_close_response_skips_lingering_close` fails on unpatched master at the 2s guard (`connection still open: lingering close was not skipped`) and passes with the fix. `test_connection_close_request_still_drains_unread_body` (parametrized over `Connection: close` and HTTP/1.0) passes before and after, pinning the preserved drain.
- `test_web_functional.py test_web_response.py test_web_protocol.py test_web_request_handler.py test_web_websocket*.py test_websocket_handshake.py test_web_server.py test_web_runner.py test_web_middleware.py`: 666 passed, 0 failed. Full suite: 4627 passed; the 10 `test_helpers.py` proxy-env failures reproduce on unpatched master in this environment (local proxy env vars set), unrelated to this change.
- `mypy` (2.1.0) and `black` (26.5.1) clean on the touched files. The pre-existing `type: ignore[redundant-expr]` moved with the reformatted condition and still suppresses the same narrowed-`self._force_close` false positive.
- A prior attempt at this issue (#13245) added `self._keepalive` to the same gate; that variant also skips the drain for HTTP/1.0 and `Connection: close` requests, and its raw-client test raced a server-side reset in CI. This PR scopes the skip to explicit `force_close()` and uses raw-TCP tests where the client never sends the remaining body, so both the bug path and the guard path are deterministic.
