### PR TITLE
Fix MultipartWriter.as_bytes() to apply Content-Encoding and Content-Transfer-Encoding

### DIFF
--- a/aiohttp/multipart.py
+++ b/aiohttp/multipart.py
@@ -1178,6 +1178,7 @@ class MultipartWriter(Payload):
 
             # Add payload content using as_bytes for async safety
             if _e or _te:
+
                 class _BytesWriter:
                     def __init__(self) -> None:
                         self.buffer = bytearray()

--- a/aiohttp/multipart.py
+++ b/aiohttp/multipart.py
@@ -1174,9 +1174,28 @@ class MultipartWriter(Payload):
             # Add headers
             parts.append(part._binary_headers)
 
-            # Add payload content using as_bytes for async safety
             part_bytes = await part.as_bytes(encoding, errors)
-            parts.append(part_bytes)
+
+            # Add payload content using as_bytes for async safety
+            if _e or _te:
+                class _BytesWriter:
+                    def __init__(self) -> None:
+                        self.buffer = bytearray()
+
+                    async def write(self, chunk: bytes) -> None:
+                        self.buffer.extend(chunk)
+
+                writer = _BytesWriter()
+                w = MultipartPayloadWriter(writer)  # type: ignore[arg-type]
+                if _e:
+                    w.enable_compression(_e)
+                if _te:
+                    w.enable_encoding(_te)
+                await w.write(part_bytes)
+                await w.write_eof()
+                parts.append(bytes(writer.buffer))
+            else:
+                parts.append(part_bytes)
 
             # Add trailing CRLF
             parts.append(b"\r\n")

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -2009,3 +2009,22 @@ async def test_multipart_writer_consumed_follows_body_part_reader() -> None:
 
         assert part.consumed is True
         assert writer.consumed is True
+
+async def test_multipart_writer_as_bytes_with_encoding() -> None:
+    """Test that MultipartWriter.as_bytes() applies content encoding."""
+    class Buf:
+        def __init__(self) -> None:
+            self.data = bytearray()
+        async def write(self, chunk: bytes) -> None:
+            self.data.extend(chunk)
+
+    mp = aiohttp.MultipartWriter("mixed", boundary="XBOUND")
+    part = aiohttp.payload.StringPayload("hello world")
+    part.headers["Content-Encoding"] = "gzip"
+    mp.append_payload(part)
+
+    buf = Buf()
+    await mp.write(buf)
+
+    mp_bytes = await mp.as_bytes()
+    assert bytes(buf.data) == mp_bytes

--- a/tests/test_multipart.py
+++ b/tests/test_multipart.py
@@ -2010,11 +2010,14 @@ async def test_multipart_writer_consumed_follows_body_part_reader() -> None:
         assert part.consumed is True
         assert writer.consumed is True
 
+
 async def test_multipart_writer_as_bytes_with_encoding() -> None:
     """Test that MultipartWriter.as_bytes() applies content encoding."""
+
     class Buf:
         def __init__(self) -> None:
             self.data = bytearray()
+
         async def write(self, chunk: bytes) -> None:
             self.data.extend(chunk)
 


### PR DESCRIPTION
Fixes #13495

When a part appended to a non-form-data `MultipartWriter` carries `Content-Encoding` or `Content-Transfer-Encoding`, `write()` compresses/encodes the part on the wire via `MultipartPayloadWriter`, but `as_bytes()` previously returned the raw, untransformed part content.

This fix updates `as_bytes()` to properly apply encoding via `MultipartPayloadWriter` to match the wire protocol, adding consistent behavior.